### PR TITLE
Remove `TARGET_NAME` override

### DIFF
--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -592,7 +592,6 @@
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "Utils-d7f562296058d6bcaf5a8f4478cf2ac93158e78a";
 				USER_HEADER_SEARCH_PATHS = (
 					.,
 					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
@@ -662,7 +661,6 @@
 				SWIFT_VERSION = 5;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example$(TARGET_BUILD_SUBPATH)";
-				TARGET_NAME = "ExampleTests-0221d31b52d43b9426596c9d57cb0a48033ce219";
 				TEST_HOST = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example.app/Example";
 			};
 			name = Debug;
@@ -717,7 +715,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG AWESOME";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "TestingUtils-5fa8a9d132eeb601bbc2933480902158980be025";
 			};
 			name = Debug;
 		};
@@ -803,7 +800,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGETED_DEVICE_FAMILY = 1;
-				TARGET_NAME = "Example-f9d780ed383b7ba19bdadca75c6b25682da08404";
 			};
 			name = Debug;
 		};
@@ -861,7 +857,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TARGET_NAME = "ExampleUITests-9c70b1eca4a64387df76c21431d5d43a517851c4";
 				TEST_TARGET_NAME = Example;
 			};
 			name = Debug;

--- a/test/fixtures/cc/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/project.xcodeproj/project.pbxproj
@@ -263,7 +263,6 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "tool-e265fbf6cf7acefb2b0f95d81c0221bc0b8bb8b0";
 				USER_HEADER_SEARCH_PATHS = (
 					.,
 					"bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
@@ -319,7 +318,6 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "examples_cc_lib_lib_impl-e169840ba582bfd664739950ded9b9f97b9a553c";
 				USER_HEADER_SEARCH_PATHS = (
 					.,
 					"bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",

--- a/test/fixtures/command_line/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/project.xcodeproj/project.pbxproj
@@ -281,7 +281,6 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "tool-c7c8a36df44880d9e6bd4e55e7f9f1fd63574b0f";
 				USER_HEADER_SEARCH_PATHS = (
 					.,
 					"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
@@ -340,7 +339,6 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "examples_command_line_lib_lib_impl-0a7ad6656ea029418c02cd14238eaa9476731050";
 				USER_HEADER_SEARCH_PATHS = (
 					.,
 					"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",

--- a/test/fixtures/generator/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/project.xcodeproj/project.pbxproj
@@ -1449,7 +1449,6 @@
 				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "XcodeProj-416999a07b9b4fe2861628b0f3f1bf140d7e5133";
 			};
 			name = Debug;
 		};
@@ -1503,7 +1502,6 @@
 				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "generator-7d9beb1b903e13e1639291847391b32c940c093e";
 			};
 			name = Debug;
 		};
@@ -1556,7 +1554,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "XCTestDynamicOverlay-214d53e7f358f83bf527722911295164c1e480fd";
 			};
 			name = Debug;
 		};
@@ -1617,7 +1614,6 @@
 				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_swift_custom_dump";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "tests-7925293a80c428e52ee6f0506d5d7f0c2f0bd702";
 			};
 			name = Debug;
 		};
@@ -1671,7 +1667,6 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "generator-b1a6fd8f04fc598922ce0a85f94497ed169f76ed";
 			};
 			name = Debug;
 		};
@@ -1724,7 +1719,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "PathKit-e1d04b0606783eede847bfb8a3cc160e64505837";
 			};
 			name = Debug;
 		};
@@ -1795,7 +1789,6 @@
 				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "CustomDump-036b30c6a018e3e4bc53c7ca6ce69a36bfba10c1";
 			};
 			name = Debug;
 		};
@@ -1848,7 +1841,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
-				TARGET_NAME = "AEXML-d0c89f3f738ca79bf01ce77698aeb50c54ca26b3";
 			};
 			name = Debug;
 		};

--- a/tools/generator/src/Generator+DisambiguateTargets.swift
+++ b/tools/generator/src/Generator+DisambiguateTargets.swift
@@ -5,13 +5,12 @@ import XcodeProj
 /// of Xcode, as well as the target itself.
 ///
 /// Xcode requires that certain properties of targets are unique, such as name,
-/// the `TARGET_NAME` and `PRODUCT_MODULE_NAME` build settings, etc. This class
-/// collects information on all of the targets and calculates unique values for
-/// each one. If the values are user facing (i.e. the target name), then they
-/// are formatted in a readable way.
+/// the `PRODUCT_MODULE_NAME` build setting, etc. This class collects
+/// information on all of the targets and calculates unique values for each one.
+/// If the values are user facing (i.e. the target name), then they are
+/// formatted in a readable way.
 struct DisambiguatedTarget: Equatable {
     let name: String
-    let nameBuildSetting: String
     let target: Target
 }
 
@@ -22,12 +21,8 @@ extension Generator {
     ) -> [TargetID: DisambiguatedTarget] {
         // Gather all information needed to distinguish the targets
         var components: [String: TargetComponents] = [:]
-        var targetHashes = Dictionary<TargetID, String>(
-            minimumCapacity: targets.count
-        )
-        for (id, target) in targets {
+        for target in targets.values {
             components[target.name, default: .init()].add(target: target)
-            targetHashes[id] = id.rawValue.sha1Hash()
         }
 
         // And then distinguish them
@@ -37,7 +32,6 @@ extension Generator {
         for (id, target) in targets {
             uniqueValues[id] = DisambiguatedTarget(
                 name: components[target.name]!.uniqueName(target: target),
-                nameBuildSetting: "\(target.name)-\(targetHashes[id]!)",
                 target: target
             )
         }

--- a/tools/generator/src/Generator+ProcessTargetMerges.swift
+++ b/tools/generator/src/Generator+ProcessTargetMerges.swift
@@ -73,7 +73,8 @@ exist
                 merged.isSwift = merging.isSwift
 
                 // Merge build settings
-                merged.buildSettings["PRODUCT_MODULE_NAME"] = merging.buildSettings["PRODUCT_MODULE_NAME"]
+                merged.buildSettings["PRODUCT_MODULE_NAME"]
+                    = merging.buildSettings["PRODUCT_MODULE_NAME"]
                 merged.buildSettings.merge(merging.buildSettings) { l, _ in l }
 
                 // Update search paths

--- a/tools/generator/src/Generator+SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator+SetTargetConfigurations.swift
@@ -74,8 +74,6 @@ Target "\(id)" not found in `pbxTargets`.
             
             buildSettings["BAZEL_PACKAGE_BIN_DIR"] = target.packageBinDir.string
 
-            buildSettings["TARGET_NAME"] = disambiguatedTarget.nameBuildSetting
-
             let swiftmodules = target.swiftmodules
             if !swiftmodules.isEmpty {
                 buildSettings["SWIFT_INCLUDE_PATHS"] = swiftmodules

--- a/tools/generator/test/DisambiguateTargetsTests.swift
+++ b/tools/generator/test/DisambiguateTargetsTests.swift
@@ -34,11 +34,6 @@ final class DisambiguateTargetsTests: XCTestCase {
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
         )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
-        )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
             targets
@@ -86,11 +81,6 @@ final class DisambiguateTargetsTests: XCTestCase {
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
-        )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
         )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
@@ -140,11 +130,6 @@ final class DisambiguateTargetsTests: XCTestCase {
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
         )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
-        )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
             targets
@@ -192,11 +177,6 @@ final class DisambiguateTargetsTests: XCTestCase {
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
-        )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
         )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
@@ -246,11 +226,6 @@ final class DisambiguateTargetsTests: XCTestCase {
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
         )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
-        )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
             targets
@@ -298,11 +273,6 @@ final class DisambiguateTargetsTests: XCTestCase {
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
-        )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
         )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
@@ -362,11 +332,6 @@ final class DisambiguateTargetsTests: XCTestCase {
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
         )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
-        )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
             targets
@@ -416,11 +381,6 @@ final class DisambiguateTargetsTests: XCTestCase {
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
-        )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
         )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
@@ -483,11 +443,6 @@ final class DisambiguateTargetsTests: XCTestCase {
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
         )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
-        )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),
             targets
@@ -548,11 +503,6 @@ final class DisambiguateTargetsTests: XCTestCase {
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.name),
             expectedTargetNames
-        )
-        XCTAssertEqual(
-            Set(disambiguatedTargets.values.map(\.nameBuildSetting)).count,
-            disambiguatedTargets.values.count,
-            "`nameBuildSetting`s are not unique"
         )
         XCTAssertNoDifference(
             disambiguatedTargets.mapValues(\.target),

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -112,7 +112,6 @@ enum Fixtures {
         for (id, target) in targets {
             disambiguatedTargets[id] = DisambiguatedTarget(
                 name: "\(id.rawValue) (Distinguished)",
-                nameBuildSetting: Data(id.rawValue.utf8).base64EncodedString(),
                 target: target
             )
         }
@@ -818,7 +817,7 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
         in pbxProj: PBXProj,
         targets: [TargetID: Target]
     ) -> [TargetID: PBXNativeTarget] {
-        let (pbxTargets, distinguished) = Fixtures.pbxTargets(
+        let (pbxTargets, _) = Fixtures.pbxTargets(
             in: pbxProj,
             targets: targets
         )
@@ -853,7 +852,6 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
         let buildSettings: [TargetID: [String: Any]] = [
             "A 1": targets["A 1"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/A 1",
-                "TARGET_NAME": distinguished["A 1"]!.nameBuildSetting,
             ]) { $1 },
             "A 2": targets["A 2"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/A 2",
@@ -864,7 +862,6 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
 """#,
                 ],
                 "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/x",
-                "TARGET_NAME": distinguished["A 2"]!.nameBuildSetting,
             ]) { $1 },
             "B 1": targets["B 1"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/B 1",
@@ -872,7 +869,6 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
 -Xcc -fmodule-map-file=a/module.modulemap
 """,
                 "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/x",
-                "TARGET_NAME": distinguished["B 1"]!.nameBuildSetting,
             ]) { $1 },
             "B 2": targets["B 2"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/B 2",
@@ -886,7 +882,6 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
                 "TARGET_BUILD_DIR": """
 $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
 """,
-                "TARGET_NAME": distinguished["B 2"]!.nameBuildSetting,
                 "TEST_HOST": "$(BUILD_DIR)/bazel-out/a1b2c/bin/A 2/A.app/A",
             ]) { $1 },
             "B 3": targets["B 3"]!.buildSettings.asDictionary.merging([
@@ -897,7 +892,6 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
 "out/p.xcodeproj/rules_xcp/targets/a1b2c/B 3/B3.LinkFileList,$(BUILD_DIR)"
 """#,
                 ],
-                "TARGET_NAME": distinguished["B 3"]!.nameBuildSetting,
                 "TEST_TARGET_NAME": pbxTargets["A 2"]!.name,
             ]) { $1 },
             "C 1": targets["C 1"]!.buildSettings.asDictionary.merging([
@@ -905,7 +899,6 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
                 "OTHER_SWIFT_FLAGS": """
 -Xcc -fmodule-map-file=bazel-out/a/b/module.modulemap
 """,
-                "TARGET_NAME": distinguished["C 1"]!.nameBuildSetting,
             ]) { $1 },
             "C 2": targets["C 2"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/C 2",
@@ -915,15 +908,12 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
 "out/p.xcodeproj/rules_xcp/targets/a1b2c/C 2/d.LinkFileList,$(BUILD_DIR)"
 """#,
                 ],
-                "TARGET_NAME": distinguished["C 2"]!.nameBuildSetting,
             ]) { $1 },
             "E1": targets["E1"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/E1",
-                "TARGET_NAME": distinguished["E1"]!.nameBuildSetting,
             ]) { $1 },
             "E2": targets["E2"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/E2",
-                "TARGET_NAME": distinguished["E2"]!.nameBuildSetting,
             ]) { $1 },
         ]
         for (id, buildSettings) in buildSettings {

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -51,7 +51,6 @@ final class GeneratorTests: XCTestCase {
         let disambiguatedTargets: [TargetID: DisambiguatedTarget] = [
             "A": .init(
                 name: "A (3456a)",
-                nameBuildSetting: "A-1234567",
                 target: mergedTargets["Y"]!
             ),
         ]


### PR DESCRIPTION
Now that we fully customize `CONFIGURATION_BUILD_DIR`, we no longer need to worry about what `TARGET_NAME` is.