### PR TITLE
Pass `logger` directly to `Generator`

### DIFF
--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -13,6 +13,4 @@ struct Environment {
         _ potentialTargetMerges: [TargetID: Set<TargetID>],
         _ requiredLinks: Set<Path>
     ) throws -> [InvalidMerge]
-
-    let logger: Logger
 }

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -8,13 +8,17 @@ import XcodeProj
 class Generator {
     static let defaultEnvironment = Environment(
         createProject: Generator.createProject,
-        processTargetMerges: Generator.processTargetMerges,
-        logger: DefaultLogger()
+        processTargetMerges: Generator.processTargetMerges
     )
 
     let environment: Environment
+    let logger: Logger
 
-    init(environment: Environment = Generator.defaultEnvironment) {
+    init(
+        environment: Environment = Generator.defaultEnvironment, 
+        logger: Logger
+    ) {
+        self.logger = logger
         self.environment = environment
     }
 
@@ -31,7 +35,7 @@ class Generator {
 
         for invalidMerge in invalidMerges {
             for destination in invalidMerge.destinations {
-                environment.logger.logWarning("""
+                logger.logWarning("""
 Was unable to merge "\(targets[invalidMerge.source]!.label) \
 (\(targets[invalidMerge.source]!.configuration))" into \
 "\(targets[destination]!.label) \

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -84,10 +84,12 @@ final class GeneratorTests: XCTestCase {
         let logger = StubLogger()
         let environment = Environment(
             createProject: createProject,
-            processTargetMerges: processTargetMerges,
+            processTargetMerges: processTargetMerges
+        )
+        let generator = Generator(
+            environment: environment,
             logger: logger
         )
-        let generator = Generator(environment: environment)
 
         // Act
 


### PR DESCRIPTION
We will want to use the same instance of `Logger` outside of the `Generator` instance, so having it be part of `Environment` makes that tricky.