### PR TITLE
Expose generated input files in an output group

### DIFF
--- a/xcodeproj/xcodeproj.bzl
+++ b/xcodeproj/xcodeproj.bzl
@@ -198,6 +198,9 @@ def _xcodeproj_impl(ctx):
         for dep in ctx.attr.targets
         if XcodeProjInfo in dep
     ]
+    generated_inputs = depset(
+        transitive = [info.generated_inputs for info in infos],
+    )
 
     spec_file = _write_json_spec(
         ctx = ctx,
@@ -222,6 +225,9 @@ def _xcodeproj_impl(ctx):
             executable = installer,
             files = depset([xcodeproj]),
             runfiles = ctx.runfiles(files = [xcodeproj]),
+        ),
+        OutputGroupInfo(
+            generated_inputs = generated_inputs,
         ),
         XcodeProjOutputInfo(
             installer = installer,


### PR DESCRIPTION
Part of https://github.com/buildbuddy-io/rules_xcodeproj/issues/100.

This allows one to specify `--output_groups=generated_inputs` to produce the generated files that are referenced in the Xcode project.