### PR TITLE
Use a custom DerivedData directory layout

### DIFF
--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -23,9 +23,7 @@
 /* Begin PBXBuildFile section */
 		29796EAB3AFB4F393E120401 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD5A69CC7A6E820FCB0BDF0 /* ContentView.swift */; };
 		302A692FEFBAE7F1EA170548 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE58C589847257693979C11 /* ExampleTests.swift */; };
-		37E5FD5070CF4429327F578D /* libTestingUtils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4B4FA9C70425835BED3D18FF /* libTestingUtils.a */; };
 		5A49B1D4C59BE2C861DAB532 /* Foo.m in Sources */ = {isa = PBXBuildFile; fileRef = A728BC96D2EE56D3A20F5D75 /* Foo.m */; };
-		6EA3628D500556DC68B536AD /* libUtils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 96457EE4FDB089F9B6CA30D8 /* libUtils.a */; };
 		874BE1DD90F654F01D46A1A2 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6A7C1EE8BAE7058EFC5B0C /* ExampleUITests.swift */; };
 		AE2C4E59A2F6A848808F8249 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D699DE3520D61FDC19A909EF /* ExampleApp.swift */; };
 		C46BFDEF6C0E0BB66EAD88CC /* ExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B582794DF84A93AA718FB7A0 /* ExampleUITestsLaunchTests.swift */; };
@@ -114,46 +112,6 @@
 		DDD5A69CC7A6E820FCB0BDF0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		F3EE8A1F985D59D79066BF9C /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		274CBE4D9108FFB059E4CA3B /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		38DC143DCB7137C5F53CBE44 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				37E5FD5070CF4429327F578D /* libTestingUtils.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		6D67008306BEFEA59394D31C /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		74006124FAE3AFE6CF3B8D5B /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BCF96D9A72AA5C1F337495CB /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6EA3628D500556DC68B536AD /* libUtils.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		1F90F600520A6B0293200062 /* bin */ = {
@@ -330,7 +288,6 @@
 			buildConfigurationList = 0ECED0C161074C949B186E2D /* Build configuration list for PBXNativeTarget "ExampleUITests" */;
 			buildPhases = (
 				E8772DBE661F0A21EC2C2998 /* Sources */,
-				274CBE4D9108FFB059E4CA3B /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -347,7 +304,6 @@
 			buildConfigurationList = 12A6E39AFF20277EB2E837E3 /* Build configuration list for PBXNativeTarget "Utils" */;
 			buildPhases = (
 				6C4A06DEA64ACEE83AA2D91B /* Sources */,
-				6D67008306BEFEA59394D31C /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -363,7 +319,6 @@
 			buildConfigurationList = 6D29AE2BA9EE48AD3E0D7E45 /* Build configuration list for PBXNativeTarget "ExampleTests" */;
 			buildPhases = (
 				085850CBF6FF7D2163FFF60A /* Sources */,
-				38DC143DCB7137C5F53CBE44 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -383,7 +338,6 @@
 			buildConfigurationList = 3EEAAC6A475B8EE72405BCF3 /* Build configuration list for PBXNativeTarget "TestingUtils" */;
 			buildPhases = (
 				EAC8F69FA419D442FF916CFF /* Sources */,
-				74006124FAE3AFE6CF3B8D5B /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -400,7 +354,6 @@
 			buildConfigurationList = 19C1A3DAF723B9973DBE381B /* Build configuration list for PBXNativeTarget "Example" */;
 			buildPhases = (
 				6315F36A6873172964A42F18 /* Sources */,
-				BCF96D9A72AA5C1F337495CB /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -639,7 +592,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "Utils-d7f562296058d6bcaf5a8f4478cf2ac93158e78a";
+				TARGET_NAME = Utils;
 				USER_HEADER_SEARCH_PATHS = (
 					.,
 					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
@@ -693,18 +646,24 @@
 					"-D__TIMESTAMP__=\"redacted\"",
 					"-D__TIME__=\"redacted\"",
 				);
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-filelist",
+					"test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleTests/ExampleTests.LinkFileList,$(BUILD_DIR)",
+					"-ObjC",
+				);
 				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.tests;
 				PRODUCT_MODULE_NAME = ExampleTests;
 				PRODUCT_NAME = ExampleTests;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG AWESOME";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TARGET_NAME = "ExampleTests-0221d31b52d43b9426596c9d57cb0a48033ce219";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Example.app/Example";
+				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example$(TARGET_BUILD_SUBPATH)";
+				TARGET_NAME = ExampleTests;
+				TEST_HOST = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example.app/Example";
 			};
 			name = Debug;
 		};
@@ -758,7 +717,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG AWESOME";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "TestingUtils-5fa8a9d132eeb601bbc2933480902158980be025";
+				TARGET_NAME = TestingUtils;
 			};
 			name = Debug;
 		};
@@ -768,10 +727,12 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BAZEL_PATH = bazel;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
 				USE_HEADERMAP = NO;
 			};
 			name = Debug;
@@ -827,7 +788,11 @@
 					"-D__TIMESTAMP__=\"redacted\"",
 					"-D__TIME__=\"redacted\"",
 				);
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-filelist",
+					"test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/Example/Example.LinkFileList,$(BUILD_DIR)",
+					"-ObjC",
+				);
 				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
 				PRODUCT_MODULE_NAME = Example;
@@ -837,7 +802,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGETED_DEVICE_FAMILY = 1;
-				TARGET_NAME = "Example-f9d780ed383b7ba19bdadca75c6b25682da08404";
+				TARGET_NAME = Example;
 			};
 			name = Debug;
 		};
@@ -895,7 +860,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TARGET_NAME = "ExampleUITests-9c70b1eca4a64387df76c21431d5d43a517851c4";
+				TARGET_NAME = ExampleUITests;
 				TEST_TARGET_NAME = Example;
 			};
 			name = Debug;

--- a/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/Example/Example.LinkFileList
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/Example/Example.LinkFileList
@@ -1,0 +1,1 @@
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/libUtils.a

--- a/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleTests/ExampleTests.LinkFileList
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleTests/ExampleTests.LinkFileList
@@ -1,0 +1,1 @@
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/libTestingUtils.a

--- a/test/fixtures/cc/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/project.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		5B4F5A0F99FCFB768BB56235 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C91EE0C5078D0455B44BD9D /* main.c */; };
-		6395AB58CB99FD923890510C /* liblib_impl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1704EC3DF20D136B9D2B8C0D /* liblib_impl.a */; };
 		CF2BABF79AFED843A0808F91 /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 76BA269B4C781557323B9158 /* lib.c */; };
 		D40AE348DB29E7FBDB040D88 /* private.h in Sources */ = {isa = PBXBuildFile; fileRef = AA8B695078A953D1EA32899E /* private.h */; };
 /* End PBXBuildFile section */
@@ -31,24 +30,6 @@
 		AA8B695078A953D1EA32899E /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
 		E37C21ED6BACCA0E92024F54 /* tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tool; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		A6EC893DB5C33B52A57824D8 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6395AB58CB99FD923890510C /* liblib_impl.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DF3C07A9FF08815D41C47C9C /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		428D294EDDF4A41D530E1B84 /* Products */ = {
@@ -119,7 +100,6 @@
 			buildConfigurationList = C1D4624860972495C5DE5D69 /* Build configuration list for PBXNativeTarget "examples_cc_lib_lib_impl" */;
 			buildPhases = (
 				1CFAC5E641D9C8803E022079 /* Sources */,
-				DF3C07A9FF08815D41C47C9C /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -135,7 +115,6 @@
 			buildConfigurationList = 867643D0A3B038E40F01DB27 /* Build configuration list for PBXNativeTarget "tool" */;
 			buildPhases = (
 				71A19865030B483AA44F971E /* Sources */,
-				A6EC893DB5C33B52A57824D8 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -222,10 +201,12 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BAZEL_PATH = bazel;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
 				USE_HEADERMAP = NO;
 			};
 			name = Debug;
@@ -271,13 +252,17 @@
 					"-D__TIMESTAMP__=\"redacted\"",
 					"-D__TIME__=\"redacted\"",
 				);
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-filelist",
+					"test/fixtures/cc/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/examples/cc/tool/tool.LinkFileList,$(BUILD_DIR)",
+					"-ObjC",
+				);
 				PRODUCT_MODULE_NAME = _tool_;
 				PRODUCT_NAME = tool;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "tool-e265fbf6cf7acefb2b0f95d81c0221bc0b8bb8b0";
+				TARGET_NAME = tool;
 				USER_HEADER_SEARCH_PATHS = (
 					.,
 					"bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
@@ -333,7 +318,7 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "examples_cc_lib_lib_impl-e169840ba582bfd664739950ded9b9f97b9a553c";
+				TARGET_NAME = examples_cc_lib_lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
 					.,
 					"bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",

--- a/test/fixtures/cc/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/examples/cc/tool/tool.LinkFileList
+++ b/test/fixtures/cc/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/examples/cc/tool/tool.LinkFileList
@@ -1,0 +1,1 @@
+bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/examples/cc/lib/liblib_impl.a

--- a/test/fixtures/command_line/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/project.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6395AB58CB99FD923890510C /* liblib_impl.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1704EC3DF20D136B9D2B8C0D /* liblib_impl.a */; };
 		7C3CD0E0D0A59C7B68CC261C /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 97093D4A77C09BF21048172D /* main.m */; };
 		902C27C94F183F5BB907F0B9 /* private.h in Sources */ = {isa = PBXBuildFile; fileRef = B5511E6B7C59A1600AEF50FA /* private.h */; };
 		B484C7F7B646A12966C80226 /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D35BF1A1F38BD9CDFCFFE22 /* lib.c */; };
@@ -31,24 +30,6 @@
 		B5511E6B7C59A1600AEF50FA /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
 		E37C21ED6BACCA0E92024F54 /* tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tool; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		9505C541823C0B1E47BE6445 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A6EC893DB5C33B52A57824D8 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6395AB58CB99FD923890510C /* liblib_impl.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		0CDF69186E00FC09E69A79AB /* tool */ = {
@@ -127,7 +108,6 @@
 			buildConfigurationList = 4947DC1147B197F5D47FE910 /* Build configuration list for PBXNativeTarget "examples_command_line_lib_lib_impl" */;
 			buildPhases = (
 				D2630741C336B3125360AAE3 /* Sources */,
-				9505C541823C0B1E47BE6445 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -143,7 +123,6 @@
 			buildConfigurationList = 867643D0A3B038E40F01DB27 /* Build configuration list for PBXNativeTarget "tool" */;
 			buildPhases = (
 				71A19865030B483AA44F971E /* Sources */,
-				A6EC893DB5C33B52A57824D8 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -230,10 +209,12 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BAZEL_PATH = bazel;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
 				USE_HEADERMAP = NO;
 			};
 			name = Debug;
@@ -289,13 +270,17 @@
 					"-D__TIMESTAMP__=\"redacted\"",
 					"-D__TIME__=\"redacted\"",
 				);
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-filelist",
+					"test/fixtures/command_line/project.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/examples/command_line/tool/tool.LinkFileList,$(BUILD_DIR)",
+					"-ObjC",
+				);
 				PRODUCT_MODULE_NAME = examples_command_line_tool_tool_library;
 				PRODUCT_NAME = tool;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "tool-c7c8a36df44880d9e6bd4e55e7f9f1fd63574b0f";
+				TARGET_NAME = tool;
 				USER_HEADER_SEARCH_PATHS = (
 					.,
 					"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
@@ -354,7 +339,7 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "examples_command_line_lib_lib_impl-0a7ad6656ea029418c02cd14238eaa9476731050";
+				TARGET_NAME = examples_command_line_lib_lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
 					.,
 					"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",

--- a/test/fixtures/command_line/project.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/examples/command_line/tool/tool.LinkFileList
+++ b/test/fixtures/command_line/project.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/examples/command_line/tool/tool.LinkFileList
@@ -1,0 +1,1 @@
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/liblib_impl.a

--- a/test/fixtures/generator/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/project.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		02182EDE6FDB241C2434DF8A /* XCScheme+TestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D351EBF697F74A32355EC048 /* XCScheme+TestItem.swift */; };
 		073D09171A88A0A4D802AA1E /* XcodeProj+CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84AD628C1B10FBFD1555866 /* XcodeProj+CustomDump.swift */; };
 		078322183A4AFB303A3DDCAD /* PBXBuildFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E76521DC3E6D3C6586C892B /* PBXBuildFile.swift */; };
-		07EF43AFD882CF6B7BF46BBE /* libAEXML.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D464DF302AC7DA6ADB66AF96 /* libAEXML.a */; };
 		08C779256A9584CE43FAB580 /* XCBuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0B173016FD0B4F0B6EC8CF8 /* XCBuildConfiguration.swift */; };
 		09BAA0C65E466D507FDA6DB3 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2079E71FB3410326ADA1B3A9 /* PBXHeadersBuildPhase.swift */; };
 		0B5354E89D74EFC00CC7758D /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C6D13675A201EF3DC4178F4 /* PBXContainerItem.swift */; };
@@ -59,7 +58,6 @@
 		593864AAE82B0A3C054E9164 /* Photos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A7A176F9192DBE89A1E3D2 /* Photos.swift */; };
 		59B76B79886BB3EB60199EEA /* XCScheme+EnvironmentVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731649630DE508B0F7DB9208 /* XCScheme+EnvironmentVariable.swift */; };
 		5AF095F1F8736234603E26C8 /* XCWorkspaceDataElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = B25719D85CD57D66E100A2FF /* XCWorkspaceDataElement.swift */; };
-		5C53CCD4CA7BD1A8C6547433 /* libPathKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FFD18AFDE2FDB1AB48221310 /* libPathKit.a */; };
 		5FBA94369D0CE7D3875EFE15 /* XCScheme+PathRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D410968B3C048435B181B8 /* XCScheme+PathRunnable.swift */; };
 		5FEBE98B5DA7737FB51522BB /* CustomDumpRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4170E9DBFFB82AEF9EA82A /* CustomDumpRepresentable.swift */; };
 		6140373CB8FF49814FCE48CD /* XCScheme+Runnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEAE7BF1D7A815801CB23DD /* XCScheme+Runnable.swift */; };
@@ -67,7 +65,6 @@
 		641CD6E2C790DF84935266F8 /* XCScheme+TestableReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF50A0E7BC5DCF4611C69D6 /* XCScheme+TestableReference.swift */; };
 		671A2237395F0A7AA5A6D5DA /* XCWorkspaceDataFileRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A0A84B16193585CD723EFBC /* XCWorkspaceDataFileRef.swift */; };
 		67C516394B7BF02746AD1933 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AB249572AD749EC16023E0 /* KeyPath.swift */; };
-		6854A6EF7F84A3A58C05B233 /* libXcodeProj.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DF300DFD2ABE57974BBBD7B /* libXcodeProj.a */; };
 		688C039393D003303E732F1B /* PBXGroup+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F19B18C578050514056544B /* PBXGroup+Extensions.swift */; };
 		68D172FB54455F7294662681 /* PBXGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC2015181B52A66256504AC /* PBXGroup.swift */; };
 		6CC400234565BC63759EB808 /* Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1CD2C449C06886A85C2382D /* Swift.swift */; };
@@ -84,7 +81,6 @@
 		7B874452171376641D966778 /* BuildSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B2BB12D425AA6DDFAAB90A1 /* BuildSetting.swift */; };
 		7CA8F38982536461963EA41B /* Xcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2821692A12A474E684B3E17B /* Xcode.swift */; };
 		81DDE6EC119F764FC49F1064 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5771B05C549E4B70A2C6B13F /* Errors.swift */; };
-		81F7DE2BA27BF16ADA4FC797 /* libXcodeProj.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0DF300DFD2ABE57974BBBD7B /* libXcodeProj.a */; };
 		854F1A6CEFB8E40EC96EE54E /* XCVersionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252DAFBF7CE99D4334FB8E8B /* XCVersionGroup.swift */; };
 		85754535EADB243478E25952 /* Dictionary+Enumerate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88C80C3562B5FC34F2C57EB4 /* Dictionary+Enumerate.swift */; };
 		85BB7250872200809B586B75 /* PopulateMainGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CB50E54B2BC9AE1AEE95513 /* PopulateMainGroupTests.swift */; };
@@ -94,7 +90,6 @@
 		8886729BBF2FA10293508D5B /* CoreMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E008F1EF5278A359CB3B73D /* CoreMotion.swift */; };
 		8904E2EAD1B70FDB029E59E6 /* UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715A6551C9994C6A35C2760E /* UIKit.swift */; };
 		8B39FE78C2EA5ADC3981AF33 /* XCConfigurationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DAAA46998797DEB40A14B26 /* XCConfigurationList.swift */; };
-		8B70E54C4D5BCC7F6590999C /* libAEXML.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D464DF302AC7DA6ADB66AF96 /* libAEXML.a */; };
 		8D9453AC423021CDE9D46A4C /* FilePathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4D6473D8C74DBCA95AF20DC /* FilePathResolver.swift */; };
 		8E685C215E585E827B84C180 /* NSRecursiveLock+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6793B6A7A5F33386C90F249D /* NSRecursiveLock+Sync.swift */; };
 		8EC6BC566C71841AEE507069 /* Array+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 193B8E4B236803D4BAEAC25E /* Array+Extras.swift */; };
@@ -121,7 +116,6 @@
 		ADB291293247580B6E5E1567 /* PBXAggregateTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F6783A87179EACC6ABF2D4 /* PBXAggregateTarget.swift */; };
 		AE69E469E35BA251FC106314 /* AnyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B237E06AFE633F40D24E0362 /* AnyType.swift */; };
 		AF1CE8BA7000C9AE1C9BEB66 /* Generator+CreateFilesAndGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA17A2F6CD794DB282973D5 /* Generator+CreateFilesAndGroups.swift */; };
-		AF29D8E43432211E9CABE98B /* libgenerator.library.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F527636CB48F7FEEE90DCEC /* libgenerator.library.a */; };
 		AFA7E00295368DAB559EBF31 /* Mirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A4898CD7992C114512F228 /* Mirror.swift */; };
 		B13EBC81839A9E111389665A /* PBXBuildRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77F38E63C88E252D34E1DE0 /* PBXBuildRule.swift */; };
 		B4DBF50081379246961365D6 /* GeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EB7777A1B1F6EBE1AAD2FF /* GeneratorTests.swift */; };
@@ -137,11 +131,9 @@
 		C17095E65032B8C2B7092B6E /* Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 569717D0F366C84B3A795094 /* Foundation.swift */; };
 		C18783A43A3263DAAAAAAD97 /* XCScheme+ProfileAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07221DD8305CDB3FF92DF228 /* XCScheme+ProfileAction.swift */; };
 		C28A39750E6C584777154815 /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD4647C5EE25A1C4D49C081 /* PBXObject.swift */; };
-		C28BD99E17E4777DCD9DFF7D /* libCustomDump.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2AB04520A58A83E77B3FDC73 /* libCustomDump.a */; };
 		C63C41EC8BE35CC3E26754D2 /* SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C36F61FCD89D5A5D6176600 /* SwiftUI.swift */; };
 		C811857CC6BF0D2613DE48C2 /* SearchPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DB2DF8B6A725C450EDD5D2 /* SearchPaths.swift */; };
 		C96BF1373FE5858C9209BAA6 /* ProcessTargetMergesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCE47306A55A2A1C54FF98E /* ProcessTargetMergesTests.swift */; };
-		CA573C72A60DA41ED4161734 /* libgenerator.library.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F527636CB48F7FEEE90DCEC /* libgenerator.library.a */; };
 		CA6E9CECD3889BBED0C7E051 /* XCWorkspaceDataElementLocationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A25E54D36493C786205DA016 /* XCWorkspaceDataElementLocationType.swift */; };
 		CAC66F28ECA08E3FA7C3DD74 /* Equality.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEA43FB27D085DA2EE9E1762 /* Equality.generated.swift */; };
 		CB58BA67F08431E41B519805 /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53F0ACC1F1AE109CD537D6C5 /* Diff.swift */; };
@@ -157,9 +149,7 @@
 		D6EC346A350563E739FFF5E9 /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 428B880684D65F0C07D376C8 /* KeyedDecodingContainer+Additions.swift */; };
 		D715429E9053714E0BB406B4 /* XCSchemeManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82CA9E60FB0EF57358DBBBF3 /* XCSchemeManagement.swift */; };
 		D7FA4DB98CAD61326ECF8F63 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85C339FAB91CEA53509EC58 /* Errors.swift */; };
-		D837CB2C507A2379460B2A9A /* libPathKit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FFD18AFDE2FDB1AB48221310 /* libPathKit.a */; };
 		D839538176E185C26C10B807 /* XCWorkspaceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3155091282EEA7B8F16C3917 /* XCWorkspaceData.swift */; };
-		D97A77D70BDE31EF949AE05A /* libXCTestDynamicOverlay.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C8D92EC4C1A8794F66DD8F2E /* libXCTestDynamicOverlay.a */; };
 		DA2AB5A36E15C84F93074ED4 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01581D5FAC25D3B188C540EF /* Error.swift */; };
 		DA9B5B0D07A3482A95190B57 /* UserNotificationsUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ECE6BA82C7C773F34572C72 /* UserNotificationsUI.swift */; };
 		DAAAC67646EBF5992BCAF80F /* XCScheme+SerialAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C078D79F0BE96267C7C39A0 /* XCScheme+SerialAction.swift */; };
@@ -428,75 +418,6 @@
 		FD5C4F0AE5C705B836C79DC0 /* AddTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTargetsTests.swift; sourceTree = "<group>"; };
 		FFD18AFDE2FDB1AB48221310 /* libPathKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPathKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		034CA7EDDEB63E58F799C5E6 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		4704231DDDFD4FCDE29921E3 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		47C0878BABCE1D6DDAD0547E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				07EF43AFD882CF6B7BF46BBE /* libAEXML.a in Frameworks */,
-				AF29D8E43432211E9CABE98B /* libgenerator.library.a in Frameworks */,
-				D837CB2C507A2379460B2A9A /* libPathKit.a in Frameworks */,
-				6854A6EF7F84A3A58C05B233 /* libXcodeProj.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		50F79DF779B218CA61F5E5A1 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DB932BF24CEA8360DEFB0366 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DEE32769A88141F42CF00588 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8B70E54C4D5BCC7F6590999C /* libAEXML.a in Frameworks */,
-				C28BD99E17E4777DCD9DFF7D /* libCustomDump.a in Frameworks */,
-				CA573C72A60DA41ED4161734 /* libgenerator.library.a in Frameworks */,
-				5C53CCD4CA7BD1A8C6547433 /* libPathKit.a in Frameworks */,
-				81F7DE2BA27BF16ADA4FC797 /* libXcodeProj.a in Frameworks */,
-				D97A77D70BDE31EF949AE05A /* libXCTestDynamicOverlay.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E2793CCBFC74D34DC5460A48 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F92FC80E86077D5A7051A084 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		0113D668D0A49A9E0AB2DF26 /* com_github_pointfreeco_xctest_dynamic_overlay */ = {
@@ -1005,7 +926,6 @@
 			buildConfigurationList = 185FBC5736E64A62D5598127 /* Build configuration list for PBXNativeTarget "generator (Library)" */;
 			buildPhases = (
 				189D8D584DE284FA4073BDE3 /* Sources */,
-				50F79DF779B218CA61F5E5A1 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1023,7 +943,6 @@
 			buildConfigurationList = D476C4D948A227EBF2C76C06 /* Build configuration list for PBXNativeTarget "tests" */;
 			buildPhases = (
 				B293689E78BF7308DB71EB2A /* Sources */,
-				DEE32769A88141F42CF00588 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1041,7 +960,6 @@
 			buildConfigurationList = 79F7F3948000F86BF6B804F0 /* Build configuration list for PBXNativeTarget "PathKit" */;
 			buildPhases = (
 				E2BC9831505AC88953D2574C /* Sources */,
-				DB932BF24CEA8360DEFB0366 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1057,7 +975,6 @@
 			buildConfigurationList = D8C76F324E0FA6BD1EB13141 /* Build configuration list for PBXNativeTarget "XcodeProj" */;
 			buildPhases = (
 				4B7C1463BD4F82DC81AD5C82 /* Sources */,
-				F92FC80E86077D5A7051A084 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1075,7 +992,6 @@
 			buildConfigurationList = B100FB87363545D43B8546E1 /* Build configuration list for PBXNativeTarget "XCTestDynamicOverlay" */;
 			buildPhases = (
 				E6FE668763F2DA5B8F31D61D /* Sources */,
-				4704231DDDFD4FCDE29921E3 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1091,7 +1007,6 @@
 			buildConfigurationList = E2C9244F4B23C151979438D7 /* Build configuration list for PBXNativeTarget "AEXML" */;
 			buildPhases = (
 				A305758A4628C287A939B7A0 /* Sources */,
-				E2793CCBFC74D34DC5460A48 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1107,7 +1022,6 @@
 			buildConfigurationList = 5574CA3400B33FA835382DD1 /* Build configuration list for PBXNativeTarget "CustomDump" */;
 			buildPhases = (
 				AD5F778016439604993CDE96 /* Sources */,
-				034CA7EDDEB63E58F799C5E6 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1124,7 +1038,6 @@
 			buildConfigurationList = 077BE3104EAF58F80BE1B791 /* Build configuration list for PBXNativeTarget "generator (Command Line Tool)" */;
 			buildPhases = (
 				B6D20F4ABAF4CEF2ECCD90CD /* Sources */,
-				47C0878BABCE1D6DDAD0547E /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1533,9 +1446,10 @@
 				PRODUCT_NAME = XcodeProj;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "XcodeProj-416999a07b9b4fe2861628b0f3f1bf140d7e5133";
+				TARGET_NAME = XcodeProj;
 			};
 			name = Debug;
 		};
@@ -1586,9 +1500,10 @@
 				PRODUCT_NAME = generator.library;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "generator-7d9beb1b903e13e1639291847391b32c940c093e";
+				TARGET_NAME = generator;
 			};
 			name = Debug;
 		};
@@ -1641,7 +1556,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "XCTestDynamicOverlay-214d53e7f358f83bf527722911295164c1e480fd";
+				TARGET_NAME = XCTestDynamicOverlay;
 			};
 			name = Debug;
 		};
@@ -1690,14 +1605,19 @@
 					"-D__TIMESTAMP__=\"redacted\"",
 					"-D__TIME__=\"redacted\"",
 				);
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-filelist",
+					"test/fixtures/generator/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/tools/generator/tests.LinkFileList,$(BUILD_DIR)",
+					"-ObjC",
+				);
 				PRODUCT_MODULE_NAME = tests;
 				PRODUCT_NAME = tests;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_swift_custom_dump";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "tests-7925293a80c428e52ee6f0506d5d7f0c2f0bd702";
+				TARGET_NAME = tests;
 			};
 			name = Debug;
 		};
@@ -1741,13 +1661,17 @@
 					"-D__TIMESTAMP__=\"redacted\"",
 					"-D__TIME__=\"redacted\"",
 				);
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-filelist",
+					"test/fixtures/generator/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/tools/generator/generator.LinkFileList,$(BUILD_DIR)",
+					"-ObjC",
+				);
 				PRODUCT_MODULE_NAME = _generator_;
 				PRODUCT_NAME = generator;
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "generator-b1a6fd8f04fc598922ce0a85f94497ed169f76ed";
+				TARGET_NAME = generator;
 			};
 			name = Debug;
 		};
@@ -1800,7 +1724,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "PathKit-e1d04b0606783eede847bfb8a3cc160e64505837";
+				TARGET_NAME = PathKit;
 			};
 			name = Debug;
 		};
@@ -1810,10 +1734,12 @@
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BAZEL_PATH = bazel;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				MARKETING_VERSION = 1.0;
 				ONLY_ACTIVE_ARCH = YES;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
 				USE_HEADERMAP = NO;
 			};
 			name = Debug;
@@ -1865,9 +1791,10 @@
 				PRODUCT_NAME = CustomDump;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "CustomDump-036b30c6a018e3e4bc53c7ca6ce69a36bfba10c1";
+				TARGET_NAME = CustomDump;
 			};
 			name = Debug;
 		};
@@ -1920,7 +1847,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "AEXML-d0c89f3f738ca79bf01ce77698aeb50c54ca26b3";
+				TARGET_NAME = AEXML;
 			};
 			name = Debug;
 		};

--- a/test/fixtures/generator/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/tools/generator/generator.LinkFileList
+++ b/test/fixtures/generator/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/tools/generator/generator.LinkFileList
@@ -1,0 +1,4 @@
+bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit/libPathKit.a
+bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml/libAEXML.a
+bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator/libgenerator.library.a

--- a/test/fixtures/generator/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/tools/generator/tests.LinkFileList
+++ b/test/fixtures/generator/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/tools/generator/tests.LinkFileList
@@ -1,0 +1,6 @@
+bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit/libPathKit.a
+bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
+bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a
+bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml/libAEXML.a
+bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator/libgenerator.library.a

--- a/test/fixtures/ios_app/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/examples/ios_app/Example/Example.LinkFileList
+++ b/test/fixtures/ios_app/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/examples/ios_app/Example/Example.LinkFileList
@@ -1,0 +1,1 @@
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/Utils/libUtils.a

--- a/test/fixtures/ios_app/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/examples/ios_app/ExampleTests/ExampleTests.LinkFileList
+++ b/test/fixtures/ios_app/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/examples/ios_app/ExampleTests/ExampleTests.LinkFileList
@@ -1,0 +1,1 @@
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/TestingUtils/libTestingUtils.a

--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -22,7 +22,7 @@ struct Environment {
         _ targets: [TargetID: Target],
         _ extraFiles: Set<FilePath>,
         _ filePathResolver: FilePathResolver
-    ) -> (
+    ) throws -> (
         files: [FilePath: File],
         rootElements: [PBXFileElement]
     )

--- a/tools/generator/src/FilePath.swift
+++ b/tools/generator/src/FilePath.swift
@@ -9,7 +9,7 @@ struct FilePath: Hashable, Decodable {
     }
 
     let type: PathType
-    let path: Path
+    var path: Path
 
     fileprivate init(type: PathType, path: Path) {
         self.type = type

--- a/tools/generator/src/FilePathResolver.swift
+++ b/tools/generator/src/FilePathResolver.swift
@@ -22,14 +22,18 @@ struct FilePathResolver: Equatable {
         return workspaceOutputPath + internalDirectoryName
     }
 
-    func resolve(_ filePath: FilePath) -> Path {
+    func resolve(_ filePath: FilePath, useBuildDir: Bool = false) -> Path {
         switch filePath.type {
         case .project:
             return filePath.path
         case .external:
             return externalDirectory + filePath.path
         case .generated:
-            return generatedDirectory + filePath.path
+            if useBuildDir {
+                return "$(BUILD_DIR)/bazel-out" + filePath.path
+            } else {
+                return generatedDirectory + filePath.path
+            }
         case .internal:
             return internalDirectory + filePath.path
         }

--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -43,11 +43,6 @@ Product for target "\(id)" not found
                 inputs: inputs,
                 files: files
             )
-            let frameworksBuildPhase = try createFrameworksPhase(
-                in: pbxProj,
-                links: target.links,
-                products: products.byPath
-            )
 
             // TODO: Framework embeds
 
@@ -58,7 +53,6 @@ Product for target "\(id)" not found
                 buildPhases: [
                     headersPhase,
                     sourcesBuildPhase,
-                    frameworksBuildPhase,
                 ].compactMap { $0 },
                 productName: target.product.name,
                 product: product,
@@ -228,32 +222,6 @@ File "\(sourceFile.filePath)" not found
 
         let buildPhase = PBXSourcesBuildPhase(
             files: try sourceFiles.map(buildFile).sortedLocalizedStandard()
-        )
-        pbxProj.add(object: buildPhase)
-
-        return buildPhase
-    }
-
-    private static func createFrameworksPhase(
-        in pbxProj: PBXProj,
-        links: Set<Path>,
-        products: [Path: PBXFileReference]
-    ) throws -> PBXFrameworksBuildPhase {
-        func buildFile(path: Path) throws -> PBXBuildFile {
-            guard let product = products[path] else {
-                throw PreconditionError(message: """
-Product with path "\(path)" not found
-""")
-            }
-            let pbxBuildFile = PBXBuildFile(file: product)
-            pbxProj.add(object: pbxBuildFile)
-            return pbxBuildFile
-        }
-
-        let buildPhase = PBXFrameworksBuildPhase(
-            files: try links
-                .map(buildFile)
-                .sortedLocalizedStandard()
         )
         pbxProj.add(object: buildPhase)
 

--- a/tools/generator/src/Generator+CreateProject.swift
+++ b/tools/generator/src/Generator+CreateProject.swift
@@ -15,9 +15,17 @@ extension Generator {
         let mainGroup = PBXGroup(sourceTree: .group)
         pbxProj.add(object: mainGroup)
 
+        var buildSettings = project.buildSettings.asDictionary
+        buildSettings["CONFIGURATION_BUILD_DIR"] = """
+$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)
+"""
+        buildSettings["TARGET_TEMP_DIR"] = """
+$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)
+"""
+
         let debugConfiguration = XCBuildConfiguration(
             name: "Debug",
-            buildSettings: project.buildSettings.asDictionary
+            buildSettings: buildSettings
         )
         pbxProj.add(object: debugConfiguration)
         let buildConfigurationList = XCConfigurationList(

--- a/tools/generator/src/Generator+DisambiguateTargets.swift
+++ b/tools/generator/src/Generator+DisambiguateTargets.swift
@@ -5,13 +5,12 @@ import XcodeProj
 /// of Xcode, as well as the target itself.
 ///
 /// Xcode requires that certain properties of targets are unique, such as name,
-/// the `TARGET_NAME` and `PRODUCT_MODULE_NAME` build settings, etc. This class
-/// collects information on all of the targets and calculates unique values for
-/// each one. If the values are user facing (i.e. the target name), then they
-/// are formatted in a readable way.
+/// the `PRODUCT_MODULE_NAME` build setting, etc. This class collects
+/// information on all of the targets and calculates unique values for each one.
+/// If the values are user facing (i.e. the target name), then they are
+/// formatted in a readable way.
 struct DisambiguatedTarget: Equatable {
     let name: String
-    let nameBuildSetting: String
     let target: Target
 }
 
@@ -22,12 +21,8 @@ extension Generator {
     ) -> [TargetID: DisambiguatedTarget] {
         // Gather all information needed to distinguish the targets
         var components: [String: TargetComponents] = [:]
-        var targetHashes = Dictionary<TargetID, String>(
-            minimumCapacity: targets.count
-        )
-        for (id, target) in targets {
+        for target in targets.values {
             components[target.name, default: .init()].add(target: target)
-            targetHashes[id] = id.rawValue.sha1Hash()
         }
 
         // And then distinguish them
@@ -37,7 +32,6 @@ extension Generator {
         for (id, target) in targets {
             uniqueValues[id] = DisambiguatedTarget(
                 name: components[target.name]!.uniqueName(target: target),
-                nameBuildSetting: "\(target.name)-\(targetHashes[id]!)",
                 target: target
             )
         }

--- a/tools/generator/src/Generator+ProcessTargetMerges.swift
+++ b/tools/generator/src/Generator+ProcessTargetMerges.swift
@@ -73,7 +73,8 @@ exist
                 merged.isSwift = merging.isSwift
 
                 // Merge build settings
-                merged.buildSettings["PRODUCT_MODULE_NAME"] = merging.buildSettings["PRODUCT_MODULE_NAME"]
+                merged.buildSettings["PRODUCT_MODULE_NAME"]
+                    = merging.buildSettings["PRODUCT_MODULE_NAME"]
                 merged.buildSettings.merge(merging.buildSettings) { l, _ in l }
 
                 // Update search paths

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -75,7 +75,7 @@ Was unable to merge "\(targets[invalidMerge.source]!.label) \
             workspaceOutputPath: workspaceOutputPath
         )
 
-        let (files, rootElements) = environment.createFilesAndGroups(
+        let (files, rootElements) = try environment.createFilesAndGroups(
             pbxProj,
             targets,
             project.extraFiles,

--- a/tools/generator/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generator/test/CreateFilesAndGroupsTests.swift
@@ -40,10 +40,10 @@ final class CreateFilesAndGroupsTests: XCTestCase {
                 path: "a.swift"
             )),
         ]
-        expectedPBXProj.add(object: expectedFiles["a.swift"]!.reference)
+        expectedPBXProj.add(object: expectedFiles["a.swift"]!.reference!)
 
         let expectedRootElements: [PBXFileElement] = [
-            expectedFiles["a.swift"]!.reference,
+            expectedFiles["a.swift"]!.reference!,
         ]
         expectedMainGroup.addChildren(expectedRootElements)
 
@@ -52,7 +52,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         let (
             createdFiles,
             createdRootElements
-        ) = Generator.createFilesAndGroups(
+        ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             targets: targets,
             extraFiles: extraFiles,
@@ -129,7 +129,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         let (
             createdFiles,
             createdRootElements
-        ) = Generator.createFilesAndGroups(
+        ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             targets: targets,
             extraFiles: extraFiles,

--- a/tools/generator/test/CreateProjectTests.swift
+++ b/tools/generator/test/CreateProjectTests.swift
@@ -19,7 +19,14 @@ final class CreateProjectTests: XCTestCase {
 
         let debugConfiguration = XCBuildConfiguration(
             name: "Debug",
-            buildSettings: project.buildSettings.asDictionary
+            buildSettings: project.buildSettings.asDictionary.merging([
+                "CONFIGURATION_BUILD_DIR": """
+$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)
+""",
+                "TARGET_TEMP_DIR": """
+$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)
+""",
+            ]) { $1 }
         )
         expectedPBXProj.add(object: debugConfiguration)
         let expectedBuildConfigurationList = XCConfigurationList(

--- a/tools/generator/test/DisambiguateTargetsTests.swift
+++ b/tools/generator/test/DisambiguateTargetsTests.swift
@@ -34,11 +34,6 @@ final class DisambiguateTargetsTests: XCTestCase {
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
         )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
-        )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
             targets
@@ -86,11 +81,6 @@ final class DisambiguateTargetsTests: XCTestCase {
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
-        )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
         )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
@@ -140,11 +130,6 @@ final class DisambiguateTargetsTests: XCTestCase {
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
         )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
-        )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
             targets
@@ -192,11 +177,6 @@ final class DisambiguateTargetsTests: XCTestCase {
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
-        )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
         )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
@@ -246,11 +226,6 @@ final class DisambiguateTargetsTests: XCTestCase {
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
         )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
-        )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
             targets
@@ -298,11 +273,6 @@ final class DisambiguateTargetsTests: XCTestCase {
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
-        )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
         )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
@@ -362,11 +332,6 @@ final class DisambiguateTargetsTests: XCTestCase {
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
         )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
-        )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
             targets
@@ -416,11 +381,6 @@ final class DisambiguateTargetsTests: XCTestCase {
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
-        )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
         )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
@@ -483,11 +443,6 @@ final class DisambiguateTargetsTests: XCTestCase {
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
         )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
-        )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
             targets
@@ -548,11 +503,6 @@ final class DisambiguateTargetsTests: XCTestCase {
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
-        )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
         )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -114,7 +114,6 @@ enum Fixtures {
         for (id, target) in targets {
             disambiguatedTargets[id] = DisambiguatedTarget(
                 name: "\(id.rawValue) (Distinguished)",
-                nameBuildSetting: Data(id.rawValue.utf8).base64EncodedString(),
                 target: target
             )
         }
@@ -414,6 +413,37 @@ enum Fixtures {
             files[filePath] = File(reference: reference, content: content)
         }
 
+        // LinkFileLists
+
+        files[.internal("targets/a1b2c/A 2/A.LinkFileList")] = File(
+            reference: nil,
+            content: """
+a/c.a
+z/A.a
+
+""")
+
+        files[.internal("targets/a1b2c/B 2/B.LinkFileList")] = File(
+            reference: nil,
+            content: """
+a/b.framework
+
+""")
+
+        files[.internal("targets/a1b2c/B 3/B3.LinkFileList")] = File(
+            reference: nil,
+            content: """
+a/b.framework
+
+""")
+
+        files[.internal("targets/a1b2c/C 2/d.LinkFileList")] = File(
+            reference: nil,
+            content: """
+a/c.a
+
+""")
+
         return (files, elements)
     }
 
@@ -566,19 +596,12 @@ enum Fixtures {
                         PBXBuildFile(file: elements["x/y.swift"]!),
                     ])
                 ),
-                PBXFrameworksBuildPhase(),
             ],
             "A 2": [
                 PBXSourcesBuildPhase(
                     files: buildFiles([PBXBuildFile(
                         file: elements[.internal("CompileStub.swift")]!
                     )])
-                ),
-                PBXFrameworksBuildPhase(
-                    files: buildFiles([
-                        PBXBuildFile(file: products.byTarget["A 1"]!),
-                        PBXBuildFile(file: products.byTarget["C 1"]!),
-                    ])
                 ),
             ],
             "B 1": [
@@ -597,18 +620,12 @@ enum Fixtures {
                         PBXBuildFile(file: elements["z.mm"]!),
                     ])
                 ),
-                PBXFrameworksBuildPhase(),
             ],
             "B 2": [
                 PBXSourcesBuildPhase(
                     files: buildFiles([PBXBuildFile(
                         file: elements[.internal("CompileStub.swift")]!
                     )])
-                ),
-                PBXFrameworksBuildPhase(
-                    files: buildFiles([
-                        PBXBuildFile(file: products.byTarget["B 1"]!),
-                    ])
                 ),
             ],
             "B 3": [
@@ -617,11 +634,6 @@ enum Fixtures {
                         file: elements[.internal("CompileStub.swift")]!
                     )])
                 ),
-                PBXFrameworksBuildPhase(
-                    files: buildFiles([
-                        PBXBuildFile(file: products.byTarget["B 1"]!),
-                    ])
-                ),
             ],
             "C 1": [
                 PBXSourcesBuildPhase(
@@ -629,17 +641,11 @@ enum Fixtures {
                         PBXBuildFile(file: elements["a/b/c.m"]!),
                     ])
                 ),
-                PBXFrameworksBuildPhase(),
             ],
             "C 2": [
                 PBXSourcesBuildPhase(
                     files: buildFiles([
                         PBXBuildFile(file: elements["a/b/d.m"]!),
-                    ])
-                ),
-                PBXFrameworksBuildPhase(
-                    files: buildFiles([
-                        PBXBuildFile(file: products.byTarget["C 1"]!),
                     ])
                 ),
             ],
@@ -649,7 +655,6 @@ enum Fixtures {
                         file: elements[.external("a_repo/a.swift")]!),
                     ])
                 ),
-                PBXFrameworksBuildPhase(),
             ],
             "E2": [
                 PBXSourcesBuildPhase(
@@ -657,7 +662,6 @@ enum Fixtures {
                         file: elements[.external("another_repo/b.swift")]!
                     )])
                 ),
-                PBXFrameworksBuildPhase(),
             ],
         ]
         buildPhases.values.forEach { buildPhases in
@@ -747,7 +751,7 @@ enum Fixtures {
         let shellScript = PBXShellScriptBuildPhase(
             outputFileListPaths: [
                 files[.internal("generated.xcfilelist")]!
-                    .reference
+                    .reference!
                     .projectRelativePath(in: pbxProj)
                     .string,
             ],
@@ -815,7 +819,7 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
         in pbxProj: PBXProj,
         targets: [TargetID: Target]
     ) -> [TargetID: PBXNativeTarget] {
-        let (pbxTargets, distinguished) = Fixtures.pbxTargets(
+        let (pbxTargets, _) = Fixtures.pbxTargets(
             in: pbxProj,
             targets: targets
         )
@@ -850,28 +854,51 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
         let buildSettings: [TargetID: [String: Any]] = [
             "A 1": targets["A 1"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/A 1",
-                "TARGET_NAME": distinguished["A 1"]!.nameBuildSetting,
+                "TARGET_NAME": targets["A 1"]!.name,
             ]) { $1 },
             "A 2": targets["A 2"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/A 2",
-                "TARGET_NAME": distinguished["A 2"]!.nameBuildSetting,
+                "OTHER_LDFLAGS": [
+                    "-filelist",
+                    #"""
+"out/p.xcodeproj/rules_xcp/targets/a1b2c/A 2/A.LinkFileList,$(BUILD_DIR)"
+"""#,
+                ],
+                "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/x",
+                "TARGET_NAME": targets["A 2"]!.name,
             ]) { $1 },
             "B 1": targets["B 1"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/B 1",
                 "OTHER_SWIFT_FLAGS": """
 -Xcc -fmodule-map-file=a/module.modulemap
 """,
-                "TARGET_NAME": distinguished["B 1"]!.nameBuildSetting,
+                "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/x",
+                "TARGET_NAME": targets["B 1"]!.name,
             ]) { $1 },
             "B 2": targets["B 2"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/B 2",
                 "BUNDLE_LOADER": "$(TEST_HOST)",
-                "TARGET_NAME": distinguished["B 2"]!.nameBuildSetting,
-                "TEST_HOST": "$(BUILT_PRODUCTS_DIR)/A.app/A",
+                "OTHER_LDFLAGS": [
+                    "-filelist",
+                    #"""
+"out/p.xcodeproj/rules_xcp/targets/a1b2c/B 2/B.LinkFileList,$(BUILD_DIR)"
+"""#,
+                ],
+                "TARGET_BUILD_DIR": """
+$(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
+""",
+                "TARGET_NAME": targets["B 2"]!.name,
+                "TEST_HOST": "$(BUILD_DIR)/bazel-out/a1b2c/bin/A 2/A.app/A",
             ]) { $1 },
             "B 3": targets["B 3"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/B 3",
-                "TARGET_NAME": distinguished["B 3"]!.nameBuildSetting,
+                "OTHER_LDFLAGS": [
+                    "-filelist",
+                    #"""
+"out/p.xcodeproj/rules_xcp/targets/a1b2c/B 3/B3.LinkFileList,$(BUILD_DIR)"
+"""#,
+                ],
+                "TARGET_NAME": targets["B 3"]!.name,
                 "TEST_TARGET_NAME": pbxTargets["A 2"]!.name,
             ]) { $1 },
             "C 1": targets["C 1"]!.buildSettings.asDictionary.merging([
@@ -879,19 +906,25 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
                 "OTHER_SWIFT_FLAGS": """
 -Xcc -fmodule-map-file=bazel-out/a/b/module.modulemap
 """,
-                "TARGET_NAME": distinguished["C 1"]!.nameBuildSetting,
+                "TARGET_NAME": targets["C 1"]!.name,
             ]) { $1 },
             "C 2": targets["C 2"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/C 2",
-                "TARGET_NAME": distinguished["C 2"]!.nameBuildSetting,
+                "OTHER_LDFLAGS": [
+                    "-filelist",
+                    #"""
+"out/p.xcodeproj/rules_xcp/targets/a1b2c/C 2/d.LinkFileList,$(BUILD_DIR)"
+"""#,
+                ],
+                "TARGET_NAME": targets["C 2"]!.name,
             ]) { $1 },
             "E1": targets["E1"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/E1",
-                "TARGET_NAME": distinguished["E1"]!.nameBuildSetting,
+                "TARGET_NAME": targets["E1"]!.name,
             ]) { $1 },
             "E2": targets["E2"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/E2",
-                "TARGET_NAME": distinguished["E2"]!.nameBuildSetting,
+                "TARGET_NAME": targets["E2"]!.name,
             ]) { $1 },
         ]
         for (id, buildSettings) in buildSettings {

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -51,7 +51,6 @@ final class GeneratorTests: XCTestCase {
         let disambiguatedTargets: [TargetID: DisambiguatedTarget] = [
             "A": .init(
                 name: "A (3456a)",
-                nameBuildSetting: "A-1234567",
                 target: mergedTargets["Y"]!
             ),
         ]


### PR DESCRIPTION
Before this change there was potential for output file clashes. This happened because Bazel has nice isolation in its output directory, while Xcode's default one is very flat. Instead of trying to rename things to work with Xcode's default layout we are now matching most of Bazel's layout.

This requires setting more search paths as not everything is sitting in the same place anymore.

Part of #131.