### PR TITLE
Add `FilePath.PathType.generated` case

### DIFF
--- a/examples/ios_app/TestingUtils/BUILD
+++ b/examples/ios_app/TestingUtils/BUILD
@@ -4,6 +4,12 @@ swift_library(
     name = "TestingUtils",
     module_name = "TestingUtils",
     testonly = True,
-    srcs = glob(["**/*.swift"]),
+    srcs = [":gen_TestingUtils.swift"],
     visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "gen_TestingUtils.swift",
+    outs = ["TestingUtils.swift"],
+    cmd = '''echo 'public let expectedGreeting = "Hello, world?"' > $@''',
 )

--- a/examples/ios_app/TestingUtils/TestingUtils.swift
+++ b/examples/ios_app/TestingUtils/TestingUtils.swift
@@ -1,1 +1,0 @@
-public let expectedGreeting = "Hello, world?"

--- a/test/fixtures/fixtures.bzl
+++ b/test/fixtures/fixtures.bzl
@@ -121,6 +121,7 @@ def xcodeproj_fixture(*, name = "xcodeproj", project_name = "project", targets):
     xcodeproj(
         name = name,
         external_dir_override = "bazel-rules_xcodeproj/external",
+        generated_dir_override = "bazel-out",
         project_name = project_name,
         targets = targets,
         xcodeproj_rule = _fixture_xcodeproj,

--- a/test/fixtures/ios_app/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/ios_app/project.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		60D4AE432EA39303B7A459BF /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DB699499FA80E901E5107C6 /* ExampleUITests.swift */; };
 		656255E546040B461DB4EAAD /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E4276A1A7B18726FD7831D /* ExampleTests.swift */; };
 		6EA3628D500556DC68B536AD /* libUtils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 96457EE4FDB089F9B6CA30D8 /* libUtils.a */; };
-		D1FB348D6C94B11B3AF495B7 /* TestingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569DB0DF80316901434D3D22 /* TestingUtils.swift */; };
+		B8018509046B5F1FC4F36A39 /* TestingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0062A95C088130193D87326B /* TestingUtils.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,11 +57,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0062A95C088130193D87326B /* TestingUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingUtils.swift; sourceTree = "<group>"; };
 		332DA7D905FE78395F8B49AB /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		377067072DA9B93172410221 /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
 		428758996F59592350934865 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		4B4FA9C70425835BED3D18FF /* libTestingUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTestingUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		569DB0DF80316901434D3D22 /* TestingUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingUtils.swift; sourceTree = "<group>"; };
 		62E4276A1A7B18726FD7831D /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
 		96457EE4FDB089F9B6CA30D8 /* libUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		9CB236421718480FDAB6C0BB /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
@@ -114,6 +114,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1363F5A63DD15C2A98425278 /* TestingUtils */ = {
+			isa = PBXGroup;
+			children = (
+				0062A95C088130193D87326B /* TestingUtils.swift */,
+			);
+			path = TestingUtils;
+			sourceTree = "<group>";
+		};
 		1C919F4154A0036A4F75FA4F /* Utils */ = {
 			isa = PBXGroup;
 			children = (
@@ -122,12 +130,21 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
-		41409B7D7ECCD7568B5FD50E /* TestingUtils */ = {
+		1F90F600520A6B0293200062 /* bin */ = {
 			isa = PBXGroup;
 			children = (
-				569DB0DF80316901434D3D22 /* TestingUtils.swift */,
+				9A4322C4D112A792D6CB6A2E /* examples */,
 			);
-			path = TestingUtils;
+			path = bin;
+			sourceTree = "<group>";
+		};
+		22D63AE4A8E6D3194DC63EEA /* Bazel Generated Files */ = {
+			isa = PBXGroup;
+			children = (
+				A25FAC8271C12219F8B2EE7D /* ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd */,
+			);
+			name = "Bazel Generated Files";
+			path = "bazel-out";
 			sourceTree = "<group>";
 		};
 		428D294EDDF4A41D530E1B84 /* Products */ = {
@@ -148,7 +165,6 @@
 				CAC69A690EA882D202DBEC22 /* Example */,
 				E08D86861E7EF4D9BC7045F7 /* ExampleTests */,
 				C3FEBB55CEE9790EA9D0C513 /* ExampleUITests */,
-				41409B7D7ECCD7568B5FD50E /* TestingUtils */,
 				1C919F4154A0036A4F75FA4F /* Utils */,
 			);
 			path = ios_app;
@@ -174,9 +190,34 @@
 			isa = PBXGroup;
 			children = (
 				5E3A6AF7F4D54FD8AC656E4D /* examples */,
+				22D63AE4A8E6D3194DC63EEA /* Bazel Generated Files */,
 				428D294EDDF4A41D530E1B84 /* Products */,
 				C66B8C06B79203E1B66DFCCF /* Frameworks */,
 			);
+			sourceTree = "<group>";
+		};
+		9A4322C4D112A792D6CB6A2E /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				AA922D36F0084FDB3490CE22 /* ios_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		A25FAC8271C12219F8B2EE7D /* ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd */ = {
+			isa = PBXGroup;
+			children = (
+				1F90F600520A6B0293200062 /* bin */,
+			);
+			path = "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd";
+			sourceTree = "<group>";
+		};
+		AA922D36F0084FDB3490CE22 /* ios_app */ = {
+			isa = PBXGroup;
+			children = (
+				1363F5A63DD15C2A98425278 /* TestingUtils */,
+			);
+			path = ios_app;
 			sourceTree = "<group>";
 		};
 		C3FEBB55CEE9790EA9D0C513 /* ExampleUITests */ = {
@@ -397,7 +438,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D1FB348D6C94B11B3AF495B7 /* TestingUtils.swift in Sources */,
+				B8018509046B5F1FC4F36A39 /* TestingUtils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/test/fixtures/ios_app/spec.json
+++ b/test/fixtures/ios_app/spec.json
@@ -604,7 +604,10 @@
                 "type": "com.apple.product-type.library.static"
             },
             "srcs": [
-                "examples/ios_app/TestingUtils/TestingUtils.swift"
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/TestingUtils/TestingUtils.swift",
+                    "t": "g"
+                }
             ],
             "test_host": null
         },

--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -22,6 +22,7 @@ struct Environment {
         _ targets: [TargetID: Target],
         _ extraFiles: Set<FilePath>,
         _ externalDirectory: Path,
+        _ generatedDirectory: Path,
         _ internalDirectoryName: String,
         _ workspaceOutputPath: Path
     ) -> (

--- a/tools/generator/src/FilePath.swift
+++ b/tools/generator/src/FilePath.swift
@@ -4,6 +4,7 @@ struct FilePath: Hashable, Decodable {
     enum PathType: String, Decodable {
         case project = "p"
         case external = "e"
+        case generated = "g"
         case `internal` = "i"
     }
 
@@ -44,6 +45,10 @@ extension FilePath {
 
     static func external(_ path: Path) -> FilePath {
         return FilePath(type: .external, path: path)
+    }
+
+    static func generated(_ path: Path) -> FilePath {
+        return FilePath(type: .generated, path: path)
     }
 
     static func `internal`(_ path: Path) -> FilePath {

--- a/tools/generator/src/Generator+Main.swift
+++ b/tools/generator/src/Generator+Main.swift
@@ -17,6 +17,7 @@ extension Generator {
                 project: project,
                 projectRootDirectory: arguments.projectRootDirectory,
                 externalDirectory: rootDirs.externalDirectory,
+                generatedDirectory: rootDirs.generatedDirectory,
                 internalDirectoryName: "rules_xcodeproj",
                 workspaceOutputPath: arguments.workspaceOutputPath,
                 outputPath: arguments.outputPath
@@ -65,6 +66,7 @@ Usage: \(CommandLine.arguments[0]) <path/to/root_dirs_file> \
 
     struct RootDirectories {
         let externalDirectory: Path
+        let generatedDirectory: Path
     }
 
     static func readRootDirectories(path: Path) throws -> RootDirectories {
@@ -72,15 +74,16 @@ Usage: \(CommandLine.arguments[0]) <path/to/root_dirs_file> \
             .split(separator: "\n")
             .map(String.init)
 
-        guard rootDirs.count == 1 else {
+        guard rootDirs.count == 2 else {
             throw UsageError(message: """
-The root_dirs_file must contain one line: one for the external repositories \
-directory
+The root_dirs_file must contain two lines: one for the external repositories \
+directory, and one for the generated files directory.
 """)
         }
 
         return RootDirectories(
-            externalDirectory: Path(rootDirs[0])
+            externalDirectory: Path(rootDirs[0]),
+            generatedDirectory: Path(rootDirs[1])
         )
     }
 

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -37,6 +37,7 @@ class Generator {
         project: Project,
         projectRootDirectory: Path,
         externalDirectory: Path,
+        generatedDirectory: Path,
         internalDirectoryName: String,
         workspaceOutputPath: Path,
         outputPath: Path
@@ -72,6 +73,7 @@ Was unable to merge "\(targets[invalidMerge.source]!.label) \
             targets,
             project.extraFiles,
             externalDirectory,
+            generatedDirectory,
             internalDirectoryName,
             workspaceOutputPath
         )

--- a/tools/generator/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generator/test/CreateFilesAndGroupsTests.swift
@@ -22,6 +22,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         ]
         let extraFiles: Set<FilePath> = []
         let externalDirectory = Path("/ext")
+        let generatedDirectory = Path("/bazel-leave")
         let internalDirectoryName = "rules_xcp"
         let workspaceOutputPath = Path("Project.xcodeproj")
 
@@ -49,6 +50,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
             targets: targets,
             extraFiles: extraFiles,
             externalDirectory: externalDirectory,
+            generatedDirectory: generatedDirectory,
             internalDirectoryName: internalDirectoryName,
             workspaceOutputPath: workspaceOutputPath
         )
@@ -79,12 +81,14 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         let targets = Fixtures.targets
         let extraFiles = Fixtures.project.extraFiles
         let externalDirectory = Path("/ext")
+        let generatedDirectory = Path("/bazel-leave")
         let internalDirectoryName = "rules_xcp"
         let workspaceOutputPath = Path("Project.xcodeproj")
 
         let expectedFilesAndGroups = Fixtures.files(
             in: expectedPBXProj,
             externalDirectory: externalDirectory,
+            generatedDirectory: generatedDirectory,
             internalDirectoryName: internalDirectoryName,
             workspaceOutputPath: workspaceOutputPath
         )
@@ -100,6 +104,8 @@ final class CreateFilesAndGroupsTests: XCTestCase {
             expectedFilesAndGroups["z.mm"]!,
             // Then Bazel External Repositories
             expectedFilesAndGroups[.external("")]!,
+            // Then Bazel Generated Files
+            expectedFilesAndGroups[.generated("")]!,
             // And finally the internal (rules_xcodeproj) group
             expectedFilesAndGroups[.internal("")]!,
         ]
@@ -115,6 +121,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
             targets: targets,
             extraFiles: extraFiles,
             externalDirectory: externalDirectory,
+            generatedDirectory: generatedDirectory,
             internalDirectoryName: internalDirectoryName,
             workspaceOutputPath: workspaceOutputPath
         )

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -16,6 +16,7 @@ enum Fixtures {
         potentialTargetMerges: [:],
         requiredLinks: [],
         extraFiles: [
+            .generated("a1b2c/bin/t.c"),
             "a/a.h",
             "a/c.h",
             "a/d/a.h",
@@ -117,10 +118,34 @@ enum Fixtures {
         in pbxProj: PBXProj,
         parentGroup group: PBXGroup? = nil,
         externalDirectory: Path = "/var/tmp/_bazel_U/HASH/external",
+        generatedDirectory: Path = "/var/tmp/_bazel_U/H/execroot/W/bazel-out",
         internalDirectoryName: String = "rules_xcodeproj",
         workspaceOutputPath: Path = "some/Project.xcodeproj"
     ) -> [FilePath: PBXFileElement] {
         var elements: [FilePath: PBXFileElement] = [:]
+
+        // bazel-out/a1b2c/bin/t.c
+        elements[.generated("a1b2c/bin/t.c")] = PBXFileReference(
+            sourceTree: .group,
+            lastKnownFileType: "sourcecode.c.c",
+            path: "t.c"
+        )
+        elements[.generated("a1b2c/bin")] = PBXGroup(
+            children: [elements[.generated("a1b2c/bin/t.c")]!],
+            sourceTree: .group,
+            path: "bin"
+        )
+        elements[.generated("a1b2c")] = PBXGroup(
+            children: [elements[.generated("a1b2c/bin")]!],
+            sourceTree: .group,
+            path: "a1b2c"
+        )
+        elements[.generated("")] = PBXGroup(
+            children: [elements[.generated("a1b2c")]!],
+            sourceTree: .absolute,
+            name: "Bazel Generated Files",
+            path: generatedDirectory.string
+        )
 
         // external/a_repo/a.swift
         elements[.external("a_repo/a.swift")] = PBXFileReference(

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -25,6 +25,7 @@ final class GeneratorTests: XCTestCase {
         
         let projectRootDirectory: Path = "~/project"
         let externalDirectory: Path = "/var/tmp/_bazel_BB/HASH/external"
+        let generatedDirectory: Path = "/var/tmp/_bazel/H/execroot/W/bazel-out"
         let internalDirectoryName = "rules_xcodeproj"
         let workspaceOutputPath: Path = "P.xcodeproj"
         let outputPath: Path = "P.xcodeproj"
@@ -130,6 +131,7 @@ final class GeneratorTests: XCTestCase {
             let targets: [TargetID: Target]
             let extraFiles: Set<FilePath>
             let externalDirectory: Path
+            let generatedDirectory: Path
             let internalDirectoryName: String
             let workspaceOutputPath: Path
         }
@@ -140,6 +142,7 @@ final class GeneratorTests: XCTestCase {
             targets: [TargetID: Target],
             extraFiles: Set<FilePath>,
             externalDirectory: Path,
+            generatedDirectory: Path,
             internalDirectoryName: String,
             workspaceOutputPath: Path
         ) -> (
@@ -151,6 +154,7 @@ final class GeneratorTests: XCTestCase {
                 targets: targets,
                 extraFiles: extraFiles,
                 externalDirectory: externalDirectory,
+                generatedDirectory: generatedDirectory,
                 internalDirectoryName: internalDirectoryName,
                 workspaceOutputPath: workspaceOutputPath
             ))
@@ -162,6 +166,7 @@ final class GeneratorTests: XCTestCase {
             targets: mergedTargets,
             extraFiles: project.extraFiles,
             externalDirectory: externalDirectory,
+            generatedDirectory: generatedDirectory,
             internalDirectoryName: internalDirectoryName,
             workspaceOutputPath: workspaceOutputPath
         )]
@@ -403,6 +408,7 @@ final class GeneratorTests: XCTestCase {
             project: project,
             projectRootDirectory: projectRootDirectory,
             externalDirectory: externalDirectory,
+            generatedDirectory: generatedDirectory,
             internalDirectoryName: internalDirectoryName,
             workspaceOutputPath: workspaceOutputPath,
             outputPath: outputPath

--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -14,6 +14,7 @@ def file_path(file):
         *   `t`: Maps to `FilePath.FileType`:
             *   "p" for `.project`
             *   "e" for `.external`
+            *   "g" for `.generated`
             *   "i" for `.internal`
     """
     path = file.path
@@ -23,5 +24,12 @@ def file_path(file):
             t = "e",
             # Path, removing `external/` prefix
             _ = path[9:],
+        )
+    if not file.is_source:
+        return struct(
+            # Type: "g" == `.generated`
+            t = "g",
+            # Path, removing `bazel-out/` prefix
+            _ = path[10:],
         )
     return path


### PR DESCRIPTION
Part of https://github.com/buildbuddy-io/rules_xcodeproj/issues/100.

Similar to external repositories, this allows `bazel-out` to be a normal directory in the workspace (as long as `--symlink_prefix` is overridden).

We show the generated files in a special group after the external repositories.