### PR TITLE
Make it clear where the generated project is

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,6 @@ You can then create the Xcode project with:
 bazel run //:xcodeproj
 ```
 
+The generated project will be in the workspace at `App.xcodeproj`.
+
 See the [examples](examples) directory for sample setups.

--- a/xcodeproj/internal/installer.template.sh
+++ b/xcodeproj/internal/installer.template.sh
@@ -59,3 +59,5 @@ plutil -remove BuildSystemType "$workspace_settings" > /dev/null || true
 # TODO: Uncomment once we create schemes ourselves
 # # Prevent Xcode from prompting the user to autocreate schemes for all targets
 # plutil -replace IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded -bool false "$workspace_settings"
+
+echo 'Updated project at "%output_path%"'


### PR DESCRIPTION
It was slightly confusing for people not used to the way generators like this work. Without this new messaging people might assume they need to use the `bazel-bin/` version.