### PR TITLE
Add support for `filegroup`

### DIFF
--- a/examples/ios_app/Example/BUILD
+++ b/examples/ios_app/Example/BUILD
@@ -24,11 +24,16 @@ swift_library(
     module_name = "Example",
     data = glob(["Assets.xcassets/**"]) + select({
         ":release_build": [],
-        "//conditions:default": glob(["Preview Content/**"]),
+        "//conditions:default": [":PreviewContent"],
     }),
     srcs = glob(["**/*.swift"]),
     deps = [
         "//examples/ios_app/Utils",
     ],
     visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "PreviewContent",
+    srcs = glob(["Preview Content/**"]),
 )

--- a/examples/ios_app/ExampleUITests/BUILD
+++ b/examples/ios_app/ExampleUITests/BUILD
@@ -14,5 +14,10 @@ swift_library(
     name = "ExampleUITests.library",
     module_name = "ExampleUITests",
     testonly = True,
+    srcs = [":Sources"],
+)
+
+filegroup(
+    name = "Sources",
     srcs = glob(["**/*.swift"]),
 )

--- a/test/fixtures/ios_app/spec.json
+++ b/test/fixtures/ios_app/spec.json
@@ -7,6 +7,9 @@
         "ONLY_ACTIVE_ARCH": true
     },
     "extra_files": [
+        "examples/ios_app/Example/Preview Content/Preview Assets.xcassets/Contents.json",
+        "examples/ios_app/Example/Preview Content/Preview Assets.xcassets/rules_xcodeproj.imageset/Contents.json",
+        "examples/ios_app/Example/Preview Content/Preview Assets.xcassets/rules_xcodeproj.imageset/rules_xcodeproj.png",
         "examples/ios_app/Example/Assets.xcassets/AccentColor.colorset/Contents.json",
         "examples/ios_app/Example/Assets.xcassets/AppIcon.appiconset/Contents.json",
         "examples/ios_app/Example/Assets.xcassets/AppIcon.appiconset/ios_2x_icon-1.png",
@@ -16,10 +19,7 @@
         "examples/ios_app/Example/Assets.xcassets/AppIcon.appiconset/ipad_1x_icon.png",
         "examples/ios_app/Example/Assets.xcassets/AppIcon.appiconset/ipad_2x_icon.png",
         "examples/ios_app/Example/Assets.xcassets/AppIcon.appiconset/ipadpro_2x_icon.png",
-        "examples/ios_app/Example/Assets.xcassets/Contents.json",
-        "examples/ios_app/Example/Preview Content/Preview Assets.xcassets/Contents.json",
-        "examples/ios_app/Example/Preview Content/Preview Assets.xcassets/rules_xcodeproj.imageset/Contents.json",
-        "examples/ios_app/Example/Preview Content/Preview Assets.xcassets/rules_xcodeproj.imageset/rules_xcodeproj.png"
+        "examples/ios_app/Example/Assets.xcassets/Contents.json"
     ],
     "name": "iOS App",
     "potential_target_merges": [


### PR DESCRIPTION
This is somewhat of a stopgap. It's making assumptions about how outputs are propagated between rules. A more holistic approach, where we look at `target.files`, will come in the future.