### PR TITLE
Set user header search paths for non-Swift targets

### DIFF
--- a/test/fixtures/generator/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/project.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		C28A39750E6C584777154815 /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD4647C5EE25A1C4D49C081 /* PBXObject.swift */; };
 		C28BD99E17E4777DCD9DFF7D /* libCustomDump.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2AB04520A58A83E77B3FDC73 /* libCustomDump.a */; };
 		C63C41EC8BE35CC3E26754D2 /* SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C36F61FCD89D5A5D6176600 /* SwiftUI.swift */; };
+		C811857CC6BF0D2613DE48C2 /* SearchPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DB2DF8B6A725C450EDD5D2 /* SearchPaths.swift */; };
 		C96BF1373FE5858C9209BAA6 /* ProcessTargetMergesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCE47306A55A2A1C54FF98E /* ProcessTargetMergesTests.swift */; };
 		CA573C72A60DA41ED4161734 /* libgenerator.library.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F527636CB48F7FEEE90DCEC /* libgenerator.library.a */; };
 		CA6E9CECD3889BBED0C7E051 /* XCWorkspaceDataElementLocationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25E54D36493C786205DA016 /* XCWorkspaceDataElementLocationType.swift */; };
@@ -305,6 +306,7 @@
 		5763D83215FDFA5A0C0DADA6 /* Generator+WriteXcodeProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+WriteXcodeProj.swift"; sourceTree = "<group>"; };
 		5771B05C549E4B70A2C6B13F /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 		57AE5A3F492E9C4A81CE09FE /* PBXNativeTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXNativeTarget.swift; sourceTree = "<group>"; };
+		58DB2DF8B6A725C450EDD5D2 /* SearchPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPaths.swift; sourceTree = "<group>"; };
 		5CB50E54B2BC9AE1AEE95513 /* PopulateMainGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopulateMainGroupTests.swift; sourceTree = "<group>"; };
 		5CC0EED86D851236527F38E4 /* PBXProductType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXProductType+Extensions.swift"; sourceTree = "<group>"; };
 		5E008F1EF5278A359CB3B73D /* CoreMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMotion.swift; sourceTree = "<group>"; };
@@ -869,6 +871,7 @@
 				6FDF0F2BD8DA0C9C64F3EC2D /* Path+Extensions.swift */,
 				8F19B18C578050514056544B /* PBXGroup+Extensions.swift */,
 				5CC0EED86D851236527F38E4 /* PBXProductType+Extensions.swift */,
+				58DB2DF8B6A725C450EDD5D2 /* SearchPaths.swift */,
 				8F977F1096269625AD5B34E8 /* Sorting.swift */,
 				CF6A6EBB69226658CE2407FD /* TargetID.swift */,
 			);
@@ -1227,6 +1230,7 @@
 				AC51F2EC61A2165B467F806A /* Path+Extensions.swift in Sources */,
 				688C039393D003303E732F1B /* PBXGroup+Extensions.swift in Sources */,
 				759030F26353AD318C78993F /* PBXProductType+Extensions.swift in Sources */,
+				C811857CC6BF0D2613DE48C2 /* SearchPaths.swift in Sources */,
 				4A504F8664313AB7A8F2C349 /* Sorting.swift in Sources */,
 				195FA199EF14567E2D2D9819 /* TargetID.swift in Sources */,
 			);
@@ -1800,6 +1804,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
+				USE_HEADERMAP = NO;
 			};
 			name = Debug;
 		};

--- a/test/fixtures/generator/spec.json
+++ b/test/fixtures/generator/spec.json
@@ -6,7 +6,8 @@
         "COPY_PHASE_STRIP": false,
         "CURRENT_PROJECT_VERSION": "1",
         "MARKETING_VERSION": "1.0",
-        "ONLY_ACTIVE_ARCH": true
+        "ONLY_ACTIVE_ARCH": true,
+        "USE_HEADERMAP": false
     },
     "extra_files": [],
     "label": "//test/fixtures/generator:xcodeproj",
@@ -102,6 +103,7 @@
                 "path": "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator/generator",
                 "type": "com.apple.product-type.tool"
             },
+            "search_paths": {},
             "test_host": null
         },
         "//tools/generator:generator.library darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -185,6 +187,7 @@
                     "tools/generator/src/PBXGroup+Extensions.swift",
                     "tools/generator/src/PBXProductType+Extensions.swift",
                     "tools/generator/src/Path+Extensions.swift",
+                    "tools/generator/src/SearchPaths.swift",
                     "tools/generator/src/Sorting.swift",
                     "tools/generator/src/TargetID.swift"
                 ]
@@ -210,6 +213,7 @@
                 "path": "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator/libgenerator.library.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         },
         "//tools/generator:tests darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -288,6 +292,7 @@
                 "path": "tools/generator/tests.xctest",
                 "type": "com.apple.product-type.bundle.unit-test"
             },
+            "search_paths": {},
             "test_host": null
         },
         "//tools/generator:tests.library darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -387,6 +392,7 @@
                 "path": "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator/libtests.library.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         },
         "@com_github_kylef_pathkit//:PathKit darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -471,6 +477,7 @@
                 "path": "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit/libPathKit.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         },
         "@com_github_pointfreeco_swift_custom_dump//:CustomDump darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -653,6 +660,7 @@
                 "path": "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         },
         "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -737,6 +745,7 @@
                 "path": "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         },
         "@com_github_tadija_aexml//:AEXML darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -837,6 +846,7 @@
                 "path": "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml/libAEXML.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         },
         "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -1300,6 +1310,7 @@
                 "path": "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         }
     ]

--- a/test/fixtures/ios_app/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/ios_app/project.xcodeproj/project.pbxproj
@@ -765,6 +765,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
+				USE_HEADERMAP = NO;
 			};
 			name = Debug;
 		};

--- a/test/fixtures/ios_app/spec.json
+++ b/test/fixtures/ios_app/spec.json
@@ -6,7 +6,8 @@
         "COPY_PHASE_STRIP": false,
         "CURRENT_PROJECT_VERSION": "1",
         "MARKETING_VERSION": "1.0",
-        "ONLY_ACTIVE_ARCH": true
+        "ONLY_ACTIVE_ARCH": true,
+        "USE_HEADERMAP": false
     },
     "extra_files": [
         "examples/ios_app/Example/Preview Content/Preview Assets.xcassets/Contents.json",
@@ -129,6 +130,7 @@
                 "path": "bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/Example/Example_archive-root/Payload/Example.app",
                 "type": "com.apple.product-type.application"
             },
+            "search_paths": {},
             "test_host": null
         },
         "//examples/ios_app/Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -214,6 +216,7 @@
                 "path": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/Example/libExample.library.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         },
         "//examples/ios_app/ExampleTests:ExampleTests.__internal__.__test_bundle applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -293,6 +296,7 @@
                 "path": "bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/ExampleTests/ExampleTests.__internal__.__test_bundle_archive-root/ExampleTests.xctest",
                 "type": "com.apple.product-type.bundle.unit-test"
             },
+            "search_paths": {},
             "test_host": "//examples/ios_app/Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
         },
         "//examples/ios_app/ExampleTests:ExampleTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -380,6 +384,7 @@
                 "path": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/ExampleTests/libExampleTests.library.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         },
         "//examples/ios_app/ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -458,6 +463,7 @@
                 "path": "bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle_archive-root/ExampleUITests.xctest",
                 "type": "com.apple.product-type.bundle.ui-testing"
             },
+            "search_paths": {},
             "test_host": "//examples/ios_app/Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
         },
         "//examples/ios_app/ExampleUITests:ExampleUITests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -542,6 +548,7 @@
                 "path": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/ExampleUITests/libExampleUITests.library.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         },
         "//examples/ios_app/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -628,6 +635,7 @@
                 "path": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/TestingUtils/libTestingUtils.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         },
         "//examples/ios_app/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -710,6 +718,7 @@
                 "path": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/Utils/libUtils.a",
                 "type": "com.apple.product-type.library.static"
             },
+            "search_paths": {},
             "test_host": null
         }
     ]

--- a/tools/generator/src/DTO.swift
+++ b/tools/generator/src/DTO.swift
@@ -19,6 +19,7 @@ struct Target: Equatable, Decodable {
     let product: Product
     let testHost: TargetID?
     var buildSettings: [String: BuildSetting]
+    let searchPaths: SearchPaths
     var inputs: Inputs
     var links: Set<Path>
     var dependencies: Set<TargetID>

--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -57,7 +57,9 @@ struct Environment {
     let setTargetConfigurations: (
         _ pbxProj: PBXProj,
         _ disambiguatedTargets: [TargetID: DisambiguatedTarget],
-        _ pbxTargets: [TargetID: PBXNativeTarget]
+        _ pbxTargets: [TargetID: PBXNativeTarget],
+        _ externalDirectory: Path,
+        _ generatedDirectory: Path
     ) throws -> Void
 
     let setTargetDependencies: (

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -99,7 +99,9 @@ Was unable to merge "\(targets[invalidMerge.source]!.label) \
         try environment.setTargetConfigurations(
             pbxProj,
             disambiguatedTargets,
-            pbxTargets
+            pbxTargets,
+            externalDirectory,
+            generatedDirectory
         )
         try environment.setTargetDependencies(
             disambiguatedTargets,

--- a/tools/generator/src/SearchPaths.swift
+++ b/tools/generator/src/SearchPaths.swift
@@ -1,0 +1,27 @@
+struct SearchPaths: Equatable {
+    let quoteHeaders: [FilePath]
+
+    init(quoteHeaders: [FilePath] = []) {
+        self.quoteHeaders = quoteHeaders
+    }
+}
+
+// MARK: - Decodable
+
+extension SearchPaths: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case quoteHeaders
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        quoteHeaders = try container.decodeFilePaths(.quoteHeaders)
+    }
+}
+
+private extension KeyedDecodingContainer where K == SearchPaths.CodingKeys {
+    func decodeFilePaths(_ key: K) throws -> [FilePath] {
+        return try decodeIfPresent([FilePath].self, forKey: key) ?? []
+    }
+}

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -289,18 +289,24 @@ final class GeneratorTests: XCTestCase {
             let pbxProj: PBXProj
             let disambiguatedTargets: [TargetID: DisambiguatedTarget]
             let pbxTargets: [TargetID: PBXNativeTarget]
+            let externalDirectory: Path
+            let generatedDirectory: Path
         }
 
         var setTargetConfigurationsCalled: [SetTargetConfigurationsCalled] = []
         func setTargetConfigurations(
             in pbxProj: PBXProj,
             for disambiguatedTargets: [TargetID: DisambiguatedTarget],
-            pbxTargets: [TargetID: PBXNativeTarget]
+            pbxTargets: [TargetID: PBXNativeTarget],
+            externalDirectory: Path,
+            generatedDirectory: Path
         ) {
             setTargetConfigurationsCalled.append(.init(
                 pbxProj: pbxProj,
                 disambiguatedTargets: disambiguatedTargets,
-                pbxTargets: pbxTargets
+                pbxTargets: pbxTargets,
+                externalDirectory: externalDirectory,
+                generatedDirectory: generatedDirectory
             ))
         }
 
@@ -308,7 +314,9 @@ final class GeneratorTests: XCTestCase {
             SetTargetConfigurationsCalled(
                 pbxProj: pbxProj,
                 disambiguatedTargets: disambiguatedTargets,
-                pbxTargets: pbxTargets
+                pbxTargets: pbxTargets,
+                externalDirectory: externalDirectory,
+                generatedDirectory: generatedDirectory
             )
         ]
 

--- a/tools/generator/test/SetTargetConfigurations.swift
+++ b/tools/generator/test/SetTargetConfigurations.swift
@@ -1,4 +1,5 @@
 import CustomDump
+import PathKit
 import XCTest
 
 @testable import generator
@@ -11,6 +12,8 @@ final class SetTargetConfigurationsTests: XCTestCase {
         let expectedPBXProj = Fixtures.pbxProj()
 
         let targets = Fixtures.targets
+        let externalDirectory: Path = "external"
+        let generatedDirectory: Path = "bazel-out"
 
         let (pbxTargets, disambiguatedTargets) = Fixtures.pbxTargets(
             in: pbxProj,
@@ -26,7 +29,9 @@ final class SetTargetConfigurationsTests: XCTestCase {
         try Generator.setTargetConfigurations(
             in: pbxProj,
             for: disambiguatedTargets,
-            pbxTargets: pbxTargets
+            pbxTargets: pbxTargets,
+            externalDirectory: externalDirectory,
+            generatedDirectory: generatedDirectory
         )
 
         try pbxProj.fixReferences()

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -10,6 +10,7 @@ extension Target {
         product: Product,
         testHost: TargetID? = nil,
         buildSettings: [String: BuildSetting] = [:],
+        searchPaths: SearchPaths = SearchPaths(),
         inputs: Inputs = Inputs(),
         links: Set<Path> = [],
         dependencies: Set<TargetID> = []
@@ -27,6 +28,7 @@ extension Target {
             product: product,
             testHost: testHost,
             buildSettings: buildSettings,
+            searchPaths: searchPaths,
             inputs: inputs,
             links: links,
             dependencies: dependencies

--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -19,17 +19,23 @@ def file_path(file):
     """
     path = file.path
     if file.owner.workspace_name:
-        return struct(
-            # Type: "e" == `.external`
-            t = "e",
-            # Path, removing `external/` prefix
-            _ = path[9:],
-        )
+        return external_file_path(path)
     if not file.is_source:
-        return struct(
-            # Type: "g" == `.generated`
-            t = "g",
-            # Path, removing `bazel-out/` prefix
-            _ = path[10:],
-        )
+        return generated_file_path(path)
     return path
+
+def external_file_path(path):
+    return struct(
+        # Type: "e" == `.external`
+        t = "e",
+        # Path, removing `external/` prefix
+        _ = path[9:],
+    )
+
+def generated_file_path(path):
+    return struct(
+        # Type: "g" == `.generated`
+        t = "g",
+        # Path, removing `bazel-out/` prefix
+        _ = path[10:],
+    )

--- a/xcodeproj/xcodeproj.bzl
+++ b/xcodeproj/xcodeproj.bzl
@@ -76,7 +76,8 @@ def _write_json_spec(*, ctx, project_name, infos):
 "COPY_PHASE_STRIP":false,\
 "CURRENT_PROJECT_VERSION":"1",\
 "MARKETING_VERSION":"1.0",\
-"ONLY_ACTIVE_ARCH":true\
+"ONLY_ACTIVE_ARCH":true,\
+"USE_HEADERMAP":false\
 }},\
 "extra_files":{extra_files},\
 "label":"{label}",\


### PR DESCRIPTION
Part of #69, #82, #83, and #84.

This will be shown off in a future change when a `cc_binary` example is checked in.