### PR TITLE
Enable all Buildifier warnings except `cc-native`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -8,20 +8,6 @@ load(
 
 _BUILDIFIER_EXCLUDE_PATTERNS = [
     "./.git/*",
-    # Buildifier wants to add a rules_cc load statement for objc_library.
-    # We do not want to add a dependency on this ruleset, at this time.
-    "examples/ios_app/Utils/BUILD",
-]
-
-_BUILDIFIER_WARNINGS = [
-    # GH176: Enable all Buildifier warnings.
-    # "all",
-]
-
-# Buildifier
-
-_BUILDIFIER_EXCLUDE_PATTERNS = [
-    "./.git/*",
 ]
 
 _BUILDIFIER_WARNINGS = [

--- a/BUILD
+++ b/BUILD
@@ -22,13 +22,11 @@ _BUILDIFIER_WARNINGS = [
 
 _BUILDIFIER_EXCLUDE_PATTERNS = [
     "./.git/*",
-    # Buildifier wants to add a rules_cc load statement for objc_library.
-    # We do not want to add a dependency on this ruleset, at this time.
-    "./examples/ios_app/Utils/BUILD",
 ]
 
 _BUILDIFIER_WARNINGS = [
     "all",
+    "-native-cc",
 ]
 
 buildifier(

--- a/BUILD
+++ b/BUILD
@@ -18,6 +18,19 @@ _BUILDIFIER_WARNINGS = [
     # "all",
 ]
 
+# Buildifier
+
+_BUILDIFIER_EXCLUDE_PATTERNS = [
+    "./.git/*",
+    # Buildifier wants to add a rules_cc load statement for objc_library.
+    # We do not want to add a dependency on this ruleset, at this time.
+    "./examples/ios_app/Utils/BUILD",
+]
+
+_BUILDIFIER_WARNINGS = [
+    "all",
+]
+
 buildifier(
     name = "buildifier.check",
     exclude_patterns = _BUILDIFIER_EXCLUDE_PATTERNS,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,18 +79,13 @@ bazel_skylib_workspace()
 
 # Buildifier
 
-# http_archive(
-#     name = "buildifier_prebuilt",
-#     sha256 = "54a58924e079a7f823a5aa30f37f10a7a966cf1ad87e14feb6fb07601389bdc1",
-#     strip_prefix = "buildifier-prebuilt-0.3.2",
-#     urls = [
-#         "http://github.com/keith/buildifier-prebuilt/archive/0.3.2.tar.gz",
-#     ],
-# )
-
-local_repository(
+http_archive(
     name = "buildifier_prebuilt",
-    path = "/Users/chuckgrindel/code/cgrindel/buildifier-prebuilt/support_mixing_warn_cat_and_modifiers",
+    sha256 = "0450069a99db3d414eff738dd8ad4c0969928af13dc8614adbd1c603a835caad",
+    strip_prefix = "buildifier-prebuilt-0.4.0",
+    urls = [
+        "http://github.com/keith/buildifier-prebuilt/archive/0.4.0.tar.gz",
+    ],
 )
 
 load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,13 +79,18 @@ bazel_skylib_workspace()
 
 # Buildifier
 
-http_archive(
+# http_archive(
+#     name = "buildifier_prebuilt",
+#     sha256 = "54a58924e079a7f823a5aa30f37f10a7a966cf1ad87e14feb6fb07601389bdc1",
+#     strip_prefix = "buildifier-prebuilt-0.3.2",
+#     urls = [
+#         "http://github.com/keith/buildifier-prebuilt/archive/0.3.2.tar.gz",
+#     ],
+# )
+
+local_repository(
     name = "buildifier_prebuilt",
-    sha256 = "54a58924e079a7f823a5aa30f37f10a7a966cf1ad87e14feb6fb07601389bdc1",
-    strip_prefix = "buildifier-prebuilt-0.3.2",
-    urls = [
-        "http://github.com/keith/buildifier-prebuilt/archive/0.3.2.tar.gz",
-    ],
+    path = "/Users/chuckgrindel/code/cgrindel/buildifier-prebuilt/support_mixing_warn_cat_and_modifiers",
 )
 
 load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")


### PR DESCRIPTION
Closes #176.

- Updated to [keith/buildifier-prebuilt 0.4.0](https://github.com/keith/buildifier-prebuilt/releases/tag/0.4.0) so that all warnings except a select few can specified.
- The `cc-native` warning wants to add a dependency on `rules_cc` that is not desired at this time.