### PR TITLE
Fix Swift clang module header search paths

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 # To update these lines, execute 
 # `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages`
-build --deleted_packages=examples/ios_app,examples/ios_app/Example,examples/ios_app/ExampleTests,examples/ios_app/ExampleUITests,examples/ios_app/TestingUtils,examples/ios_app/Utils,examples/ios_app/test/fixtures
-query --deleted_packages=examples/ios_app,examples/ios_app/Example,examples/ios_app/ExampleTests,examples/ios_app/ExampleUITests,examples/ios_app/TestingUtils,examples/ios_app/Utils,examples/ios_app/test/fixtures
+build --deleted_packages=examples/ios_app,examples/ios_app/CoreUtilsObjC,examples/ios_app/Example,examples/ios_app/ExampleTests,examples/ios_app/ExampleUITests,examples/ios_app/TestingUtils,examples/ios_app/Utils,examples/ios_app/test/fixtures
+query --deleted_packages=examples/ios_app,examples/ios_app/CoreUtilsObjC,examples/ios_app/Example,examples/ios_app/ExampleTests,examples/ios_app/ExampleUITests,examples/ios_app/TestingUtils,examples/ios_app/Utils,examples/ios_app/test/fixtures
 
 # Import Shared settings
 import %workspace%/shared.bazelrc

--- a/examples/ios_app/CoreUtilsObjC/Answers.m
+++ b/examples/ios_app/CoreUtilsObjC/Answers.m
@@ -1,0 +1,9 @@
+#import <CoreUtils/Answers.h>
+
+@implementation Answers
+
+- (NSInteger)answer {
+    return 42;
+}
+
+@end

--- a/examples/ios_app/CoreUtilsObjC/BUILD
+++ b/examples/ios_app/CoreUtilsObjC/BUILD
@@ -1,13 +1,12 @@
 objc_library(
-    name = "Utils",
+    name = "CoreUtilsObjC",
     srcs = glob(
         ["**/*.m"],
         # Headers included here on purpose, to test `hdrs` collection logic
         ["**/*.h"],
     ),
     hdrs = glob(["**/*.h"]),
-    enable_modules = True,
-    module_name = "Utils",
+    includes = [""],
+    module_name = "CoreUtils",
     visibility = ["//visibility:public"],
-    deps = ["//CoreUtilsObjC"],
 )

--- a/examples/ios_app/CoreUtilsObjC/CoreUtils/Answers.h
+++ b/examples/ios_app/CoreUtilsObjC/CoreUtils/Answers.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface Answers: NSObject
+
+- (NSInteger)answer;
+
+@end

--- a/examples/ios_app/Utils/Foo.h
+++ b/examples/ios_app/Utils/Foo.h
@@ -1,4 +1,5 @@
 @import Foundation;
+#import <CoreUtils/Answers.h>
 
 @interface Foo: NSObject
 

--- a/examples/ios_app/Utils/Foo.m
+++ b/examples/ios_app/Utils/Foo.m
@@ -7,7 +7,7 @@
 }
 
 - (NSInteger)answer {
-    return 42;
+    return [Answers new].answer;
 }
 
 @end

--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		29796EAB3AFB4F393E120401 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDD5A69CC7A6E820FCB0BDF0 /* ContentView.swift */; };
 		302A692FEFBAE7F1EA170548 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE58C589847257693979C11 /* ExampleTests.swift */; };
 		5A49B1D4C59BE2C861DAB532 /* Foo.m in Sources */ = {isa = PBXBuildFile; fileRef = A728BC96D2EE56D3A20F5D75 /* Foo.m */; };
+		62B8102681367226781BF989 /* Answers.m in Sources */ = {isa = PBXBuildFile; fileRef = AD316B4515635DE6DE64F1C1 /* Answers.m */; };
 		874BE1DD90F654F01D46A1A2 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6A7C1EE8BAE7058EFC5B0C /* ExampleUITests.swift */; };
 		AE2C4E59A2F6A848808F8249 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D699DE3520D61FDC19A909EF /* ExampleApp.swift */; };
 		C46BFDEF6C0E0BB66EAD88CC /* ExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B582794DF84A93AA718FB7A0 /* ExampleUITestsLaunchTests.swift */; };
@@ -66,6 +67,13 @@
 			remoteGlobalIDString = EAB95A4512529D4CB8BE5D4E;
 			remoteInfo = Example;
 		};
+		91DC4BA6F7C3B979FE22DBAD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 97C662B23ADBAB4107ABDAE8;
+			remoteInfo = CoreUtils;
+		};
 		CCFE8F5D4A45AFCAF6805B5E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
@@ -100,8 +108,11 @@
 		3F6A7C1EE8BAE7058EFC5B0C /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
 		4B4FA9C70425835BED3D18FF /* libTestingUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTestingUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		7126B3B29F2941E2615E8B45 /* Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
+		7458A79A895427FF2B5EF451 /* Answers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Answers.h; sourceTree = "<group>"; };
+		772995ACCC05420BD8295F13 /* libCoreUtilsObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCoreUtilsObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		96457EE4FDB089F9B6CA30D8 /* libUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A728BC96D2EE56D3A20F5D75 /* Foo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Foo.m; sourceTree = "<group>"; };
+		AD316B4515635DE6DE64F1C1 /* Answers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Answers.m; sourceTree = "<group>"; };
 		B582794DF84A93AA718FB7A0 /* ExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		BB5454138C3DB7B7F7E1308A /* Answer.swift.stencil */ = {isa = PBXFileReference; path = Answer.swift.stencil; sourceTree = "<group>"; };
 		C2288FA66726CD35CFB04516 /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -163,6 +174,7 @@
 				C5E39D6F9D4DAE2C1137ABB0 /* Example.app */,
 				332DA7D905FE78395F8B49AB /* ExampleTests.xctest */,
 				C2288FA66726CD35CFB04516 /* ExampleUITests.xctest */,
+				772995ACCC05420BD8295F13 /* libCoreUtilsObjC.a */,
 				4B4FA9C70425835BED3D18FF /* libTestingUtils.a */,
 				96457EE4FDB089F9B6CA30D8 /* libUtils.a */,
 			);
@@ -175,6 +187,14 @@
 				0F331B89287AC5CF95CBE242 /* PreviewAssets.xcassets */,
 			);
 			path = PreviewContent;
+			sourceTree = "<group>";
+		};
+		47E17F6EE7635213AF42FFCE /* CoreUtils */ = {
+			isa = PBXGroup;
+			children = (
+				7458A79A895427FF2B5EF451 /* Answers.h */,
+			);
+			path = CoreUtils;
 			sourceTree = "<group>";
 		};
 		52922DC1C268A3FE9B5C3C38 /* Bazel External Repositories */ = {
@@ -206,9 +226,19 @@
 			path = Example;
 			sourceTree = "<group>";
 		};
+		8FFA43D4D9C2A095F2147970 /* CoreUtilsObjC */ = {
+			isa = PBXGroup;
+			children = (
+				47E17F6EE7635213AF42FFCE /* CoreUtils */,
+				AD316B4515635DE6DE64F1C1 /* Answers.m */,
+			);
+			path = CoreUtilsObjC;
+			sourceTree = "<group>";
+		};
 		91B19B3116ADB8C8ECC2934E = {
 			isa = PBXGroup;
 			children = (
+				8FFA43D4D9C2A095F2147970 /* CoreUtilsObjC */,
 				59299A1A4E3C2D59D7A458D9 /* Example */,
 				BAF0E3E8914C1F0BED0421C4 /* ExampleTests */,
 				BE5C020511A0C620C6F4F2A5 /* ExampleUITests */,
@@ -308,6 +338,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				0C1B1ED25163DD5F62493B52 /* PBXTargetDependency */,
 			);
 			name = Utils;
 			productName = Utils;
@@ -347,6 +378,21 @@
 			name = TestingUtils;
 			productName = TestingUtils;
 			productReference = 4B4FA9C70425835BED3D18FF /* libTestingUtils.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		97C662B23ADBAB4107ABDAE8 /* CoreUtils */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 462F18546F8372FF38AE6AEF /* Build configuration list for PBXNativeTarget "CoreUtils" */;
+			buildPhases = (
+				D3E1B1D4EB79EAA47122EA87 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CoreUtils;
+			productName = CoreUtilsObjC;
+			productReference = 772995ACCC05420BD8295F13 /* libCoreUtilsObjC.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		EAB95A4512529D4CB8BE5D4E /* Example */ = {
@@ -397,6 +443,10 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
+					97C662B23ADBAB4107ABDAE8 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
 					EAB95A4512529D4CB8BE5D4E = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -417,6 +467,7 @@
 			projectRoot = "";
 			targets = (
 				3064A34776444DE49627998E /* Bazel Generated Files */,
+				97C662B23ADBAB4107ABDAE8 /* CoreUtils */,
 				EAB95A4512529D4CB8BE5D4E /* Example */,
 				7278503E9BEEE7A8C78E3CB5 /* ExampleTests */,
 				0C5146C273C8B8DA7C1DF1CB /* ExampleUITests */,
@@ -473,6 +524,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D3E1B1D4EB79EAA47122EA87 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				62B8102681367226781BF989 /* Answers.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E8772DBE661F0A21EC2C2998 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -498,6 +557,12 @@
 			name = Example;
 			target = EAB95A4512529D4CB8BE5D4E /* Example */;
 			targetProxy = 82112301926FACC7FF21FB36 /* PBXContainerItemProxy */;
+		};
+		0C1B1ED25163DD5F62493B52 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CoreUtils;
+			target = 97C662B23ADBAB4107ABDAE8 /* CoreUtils */;
+			targetProxy = 91DC4BA6F7C3B979FE22DBAD /* PBXContainerItemProxy */;
 		};
 		1080087DA48C3AE162B8AB58 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -552,6 +617,10 @@
 				CLANG_ENABLE_MODULES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
+				HEADER_SEARCH_PATHS = (
+					CoreUtilsObjC,
+					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
@@ -600,6 +669,65 @@
 			};
 			name = Debug;
 		};
+		4F847ED4259B5C84414372C5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				HEADER_SEARCH_PATHS = (
+					CoreUtilsObjC,
+					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-fstack-protector",
+					"-fcolor-diagnostics",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-DDEBUG",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+					"-D__DATE__=\"redacted\"",
+					"-D__TIMESTAMP__=\"redacted\"",
+					"-D__TIME__=\"redacted\"",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-fstack-protector",
+					"-fcolor-diagnostics",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-DDEBUG",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+					"-D__DATE__=\"redacted\"",
+					"-D__TIMESTAMP__=\"redacted\"",
+					"-D__TIME__=\"redacted\"",
+				);
+				PRODUCT_MODULE_NAME = CoreUtils;
+				PRODUCT_NAME = CoreUtilsObjC;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = CoreUtils;
+				USER_HEADER_SEARCH_PATHS = (
+					.,
+					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+				);
+			};
+			name = Debug;
+		};
 		54410A927B8DA6FB279AEF77 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -611,6 +739,10 @@
 				ENABLE_TESTABILITY = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					CoreUtilsObjC,
+					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
@@ -651,7 +783,7 @@
 					"test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleTests/ExampleTests.LinkFileList,$(BUILD_DIR)",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap";
+				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap -Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.tests;
 				PRODUCT_MODULE_NAME = ExampleTests;
 				PRODUCT_NAME = ExampleTests;
@@ -664,6 +796,10 @@
 				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example$(TARGET_BUILD_SUBPATH)";
 				TARGET_NAME = ExampleTests;
 				TEST_HOST = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example.app/Example";
+				USER_HEADER_SEARCH_PATHS = (
+					.,
+					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+				);
 			};
 			name = Debug;
 		};
@@ -753,6 +889,10 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					CoreUtilsObjC,
+					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
@@ -793,7 +933,7 @@
 					"test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/Example/Example.LinkFileList,$(BUILD_DIR)",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap";
+				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap -Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
 				PRODUCT_MODULE_NAME = Example;
 				PRODUCT_NAME = Example;
@@ -803,6 +943,10 @@
 				SWIFT_VERSION = 5;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = Example;
+				USER_HEADER_SEARCH_PATHS = (
+					.,
+					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+				);
 			};
 			name = Debug;
 		};
@@ -896,6 +1040,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6494BAE58154BF84E3AF60D9 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		462F18546F8372FF38AE6AEF /* Build configuration list for PBXNativeTarget "CoreUtils" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4F847ED4259B5C84414372C5 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,2 +1,3 @@
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap
 bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swift
 bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap

--- a/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/Example/Example.LinkFileList
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/Example/Example.LinkFileList
@@ -1,1 +1,2 @@
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/libCoreUtilsObjC.a
 bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/libUtils.a

--- a/examples/ios_app/test/fixtures/spec.json
+++ b/examples/ios_app/test/fixtures/spec.json
@@ -50,10 +50,105 @@
         ]
     ],
     "required_links": [
+        "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/libCoreUtilsObjC.a",
         "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/libTestingUtils.a",
         "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/libUtils.a"
     ],
     "targets": [
+        "//CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-D_FORTIFY_SOURCE=1",
+                    "-fstack-protector",
+                    "-fcolor-diagnostics",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-DDEBUG",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined",
+                    "-D__DATE__=\"redacted\"",
+                    "-D__TIMESTAMP__=\"redacted\"",
+                    "-D__TIME__=\"redacted\""
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-D_FORTIFY_SOURCE=1",
+                    "-fstack-protector",
+                    "-fcolor-diagnostics",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-DDEBUG",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined",
+                    "-D__DATE__=\"redacted\"",
+                    "-D__TIMESTAMP__=\"redacted\"",
+                    "-D__TIME__=\"redacted\""
+                ],
+                "PRODUCT_MODULE_NAME": "CoreUtils",
+                "PRODUCT_NAME": "CoreUtilsObjC",
+                "SDKROOT": "iphoneos",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
+            "dependencies": [],
+            "inputs": {
+                "hdrs": [
+                    "CoreUtilsObjC/CoreUtils/Answers.h"
+                ],
+                "srcs": [
+                    "CoreUtilsObjC/Answers.m"
+                ]
+            },
+            "is_swift": false,
+            "label": "//CoreUtilsObjC:CoreUtilsObjC",
+            "links": [],
+            "modulemaps": [],
+            "name": "CoreUtils",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "iOS"
+            },
+            "product": {
+                "name": "CoreUtilsObjC",
+                "path": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/libCoreUtilsObjC.a",
+                "type": "com.apple.product-type.library.static"
+            },
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_headers": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        },
         "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
         {
             "build_settings": {
@@ -114,6 +209,7 @@
             "label": "//Example:Example",
             "links": [
                 "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/libUtils.a",
+                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/libCoreUtilsObjC.a",
                 "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/libExample.library.a"
             ],
             "modulemaps": [],
@@ -133,7 +229,22 @@
                 "path": "bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example_archive-root/Payload/Example.app",
                 "type": "com.apple.product-type.application"
             },
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_headers": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null
         },
@@ -201,6 +312,10 @@
             "links": [],
             "modulemaps": [
                 {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
+                    "t": "g"
+                },
+                {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap",
                     "t": "g"
                 }
@@ -226,7 +341,22 @@
                 "path": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/libExample.library.a",
                 "type": "com.apple.product-type.library.static"
             },
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_headers": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null
         },
@@ -310,7 +440,22 @@
                 "path": "bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle_archive-root/ExampleTests.xctest",
                 "type": "com.apple.product-type.bundle.unit-test"
             },
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_headers": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
         },
@@ -380,6 +525,10 @@
             "links": [],
             "modulemaps": [
                 {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
+                    "t": "g"
+                },
+                {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap",
                     "t": "g"
                 }
@@ -405,7 +554,22 @@
                 "path": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/libExampleTests.library.a",
                 "type": "com.apple.product-type.library.static"
             },
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_headers": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example.swiftmodule",
@@ -497,7 +661,22 @@
                 "path": "bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle_archive-root/ExampleUITests.xctest",
                 "type": "com.apple.product-type.bundle.ui-testing"
             },
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_headers": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
         },
@@ -726,7 +905,9 @@
                 "SWIFT_VERSION": "5"
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
-            "dependencies": [],
+            "dependencies": [
+                "//CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
+            ],
             "inputs": {
                 "hdrs": [
                     "Utils/Foo.h",
@@ -755,7 +936,13 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {
-                "includes": [],
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
                 "quote_headers": [
                     ".",
                     {

--- a/test/fixtures/cc/spec.json
+++ b/test/fixtures/cc/spec.json
@@ -92,7 +92,6 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {
-                "includes": [],
                 "quote_headers": [
                     ".",
                     {
@@ -180,7 +179,6 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {
-                "includes": [],
                 "quote_headers": [
                     ".",
                     {
@@ -274,7 +272,6 @@
                 "type": "com.apple.product-type.tool"
             },
             "search_paths": {
-                "includes": [],
                 "quote_headers": [
                     ".",
                     {

--- a/test/fixtures/command_line/spec.json
+++ b/test/fixtures/command_line/spec.json
@@ -101,7 +101,6 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {
-                "includes": [],
                 "quote_headers": [
                     ".",
                     {
@@ -192,7 +191,22 @@
                 "path": "bazel-out/applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/tool/tool",
                 "type": "com.apple.product-type.tool"
             },
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "examples/command_line/lib/dir with space",
+                    {
+                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/dir with space",
+                        "t": "g"
+                    }
+                ],
+                "quote_headers": [
+                    ".",
+                    {
+                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null
         },

--- a/test/fixtures/ios_app/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/examples/ios_app/Example/Example.LinkFileList
+++ b/test/fixtures/ios_app/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/examples/ios_app/Example/Example.LinkFileList
@@ -1,1 +1,2 @@
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/CoreUtilsObjC/libCoreUtilsObjC.a
 bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/examples/ios_app/Utils/libUtils.a


### PR DESCRIPTION
Also updates the example to expose the failure we had.