### PR TITLE
Push `FilePath` creation out to DTO

### DIFF
--- a/test/fixtures/generator/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/project.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		1C9302398624AC0EF61B4E42 /* XCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EE28F3E78BFA30B6BC27157 /* XCSharedData.swift */; };
 		1DF3D75C1A0A0BD817951AEA /* XCScheme+TestPlanReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66481761818CF96152100568 /* XCScheme+TestPlanReference.swift */; };
 		1E5D71A0D9B1FA421FAFC99C /* CreateFilesAndGroupsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBE718DED105ECB828959C4E /* CreateFilesAndGroupsTests.swift */; };
+		1ECFA5B8B919DC10F2538D28 /* FilePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FA37AAFE94856E13AF17D3 /* FilePath.swift */; };
 		1FA8A6B10AA4130856920B0D /* Decoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = B04B6231A28B45AAA7B16ED4 /* Decoders.swift */; };
 		20B471143A628BC3A9A67002 /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB53FEBC739A97352D13423 /* Element.swift */; };
 		214E6D8D7DDFBF81EB02E762 /* XCTFail.swift in Sources */ = {isa = PBXBuildFile; fileRef = B852818BA581DE0BF5B342FB /* XCTFail.swift */; };
@@ -323,6 +324,7 @@
 		715A6551C9994C6A35C2760E /* UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKit.swift; sourceTree = "<group>"; };
 		71BDC7E12D4D474B0F7A36F9 /* WorkspaceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSettings.swift; sourceTree = "<group>"; };
 		731649630DE508B0F7DB9208 /* XCScheme+EnvironmentVariable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+EnvironmentVariable.swift"; sourceTree = "<group>"; };
+		73FA37AAFE94856E13AF17D3 /* FilePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePath.swift; sourceTree = "<group>"; };
 		755289FCCDF72EC8CEE224FA /* Speech.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Speech.swift; sourceTree = "<group>"; };
 		76833E2B2EBB7309BEB734AF /* Bool+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bool+Extras.swift"; sourceTree = "<group>"; };
 		7695912589F7CC31B690CF39 /* PBXSourcesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXSourcesBuildPhase.swift; sourceTree = "<group>"; };
@@ -846,6 +848,7 @@
 				4D379A8ACB50AB221622B35F /* DTO.swift */,
 				B4F0472ABB97D909352E00C6 /* Environment.swift */,
 				C85C339FAB91CEA53509EC58 /* Errors.swift */,
+				73FA37AAFE94856E13AF17D3 /* FilePath.swift */,
 				97DE705E5D1963950A8787DD /* Generator.swift */,
 				5F4938CB5948C8AEC7B07294 /* Generator+AddTargets.swift */,
 				FAA17A2F6CD794DB282973D5 /* Generator+CreateFilesAndGroups.swift */,
@@ -1202,6 +1205,7 @@
 				F07C41E7C121458095C495AB /* DTO.swift in Sources */,
 				EC843052E421638CE0714F03 /* Environment.swift in Sources */,
 				D7FA4DB98CAD61326ECF8F63 /* Errors.swift in Sources */,
+				1ECFA5B8B919DC10F2538D28 /* FilePath.swift in Sources */,
 				4318EC05544CA53237842D70 /* Generator.swift in Sources */,
 				A9208A327209350C4B224371 /* Generator+AddTargets.swift in Sources */,
 				AF1CE8BA7000C9AE1C9BEB66 /* Generator+CreateFilesAndGroups.swift in Sources */,

--- a/test/fixtures/generator/spec.json
+++ b/test/fixtures/generator/spec.json
@@ -184,6 +184,7 @@
                 "tools/generator/src/DTO.swift",
                 "tools/generator/src/Environment.swift",
                 "tools/generator/src/Errors.swift",
+                "tools/generator/src/FilePath.swift",
                 "tools/generator/src/Generator+AddTargets.swift",
                 "tools/generator/src/Generator+CreateFilesAndGroups.swift",
                 "tools/generator/src/Generator+CreateProducts.swift",

--- a/tools/generator/src/DTO.swift
+++ b/tools/generator/src/DTO.swift
@@ -7,7 +7,7 @@ struct Project: Equatable, Decodable {
     var targets: [TargetID: Target]
     let potentialTargetMerges: [TargetID: Set<TargetID>]
     let requiredLinks: Set<Path>
-    let extraFiles: Set<Path>
+    let extraFiles: Set<FilePath>
 }
 
 struct Target: Equatable, Decodable {
@@ -18,7 +18,7 @@ struct Target: Equatable, Decodable {
     let product: Product
     let testHost: TargetID?
     var buildSettings: [String: BuildSetting]
-    var srcs: Set<Path>
+    var srcs: Set<FilePath>
     var links: Set<Path>
     var dependencies: Set<TargetID>
 }

--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -20,7 +20,7 @@ struct Environment {
     let createFilesAndGroups: (
         _ pbxProj: PBXProj,
         _ targets: [TargetID: Target],
-        _ extraFiles: Set<Path>,
+        _ extraFiles: Set<FilePath>,
         _ externalDirectory: Path,
         _ internalDirectoryName: String,
         _ workspaceOutputPath: Path

--- a/tools/generator/src/FilePath.swift
+++ b/tools/generator/src/FilePath.swift
@@ -1,0 +1,53 @@
+import PathKit
+
+struct FilePath: Hashable, Decodable {
+    enum PathType: String, Decodable {
+        case input
+        case `internal`
+    }
+
+    let type: PathType
+    let path: Path
+
+    fileprivate init(type: PathType, path: Path) {
+        self.type = type
+        self.path = path
+    }
+
+    // MARK: Decodable
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case path
+    }
+
+    init(from decoder: Decoder) throws {
+        // A plain string is interpreted as a source file
+        if let path = try? decoder.singleValueContainer().decode(Path.self) {
+            type = .input
+            self.path = path
+            return
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        path = try container.decode(Path.self, forKey: .path)
+        type = try container.decodeIfPresent(PathType.self, forKey: .type)
+            ?? .input
+    }
+}
+
+extension FilePath {
+    static func input(_ path: Path) -> FilePath {
+        return FilePath(type: .input, path: path)
+    }
+
+    static func `internal`(_ path: Path) -> FilePath {
+        return FilePath(type: .internal, path: path)
+    }
+}
+
+// MARK: Operators
+
+func +(lhs: FilePath, rhs: String) -> FilePath {
+    return FilePath(type: lhs.type, path: lhs.path + rhs)
+}

--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -62,7 +62,7 @@ Product for target "\(id)" not found
 
     private static func createCompileSourcesPhase(
         in pbxProj: PBXProj,
-        sources: Set<Path>,
+        sources: Set<FilePath>,
         files: [FilePath: PBXFileElement]
     ) throws -> PBXSourcesBuildPhase {
         func buildFile(filePath: FilePath) throws -> PBXBuildFile {
@@ -80,7 +80,7 @@ File "\(filePath)" not found
         if sources.isEmpty {
             filePaths = [.internal(compileStubPath)]
         } else {
-            filePaths = Set(sources.map(FilePath.input))
+            filePaths = sources
         }
 
         let buildPhase = PBXSourcesBuildPhase(

--- a/tools/generator/src/Generator+WriteXcodeProj.swift
+++ b/tools/generator/src/Generator+WriteXcodeProj.swift
@@ -28,21 +28,5 @@ extension Generator {
 }
 
 private extension FilePath {
-    var isInternal: Bool {
-        switch self {
-        case .internal:
-            return true
-        default:
-            return false
-        }
-    }
-
-    var path: Path {
-        switch self {
-        case .internal(let path):
-            return path
-        case .input(let path):
-            return path
-        }
-    }
+    var isInternal: Bool { type == .internal }
 }

--- a/tools/generator/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generator/test/CreateFilesAndGroupsTests.swift
@@ -20,7 +20,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
                 srcs: ["a.swift"]
             ),
         ]
-        let extraFiles: Set<Path> = []
+        let extraFiles: Set<FilePath> = []
         let externalDirectory = Path("/ext")
         let internalDirectoryName = "rules_xcp"
         let workspaceOutputPath = Path("Project.xcodeproj")

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -128,7 +128,7 @@ final class GeneratorTests: XCTestCase {
         struct CreateFilesAndGroupsCalled: Equatable {
             let pbxProj: PBXProj
             let targets: [TargetID: Target]
-            let extraFiles: Set<Path>
+            let extraFiles: Set<FilePath>
             let externalDirectory: Path
             let internalDirectoryName: String
             let workspaceOutputPath: Path
@@ -138,7 +138,7 @@ final class GeneratorTests: XCTestCase {
         func createFilesAndGroups(
             in pbxProj: PBXProj,
             targets: [TargetID: Target],
-            extraFiles: Set<Path>,
+            extraFiles: Set<FilePath>,
             externalDirectory: Path,
             internalDirectoryName: String,
             workspaceOutputPath: Path

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -10,7 +10,7 @@ extension Target {
         product: Product,
         testHost: TargetID? = nil,
         buildSettings: [String: BuildSetting] = [:],
-        srcs: Set<Path> = [],
+        srcs: Set<FilePath> = [],
         links: Set<Path> = [],
         dependencies: Set<TargetID> = []
     ) -> Self {


### PR DESCRIPTION
This is in preperation adding more information to `FilePath` from the spec, such as if the input was generated or in an external repository.