### PR TITLE
Allow merging into multiple destinations

### DIFF
--- a/tools/generator/src/DTO.swift
+++ b/tools/generator/src/DTO.swift
@@ -4,7 +4,7 @@ import XcodeProj
 struct Project: Equatable, Decodable {
     let name: String
     var targets: [TargetID: Target]
-    let potentialTargetMerges: [TargetID: TargetID]
+    let potentialTargetMerges: [TargetID: Set<TargetID>]
     let requiredLinks: Set<Path>
 }
 

--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -10,7 +10,7 @@ struct Environment {
 
     let processTargetMerges: (
         _ targets: inout [TargetID: Target],
-        _ potentialTargetMerges: [TargetID: TargetID],
+        _ potentialTargetMerges: [TargetID: Set<TargetID>],
         _ requiredLinks: Set<Path>
     ) throws -> [InvalidMerge]
 

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -30,12 +30,14 @@ class Generator {
         )
 
         for invalidMerge in invalidMerges {
-            environment.logger.logWarning("""
-Was unable to merge "\(targets[invalidMerge.src]!.label) \
-(\(targets[invalidMerge.src]!.configuration))" into \
-"\(targets[invalidMerge.dest]!.label) \
-(\(targets[invalidMerge.dest]!.configuration))"
+            for destination in invalidMerge.destinations {
+                environment.logger.logWarning("""
+Was unable to merge "\(targets[invalidMerge.source]!.label) \
+(\(targets[invalidMerge.source]!.configuration))" into \
+"\(targets[destination]!.label) \
+(\(targets[destination]!.configuration))"
 """)
+            }
         }
     }
 }
@@ -48,6 +50,6 @@ struct PreconditionError: Error {
 /// When a potential merge wasn't valid, then the ids of the targets involved
 /// are returned in this `struct`.
 struct InvalidMerge: Equatable {
-    let src: TargetID
-    let dest: TargetID
+    let source: TargetID
+    let destinations: Set<TargetID>
 }

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -40,7 +40,12 @@ enum Fixtures {
         "B 2": Target.mock(
             product: .init(type: .unitTestBundle, name: "B", path: "B.xctest"),
             links: ["a/b.a"],
-            dependencies: ["B 1"]
+            dependencies: ["A 2", "B 1"]
+        ),
+        "B 3": Target.mock(
+            product: .init(type: .uiTestBundle, name: "B3", path: "B3.xctest"),
+            links: ["a/b.a"],
+            dependencies: ["A 2", "B 1"]
         ),
         "C 1": Target.mock(
             product: .init(type: .staticLibrary, name: "c", path: "a/c.a"),

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -51,14 +51,14 @@ final class GeneratorTests: XCTestCase {
 
         struct ProcessTargetMergesCalled: Equatable {
             let targets: [TargetID: Target]
-            let potentialTargetMerges: [TargetID: TargetID]
+            let potentialTargetMerges: [TargetID: Set<TargetID>]
             let requiredLinks: Set<Path>
         }
 
         var processTargetMergesCalled: [ProcessTargetMergesCalled] = []
         func processTargetMerges(
             targets: inout [TargetID: Target],
-            potentialTargetMerges: [TargetID: TargetID],
+            potentialTargetMerges: [TargetID: Set<TargetID>],
             requiredLinks: Set<Path>
         ) throws -> [InvalidMerge] {
             processTargetMergesCalled.append(ProcessTargetMergesCalled(
@@ -67,7 +67,7 @@ final class GeneratorTests: XCTestCase {
                 requiredLinks: requiredLinks
             ))
             targets = mergedTargets
-            return [InvalidMerge(src: "Y", dest: "Z")]
+            return [InvalidMerge(source: "Y", destinations: ["Z"])]
         }
 
         let expectedProcessTargetMergesCalled = [ProcessTargetMergesCalled(


### PR DESCRIPTION
A single library can be used by multiple executable targets, so we need to allow merging into multiple destinations.