### PR TITLE
Provide `swiftmodules` to the generator

### DIFF
--- a/examples/ios_app/test/fixtures/BUILD
+++ b/examples/ios_app/test/fixtures/BUILD
@@ -9,8 +9,8 @@ load("//:xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
 
 xcodeproj_fixture(
     name = "fixture",
-    workspace_name = "ios_app",
     targets = XCODEPROJ_TARGETS,
+    workspace_name = "ios_app",
 )
 
 update_fixtures(

--- a/examples/ios_app/test/fixtures/spec.json
+++ b/examples/ios_app/test/fixtures/spec.json
@@ -132,6 +132,7 @@
                 "type": "com.apple.product-type.application"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": null
         },
         "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -222,6 +223,7 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": null
         },
         "//ExampleTests:ExampleTests.__internal__.__test_bundle applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -303,6 +305,7 @@
                 "type": "com.apple.product-type.bundle.unit-test"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
         },
         "//ExampleTests:ExampleTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -395,6 +398,16 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {},
+            "swiftmodules": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swiftmodule",
+                    "t": "g"
+                }
+            ],
             "test_host": null
         },
         "//ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -475,6 +488,7 @@
                 "type": "com.apple.product-type.bundle.ui-testing"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
         },
         "//ExampleUITests:ExampleUITests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -559,6 +573,7 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": null
         },
         "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -645,6 +660,7 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": null
         },
         "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
@@ -732,6 +748,7 @@
                     }
                 ]
             },
+            "swiftmodules": [],
             "test_host": null
         }
     ]

--- a/test/fixtures/cc/spec.json
+++ b/test/fixtures/cc/spec.json
@@ -100,6 +100,7 @@
                     }
                 ]
             },
+            "swiftmodules": [],
             "test_host": null
         },
         "//examples/cc/tool:tool darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -189,6 +190,7 @@
                     }
                 ]
             },
+            "swiftmodules": [],
             "test_host": null
         }
     ]

--- a/test/fixtures/command_line/spec.json
+++ b/test/fixtures/command_line/spec.json
@@ -108,6 +108,7 @@
                     }
                 ]
             },
+            "swiftmodules": [],
             "test_host": null
         },
         "//examples/command_line/tool:tool applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57",
@@ -188,6 +189,7 @@
                 "type": "com.apple.product-type.tool"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": null
         },
         "//examples/command_line/tool:tool.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57",
@@ -282,6 +284,7 @@
                     }
                 ]
             },
+            "swiftmodules": [],
             "test_host": null
         }
     ]

--- a/test/fixtures/generator/spec.json
+++ b/test/fixtures/generator/spec.json
@@ -105,6 +105,7 @@
                 "type": "com.apple.product-type.tool"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": null
         },
         "//tools/generator:generator.library darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -215,6 +216,20 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {},
+            "swiftmodules": [
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
+                    "t": "g"
+                }
+            ],
             "test_host": null
         },
         "//tools/generator:tests darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -295,6 +310,7 @@
                 "type": "com.apple.product-type.bundle.unit-test"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": null
         },
         "//tools/generator:tests.library darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -394,6 +410,32 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {},
+            "swiftmodules": [
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator/generator.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule",
+                    "t": "g"
+                }
+            ],
             "test_host": null
         },
         "@com_github_kylef_pathkit//:PathKit darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -478,6 +520,7 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": null
         },
         "@com_github_pointfreeco_swift_custom_dump//:CustomDump darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -660,6 +703,12 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {},
+            "swiftmodules": [
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
+                    "t": "g"
+                }
+            ],
             "test_host": null
         },
         "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -744,6 +793,7 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": null
         },
         "@com_github_tadija_aexml//:AEXML darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -844,6 +894,7 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {},
+            "swiftmodules": [],
             "test_host": null
         },
         "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-fastbuild-ST-1b9bd654f600",
@@ -1307,6 +1358,16 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {},
+            "swiftmodules": [
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                    "t": "g"
+                }
+            ],
             "test_host": null
         }
     ]

--- a/tools/generator/src/DTO.swift
+++ b/tools/generator/src/DTO.swift
@@ -21,6 +21,7 @@ struct Target: Equatable, Decodable {
     var buildSettings: [String: BuildSetting]
     var searchPaths: SearchPaths
     var modulemaps: [FilePath]
+    var swiftmodules: [FilePath]
     var inputs: Inputs
     var links: Set<Path>
     var dependencies: Set<TargetID>

--- a/tools/generator/src/Generator+ProcessTargetMerges.swift
+++ b/tools/generator/src/Generator+ProcessTargetMerges.swift
@@ -72,6 +72,9 @@ exist
                 // Update modulemaps
                 merged.modulemaps = merging.modulemaps
 
+                // Update swiftmodules
+                merged.swiftmodules = merging.swiftmodules
+
                 // Update inputs
                 merged.inputs = merging.inputs
 

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -43,6 +43,7 @@ enum Fixtures {
                 "T": .string("43"),
                 "Z": .string("0")
             ],
+            swiftmodules: [.generated("x/y.swiftmodule")],
             links: ["a/c.a", "z/A.a"],
             dependencies: ["C 1", "A 1"]
         ),
@@ -53,6 +54,7 @@ enum Fixtures {
                 path: "a/b.framework"
             ),
             modulemaps: ["a/module.modulemap"],
+            swiftmodules: [.generated("x/y.swiftmodule")],
             inputs: .init(srcs: ["z.h", "z.mm"], hdrs: ["d.h"]),
             dependencies: ["A 1"]
         ),

--- a/tools/generator/test/ProcessTargetMergesTests.swift
+++ b/tools/generator/test/ProcessTargetMergesTests.swift
@@ -54,6 +54,7 @@ final class TargetMergingTests: XCTestCase {
                 "Z": .string("0")
             ],
             modulemaps: targets["A 1"]!.modulemaps,
+            swiftmodules: targets["A 1"]!.swiftmodules,
             inputs: targets["A 1"]!.inputs,
             // Removed "A 1"'s product
             links: ["a/c.a"],
@@ -64,6 +65,7 @@ final class TargetMergingTests: XCTestCase {
             product: targets["B 2"]!.product,
             testHost: "A 2",
             modulemaps: targets["B 1"]!.modulemaps,
+            swiftmodules: targets["B 1"]!.swiftmodules,
             inputs: targets["B 1"]!.inputs,
             // Removed "A 1"'s and "B 1"'s product
             links: [],
@@ -74,6 +76,7 @@ final class TargetMergingTests: XCTestCase {
             product: targets["B 3"]!.product,
             testHost: "A 2",
             modulemaps: targets["B 1"]!.modulemaps,
+            swiftmodules: targets["B 1"]!.swiftmodules,
             inputs: targets["B 1"]!.inputs,
             // Removed "B 1"'s product
             links: [],
@@ -121,6 +124,7 @@ final class TargetMergingTests: XCTestCase {
         expectedTargets["B 2"] = Target.mock(
             product: targets["B 2"]!.product,
             modulemaps: targets["B 1"]!.modulemaps,
+            swiftmodules: targets["B 1"]!.swiftmodules,
             inputs: targets["B 1"]!.inputs,
             // Removed "B 1"'s product
             links: ["z/A.a"],
@@ -131,6 +135,7 @@ final class TargetMergingTests: XCTestCase {
             product: targets["B 3"]!.product,
             testHost: "A 2",
             modulemaps: targets["B 1"]!.modulemaps,
+            swiftmodules: targets["B 1"]!.swiftmodules,
             inputs: targets["B 1"]!.inputs,
             // Removed "B 1"'s product
             links: [],

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -12,6 +12,7 @@ extension Target {
         buildSettings: [String: BuildSetting] = [:],
         searchPaths: SearchPaths = SearchPaths(),
         modulemaps: [FilePath] = [],
+        swiftmodules: [FilePath] = [],
         inputs: Inputs = Inputs(),
         links: Set<Path> = [],
         dependencies: Set<TargetID> = []
@@ -31,6 +32,7 @@ extension Target {
             buildSettings: buildSettings,
             searchPaths: searchPaths,
             modulemaps: modulemaps,
+            swiftmodules: swiftmodules,
             inputs: inputs,
             links: links,
             dependencies: dependencies

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -341,6 +341,7 @@ def _xcode_target(
         build_settings,
         search_paths,
         modulemaps,
+        swiftmodules,
         inputs_info,
         links,
         dependencies,
@@ -363,6 +364,7 @@ def _xcode_target(
         build_settings: A `dict` of Xcode build settings for the target.
         search_paths: The value returned from `_process_search_paths()`.
         modulemaps: The value returned from `_process_modulemaps()`.
+        swiftmodules: The value returned from `_process_swiftmodules()`.
         inputs_info: An `InputFilesInfo` provider.
         links: A `list` of file paths for libraries that the target links
             against.
@@ -391,6 +393,7 @@ def _xcode_target(
         build_settings = build_settings,
         search_paths = search_paths,
         modulemaps = modulemaps.file_paths,
+        swiftmodules = swiftmodules,
         inputs = _process_inputs(inputs_info),
         links = links,
         dependencies = dependencies,
@@ -603,6 +606,9 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
     modulemaps = _process_modulemaps(
         swift_info = target[SwiftInfo] if SwiftInfo in target else None,
     )
+    is_swift = SwiftInfo in target
+    swift_info = target[SwiftInfo] if is_swift else None
+    modulemaps = _process_modulemaps(swift_info = swift_info)
     search_paths = _process_search_paths(
         bin_dir_path = ctx.bin_dir.path,
         includes = getattr(ctx.rule.attr, "includes", []),
@@ -612,7 +618,7 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
 
     return _processed_target(
         defines = _process_defines(
-            is_swift = SwiftInfo in target,
+            is_swift = is_swift,
             defines = getattr(ctx.rule.attr, "defines", []),
             local_defines = getattr(ctx.rule.attr, "local_defines", []),
             transitive_infos = transitive_infos,
@@ -645,10 +651,13 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
                 linker_inputs = linker_inputs,
                 build_settings = build_settings,
             ),
-            test_host = test_host_target_info.target.id if test_host_target_info else None,
+            test_host = (
+                test_host_target_info.target.id if test_host_target_info else None
+            ),
             build_settings = build_settings,
             search_paths = search_paths,
             modulemaps = modulemaps,
+            swiftmodules = _process_swiftmodules(swift_info = swift_info),
             inputs_info = inputs_info,
             links = links,
             dependencies = dependencies,
@@ -710,9 +719,9 @@ def _process_library_target(*, ctx, target, transitive_infos):
     )
 
     inputs_info = target[InputFilesInfo]
-    modulemaps = _process_modulemaps(
-        swift_info = target[SwiftInfo] if SwiftInfo in target else None,
-    )
+    is_swift = SwiftInfo in target
+    swift_info = target[SwiftInfo] if is_swift else None
+    modulemaps = _process_modulemaps(swift_info = swift_info)
     search_paths = _process_search_paths(
         bin_dir_path = ctx.bin_dir.path,
         includes = getattr(ctx.rule.attr, "includes", []),
@@ -745,6 +754,8 @@ def _process_library_target(*, ctx, target, transitive_infos):
             id = id,
             name = module_name,
             label = target.label,
+            configuration = configuration,
+            platform = platform,
             product = _process_product(
                 target = target,
                 product_name = product_name,
@@ -753,12 +764,11 @@ def _process_library_target(*, ctx, target, transitive_infos):
                 linker_inputs = linker_inputs,
                 build_settings = build_settings,
             ),
-            configuration = configuration,
-            platform = platform,
+            test_host = None,
             build_settings = build_settings,
             search_paths = search_paths,
             modulemaps = modulemaps,
-            test_host = None,
+            swiftmodules = _process_swiftmodules(swift_info = swift_info),
             inputs_info = inputs_info,
             links = [],
             dependencies = dependencies,
@@ -1099,8 +1109,11 @@ def _process_modulemaps(*, swift_info):
     modulemap_file_paths = []
     modulemap_files = []
     for module in swift_info.transitive_modules.to_list():
-        module_map = module.clang.module_map
-        if not module.clang or not module_map:
+        clang_module = module.clang
+        if not clang_module:
+            continue
+        module_map = clang_module.module_map
+        if not module_map:
             continue
 
         if type(module_map) == "File":
@@ -1117,6 +1130,23 @@ def _process_modulemaps(*, swift_info):
         file_paths = {x: None for x in modulemap_file_paths}.keys(),
         files = {x: None for x in modulemap_files}.keys(),
     )
+
+def _process_swiftmodules(*, swift_info):
+    if not swift_info:
+        return []
+
+    direct_modules = swift_info.direct_modules
+
+    file_paths = []
+    for module in swift_info.transitive_modules.to_list():
+        if module in direct_modules:
+            continue
+        swift_module = module.swift
+        if not swift_module:
+            continue
+        file_paths.append(file_path(swift_module.swiftmodule))
+
+    return file_paths
 
 def _process_target(*, ctx, target, transitive_infos):
     """Creates the target portion of an `XcodeProjInfo` for a `Target`.


### PR DESCRIPTION
These values aren't used yet, but in a future change where we change the directory layout of DerivedData they will be used to set `SWIFT_INCLUDE_PATHS`.