### PR TITLE
Add short timeout for Stalark unit tests

### DIFF
--- a/test/internal/build_settings/calculate_module_name_tests.bzl
+++ b/test/internal/build_settings/calculate_module_name_tests.bzl
@@ -52,6 +52,7 @@ def calculate_module_name_test_suite(name):
             label = label,
             module_name = module_name,
             expected_module_name = expected_module_name,
+            timeout = "short",
         )
 
     # Module name

--- a/test/internal/build_settings/get_targeted_device_family_tests.bzl
+++ b/test/internal/build_settings/get_targeted_device_family_tests.bzl
@@ -46,6 +46,7 @@ def get_targeted_device_family_test_suite(name):
             name = name,
             families = families,
             expected_targeted_device_family = expected_targeted_device_family,
+            timeout = "short",
         )
 
     # macOS

--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -65,6 +65,7 @@ def process_compiler_opts_test_suite(name):
             cxxopts = cxxopts,
             swiftcopts = swiftcopts,
             expected_build_settings = stringify_dict(expected_build_settings),
+            timeout = "short",
         )
 
     # Base

--- a/test/internal/opts/process_linker_opts_tests.bzl
+++ b/test/internal/opts/process_linker_opts_tests.bzl
@@ -52,6 +52,7 @@ def process_linker_opts_test_suite(name):
             name = name,
             linkopts = linkopts,
             expected_build_settings = stringify_dict(expected_build_settings),
+            timeout = "short",
         )
 
     # Base

--- a/test/internal/platform/generate_platform_information_tests.bzl
+++ b/test/internal/platform/generate_platform_information_tests.bzl
@@ -74,6 +74,7 @@ def generate_platform_information_test_suite(name):
             minimum_deployment_os_version = minimum_deployment_os_version,
             expected_platform_dict = expected_platform_dict,
             expected_build_settings = stringify_dict(expected_build_settings),
+            timeout = "short",
         )
 
     # Minimum OS version

--- a/test/internal/target/calculate_configuration_tests.bzl
+++ b/test/internal/target/calculate_configuration_tests.bzl
@@ -46,6 +46,7 @@ def calculate_configuration_test_suite(name):
             name = name,
             bin_dir = bin_dir_path,
             expected_configuration = expected_configuration,
+            timeout = "short",
         )
 
     # Valid

--- a/test/internal/target/process_libraries_tests.bzl
+++ b/test/internal/target/process_libraries_tests.bzl
@@ -72,6 +72,7 @@ def process_libraries_test_suite(name):
             required_links = required_links,
             expected_links = expected_links,
             expected_required_links = expected_required_links,
+            timeout = "short",
         )
 
     # No changes

--- a/test/internal/target/process_top_level_properties_tests.bzl
+++ b/test/internal/target/process_top_level_properties_tests.bzl
@@ -133,6 +133,7 @@ def process_top_level_properties_test_suite(name):
             expected_product_name = expected_product_name,
             expected_product_type = expected_product_type,
             expected_build_settings = stringify_dict(expected_build_settings),
+            timeout = "short",
         )
 
     # Non-bundles


### PR DESCRIPTION
Removes a Bazel warning, and they really should be quick.