### PR TITLE
Move fixture transition to `xcodegen.targets`

### DIFF
--- a/test/fixtures/fixtures.bzl
+++ b/test/fixtures/fixtures.bzl
@@ -1,7 +1,12 @@
 """Functions for updating test fixtures."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("//xcodeproj:xcodeproj.bzl", "xcodeproj", "XcodeProjOutputInfo")
+load(
+    "//xcodeproj:xcodeproj.bzl",
+    "make_xcodeproj_rule",
+    "xcodeproj",
+    "XcodeProjOutputInfo",
+)
 
 # Utility
 
@@ -104,6 +109,10 @@ def update_fixtures(**kwargs):
         **kwargs
     )
 
+_fixture_xcodeproj = make_xcodeproj_rule(
+    transition = fixtures_transition,
+)
+
 def xcodeproj_fixture(*, name = "xcodeproj", project_name = "project", targets):
     native.exports_files([
         "spec.json",
@@ -114,6 +123,7 @@ def xcodeproj_fixture(*, name = "xcodeproj", project_name = "project", targets):
         external_dir_override = "bazel-rules_xcodeproj/external",
         project_name = project_name,
         targets = targets,
+        xcodeproj_rule = _fixture_xcodeproj,
         visibility = ["//test:__subpackages__"],
     )
 


### PR DESCRIPTION
This prevents applying the transition `xcodeproj`'s other dependencies, such as `generator`. It also allows for calling the `xcodeproj` targets in `//test/fixtures` and them having the correct transition applied. This will be needed later for generated files support.