### PR TITLE
Fix `file_path()` ordering

### DIFF
--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -20,10 +20,10 @@ def file_path(file):
             *   "i" for `.internal`
     """
     path = file.path
-    if file.owner.workspace_name:
-        return external_file_path(path)
     if not file.is_source:
         return generated_file_path(path)
+    if file.owner.workspace_name:
+        return external_file_path(path)
     return project_file_path(path)
 
 def external_file_path(path):


### PR DESCRIPTION
We care if it's generated more than if it's an external source, so for files generated in an external repo, we need to report it as `.generated`.