### PR TITLE
Conform `PreconditionError` to `LocalizedError`

### DIFF
--- a/tools/generator/src/Errors.swift
+++ b/tools/generator/src/Errors.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// An `Error` that represents a programming error.
+struct PreconditionError: Error {
+    let message: String
+}
+
+// MARK: LocalizedError
+
+extension PreconditionError: LocalizedError {
+    var errorDescription: String? {
+        return """
+Internal precondition failure:
+\(message)
+Please file a bug report at \
+https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md
+"""
+    }
+}
+

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -40,11 +40,6 @@ Was unable to merge "\(targets[invalidMerge.src]!.label) \
     }
 }
 
-/// An `Error` that represents a programming error.
-struct PreconditionError: Error {
-    let message: String
-}
-
 /// When a potential merge wasn't valid, then the ids of the targets involved
 /// are returned in this `struct`.
 struct InvalidMerge: Equatable {


### PR DESCRIPTION
`LocalizedError` allows us to easily display a user facing message for errors. I've included a call to action to file a bug if a user sees a `PreconditionError`.

There will be more errors in the future, so I also moved it to its own file.