### PR TITLE
Don't return `PBXProject` from `createProject()`

### DIFF
--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -6,7 +6,7 @@ import XcodeProj
 /// The main purpose of `Environment` is to enable dependency injection,
 /// allowing for different implementations to be used in tests.
 struct Environment {
-    let createProject: (_ project: Project) -> (PBXProj, PBXProject)
+    let createProject: (_ project: Project) -> PBXProj
 
     let processTargetMerges: (
         _ targets: inout [TargetID: Target],

--- a/tools/generator/src/Generator+CreateProject.swift
+++ b/tools/generator/src/Generator+CreateProject.swift
@@ -2,7 +2,10 @@ import XcodeProj
 
 extension Generator {
     /// Creates the `PBXProj` and `PBXProject` objects for the given `Project`.
-    static func createProject(project: Project) -> (PBXProj, PBXProject) {
+    ///
+    /// The `PBXProject` is also created and assigned as the `PBXProj`'s
+    /// `rootObject`.
+    static func createProject(project: Project) -> PBXProj {
         let pbxProj = PBXProj()
 
         let mainGroup = PBXGroup()
@@ -32,6 +35,6 @@ extension Generator {
         pbxProj.add(object: pbxProject)
         pbxProj.rootObject = pbxProject
 
-        return (pbxProj, pbxProject)
+        return pbxProj
     }
 }

--- a/tools/generator/test/CreateProjectTests.swift
+++ b/tools/generator/test/CreateProjectTests.swift
@@ -38,7 +38,7 @@ final class CreateProjectTests: XCTestCase {
 
         // Act
 
-        let (createdPBXProj, createdPBXProject) = Generator.createProject(
+        let createdPBXProj = Generator.createProject(
             project: project
         )
 
@@ -48,6 +48,5 @@ final class CreateProjectTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(createdPBXProj, expectedPBXProj)
-        XCTAssertNoDifference(createdPBXProject, expectedPBXProject)
     }
 }

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -55,7 +55,7 @@ enum Fixtures {
             srcs: ["external/another_repo/b.swift"]
         ),
     ]
-    static func pbxProject() -> (PBXProj, PBXProject) {
+    static func pbxProj() -> PBXProj {
         let pbxProj = PBXProj()
 
         let mainGroup = PBXGroup()
@@ -73,6 +73,6 @@ enum Fixtures {
         pbxProj.add(object: pbxProject)
         pbxProj.rootObject = pbxProject
 
-        return (pbxProj, pbxProject)
+        return pbxProj
     }
 }

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -15,7 +15,7 @@ final class GeneratorTests: XCTestCase {
             potentialTargetMerges: [:],
             requiredLinks: []
         )
-        let (pbxProj, pbxProject) = Fixtures.pbxProject()
+        let pbxProj = Fixtures.pbxProj()
         let mergedTargets: [TargetID: Target] = [
             "Y": Target.mock(
                 configuration: "a1b2c",
@@ -36,11 +36,11 @@ final class GeneratorTests: XCTestCase {
         }
 
         var createProjectCalled: [CreateProjectCalled] = []
-        func createProject(project: Project) -> (PBXProj, PBXProject) {
+        func createProject(project: Project) -> PBXProj {
             createProjectCalled.append(CreateProjectCalled(
                 project: project
             ))
-            return (pbxProj, pbxProject)
+            return pbxProj
         }
 
         let expectedCreateProjectCalled = [CreateProjectCalled(


### PR DESCRIPTION
The `PBXProject` is cannonically accessed through `PBXProj.rootObject`.