### PR TITLE
Set `OTHER_SWIFT_FLAGS` as a string

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -118,7 +118,7 @@ def process_compiler_opts_test_suite(name):
         ],
         expected_build_settings = {
             "ENABLE_TESTABILITY": "True",
-            "OTHER_SWIFT_FLAGS": ["weird", "-unhandled"],
+            "OTHER_SWIFT_FLAGS": "weird -unhandled",
             "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
         },
     )
@@ -247,16 +247,16 @@ def process_compiler_opts_test_suite(name):
                 "-passthrough",
                 "-passthrough",
             ],
-            "OTHER_SWIFT_FLAGS": [
-                "-passthrough",
-                "-passthrough",
-                "-passthrough",
-                "-passthrough",
-                "-passthrough",
-                "-passthrough",
-                "-keep-me=something.swift",
-                "-passthrough",
-            ],
+            "OTHER_SWIFT_FLAGS": """\
+-passthrough \
+-passthrough \
+-passthrough \
+-passthrough \
+-passthrough \
+-passthrough \
+-keep-me=something.swift \
+-passthrough\
+""",
         },
     )
 

--- a/tools/generator/src/Generator+SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator+SetTargetConfigurations.swift
@@ -58,6 +58,7 @@ Target "\(id)" not found in `pbxTargets`.
                             .string.quoted
                         return "-Xcc -fmodule-map-file=\(modulemap)"
                     }
+                    .joined(separator: " ")
             )
 
             if !target.links.isEmpty {
@@ -148,6 +149,29 @@ $(BUILD_DIR)/\(testHost.packageBinDir)/\(productPath)/\(productName)
 }
 
 private extension Dictionary where Value == BuildSetting {
+    mutating func prepend(onKey key: Key, _ content: String) throws {
+        let buildSetting = self[key, default: .string("")]
+        switch buildSetting {
+        case .string(let existing):
+            let new: String
+            if content.isEmpty {
+                new = existing
+            } else if existing.isEmpty {
+                new = content
+            } else {
+                new = "\(content) \(existing)"
+            }
+            guard !new.isEmpty else {
+                return
+            }
+            self[key] = .string(new)
+        default:
+            throw PreconditionError(message: """
+Build setting for \(key) is not a string: \(buildSetting)
+""")
+        }
+    }
+
     mutating func prepend(onKey key: Key, _ content: [String]) throws {
         let buildSetting = self[key, default: .array([])]
         switch buildSetting {

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -378,7 +378,7 @@ def _process_compiler_opts(*, conlyopts, cxxopts, swiftcopts, build_settings):
     set_if_true(
         build_settings,
         "OTHER_SWIFT_FLAGS",
-        swiftcopts,
+        " ".join(swiftcopts),
     )
 
 def _process_target_compiler_opts(*, ctx, target, build_settings):


### PR DESCRIPTION
Xcode prefers it this way. There really is no rhyme or reason to this, is there?