### PR TITLE
Refactor return type of `createFilesAndGroups()`

### DIFF
--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -26,7 +26,7 @@ struct Environment {
         _ internalDirectoryName: String,
         _ workspaceOutputPath: Path
     ) -> (
-        elements: [FilePath: PBXFileElement],
+        files: [FilePath: File],
         rootElements: [PBXFileElement]
     )
 
@@ -50,7 +50,7 @@ struct Environment {
         _ pbxProj: PBXProj,
         _ disambiguatedTargets: [TargetID: DisambiguatedTarget],
         _ products: Products,
-        _ files: [FilePath: PBXFileElement]
+        _ files: [FilePath: File]
     ) throws -> [TargetID: PBXNativeTarget]
 
     let setTargetConfigurations: (
@@ -68,7 +68,7 @@ struct Environment {
 
     let writeXcodeProj: (
         _ xcodeProj: XcodeProj,
-        _ files: [FilePath: PBXFileElement],
+        _ files: [FilePath: File],
         _ internalDirectoryName: String,
         _ outputPath: Path
     ) throws -> Void

--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -6,7 +6,7 @@ extension Generator {
         in pbxProj: PBXProj,
         for disambiguatedTargets: [TargetID: DisambiguatedTarget],
         products: Products,
-        files: [FilePath: PBXFileElement]
+        files: [FilePath: File]
     ) throws -> [TargetID: PBXNativeTarget] {
         let pbxProject = pbxProj.rootObject!
 
@@ -63,15 +63,15 @@ Product for target "\(id)" not found
     private static func createCompileSourcesPhase(
         in pbxProj: PBXProj,
         sources: Set<FilePath>,
-        files: [FilePath: PBXFileElement]
+        files: [FilePath: File]
     ) throws -> PBXSourcesBuildPhase {
         func buildFile(filePath: FilePath) throws -> PBXBuildFile {
-            guard let fileElement = files[filePath] else {
+            guard let file = files[filePath] else {
                 throw PreconditionError(message: """
 File "\(filePath)" not found
 """)
             }
-            let pbxBuildFile = PBXBuildFile(file: fileElement)
+            let pbxBuildFile = PBXBuildFile(file: file.reference)
             pbxProj.add(object: pbxBuildFile)
             return pbxBuildFile
         }

--- a/tools/generator/src/Generator+CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator+CreateFilesAndGroups.swift
@@ -1,6 +1,21 @@
 import PathKit
 import XcodeProj
 
+/// Wrapper for `PBXFileReference`, adding additional associated data.
+struct File: Equatable {
+    let reference: PBXFileReference
+
+    /// File content to be written to disk.
+    ///
+    /// This is only used by the `FilePath.PathType.internal` files.
+    let content: String
+
+    init(reference: PBXFileReference, content: String = "") {
+        self.reference = reference
+        self.content = content
+    }
+}
+
 extension Generator {
     static let compileStubPath = Path("CompileStub.swift")
 
@@ -13,7 +28,7 @@ extension Generator {
         internalDirectoryName: String,
         workspaceOutputPath: Path
     ) -> (
-        elements: [FilePath: PBXFileElement],
+        files: [FilePath: File],
         rootElements: [PBXFileElement]
     ) {
         var elements: [FilePath: PBXFileElement] = [:]
@@ -173,6 +188,15 @@ extension Generator {
             }
         }
 
+        var files: [FilePath: File] = [:]
+        for (filePath, element) in elements {
+            guard let reference = element as? PBXFileReference else {
+                continue
+            }
+
+            files[filePath] = File(reference: reference)
+        }
+
         // Handle special groups
 
         rootElements.sortGroupedLocalizedStandard()
@@ -189,7 +213,7 @@ extension Generator {
             rootElements.append(internalGroup)
         }
 
-        return (elements, rootElements)
+        return (files, rootElements)
     }
 }
 

--- a/tools/generator/src/Generator+WriteXcodeProj.swift
+++ b/tools/generator/src/Generator+WriteXcodeProj.swift
@@ -5,7 +5,7 @@ extension Generator {
     ///
     static func writeXcodeProj(
         _ xcodeProj: XcodeProj,
-        files: [FilePath: PBXFileElement],
+        files: [FilePath: File],
         internalDirectoryName: String,
         to outputPath: Path
     ) throws {
@@ -13,16 +13,10 @@ extension Generator {
 
         let internalOutputPath = outputPath + internalDirectoryName
 
-        // This will have to be improved when we eventually write different
-        // types of internal files
-        for (filePath, fileElement) in files.filter(\.key.isInternal) {
+        for (filePath, file) in files.filter(\.key.isInternal) {
             let path = internalOutputPath + filePath.path
-            if fileElement is PBXGroup {
-                try path.mkpath()
-            } else {
-                try path.parent().mkpath()
-                try path.write("")
-            }
+            try path.parent().mkpath()
+            try path.write(file.content)
         }
     }
 }

--- a/tools/generator/test/AddTargetsTests.swift
+++ b/tools/generator/test/AddTargetsTests.swift
@@ -15,8 +15,8 @@ final class AddTargetsTests: XCTestCase {
 
         let targets = Fixtures.targets
 
-        let files = Fixtures.files(in: pbxProj, parentGroup: mainGroup)
-        let expectedFiles = Fixtures.files(
+        let (files, _) = Fixtures.files(in: pbxProj, parentGroup: mainGroup)
+        let (expectedFiles, _) = Fixtures.files(
             in: expectedPBXProj,
             parentGroup: expectedMainGroup
         )

--- a/tools/generator/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generator/test/CreateFilesAndGroupsTests.swift
@@ -26,24 +26,24 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         let internalDirectoryName = "rules_xcp"
         let workspaceOutputPath = Path("Project.xcodeproj")
 
-        let expectedFilesAndGroups: [FilePath: PBXFileElement] = [
-            "a.swift": PBXFileReference(
+        let expectedFiles: [FilePath: File] = [
+            "a.swift": File(reference: PBXFileReference(
                 sourceTree: .group,
                 lastKnownFileType: "sourcecode.swift",
                 path: "a.swift"
-            ),
+            )),
         ]
-        expectedPBXProj.add(object: expectedFilesAndGroups["a.swift"]!)
+        expectedPBXProj.add(object: expectedFiles["a.swift"]!.reference)
 
         let expectedRootElements: [PBXFileElement] = [
-            expectedFilesAndGroups["a.swift"]!,
+            expectedFiles["a.swift"]!.reference,
         ]
         expectedMainGroup.addChildren(expectedRootElements)
 
         // Act
 
         let (
-            createdFilesAndGroups,
+            createdFiles,
             createdRootElements
         ) = Generator.createFilesAndGroups(
             in: pbxProj,
@@ -65,7 +65,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(createdRootElements, expectedRootElements)
-        XCTAssertNoDifference(createdFilesAndGroups, expectedFilesAndGroups)
+        XCTAssertNoDifference(createdFiles, expectedFiles)
 
         XCTAssertNoDifference(pbxProj, expectedPBXProj)
     }
@@ -85,7 +85,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         let internalDirectoryName = "rules_xcp"
         let workspaceOutputPath = Path("Project.xcodeproj")
 
-        let expectedFilesAndGroups = Fixtures.files(
+        let (expectedFiles, expectedElements) = Fixtures.files(
             in: expectedPBXProj,
             externalDirectory: externalDirectory,
             generatedDirectory: generatedDirectory,
@@ -95,26 +95,26 @@ final class CreateFilesAndGroupsTests: XCTestCase {
 
         let expectedRootElements: [PBXFileElement] = [
             // Root group that holds "a/b/c.m" and "a/a.h"
-            expectedFilesAndGroups["a"]!,
+            expectedElements["a"]!,
             // Root group that holds "x/y.swift"
-            expectedFilesAndGroups["x"]!,
+            expectedElements["x"]!,
             // Files are sorted below groups
-            expectedFilesAndGroups["Assets.xcassets"]!,
-            expectedFilesAndGroups["b.c"]!,
-            expectedFilesAndGroups["z.mm"]!,
+            expectedElements["Assets.xcassets"]!,
+            expectedElements["b.c"]!,
+            expectedElements["z.mm"]!,
             // Then Bazel External Repositories
-            expectedFilesAndGroups[.external("")]!,
+            expectedElements[.external("")]!,
             // Then Bazel Generated Files
-            expectedFilesAndGroups[.generated("")]!,
+            expectedElements[.generated("")]!,
             // And finally the internal (rules_xcodeproj) group
-            expectedFilesAndGroups[.internal("")]!,
+            expectedElements[.internal("")]!,
         ]
         expectedMainGroup.addChildren(expectedRootElements)
 
         // Act
 
         let (
-            createdFilesAndGroups,
+            createdFiles,
             createdRootElements
         ) = Generator.createFilesAndGroups(
             in: pbxProj,
@@ -136,7 +136,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(createdRootElements, expectedRootElements)
-        XCTAssertNoDifference(createdFilesAndGroups, expectedFilesAndGroups)
+        XCTAssertNoDifference(createdFiles, expectedFiles)
 
         XCTAssertNoDifference(pbxProj, expectedPBXProj)
     }

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -47,13 +47,13 @@ final class GeneratorTests: XCTestCase {
                 target: mergedTargets["Y"]!
             ),
         ]
-        let files = Fixtures.files(
+        let (files, filesAndGroups) = Fixtures.files(
             in: pbxProj,
             externalDirectory: externalDirectory,
             internalDirectoryName: internalDirectoryName,
             workspaceOutputPath: workspaceOutputPath
         )
-        let rootElements = [files["a"]!, files["x"]!]
+        let rootElements = [filesAndGroups["a"]!, filesAndGroups["x"]!]
         let products = Fixtures.products(in: pbxProj)
         
         let productsGroup = PBXGroup(name: "42")
@@ -146,7 +146,7 @@ final class GeneratorTests: XCTestCase {
             internalDirectoryName: String,
             workspaceOutputPath: Path
         ) -> (
-            elements: [FilePath: PBXFileElement],
+            files: [FilePath: File],
             rootElements: [PBXFileElement]
         ) {
             createFilesAndGroupsCalled.append(.init(
@@ -252,7 +252,7 @@ final class GeneratorTests: XCTestCase {
             let pbxProj: PBXProj
             let disambiguatedTargets: [TargetID: DisambiguatedTarget]
             let products: Products
-            let files: [FilePath: PBXFileElement]
+            let files: [FilePath: File]
         }
 
         var addTargetsCalled: [AddTargetsCalled] = []
@@ -260,7 +260,7 @@ final class GeneratorTests: XCTestCase {
             in pbxProj: PBXProj,
             for disambiguatedTargets: [TargetID: DisambiguatedTarget],
             products: Products,
-            files: [FilePath: PBXFileElement]
+            files: [FilePath: File]
         ) throws -> [TargetID: PBXNativeTarget] {
             addTargetsCalled.append(.init(
                 pbxProj: pbxProj,
@@ -354,7 +354,7 @@ final class GeneratorTests: XCTestCase {
 
         struct WriteXcodeProjCalled: Equatable {
             let xcodeProj: XcodeProj
-            let files: [FilePath: PBXFileElement]
+            let files: [FilePath: File]
             let internalDirectoryName: String
             let outputPath: Path
         }
@@ -362,7 +362,7 @@ final class GeneratorTests: XCTestCase {
         var writeXcodeProjCalled: [WriteXcodeProjCalled] = []
         func writeXcodeProj(
             xcodeProj: XcodeProj,
-            files: [FilePath: PBXFileElement],
+            files: [FilePath: File],
             internalDirectoryName: String,
             to outputPath: Path
         ) {


### PR DESCRIPTION
This cleans up the logic in `writeXcodeProj()`, which unlocks the ability to write other internal files with non-empty content.