### PR TITLE
Use a string for `SWIFT_ACTIVE_COMPILATION_CONDITIONS`

### DIFF
--- a/test/fixtures/generator/spec.json
+++ b/test/fixtures/generator/spec.json
@@ -152,9 +152,7 @@
                 "PRODUCT_MODULE_NAME": "generator",
                 "PRODUCT_NAME": "generator.library",
                 "SDKROOT": "macosx",
-                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
-                    "DEBUG"
-                ],
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -344,9 +342,7 @@
                 "PRODUCT_MODULE_NAME": "tests",
                 "PRODUCT_NAME": "tests.library",
                 "SDKROOT": "macosx",
-                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
-                    "DEBUG"
-                ],
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -444,9 +440,7 @@
                 "PRODUCT_MODULE_NAME": "PathKit",
                 "PRODUCT_NAME": "PathKit",
                 "SDKROOT": "macosx",
-                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
-                    "DEBUG"
-                ],
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -530,9 +524,7 @@
                 "PRODUCT_MODULE_NAME": "CustomDump",
                 "PRODUCT_NAME": "CustomDump",
                 "SDKROOT": "macosx",
-                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
-                    "DEBUG"
-                ],
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -714,9 +706,7 @@
                 "PRODUCT_MODULE_NAME": "XCTestDynamicOverlay",
                 "PRODUCT_NAME": "XCTestDynamicOverlay",
                 "SDKROOT": "macosx",
-                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
-                    "DEBUG"
-                ],
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -800,9 +790,7 @@
                 "PRODUCT_MODULE_NAME": "AEXML",
                 "PRODUCT_NAME": "AEXML",
                 "SDKROOT": "macosx",
-                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
-                    "DEBUG"
-                ],
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -902,9 +890,7 @@
                 "PRODUCT_MODULE_NAME": "XcodeProj",
                 "PRODUCT_NAME": "XcodeProj",
                 "SDKROOT": "macosx",
-                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
-                    "DEBUG"
-                ],
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },

--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -119,7 +119,7 @@ def process_compiler_opts_test_suite(name):
         expected_build_settings = {
             "ENABLE_TESTABILITY": "True",
             "OTHER_SWIFT_FLAGS": ["weird", "-unhandled"],
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": ["DEBUG"],
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
         },
     )
 
@@ -352,17 +352,12 @@ def process_compiler_opts_test_suite(name):
         name = "{}_defines".format(name),
         swiftcopts = [
             "-DDEBUG",
-            "-DBAZEL=1",
-            "-DDEBUG=1",
-            "-DBAZEL=1",
+            "-DBAZEL",
+            "-DDEBUG",
+            "-DBAZEL",
         ],
         expected_build_settings = {
-            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": [
-                "DEBUG",
-                "BAZEL=1",
-                "DEBUG=1",
-                "BAZEL=1",
-            ],
+            "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG BAZEL",
         },
     )
 

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -337,7 +337,8 @@ def _process_swiftcopts(*, opts, build_settings):
     set_if_true(
         build_settings,
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS",
-        defines,
+        # Eliminate duplicates
+        " ".join({x: None for x in defines}.keys()),
     )
 
     return unhandled_opts


### PR DESCRIPTION
Xcode prefers this as a string.