### PR TITLE
Split `.input` into `.project` and `.external`

### DIFF
--- a/test/fixtures/generator/spec.json
+++ b/test/fixtures/generator/spec.json
@@ -457,7 +457,10 @@
                 "type": "com.apple.product-type.library.static"
             },
             "srcs": [
-                "external/com_github_kylef_pathkit/Sources/PathKit.swift"
+                {
+                    "_": "com_github_kylef_pathkit/Sources/PathKit.swift",
+                    "t": "e"
+                }
             ],
             "test_host": null
         },
@@ -538,31 +541,106 @@
                 "type": "com.apple.product-type.library.static"
             },
             "srcs": [
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreImage.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreLocation.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreMotion.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Foundation.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/GameKit.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/KeyPath.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Photos.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Speech.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/StoreKit.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Swift.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/SwiftUI.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/UIKit.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/UserNotifications.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/UserNotificationsUI.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/CustomDumpReflectable.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/CustomDumpRepresentable.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/CustomDumpStringConvertible.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Diff.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Dump.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/AnyType.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/Box.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/CollectionDifference.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/Mirror.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/String.swift",
-                "external/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/XCTAssertNoDifference.swift"
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreImage.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreLocation.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreMotion.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Foundation.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/GameKit.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/KeyPath.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Photos.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Speech.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/StoreKit.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Swift.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/SwiftUI.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/UIKit.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/UserNotifications.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/UserNotificationsUI.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/CustomDumpReflectable.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/CustomDumpRepresentable.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/CustomDumpStringConvertible.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Diff.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Dump.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/AnyType.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/Box.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/CollectionDifference.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/Mirror.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/String.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/XCTAssertNoDifference.swift",
+                    "t": "e"
+                }
             ],
             "test_host": null
         },
@@ -641,7 +719,10 @@
                 "type": "com.apple.product-type.library.static"
             },
             "srcs": [
-                "external/com_github_pointfreeco_xctest_dynamic_overlay/Sources/XCTestDynamicOverlay/XCTFail.swift"
+                {
+                    "_": "com_github_pointfreeco_xctest_dynamic_overlay/Sources/XCTestDynamicOverlay/XCTFail.swift",
+                    "t": "e"
+                }
             ],
             "test_host": null
         },
@@ -720,11 +801,26 @@
                 "type": "com.apple.product-type.library.static"
             },
             "srcs": [
-                "external/com_github_tadija_aexml/Sources/AEXML/Document.swift",
-                "external/com_github_tadija_aexml/Sources/AEXML/Element.swift",
-                "external/com_github_tadija_aexml/Sources/AEXML/Error.swift",
-                "external/com_github_tadija_aexml/Sources/AEXML/Options.swift",
-                "external/com_github_tadija_aexml/Sources/AEXML/Parser.swift"
+                {
+                    "_": "com_github_tadija_aexml/Sources/AEXML/Document.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tadija_aexml/Sources/AEXML/Element.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tadija_aexml/Sources/AEXML/Error.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tadija_aexml/Sources/AEXML/Options.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tadija_aexml/Sources/AEXML/Parser.swift",
+                    "t": "e"
+                }
             ],
             "test_host": null
         },
@@ -806,101 +902,386 @@
                 "type": "com.apple.product-type.library.static"
             },
             "srcs": [
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Errors/Errors.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Array+Extras.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Bool+Extras.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Dictionary+Enumerate.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Dictionary+Extras.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/NSRecursiveLock+Sync.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Path+Extras.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/String+Utils.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/String+md5.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/BuildPhase.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXBuildFile.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXBuildPhase.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXBuildRule.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXCopyFilesBuildPhase.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXFrameworksBuildPhase.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXHeadersBuildPhase.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXResourcesBuildPhase.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXRezBuildPhase.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXShellScriptBuildPhase.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXSourcesBuildPhase.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Configuration/BuildSettings.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Configuration/XCBuildConfiguration.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Configuration/XCConfigurationList.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXContainerItem.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXContainerItemProxy.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXFileElement.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXFileReference.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXGroup.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXSourceTree.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXVariantGroup.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/XCVersionGroup.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObject.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObjectParser.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObjectReference.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObjects.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXOutputSettings.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXProj.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXProject.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Sourcery/Sourcery.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXAggregateTarget.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXLegacyTarget.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXNativeTarget.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXProductType.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXReferenceProxy.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXTarget.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXTargetDependency.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Project/WorkspaceSettings.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Project/XCBreakpointList.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Project/XCSharedData.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Project/Xcode.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Project/XcodeProj.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Protocols/Writable.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+AditionalOption.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+AnalyzeAction.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+ArchiveAction.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+BuildableProductRunnable.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+BuildableReference.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+CommandLineArguments.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+EnvironmentVariable.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+ExecutionAction.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+LocationScenarioReference.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+PathRunnable.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+ProfileAction.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+RemoteRunnable.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+Runnable.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+SerialAction.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+StoreKitConfigurationFileReference.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestItem.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestPlanReference.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCSchemeManagement.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/BuildSettingsProvider.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/CommentedString.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/Decoders.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/JSONDecoding.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/PBXBatchUpdater.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/PlistValue.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/ReferenceGenerator.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/XCConfig.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspace.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceData.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataElement.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataElementLocationType.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataFileRef.swift",
-                "external/com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataGroup.swift"
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Errors/Errors.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Array+Extras.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Bool+Extras.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Dictionary+Enumerate.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Dictionary+Extras.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/NSRecursiveLock+Sync.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Path+Extras.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/String+Utils.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/String+md5.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/BuildPhase.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXBuildFile.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXBuildPhase.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXBuildRule.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXCopyFilesBuildPhase.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXFrameworksBuildPhase.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXHeadersBuildPhase.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXResourcesBuildPhase.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXRezBuildPhase.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXShellScriptBuildPhase.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXSourcesBuildPhase.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Configuration/BuildSettings.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Configuration/XCBuildConfiguration.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Configuration/XCConfigurationList.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXContainerItem.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXContainerItemProxy.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXFileElement.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXFileReference.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXGroup.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXSourceTree.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXVariantGroup.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/XCVersionGroup.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObject.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObjectParser.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObjectReference.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObjects.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXOutputSettings.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXProj.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXProject.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Sourcery/Sourcery.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXAggregateTarget.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXLegacyTarget.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXNativeTarget.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXProductType.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXReferenceProxy.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXTarget.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXTargetDependency.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Project/WorkspaceSettings.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Project/XCBreakpointList.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Project/XCSharedData.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Project/Xcode.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Project/XcodeProj.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Protocols/Writable.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+AditionalOption.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+AnalyzeAction.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+ArchiveAction.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+BuildableProductRunnable.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+BuildableReference.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+CommandLineArguments.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+EnvironmentVariable.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+ExecutionAction.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+LocationScenarioReference.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+PathRunnable.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+ProfileAction.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+RemoteRunnable.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+Runnable.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+SerialAction.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+StoreKitConfigurationFileReference.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestItem.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestPlanReference.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCSchemeManagement.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/BuildSettingsProvider.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/CommentedString.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/Decoders.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/JSONDecoding.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/PBXBatchUpdater.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/PlistValue.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/ReferenceGenerator.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/XCConfig.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspace.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceData.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataElement.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataElementLocationType.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataFileRef.swift",
+                    "t": "e"
+                },
+                {
+                    "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataGroup.swift",
+                    "t": "e"
+                }
             ],
             "test_host": null
         }

--- a/tools/generator/src/FilePath.swift
+++ b/tools/generator/src/FilePath.swift
@@ -2,8 +2,9 @@ import PathKit
 
 struct FilePath: Hashable, Decodable {
     enum PathType: String, Decodable {
-        case input
-        case `internal`
+        case project = "p"
+        case external = "e"
+        case `internal` = "i"
     }
 
     let type: PathType
@@ -17,14 +18,14 @@ struct FilePath: Hashable, Decodable {
     // MARK: Decodable
 
     enum CodingKeys: String, CodingKey {
-        case type
-        case path
+        case type = "t"
+        case path = "_"
     }
 
     init(from decoder: Decoder) throws {
         // A plain string is interpreted as a source file
         if let path = try? decoder.singleValueContainer().decode(Path.self) {
-            type = .input
+            type = .project
             self.path = path
             return
         }
@@ -32,13 +33,17 @@ struct FilePath: Hashable, Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         path = try container.decode(Path.self, forKey: .path)
         type = try container.decodeIfPresent(PathType.self, forKey: .type)
-            ?? .input
+            ?? .project
     }
 }
 
 extension FilePath {
-    static func input(_ path: Path) -> FilePath {
-        return FilePath(type: .input, path: path)
+    static func project(_ path: Path) -> FilePath {
+        return FilePath(type: .project, path: path)
+    }
+
+    static func external(_ path: Path) -> FilePath {
+        return FilePath(type: .external, path: path)
     }
 
     static func `internal`(_ path: Path) -> FilePath {

--- a/tools/generator/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generator/test/CreateFilesAndGroupsTests.swift
@@ -99,7 +99,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
             expectedFilesAndGroups["b.c"]!,
             expectedFilesAndGroups["z.mm"]!,
             // Then Bazel External Repositories
-            expectedFilesAndGroups["external"]!,
+            expectedFilesAndGroups[.external("")]!,
             // And finally the internal (rules_xcodeproj) group
             expectedFilesAndGroups[.internal("")]!,
         ]

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -68,11 +68,11 @@ enum Fixtures {
         ),
         "E1": Target.mock(
             product: .init(type: .staticLibrary, name: "E1", path: "e1/E.a"),
-            srcs: ["external/a_repo/a.swift"]
+            srcs: [.external("a_repo/a.swift")]
         ),
         "E2": Target.mock(
             product: .init(type: .staticLibrary, name: "E2", path: "e2/E.a"),
-            srcs: ["external/another_repo/b.swift"]
+            srcs: [.external("another_repo/b.swift")]
         ),
     ]
 
@@ -123,34 +123,34 @@ enum Fixtures {
         var elements: [FilePath: PBXFileElement] = [:]
 
         // external/a_repo/a.swift
-        elements["external/a_repo/a.swift"] = PBXFileReference(
+        elements[.external("a_repo/a.swift")] = PBXFileReference(
             sourceTree: .group,
             lastKnownFileType: "sourcecode.swift",
             path: "a.swift"
         )
-        elements["external/a_repo"] = PBXGroup(
-            children: [elements["external/a_repo/a.swift"]!],
+        elements[.external("a_repo")] = PBXGroup(
+            children: [elements[.external("a_repo/a.swift")]!],
             sourceTree: .group,
             path: "a_repo"
         )
 
         // external/another_repo/b.swift
-        elements["external/another_repo/b.swift"] = PBXFileReference(
+        elements[.external("another_repo/b.swift")] = PBXFileReference(
             sourceTree: .group,
             lastKnownFileType: "sourcecode.swift",
             path: "b.swift"
         )
-        elements["external/another_repo"] = PBXGroup(
-            children: [elements["external/another_repo/b.swift"]!],
+        elements[.external("another_repo")] = PBXGroup(
+            children: [elements[.external("another_repo/b.swift")]!],
             sourceTree: .group,
             path: "another_repo"
         )
 
         // external
-        elements["external"] = PBXGroup(
+        elements[.external("")] = PBXGroup(
             children: [
-                elements["external/a_repo"]!,
-                elements["external/another_repo"]!,
+                elements[.external("a_repo")]!,
+                elements[.external("another_repo")]!,
             ],
             sourceTree: .absolute,
             name: "Bazel External Repositories",
@@ -402,8 +402,8 @@ enum Fixtures {
             "A 1": [
                 PBXSourcesBuildPhase(
                     files: buildFiles([
-                        PBXBuildFile(file: files["b.c"]),
-                        PBXBuildFile(file: files["x/y.swift"]),
+                        PBXBuildFile(file: files["b.c"]!),
+                        PBXBuildFile(file: files["x/y.swift"]!),
                     ])
                 ),
                 PBXFrameworksBuildPhase(),
@@ -411,20 +411,20 @@ enum Fixtures {
             "A 2": [
                 PBXSourcesBuildPhase(
                     files: buildFiles([PBXBuildFile(
-                        file: files[.internal("CompileStub.swift")]
+                        file: files[.internal("CompileStub.swift")]!
                     )])
                 ),
                 PBXFrameworksBuildPhase(
                     files: buildFiles([
-                        PBXBuildFile(file: products.byTarget["A 1"]),
-                        PBXBuildFile(file: products.byTarget["C 1"]),
+                        PBXBuildFile(file: products.byTarget["A 1"]!),
+                        PBXBuildFile(file: products.byTarget["C 1"]!),
                     ])
                 ),
             ],
             "B 1": [
                 PBXSourcesBuildPhase(
                     files: buildFiles([
-                        PBXBuildFile(file: files["z.mm"]),
+                        PBXBuildFile(file: files["z.mm"]!),
                     ])
                 ),
                 PBXFrameworksBuildPhase(),
@@ -432,31 +432,31 @@ enum Fixtures {
             "B 2": [
                 PBXSourcesBuildPhase(
                     files: buildFiles([PBXBuildFile(
-                        file: files[.internal("CompileStub.swift")]
+                        file: files[.internal("CompileStub.swift")]!
                     )])
                 ),
                 PBXFrameworksBuildPhase(
                     files: buildFiles([
-                        PBXBuildFile(file: products.byTarget["B 1"]),
+                        PBXBuildFile(file: products.byTarget["B 1"]!),
                     ])
                 ),
             ],
             "B 3": [
                 PBXSourcesBuildPhase(
                     files: buildFiles([PBXBuildFile(
-                        file: files[.internal("CompileStub.swift")]
+                        file: files[.internal("CompileStub.swift")]!
                     )])
                 ),
                 PBXFrameworksBuildPhase(
                     files: buildFiles([
-                        PBXBuildFile(file: products.byTarget["B 1"]),
+                        PBXBuildFile(file: products.byTarget["B 1"]!),
                     ])
                 ),
             ],
             "C 1": [
                 PBXSourcesBuildPhase(
                     files: buildFiles([
-                        PBXBuildFile(file: files["a/b/c.m"]),
+                        PBXBuildFile(file: files["a/b/c.m"]!),
                     ])
                 ),
                 PBXFrameworksBuildPhase(),
@@ -464,7 +464,7 @@ enum Fixtures {
             "E1": [
                 PBXSourcesBuildPhase(
                     files: buildFiles([
-                        PBXBuildFile(file: files["external/a_repo/a.swift"]),
+                        PBXBuildFile(file: files[.external("a_repo/a.swift")]!),
                     ])
                 ),
                 PBXFrameworksBuildPhase(),
@@ -472,7 +472,7 @@ enum Fixtures {
             "E2": [
                 PBXSourcesBuildPhase(
                     files: buildFiles([PBXBuildFile(
-                        file: files["external/another_repo/b.swift"]
+                        file: files[.external("another_repo/b.swift")]!
                     )])
                 ),
                 PBXFrameworksBuildPhase(),

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -58,14 +58,14 @@ extension FilePath: ExpressibleByStringLiteral {
     public typealias UnicodeScalarLiteralType = StringLiteralType
 
     public init(extendedGraphemeClusterLiteral path: StringLiteralType) {
-        self = .input(Path(path))
+        self = .project(Path(path))
     }
 
     public init(unicodeScalarLiteral path: StringLiteralType) {
-        self = .input(Path(path))
+        self = .project(Path(path))
     }
 
     public init(stringLiteral value: StringLiteralType) {
-        self = .input(Path(value))
+        self = .project(Path(value))
     }
 }

--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -1,0 +1,27 @@
+"""Functions for processing `File`s."""
+
+def file_path(file):
+    """Converts a `File` into a `FilePath` Swift DTO value.
+
+    Args:
+        file: A `File`.
+
+    Returns:
+        A `FilePath` Swift DTO value, which is either a string or a `struct`
+        containing the following fields:
+
+        *   `_`: The file path.
+        *   `t`: Maps to `FilePath.FileType`:
+            *   "p" for `.project`
+            *   "e" for `.external`
+            *   "i" for `.internal`
+    """
+    path = file.path
+    if file.owner.workspace_name:
+        return struct(
+            # Type: "e" == `.external`
+            t = "e",
+            # Path, removing `external/` prefix
+            _ = path[9:],
+        )
+    return path

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -15,6 +15,10 @@ load(
     "set_if_true",
 )
 load(
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj/internal:files.bzl",
+    "file_path",
+)
+load(
     "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj/internal:opts.bzl",
     "process_opts",
 )
@@ -27,11 +31,11 @@ XcodeProjInfo = provider(
     "Provides information needed to generate an Xcode project.",
     fields = {
         "extra_files": """\
-A `depset` of files that should be added to the Xcode project, but not
+A `depset` of `File`s that should be added to the Xcode project, but not
 associated with any targets.
 """,
         "required_links": """\
-A `depset` of all static library files that are linked into top-level targets
+A `depset` of all static library paths that are linked into top-level targets
 besides their primary top-level targets.
 """,
         "potential_target_merges": """\
@@ -580,7 +584,7 @@ def _process_library_target(*, ctx, target, transitive_infos):
             getattr(ctx.rule.attr, "non_arc_srcs", [])
         )
     ]).to_list()
-    srcs = [file.path for file in src_files]
+    srcs = [file_path(file) for file in src_files]
 
     return struct(
         potential_target_merges = [],

--- a/xcodeproj/xcodeproj.bzl
+++ b/xcodeproj/xcodeproj.bzl
@@ -1,6 +1,10 @@
 """Implementation of the `xcodeproj` rule."""
 
 load(
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj/internal:files.bzl",
+    "file_path",
+)
+load(
     "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj/internal:flattened_key_values.bzl",
     "flattened_key_values",
 )
@@ -80,9 +84,9 @@ def _write_json_spec(*, ctx, project_name, infos):
 "targets":{targets}\
 }}
 """.format(
-        extra_files = json.encode(
-            [file.path for file in extra_files.to_list()],
-        ),
+        extra_files = json.encode([
+            file_path(file) for file in extra_files.to_list()
+        ]),
         potential_target_merges = potential_target_merges_json,
         name = project_name,
         targets = targets_json,


### PR DESCRIPTION
This allows for `//external` (in workspace) sources to be handled properly.