### PR TITLE
Refactor `process_opts()` to take in `build_settings`

### DIFF
--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -464,19 +464,20 @@ def _xcode_std_value(std):
 
 # API
 
-def process_opts(*, ctx, target):
+def process_opts(*, ctx, target, build_settings):
     """Processes the compiler and linker options for a target.
 
     Args:
         ctx: The aspect context.
         target: The `Target` that the compiler and linker options will be
             retrieved from.
+        build_settings: A mutable `dict` that will be updated with build
+            settings that are parsed from the compiler and linker options.
 
     Returns:
         A `dict` of Xcode build settings that correspond to the compiler and
         linker options for the target.
     """
-    build_settings = {}
     _process_target_compiler_opts(
         ctx = ctx,
         target = target,
@@ -486,7 +487,6 @@ def process_opts(*, ctx, target):
         ctx = ctx,
         build_settings = build_settings,
     )
-    return build_settings
 
 # These functions are exposed only for access in unit tests.
 testable = struct(

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -453,7 +453,9 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
         potential_target_merges = []
         mergeable_label = None
 
-    build_settings = process_opts(ctx = ctx, target = target)
+    build_settings = {}
+
+    process_opts(ctx = ctx, target = target, build_settings = build_settings)
 
     tree_artifact_enabled = (
         ctx.var.get("apple.experimental.tree_artifact_outputs", "").lower()
@@ -572,7 +574,9 @@ def _process_library_target(*, ctx, target, transitive_infos):
     configuration = _get_configuration(ctx)
     id = _get_id(label = target.label, configuration = configuration)
 
-    build_settings = process_opts(ctx = ctx, target = target)
+    build_settings = {}
+
+    process_opts(ctx = ctx, target = target, build_settings = build_settings)
     product_name = ctx.rule.attr.name
     module_name = get_product_module_name(ctx = ctx, target = target)
     build_settings["PRODUCT_MODULE_NAME"] = module_name


### PR DESCRIPTION
This makes it match the API of the other functions, and allows it to not be the first function to set build settings.