### PR TITLE
Set `externalDirectory` to a relative path in fixtures

### DIFF
--- a/test/fixtures/fixtures.bzl
+++ b/test/fixtures/fixtures.bzl
@@ -111,6 +111,7 @@ def xcodeproj_fixture(*, name = "xcodeproj", project_name = "project", targets):
 
     xcodeproj(
         name = name,
+        external_dir_override = "bazel-rules_xcodeproj/external",
         project_name = project_name,
         targets = targets,
         visibility = ["//test:__subpackages__"],

--- a/test/fixtures/generator/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/project.xcodeproj/project.pbxproj
@@ -575,8 +575,8 @@
 				C7827CA75B49ED3974E7D841 /* com_github_tuist_xcodeproj */,
 			);
 			name = "Bazel External Repositories";
-			path = /var/tmp/_bazel_brentley/3d5821071b04bd5519a8cc5bb33889a1/external;
-			sourceTree = "<absolute>";
+			path = "bazel-rules_xcodeproj/external";
+			sourceTree = "<group>";
 		};
 		55109E883B6F1B3D9D44B0C2 /* Sources */ = {
 			isa = PBXGroup;

--- a/tools/generator/src/Generator+CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator+CreateFilesAndGroups.swift
@@ -26,7 +26,7 @@ extension Generator {
             // TODO: Handle in-workspace "external/" paths
             if filePath == .input("external") {
                 group = PBXGroup(
-                    sourceTree: .absolute,
+                    sourceTree: externalDirectory.sourceTree,
                     name: "Bazel External Repositories",
                     path: externalDirectory.string
                 )
@@ -168,4 +168,8 @@ func +(lhs: FilePath, rhs: String) -> FilePath {
     case .internal(let path):
         return .internal(path + rhs)
     }
+}
+
+private extension Path {
+    var sourceTree: PBXSourceTree { isAbsolute ? .absolute : .group }
 }

--- a/xcodeproj/xcodeproj.bzl
+++ b/xcodeproj/xcodeproj.bzl
@@ -86,9 +86,14 @@ def _write_json_spec(*, ctx, project_name, infos):
     return output
 
 def _write_root_dirs(*, ctx):
+    output = ctx.actions.declare_file("{}_root_dirs".format(ctx.attr.name))
+
+    if ctx.attr.external_dir_override:
+        ctx.actions.write(output, ctx.attr.external_dir_override)
+        return output
+
     an_external_input = ctx.file._external_file_marker
 
-    output = ctx.actions.declare_file("{}_root_dirs".format(ctx.attr.name))
     ctx.actions.run_shell(
         inputs = [an_external_input],
         outputs = [output],
@@ -204,6 +209,9 @@ def _xcodeproj_impl(ctx):
 _xcodeproj = rule(
     implementation = _xcodeproj_impl,
     attrs = {
+        "external_dir_override": attr.string(
+            default = "",
+        ),
         "project_name": attr.string(),
         "targets": attr.label_list(
             mandatory = True,


### PR DESCRIPTION
We don't use a relative path by default because the symlinks in `bazel-WORKSPACE/external` change with each build, causing the files to become unavailable in Xcode from time to time. I'm fine with making the use of the fixture projects a little more finicky in order to have deterministic fixtures.