### PR TITLE
Add initial buildifier check and fix commands

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,19 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+
+buildifier(
+    name = "buildifier.check",
+    exclude_patterns = [
+        "./.git/*",
+    ],
+    lint_mode = "warn",
+    mode = "diff",
+)
+
+buildifier(
+    name = "buildifier.fix",
+    exclude_patterns = [
+        "./.git/*",
+    ],
+    lint_mode = "fix",
+    mode = "fix",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,3 +76,22 @@ swift_library(
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
+
+# Buildifier
+
+http_archive(
+    name = "buildifier_prebuilt",
+    sha256 = "54a58924e079a7f823a5aa30f37f10a7a966cf1ad87e14feb6fb07601389bdc1",
+    strip_prefix = "buildifier-prebuilt-0.3.2",
+    urls = [
+        "http://github.com/keith/buildifier-prebuilt/archive/0.3.2.tar.gz",
+    ],
+)
+
+load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
+
+buildifier_prebuilt_deps()
+
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
+
+buildifier_prebuilt_register_toolchains()

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -21,4 +21,4 @@ actions:
   #       branches:
   #         - "main"
   #   bazel_commands:
-  #     - "run //:buildifier.check"
+  #     - "run --config=workflows //:buildifier.check"

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -10,3 +10,5 @@ actions:
           - "main"
     bazel_commands:
       - "test --config=workflows //tools/... //test/..."
+      # GH126: Enable the Buildifier check once the current lint issues are addressed.
+      # - "run //:buildifier.check"

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -10,5 +10,15 @@ actions:
           - "main"
     bazel_commands:
       - "test --config=workflows //tools/... //test/..."
-      # GH126: Enable the Buildifier check once the current lint issues are addressed.
-      # - "run //:buildifier.check"
+
+  # GH126: Enable the Buildifier check once the current lint issues are addressed.
+  # - name: Lint
+  #   triggers:
+  #     push:
+  #       branches:
+  #         - "main"
+  #     pull_request:
+  #       branches:
+  #         - "main"
+  #   bazel_commands:
+  #     - "run //:buildifier.check"


### PR DESCRIPTION
Related to #126.

- Added dev-only dependency on `keith/buildifier-prebuilt`.
- Added two runnable targets to the root of the workspace: `//:buildifier.check` and `//:buildifier.fix`.