### PR TITLE
Addressed Buildifier lint issues and enabled Buildifier check in CI pipeline.

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -11,14 +11,13 @@ actions:
     bazel_commands:
       - "test --config=workflows //tools/... //test/..."
 
-  # GH126: Enable the Buildifier check once the current lint issues are addressed.
-  # - name: Lint
-  #   triggers:
-  #     push:
-  #       branches:
-  #         - "main"
-  #     pull_request:
-  #       branches:
-  #         - "main"
-  #   bazel_commands:
-  #     - "run --config=workflows //:buildifier.check"
+  - name: Buildifier Lint
+    triggers:
+      push:
+        branches:
+          - "main"
+      pull_request:
+        branches:
+          - "main"
+    bazel_commands:
+      - "run --config=workflows //:buildifier.check"

--- a/examples/ios_app/BUILD
+++ b/examples/ios_app/BUILD
@@ -4,6 +4,6 @@ load(":xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
 xcodeproj(
     name = "xcodeproj",
     project_name = "iOS App",
-    targets = XCODEPROJ_TARGETS,
     tags = ["manual"],
+    targets = XCODEPROJ_TARGETS,
 )

--- a/examples/ios_app/Example/BUILD
+++ b/examples/ios_app/Example/BUILD
@@ -15,22 +15,22 @@ ios_application(
     families = ["iphone"],
     infoplists = [":Info.plist"],
     minimum_os_version = "15.0",
-    deps = [":Example.library"],
     visibility = ["//visibility:public"],
+    deps = [":Example.library"],
 )
 
 swift_library(
     name = "Example.library",
-    module_name = "Example",
+    srcs = glob(["**/*.swift"]),
     data = glob(["Assets.xcassets/**"]) + select({
         ":release_build": [],
         "//conditions:default": [":PreviewContent"],
     }),
-    srcs = glob(["**/*.swift"]),
+    module_name = "Example",
+    visibility = ["//visibility:public"],
     deps = [
         "//examples/ios_app/Utils",
     ],
-    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/examples/ios_app/ExampleTests/BUILD
+++ b/examples/ios_app/ExampleTests/BUILD
@@ -6,15 +6,15 @@ ios_unit_test(
     bundle_id = "io.buildbuddy.example.tests",
     minimum_os_version = "15.0",
     test_host = "//examples/ios_app/Example",
-    deps = [":ExampleTests.library"],
     visibility = ["//visibility:public"],
+    deps = [":ExampleTests.library"],
 )
 
 swift_library(
     name = "ExampleTests.library",
-    module_name = "ExampleTests",
     testonly = True,
     srcs = glob(["**/*.swift"]),
+    module_name = "ExampleTests",
     deps = [
         "//examples/ios_app/Example:Example.library",
         "//examples/ios_app/TestingUtils",

--- a/examples/ios_app/ExampleUITests/BUILD
+++ b/examples/ios_app/ExampleUITests/BUILD
@@ -6,15 +6,15 @@ ios_ui_test(
     bundle_id = "io.buildbuddy.example.uitests",
     minimum_os_version = "15.0",
     test_host = "//examples/ios_app/Example",
-    deps = [":ExampleUITests.library"],
     visibility = ["//visibility:public"],
+    deps = [":ExampleUITests.library"],
 )
 
 swift_library(
     name = "ExampleUITests.library",
-    module_name = "ExampleUITests",
     testonly = True,
     srcs = [":Sources"],
+    module_name = "ExampleUITests",
 )
 
 filegroup(

--- a/examples/ios_app/TestingUtils/BUILD
+++ b/examples/ios_app/TestingUtils/BUILD
@@ -2,7 +2,6 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(
     name = "TestingUtils",
-    module_name = "TestingUtils",
     testonly = True,
     srcs = [":gen_TestingUtils.swift"],
     visibility = ["//visibility:public"],
@@ -12,14 +11,14 @@ genrule(
     name = "gen_Answer.swift",
     srcs = ["Answer.swift.stencil"],
     outs = ["Answer.swift"],
-    cmd = '''sed 's/{{ answer }}/42/' $< > $@''',
+    cmd = """sed 's/{{ answer }}/42/' $< > $@""",
 )
 
 genrule(
     name = "gen_Greeting.swift",
     srcs = ["Greeting.swift.stencil"],
     outs = ["Greeting.swift"],
-    cmd = '''sed 's/{{ greeting }}/Hello, world?/' $< > $@''',
+    cmd = """sed 's/{{ greeting }}/Hello, world?/' $< > $@""",
 )
 
 genrule(
@@ -29,5 +28,5 @@ genrule(
         ":gen_Answer.swift",
     ],
     outs = ["TestingUtils.swift"],
-    cmd = '''cat $(SRCS) > $@''',
+    cmd = """cat $(SRCS) > $@""",
 )

--- a/examples/ios_app/TestingUtils/BUILD
+++ b/examples/ios_app/TestingUtils/BUILD
@@ -4,6 +4,7 @@ swift_library(
     name = "TestingUtils",
     testonly = True,
     srcs = [":gen_TestingUtils.swift"],
+    module_name = "TestingUtils",
     visibility = ["//visibility:public"],
 )
 

--- a/examples/ios_app/Utils/BUILD
+++ b/examples/ios_app/Utils/BUILD
@@ -2,7 +2,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(
     name = "Utils",
-    module_name = "Utils",
     srcs = glob(["**/*.swift"]),
+    module_name = "Utils",
     visibility = ["//visibility:public"],
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -9,11 +9,11 @@ xcodeproj_test_suite(name = "xcodeproj")
 test_suite(
     name = "test",
     tests = [
+        ":xcodeproj",
         "//test/internal/build_settings",
         "//test/internal/opts",
         "//test/internal/platform",
         "//test/internal/target",
-        ":xcodeproj",
     ],
 )
 
@@ -22,7 +22,7 @@ bzl_library(
     srcs = glob(["*_tests.bzl"]),
     deps = [
         "//test/internal/opts:starlark_tests_bzls",
-    ]
+    ],
 )
 
 bzl_library(

--- a/test/fixtures/BUILD
+++ b/test/fixtures/BUILD
@@ -2,9 +2,9 @@ load(":fixtures.bzl", "update_fixtures")
 
 update_fixtures(
     name = "update",
+    tags = ["manual"],
     targets = [
         "//test/fixtures/ios_app:xcodeproj",
         "//test/fixtures/generator:xcodeproj",
     ],
-    tags = ["manual"],
 )

--- a/test/fixtures/fixtures.bzl
+++ b/test/fixtures/fixtures.bzl
@@ -1,6 +1,5 @@
 """Functions for updating test fixtures."""
 
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "//xcodeproj:xcodeproj.bzl",
     "XcodeProjOutputInfo",
@@ -8,18 +7,9 @@ load(
     "xcodeproj",
 )
 
-# Utility
-
-def _install_path(xcodeproj):
-    # "example/ios_app/p.xcodeproj" -> "test/fixtures/ios_app/project.xcodeproj"
-    return paths.join(
-        "test/fixtures",
-        xcodeproj.short_path.split("/")[1],
-        "project.xcodeproj",
-    )
-
 # Transition
 
+# buildifier: disable=unused-variable
 def _fixtures_transition_impl(settings, attr):
     """Rule transition that standardizes command-line options for fixtures."""
     return {
@@ -66,10 +56,10 @@ def _update_fixtures_impl(ctx):
         output = updater,
         is_executable = True,
         substitutions = {
-            "%specs%": "  \n".join([spec.short_path for spec in specs]),
             "%installers%": "  \n".join(
                 [installer.short_path for installer in installers],
             ),
+            "%specs%": "  \n".join([spec.short_path for spec in specs]),
         },
     )
 

--- a/test/fixtures/fixtures.bzl
+++ b/test/fixtures/fixtures.bzl
@@ -3,9 +3,9 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load(
     "//xcodeproj:xcodeproj.bzl",
+    "XcodeProjOutputInfo",
     "make_xcodeproj_rule",
     "xcodeproj",
-    "XcodeProjOutputInfo",
 )
 
 # Utility
@@ -49,10 +49,12 @@ fixtures_transition = transition(
 def _update_fixtures_impl(ctx):
     specs = [target[XcodeProjOutputInfo].spec for target in ctx.attr.targets]
     installers = [
-        target[XcodeProjOutputInfo].installer for target in ctx.attr.targets
+        target[XcodeProjOutputInfo].installer
+        for target in ctx.attr.targets
     ]
     xcodeprojs = [
-        target[XcodeProjOutputInfo].xcodeproj for target in ctx.attr.targets
+        target[XcodeProjOutputInfo].xcodeproj
+        for target in ctx.attr.targets
     ]
 
     updater = ctx.actions.declare_file(

--- a/test/fixtures/fixtures.bzl
+++ b/test/fixtures/fixtures.bzl
@@ -9,8 +9,7 @@ load(
 
 # Transition
 
-# buildifier: disable=unused-variable
-def _fixtures_transition_impl(settings, attr):
+def _fixtures_transition_impl(_settings, _attr):
     """Rule transition that standardizes command-line options for fixtures."""
     return {
         "//command_line_option:cpu": "darwin_x86_64",

--- a/test/fixtures/generator/spec.json
+++ b/test/fixtures/generator/spec.json
@@ -157,8 +157,8 @@
             },
             "configuration": "darwin_x86_64-fastbuild-ST-1b9bd654f600",
             "dependencies": [
-                "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-fastbuild-ST-1b9bd654f600",
-                "@com_github_kylef_pathkit//:PathKit darwin_x86_64-fastbuild-ST-1b9bd654f600"
+                "@com_github_kylef_pathkit//:PathKit darwin_x86_64-fastbuild-ST-1b9bd654f600",
+                "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-fastbuild-ST-1b9bd654f600"
             ],
             "inputs": {
                 "srcs": [
@@ -269,12 +269,12 @@
             "label": "//tools/generator:tests",
             "links": [
                 "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator/libtests.library.a",
-                "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
-                "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a",
                 "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator/libgenerator.library.a",
                 "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
                 "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml/libAEXML.a",
-                "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit/libPathKit.a"
+                "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit/libPathKit.a",
+                "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
+                "bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a"
             ],
             "name": "tests",
             "outputs": {},
@@ -344,8 +344,8 @@
             },
             "configuration": "darwin_x86_64-fastbuild-ST-1b9bd654f600",
             "dependencies": [
-                "@com_github_pointfreeco_swift_custom_dump//:CustomDump darwin_x86_64-fastbuild-ST-1b9bd654f600",
-                "//tools/generator:generator.library darwin_x86_64-fastbuild-ST-1b9bd654f600"
+                "//tools/generator:generator.library darwin_x86_64-fastbuild-ST-1b9bd654f600",
+                "@com_github_pointfreeco_swift_custom_dump//:CustomDump darwin_x86_64-fastbuild-ST-1b9bd654f600"
             ],
             "inputs": {
                 "srcs": [

--- a/test/internal/build_settings/calculate_module_name_tests.bzl
+++ b/test/internal/build_settings/calculate_module_name_tests.bzl
@@ -1,6 +1,8 @@
 """Tests for module name build setting functions."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:build_settings.bzl", "testable")
 
 calculate_module_name = testable.calculate_module_name
@@ -25,9 +27,9 @@ def _calculate_module_name_test_impl(ctx):
 calculate_module_name_test = unittest.make(
     impl = _calculate_module_name_test_impl,
     attrs = {
+        "expected_module_name": attr.string(mandatory = True),
         "label": attr.label(mandatory = True),
         "module_name": attr.string(mandatory = False),
-        "expected_module_name": attr.string(mandatory = True),
     },
 )
 

--- a/test/internal/build_settings/calculate_module_name_tests.bzl
+++ b/test/internal/build_settings/calculate_module_name_tests.bzl
@@ -41,11 +41,11 @@ def calculate_module_name_test_suite(name):
     test_names = []
 
     def _add_test(
-        *,
-        name,
-        label,
-        module_name,
-        expected_module_name):
+            *,
+            name,
+            label,
+            module_name,
+            expected_module_name):
         test_names.append(name)
         calculate_module_name_test(
             name = name,

--- a/test/internal/build_settings/get_targeted_device_family_tests.bzl
+++ b/test/internal/build_settings/get_targeted_device_family_tests.bzl
@@ -37,10 +37,10 @@ def get_targeted_device_family_test_suite(name):
     test_names = []
 
     def _add_test(
-        *,
-        name,
-        families,
-        expected_targeted_device_family):
+            *,
+            name,
+            families,
+            expected_targeted_device_family):
         test_names.append(name)
         get_targeted_device_family_test(
             name = name,
@@ -92,7 +92,6 @@ def get_targeted_device_family_test_suite(name):
         families = ["watch"],
         expected_targeted_device_family = "4",
     )
-
 
     # Test suite
 

--- a/test/internal/build_settings/get_targeted_device_family_tests.bzl
+++ b/test/internal/build_settings/get_targeted_device_family_tests.bzl
@@ -1,6 +1,8 @@
 """Tests for module name build setting functions."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:build_settings.bzl", "get_targeted_device_family")
 
 def _get_targeted_device_family_test_impl(ctx):
@@ -22,8 +24,8 @@ def _get_targeted_device_family_test_impl(ctx):
 get_targeted_device_family_test = unittest.make(
     impl = _get_targeted_device_family_test_impl,
     attrs = {
-        "families": attr.string_list(mandatory = True),
         "expected_targeted_device_family": attr.string(mandatory = False),
+        "families": attr.string_list(mandatory = True),
     },
 )
 

--- a/test/internal/flattened_key_values/flattened_key_values_tests.bzl
+++ b/test/internal/flattened_key_values/flattened_key_values_tests.bzl
@@ -1,4 +1,8 @@
+"""Tests for flattened_key_values module."""
+
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:flattened_key_values.bzl", "flattened_key_values")
 
 def _to_dict_test(ctx):

--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -2,6 +2,8 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//test:utils.bzl", "stringify_dict")
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:opts.bzl", "testable")
 
 process_compiler_opts = testable.process_compiler_opts
@@ -37,8 +39,8 @@ process_compiler_opts_test = unittest.make(
     attrs = {
         "conlyopts": attr.string_list(mandatory = True),
         "cxxopts": attr.string_list(mandatory = True),
-        "swiftcopts": attr.string_list(mandatory = True),
         "expected_build_settings": attr.string_dict(mandatory = True),
+        "swiftcopts": attr.string_list(mandatory = True),
     },
 )
 

--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -52,12 +52,12 @@ def process_compiler_opts_test_suite(name):
     test_names = []
 
     def _add_test(
-        *,
-        name,
-        expected_build_settings,
-        conlyopts = [],
-        cxxopts = [],
-        swiftcopts = []):
+            *,
+            name,
+            expected_build_settings,
+            conlyopts = [],
+            cxxopts = [],
+            swiftcopts = []):
         test_names.append(name)
         process_compiler_opts_test(
             name = name,
@@ -395,7 +395,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_option-wmo".format(name),
-        swiftcopts = ["-wmo",],
+        swiftcopts = ["-wmo"],
         expected_build_settings = {
             "SWIFT_COMPILATION_MODE": "wholemodule",
         },

--- a/test/internal/opts/process_linker_opts_tests.bzl
+++ b/test/internal/opts/process_linker_opts_tests.bzl
@@ -2,6 +2,8 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//test:utils.bzl", "stringify_dict")
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:opts.bzl", "testable")
 
 process_linker_opts = testable.process_linker_opts
@@ -28,8 +30,8 @@ def _process_linker_opts_test_impl(ctx):
 process_linker_opts_test = unittest.make(
     impl = _process_linker_opts_test_impl,
     attrs = {
-        "linkopts": attr.string_list(mandatory = True),
         "expected_build_settings": attr.string_dict(mandatory = True),
+        "linkopts": attr.string_list(mandatory = True),
     },
 )
 

--- a/test/internal/opts/process_linker_opts_tests.bzl
+++ b/test/internal/opts/process_linker_opts_tests.bzl
@@ -12,7 +12,7 @@ def _process_linker_opts_test_impl(ctx):
     build_settings = {}
     process_linker_opts(
         linkopts = ctx.attr.linkopts,
-        build_settings = build_settings
+        build_settings = build_settings,
     )
     string_build_settings = stringify_dict(build_settings)
 
@@ -43,10 +43,10 @@ def process_linker_opts_test_suite(name):
     test_names = []
 
     def _add_test(
-        *,
-        name,
-        linkopts,
-        expected_build_settings):
+            *,
+            name,
+            linkopts,
+            expected_build_settings):
         test_names.append(name)
         process_linker_opts_test(
             name = name,

--- a/test/internal/platform/generate_platform_information_tests.bzl
+++ b/test/internal/platform/generate_platform_information_tests.bzl
@@ -2,6 +2,8 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//test:utils.bzl", "stringify_dict")
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:platform.bzl", "testable")
 
 generate_platform_information = testable.generate_platform_information
@@ -38,12 +40,12 @@ def _generate_platform_information_test_impl(ctx):
 generate_platform_information_test = unittest.make(
     impl = _generate_platform_information_test_impl,
     attrs = {
-        "platform_key": attr.string(mandatory = True),
         "arch": attr.string(mandatory = True),
-        "minimum_os_version": attr.string(mandatory = True),
-        "minimum_deployment_os_version": attr.string(mandatory = False),
         "expected_build_settings": attr.string_dict(mandatory = True),
         "expected_platform_dict": attr.string_dict(mandatory = True),
+        "minimum_deployment_os_version": attr.string(mandatory = False),
+        "minimum_os_version": attr.string(mandatory = True),
+        "platform_key": attr.string(mandatory = True),
     },
 )
 
@@ -86,10 +88,10 @@ def generate_platform_information_test_suite(name):
         minimum_os_version = "12.0",
         minimum_deployment_os_version = None,
         expected_platform_dict = {
-            "os": "tvOS",
             "arch": "wild",
-            "minimum_os_version": "12.0",
             "environment": "Simulator",
+            "minimum_os_version": "12.0",
+            "os": "tvOS",
         },
         expected_build_settings = {
             "SDKROOT": "appletvos",
@@ -104,14 +106,14 @@ def generate_platform_information_test_suite(name):
         minimum_os_version = "11.0",
         minimum_deployment_os_version = "13.0",
         expected_platform_dict = {
-            "os": "iOS",
             "arch": "x86_64",
-            "minimum_os_version": "11.0",
             "environment": "Simulator",
+            "minimum_os_version": "11.0",
+            "os": "iOS",
         },
         expected_build_settings = {
-            "SDKROOT": "iphoneos",
             "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
+            "SDKROOT": "iphoneos",
         },
     )
 
@@ -124,13 +126,13 @@ def generate_platform_information_test_suite(name):
         minimum_os_version = "12.1",
         minimum_deployment_os_version = None,
         expected_platform_dict = {
-            "os": "macOS",
             "arch": "arm64",
             "minimum_os_version": "12.1",
+            "os": "macOS",
         },
         expected_build_settings = {
-            "SDKROOT": "macosx",
             "MACOSX_DEPLOYMENT_TARGET": "12.1",
+            "SDKROOT": "macosx",
         },
     )
 

--- a/test/internal/platform/generate_platform_information_tests.bzl
+++ b/test/internal/platform/generate_platform_information_tests.bzl
@@ -57,14 +57,14 @@ def generate_platform_information_test_suite(name):
     test_names = []
 
     def _add_test(
-        *,
-        name,
-        platform_key,
-        arch,
-        minimum_os_version,
-        minimum_deployment_os_version,
-        expected_platform_dict,
-        expected_build_settings):
+            *,
+            name,
+            platform_key,
+            arch,
+            minimum_os_version,
+            minimum_deployment_os_version,
+            expected_platform_dict,
+            expected_build_settings):
         test_names.append(name)
         generate_platform_information_test(
             name = name,
@@ -123,7 +123,7 @@ def generate_platform_information_test_suite(name):
         arch = "arm64",
         minimum_os_version = "12.1",
         minimum_deployment_os_version = None,
-        expected_platform_dict =  {
+        expected_platform_dict = {
             "os": "macOS",
             "arch": "arm64",
             "minimum_os_version": "12.1",

--- a/test/internal/target/calculate_configuration_tests.bzl
+++ b/test/internal/target/calculate_configuration_tests.bzl
@@ -37,10 +37,10 @@ def calculate_configuration_test_suite(name):
     test_names = []
 
     def _add_test(
-        *,
-        name,
-        bin_dir_path,
-        expected_configuration):
+            *,
+            name,
+            bin_dir_path,
+            expected_configuration):
         test_names.append(name)
         calculate_configuration_test(
             name = name,

--- a/test/internal/target/calculate_configuration_tests.bzl
+++ b/test/internal/target/calculate_configuration_tests.bzl
@@ -1,6 +1,8 @@
 """Tests for platform processing functions."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:target.bzl", "testable")
 
 calculate_configuration = testable.calculate_configuration

--- a/test/internal/target/process_libraries_tests.bzl
+++ b/test/internal/target/process_libraries_tests.bzl
@@ -1,6 +1,5 @@
 """Tests for platform processing functions."""
 
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//xcodeproj/internal:target.bzl", "testable")
 
@@ -12,7 +11,8 @@ def _process_libraries_test_impl(ctx):
     links, required_links = process_libraries(
         product_type = ctx.attr.product_type,
         test_host_libraries = [
-            struct(path = path) for path in ctx.attr.test_host_libraries
+            struct(path = path)
+            for path in ctx.attr.test_host_libraries
         ],
         links = ctx.attr.links,
         required_links = ctx.attr.required_links,
@@ -36,12 +36,12 @@ def _process_libraries_test_impl(ctx):
 process_libraries_test = unittest.make(
     impl = _process_libraries_test_impl,
     attrs = {
-        "product_type": attr.string(mandatory = True),
-        "test_host_libraries": attr.string_list(mandatory = True),
-        "links": attr.string_list(mandatory = True),
-        "required_links": attr.string_list(mandatory = True),
         "expected_links": attr.string_list(mandatory = True),
         "expected_required_links": attr.string_list(mandatory = True),
+        "links": attr.string_list(mandatory = True),
+        "product_type": attr.string(mandatory = True),
+        "required_links": attr.string_list(mandatory = True),
+        "test_host_libraries": attr.string_list(mandatory = True),
     },
 )
 
@@ -55,14 +55,14 @@ def process_libraries_test_suite(name):
     test_names = []
 
     def _add_test(
-        *,
-        name,
-        product_type,
-        test_host_libraries,
-        links,
-        required_links,
-        expected_links,
-        expected_required_links):
+            *,
+            name,
+            product_type,
+            test_host_libraries,
+            links,
+            required_links,
+            expected_links,
+            expected_required_links):
         test_names.append(name)
         process_libraries_test(
             name = name,

--- a/test/internal/target/process_libraries_tests.bzl
+++ b/test/internal/target/process_libraries_tests.bzl
@@ -1,6 +1,8 @@
 """Tests for platform processing functions."""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:target.bzl", "testable")
 
 process_libraries = testable.process_libraries

--- a/test/internal/target/process_top_level_properties_tests.bzl
+++ b/test/internal/target/process_top_level_properties_tests.bzl
@@ -68,14 +68,14 @@ process_top_level_properties_test = unittest.make(
 )
 
 def _bundle_info(
-    *,
-    archive_path,
-    archive_root,
-    bundle_id,
-    bundle_extension,
-    bundle_name,
-    minimum_deployment_os_version,
-    product_type):
+        *,
+        archive_path,
+        archive_root,
+        bundle_id,
+        bundle_extension,
+        bundle_name,
+        minimum_deployment_os_version,
+        product_type):
     return {
         "archive.path": archive_path,
         "archive_root": archive_root,
@@ -109,17 +109,17 @@ def process_top_level_properties_test_suite(name):
     test_names = []
 
     def _add_test(
-        *,
-        name,
-        target_name,
-        files,
-        bundle_info,
-        tree_artifact_enabled,
-        expected_bundle_path,
-        expected_minimum_deployment_os_version,
-        expected_product_name,
-        expected_product_type,
-        expected_build_settings):
+            *,
+            name,
+            target_name,
+            files,
+            bundle_info,
+            tree_artifact_enabled,
+            expected_bundle_path,
+            expected_minimum_deployment_os_version,
+            expected_product_name,
+            expected_product_type,
+            expected_build_settings):
         test_names.append(name)
         process_top_level_properties_test(
             name = name,

--- a/test/internal/target/process_top_level_properties_tests.bzl
+++ b/test/internal/target/process_top_level_properties_tests.bzl
@@ -2,6 +2,8 @@
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//test:utils.bzl", "stringify_dict")
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:target.bzl", "testable")
 
 process_top_level_properties = testable.process_top_level_properties
@@ -55,15 +57,15 @@ def _process_top_level_properties_test_impl(ctx):
 process_top_level_properties_test = unittest.make(
     impl = _process_top_level_properties_test_impl,
     attrs = {
-        "target_name": attr.string(mandatory = True),
-        "files": attr.string_list(mandatory = True),
         "bundle_info": attr.string_dict(mandatory = False),
-        "tree_artifact_enabled": attr.bool(mandatory = True),
+        "expected_build_settings": attr.string_dict(mandatory = True),
         "expected_bundle_path": attr.string(mandatory = False),
         "expected_minimum_deployment_version": attr.string(mandatory = False),
         "expected_product_name": attr.string(mandatory = True),
         "expected_product_type": attr.string(mandatory = True),
-        "expected_build_settings": attr.string_dict(mandatory = True),
+        "files": attr.string_list(mandatory = True),
+        "target_name": attr.string(mandatory = True),
+        "tree_artifact_enabled": attr.bool(mandatory = True),
     },
 )
 
@@ -79,8 +81,8 @@ def _bundle_info(
     return {
         "archive.path": archive_path,
         "archive_root": archive_root,
-        "bundle_id": bundle_id,
         "bundle_extension": bundle_extension,
+        "bundle_id": bundle_id,
         "bundle_name": bundle_name,
         "minimum_deployment_os_version": minimum_deployment_os_version,
         "product_type": product_type,
@@ -164,8 +166,8 @@ def process_top_level_properties_test_suite(name):
         expected_product_name = "test",
         expected_product_type = "com.apple.product-type.bundle.unit-test",
         expected_build_settings = {
-            "PRODUCT_MODULE_NAME": "_test_",
             "GENERATE_INFOPLIST_FILE": True,
+            "PRODUCT_MODULE_NAME": "_test_",
         },
     )
 
@@ -190,9 +192,9 @@ def process_top_level_properties_test_suite(name):
         expected_product_name = "flagship",
         expected_product_type = "com.apple.product-type.application",
         expected_build_settings = {
-            "PRODUCT_MODULE_NAME": "_flagship_",
-            "PRODUCT_BUNDLE_IDENTIFIER": "com.example.flagship",
             "GENERATE_INFOPLIST_FILE": True,
+            "PRODUCT_BUNDLE_IDENTIFIER": "com.example.flagship",
+            "PRODUCT_MODULE_NAME": "_flagship_",
         },
     )
 
@@ -215,9 +217,9 @@ def process_top_level_properties_test_suite(name):
         expected_product_name = "flagship",
         expected_product_type = "com.apple.product-type.application",
         expected_build_settings = {
-            "PRODUCT_MODULE_NAME": "_flagship_",
-            "PRODUCT_BUNDLE_IDENTIFIER": "com.example.flagship",
             "GENERATE_INFOPLIST_FILE": True,
+            "PRODUCT_BUNDLE_IDENTIFIER": "com.example.flagship",
+            "PRODUCT_MODULE_NAME": "_flagship_",
         },
     )
 
@@ -240,9 +242,9 @@ def process_top_level_properties_test_suite(name):
         expected_product_name = "flagship",
         expected_product_type = "com.apple.product-type.bundle.unit-test",
         expected_build_settings = {
-            "PRODUCT_MODULE_NAME": "_flagship_",
-            "PRODUCT_BUNDLE_IDENTIFIER": "com.example.flagship.test",
             "GENERATE_INFOPLIST_FILE": True,
+            "PRODUCT_BUNDLE_IDENTIFIER": "com.example.flagship.test",
+            "PRODUCT_MODULE_NAME": "_flagship_",
         },
     )
 

--- a/test/xcodeproj_tests.bzl
+++ b/test/xcodeproj_tests.bzl
@@ -55,7 +55,7 @@ xcodeproj_test = rule(
         "_validator_template": attr.label(
             allow_single_file = True,
             default = ":validator.template.sh",
-        )
+        ),
     },
     test = True,
 )
@@ -70,11 +70,11 @@ def xcodeproj_test_suite(name):
     test_names = []
 
     def _add_test(
-        *,
-        name,
-        target_under_test,
-        expected_spec,
-        expected_xcodeproj):
+            *,
+            name,
+            target_under_test,
+            expected_spec,
+            expected_xcodeproj):
         test_names.append(name)
         xcodeproj_test(
             name = name,

--- a/tools/generator/BUILD
+++ b/tools/generator/BUILD
@@ -12,44 +12,44 @@ load(":xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
 
 swift_library(
     name = "generator.library",
-    module_name = "generator",
     srcs = glob(["src/**/*.swift"]),
+    module_name = "generator",
     deps = [
-        "@com_github_tuist_xcodeproj//:XcodeProj",
         "@com_github_kylef_pathkit//:PathKit",
+        "@com_github_tuist_xcodeproj//:XcodeProj",
     ],
 )
 
 swift_binary(
     name = "generator",
+    visibility = ["//visibility:public"],
     deps = [
         ":generator.library",
     ],
-    visibility = ["//visibility:public"],
 )
 
 swift_library(
     name = "tests.library",
-    module_name = "tests",
-    srcs = glob(["test/**/*.swift"]),
     testonly = True,
+    srcs = glob(["test/**/*.swift"]),
+    module_name = "tests",
     deps = [
-        "@com_github_pointfreeco_swift_custom_dump//:CustomDump",
         ":generator.library",
+        "@com_github_pointfreeco_swift_custom_dump//:CustomDump",
     ],
 )
 
 swift_test(
     name = "tests",
+    visibility = ["//test:__subpackages__"],
     deps = [
         ":tests.library",
     ],
-    visibility = ["//test:__subpackages__"],
 )
 
 xcodeproj(
     name = "xcodeproj",
     project_name = "generator",
-    targets = XCODEPROJ_TARGETS,
     tags = ["manual"],
+    targets = XCODEPROJ_TARGETS,
 )

--- a/xcodeproj/internal/flattened_key_values.bzl
+++ b/xcodeproj/internal/flattened_key_values.bzl
@@ -1,3 +1,5 @@
+"""Utility functions to manage flattend key-value lists."""
+
 def _to_dict(iterable):
     """Converts an iterable of flattened key-value pairs to a dictionary.
 

--- a/xcodeproj/internal/input_files_aspect.bzl
+++ b/xcodeproj/internal/input_files_aspect.bzl
@@ -1,7 +1,7 @@
 """Implementation of the `input_files_aspect` aspect."""
 
-load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo")
 load(
     "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:providers.bzl",
     "InputFileAttributesInfo",
@@ -124,6 +124,7 @@ def _input_files_aspect_impl(target, ctx):
     non_arc_srcs = []
     other = []
 
+    # buildifier: disable=uninitialized
     def _handle_file(file, *, attr):
         if file:
             if file.is_source:
@@ -138,6 +139,7 @@ def _input_files_aspect_impl(target, ctx):
             else:
                 other.append(file)
 
+    # buildifier: disable=uninitialized
     def _handle_dep(dep):
         if dep and InputFilesInfo in dep:
             info = dep[InputFilesInfo]

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -182,6 +182,7 @@ def _process_conlyopts(opts):
         *   A `list` of C compiler optimization levels parsed.
     """
     optimizations = []
+
     def process(opt):
         if opt.startswith("-O"):
             optimizations.append(opt)
@@ -211,6 +212,7 @@ def _process_cxxopts(*, opts, build_settings):
         *   A `list` of C++ compiler optimization levels parsed.
     """
     optimizations = []
+
     def process(opt):
         if opt.startswith("-O"):
             optimizations.append(opt)
@@ -287,12 +289,14 @@ def _process_swiftcopts(*, opts, build_settings):
     Returns:
         A `list` of unhandled Swift compiler options.
     """
+
     # Xcode needs a value for SWIFT_VERSION, so we set it to "5" by default.
     # We will have to figure out a way to detect what the default is before
     # Swift 6 (which will probably have a new language version).
     build_settings["SWIFT_VERSION"] = "5"
 
     defines = []
+
     def process(opt):
         if opt.startswith("-O"):
             build_settings["SWIFT_OPTIMIZATION_LEVEL"] = opt

--- a/xcodeproj/internal/platform.bzl
+++ b/xcodeproj/internal/platform.bzl
@@ -22,12 +22,12 @@ _SDK_ROOT = {
 }
 
 def _generate_platform_information(
-    *,
-    platform,
-    arch,
-    minimum_os_version,
-    minimum_deployment_os_version,
-    build_settings):
+        *,
+        platform,
+        arch,
+        minimum_os_version,
+        minimum_deployment_os_version,
+        build_settings):
     """Generates the platform information for a given platform.
 
     Args:
@@ -60,8 +60,7 @@ def _generate_platform_information(
 
     build_settings["SDKROOT"] = _SDK_ROOT[platform_type]
     build_settings[_DEPLOYMENT_TARGET_KEY[platform_type]] = (
-        minimum_deployment_os_version if minimum_deployment_os_version
-        else minimum_os_version
+        minimum_deployment_os_version if minimum_deployment_os_version else minimum_os_version
     )
 
     return platform_dict

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -46,10 +46,6 @@ A `depset` of structs with 'src' and 'dest' fields. The 'src' field is the id of
 the target that can be merged into the target with the id of the 'dest' field.
 """,
         "required_links": """\
-A `depset` of all static library paths that are linked into top-level targets
-besides their primary top-level targets.
-""",
-        "required_links": """\
 A `depset` of all static library files that are linked into top-level targets
 besides their primary top-level targets.
 """,

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -1,13 +1,13 @@
 """Functions for creating `XcodeProjInfo` providers."""
 
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//lib:sets.bzl", "sets")
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
     "IosXcTestBundleInfo",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
-load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_skylib//lib:sets.bzl", "sets")
 load(
     "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj/internal:build_settings.bzl",
     "get_product_module_name",
@@ -41,13 +41,17 @@ associated with any targets.
         "generated_inputs": """\
 A `depset` of generated `File`s that are used by the Xcode project.
 """,
+        "potential_target_merges": """\
+A `depset` of structs with 'src' and 'dest' fields. The 'src' field is the id of
+the target that can be merged into the target with the id of the 'dest' field.
+""",
         "required_links": """\
 A `depset` of all static library paths that are linked into top-level targets
 besides their primary top-level targets.
 """,
-        "potential_target_merges": """\
-A `depset` of structs with 'src' and 'dest' fields. The 'src' field is the id of
-the target that can be merged into the target with the id of the 'dest' field.
+        "required_links": """\
+A `depset` of all static library files that are linked into top-level targets
+besides their primary top-level targets.
 """,
         "target": """\
 A `struct` that contains information about the current target that is
@@ -150,13 +154,13 @@ def _get_static_library(*, label, libraries):
     return None
 
 def _process_product(
-    *,
-    target,
-    product_name,
-    product_type,
-    bundle_path,
-    libraries,
-    build_settings):
+        *,
+        target,
+        product_name,
+        product_type,
+        bundle_path,
+        libraries,
+        build_settings):
     """Generates information about the target's product.
 
     Args:
@@ -191,8 +195,8 @@ def _process_product(
 
     return {
         "name": product_name,
-        "type": product_type,
         "path": path,
+        "type": product_type,
     }
 
 # Outputs
@@ -211,7 +215,8 @@ def _process_outputs(target):
     if OutputGroupInfo in target:
         if "dsyms" in target[OutputGroupInfo]:
             outputs["dsyms"] = [
-                file.path for file in target[OutputGroupInfo].dsyms.to_list()
+                file.path
+                for file in target[OutputGroupInfo].dsyms.to_list()
             ]
     if SwiftInfo in target:
         outputs["swift_module"] = _swift_module_output([
@@ -236,7 +241,7 @@ def _swift_module_output(module):
     swift = module.swift
 
     output = {
-        "name": module.name + '.swiftmodule',
+        "name": module.name + ".swiftmodule",
         "swiftdoc": swift.swiftdoc.path,
         "swiftmodule": swift.swiftmodule.path,
     }
@@ -250,12 +255,12 @@ def _swift_module_output(module):
 # Processed target
 
 def _processed_target(
-    *,
-    inputs_info,
-    potential_target_merges,
-    required_links,
-    target,
-    xcode_target):
+        *,
+        inputs_info,
+        potential_target_merges,
+        required_links,
+        target,
+        xcode_target):
     """Generates the return value for target processing functions.
 
     Args:
@@ -282,19 +287,19 @@ def _processed_target(
     )
 
 def _xcode_target(
-    *,
-    id,
-    name,
-    label,
-    configuration,
-    platform,
-    product,
-    test_host,
-    build_settings,
-    inputs,
-    links,
-    dependencies,
-    outputs):
+        *,
+        id,
+        name,
+        label,
+        configuration,
+        platform,
+        product,
+        test_host,
+        build_settings,
+        inputs,
+        links,
+        dependencies,
+        outputs):
     """Generates the partial json string representation of an Xcode target.
 
     Args:
@@ -344,12 +349,12 @@ def _xcode_target(
 # Top-level targets
 
 def _process_top_level_properties(
-    *,
-    target_name,
-    files,
-    bundle_info,
-    tree_artifact_enabled,
-    build_settings):
+        *,
+        target_name,
+        files,
+        bundle_info,
+        tree_artifact_enabled,
+        build_settings):
     if bundle_info:
         product_name = bundle_info.bundle_name
         product_type = bundle_info.product_type
@@ -362,7 +367,9 @@ def _process_top_level_properties(
             bundle = "{}{}".format(bundle_info.bundle_name, bundle_extension)
             if bundle_extension == ".app":
                 bundle_path = paths.join(
-                    bundle_info.archive_root, "Payload", bundle,
+                    bundle_info.archive_root,
+                    "Payload",
+                    bundle,
                 )
             else:
                 bundle_path = paths.join(bundle_info.archive_root, bundle)
@@ -382,6 +389,7 @@ def _process_top_level_properties(
             # This is something like `swift_test`: it creates an xctest bundle
             product_type = "com.apple.product-type.bundle.unit-test"
             build_settings["GENERATE_INFOPLIST_FILE"] = True
+
             # "some/test.xctest/binary" -> "some/test.xctest"
             bundle_path = xctest[:-(len(xctest.split(".xctest/")[1]) + 1)]
         else:
@@ -398,23 +406,24 @@ def _process_top_level_properties(
     )
 
 def _process_libraries(
-    *,
-    product_type,
-    test_host_libraries,
-    links,
-    required_links):
+        *,
+        product_type,
+        test_host_libraries,
+        links,
+        required_links):
     if (test_host_libraries and
         product_type == "com.apple.product-type.bundle.unit-test"):
         # Unit tests have their test host as a bundle loader. So the
         # test host and its dependencies should be removed from the
         # unit test's links.
         avoid_links = [
-            file.path for file in test_host_libraries
+            file.path
+            for file in test_host_libraries
         ]
 
         def remove_avoided(links):
             return sets.to_list(
-                sets.difference(sets.make(links), sets.make(avoid_links))
+                sets.difference(sets.make(links), sets.make(avoid_links)),
             )
 
         links = [file for file in remove_avoided(links)]
@@ -475,8 +484,8 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
     build_settings = process_opts(ctx = ctx, target = target)
 
     tree_artifact_enabled = (
-        ctx.var.get("apple.experimental.tree_artifact_outputs", "").lower()
-          in ("true", "yes", "1")
+        ctx.var.get("apple.experimental.tree_artifact_outputs", "").lower() in
+        ("true", "yes", "1")
     )
     props = _process_top_level_properties(
         target_name = ctx.rule.attr.name,
@@ -510,7 +519,8 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
     )
 
     build_settings["OTHER_LDFLAGS"] = ["-ObjC"] + build_settings.get(
-        "OTHER_LDFLAGS", [],
+        "OTHER_LDFLAGS",
+        [],
     )
 
     set_if_true(
@@ -550,7 +560,7 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
                 product_type = props.product_type,
                 bundle_path = props.bundle_path,
                 libraries = libraries,
-                build_settings = build_settings
+                build_settings = build_settings,
             ),
             test_host = test_host_target.id if test_host_target else None,
             build_settings = build_settings,
@@ -586,6 +596,7 @@ def _process_library_target(*, ctx, target, transitive_infos):
     libraries = _get_static_libraries(cc_info = target[CcInfo])
 
     cpp = ctx.fragments.cpp
+
     # TODO: Get the value for device builds, even when active config is not for
     # device, as Xcode only uses this value for device builds
     build_settings["ENABLE_BITCODE"] = str(cpp.apple_bitcode_mode) != "none"
@@ -661,6 +672,7 @@ def _should_process_target(target):
         only include their files in the project, but we don't create targets
         for them.
     """
+
     # Targets that don't produce files are ignored (e.g. imports)
     return target.files != depset() and (
         # Top level bundles
@@ -684,21 +696,22 @@ def _should_passthrough_target(*, ctx, target):
     Returns:
         `True` if `target` should be skipped for target generation.
     """
+
     # TODO: Find a way to detect TestEnvironment instead
     return (
-        IosXcTestBundleInfo in target
-        and len(ctx.rule.attr.deps) == 1
-        and IosXcTestBundleInfo in ctx.rule.attr.deps[0]
+        IosXcTestBundleInfo in target and
+        len(ctx.rule.attr.deps) == 1 and
+        IosXcTestBundleInfo in ctx.rule.attr.deps[0]
     )
 
 def _target_info_fields(
-    *,
-    extra_files,
-    generated_inputs,
-    potential_target_merges,
-    required_links,
-    target,
-    xcode_targets):
+        *,
+        extra_files,
+        generated_inputs,
+        potential_target_merges,
+        required_links,
+        target,
+        xcode_targets):
     """Generates target specific fields for the `XcodeProjInfo`.
 
     This should be merged with other fields to fully create an `XcodeProjInfo`.
@@ -748,17 +761,20 @@ def _passthrough_target(*, transitive_infos):
     return _target_info_fields(
         extra_files = depset(
             transitive = [
-                info.extra_files for info in transitive_infos
+                info.extra_files
+                for info in transitive_infos
             ],
         ),
         generated_inputs = depset(
             transitive = [
-                info.generated_inputs for info in transitive_infos
+                info.generated_inputs
+                for info in transitive_infos
             ],
         ),
         potential_target_merges = depset(
             transitive = [
-                info.potential_target_merges for info in transitive_infos
+                info.potential_target_merges
+                for info in transitive_infos
             ],
         ),
         required_links = depset(
@@ -813,19 +829,22 @@ def _process_target(*, ctx, target, transitive_infos):
                 transitive = inputs_info.transitive_non_generated,
             ).to_list(),
             transitive = [
-                info.extra_files for info in transitive_infos
+                info.extra_files
+                for info in transitive_infos
             ],
         ),
         generated_inputs = depset(
             inputs_info.generated,
             transitive = [
-                info.generated_inputs for info in transitive_infos
+                info.generated_inputs
+                for info in transitive_infos
             ],
         ),
         potential_target_merges = depset(
             processed_target.potential_target_merges,
             transitive = [
-                info.potential_target_merges for info in transitive_infos
+                info.potential_target_merges
+                for info in transitive_infos
             ],
         ),
         required_links = depset(

--- a/xcodeproj/internal/xcodeproj_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_aspect.bzl
@@ -6,12 +6,12 @@ load(
 )
 load(
     "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj/internal:target.bzl",
+    "XcodeProjInfo",
     "as_resource",
     "process_target",
-    "XcodeProjInfo",
 )
 
-_ASPECT_DEP_ATTR= [
+_ASPECT_DEP_ATTR = [
     "test_host",
 ]
 

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj/internal:logging.bzl",
     "green",
-    "yellow",
     "warn",
+    "yellow",
 )
 
 def _maybe(repo_rule, name, ignore_version_differences, **kwargs):

--- a/xcodeproj/xcodeproj.bzl
+++ b/xcodeproj/xcodeproj.bzl
@@ -88,7 +88,8 @@ def _write_json_spec(*, ctx, project_name, infos):
 """.format(
         bazel_path = ctx.attr.bazel_path,
         extra_files = json.encode([
-            file_path(file) for file in extra_files.to_list()
+            file_path(file)
+            for file in extra_files.to_list()
         ]),
         label = ctx.label,
         potential_target_merges = potential_target_merges_json,


### PR DESCRIPTION
Closes #126 

- Ran `//:buildifier.fix` on the codebase.
- Addressed issues uncovered by running `//:buildifier.check`.
- Enabled CI pipeline action to run `//:buildifier.check`.