### PR TITLE
Split integration tests into their own workflow

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -21,7 +21,19 @@ actions:
         branches:
           - "main"
     bazel_commands:
-      - "test --config=workflows //tools/... //test/... //:all_integration_tests"
+      - "test --config=workflows //tools/... //test/..."
+
+  - name: Integration Test
+    os: "darwin"
+    triggers:
+      push:
+        branches:
+          - "main"
+      pull_request:
+        branches:
+          - "main"
+    bazel_commands:
+      - "test --config=workflows //:all_integration_tests"
 
   - name: Buildifier Lint
     triggers:


### PR DESCRIPTION
Integration tests are much slower than the unit tests. By splitting them off into their own workflow PR authors can get feedback on the non-integration tests faster.