### PR TITLE
Refactor search paths collection

### DIFF
--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -720,8 +720,8 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
-					CoreUtilsObjC,
-					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+					"$(PROJECT_DIR)/CoreUtilsObjC",
+					"$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
@@ -766,8 +766,9 @@
 				SWIFT_VERSION = 5;
 				TARGET_NAME = Utils;
 				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
 				);
 			};
 			name = Debug;
@@ -784,8 +785,8 @@
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
-					CoreUtilsObjC,
-					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+					"$(PROJECT_DIR)/CoreUtilsObjC",
+					"$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
@@ -826,7 +827,7 @@
 					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(TARGET_DEVICE_PLATFORM_NAME)",
 					"-L/usr/lib/swift",
 					"-filelist",
-					"test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleObjcTests/ExampleObjcTests.LinkFileList,$(BUILD_DIR)",
+					"$(PROJECT_DIR)/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleObjcTests/ExampleObjcTests.LinkFileList,$(BUILD_DIR)",
 					"-ObjC",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.objctests;
@@ -841,9 +842,9 @@
 				TARGET_NAME = ExampleObjcTests;
 				TEST_HOST = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example.app/Example";
 				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(PROJECT_DIR)",
 					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
 				);
 			};
 			name = Debug;
@@ -856,8 +857,8 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				HEADER_SEARCH_PATHS = (
-					CoreUtilsObjC,
-					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+					"$(PROJECT_DIR)/CoreUtilsObjC",
+					"$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
@@ -902,8 +903,9 @@
 				SWIFT_VERSION = 5;
 				TARGET_NAME = CoreUtils;
 				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
 				);
 			};
 			name = Debug;
@@ -920,8 +922,8 @@
 				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
-					CoreUtilsObjC,
-					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+					"$(PROJECT_DIR)/CoreUtilsObjC",
+					"$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
@@ -960,10 +962,10 @@
 				);
 				OTHER_LDFLAGS = (
 					"-filelist",
-					"test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleTests/ExampleTests.LinkFileList,$(BUILD_DIR)",
+					"$(PROJECT_DIR)/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleTests/ExampleTests.LinkFileList,$(BUILD_DIR)",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap -Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap -Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swift.modulemap";
+				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap -Xcc -fmodule-map-file=$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap -Xcc -fmodule-map-file=$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swift.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.tests;
 				PRODUCT_MODULE_NAME = ExampleTests;
 				PRODUCT_NAME = ExampleTests;
@@ -978,9 +980,8 @@
 				TARGET_NAME = ExampleTests;
 				TEST_HOST = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example.app/Example";
 				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
-					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
 				);
 			};
 			name = Debug;
@@ -1029,7 +1030,7 @@
 					"-D__TIMESTAMP__=\"redacted\"",
 					"-D__TIME__=\"redacted\"",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swift.modulemap";
+				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swift.modulemap";
 				PRODUCT_MODULE_NAME = TestingUtils;
 				PRODUCT_NAME = TestingUtils;
 				SDKROOT = iphoneos;
@@ -1038,7 +1039,10 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGET_NAME = TestingUtils;
-				USER_HEADER_SEARCH_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin";
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+				);
 			};
 			name = Debug;
 		};
@@ -1075,8 +1079,8 @@
 				ENABLE_TESTABILITY = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
-					CoreUtilsObjC,
-					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+					"$(PROJECT_DIR)/CoreUtilsObjC",
+					"$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
@@ -1115,10 +1119,10 @@
 				);
 				OTHER_LDFLAGS = (
 					"-filelist",
-					"test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/Example/Example.LinkFileList,$(BUILD_DIR)",
+					"$(PROJECT_DIR)/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/Example/Example.LinkFileList,$(BUILD_DIR)",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap -Xcc -fmodule-map-file=bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap";
+				OTHER_SWIFT_FLAGS = "-Xcc -fmodule-map-file=$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap -Xcc -fmodule-map-file=$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
 				PRODUCT_MODULE_NAME = Example;
 				PRODUCT_NAME = Example;
@@ -1130,8 +1134,8 @@
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = Example;
 				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
 				);
 			};
 			name = Debug;

--- a/examples/ios_app/test/fixtures/spec.json
+++ b/examples/ios_app/test/fixtures/spec.json
@@ -142,7 +142,7 @@
                         "t": "g"
                     }
                 ],
-                "quote_headers": [
+                "quote_includes": [
                     ".",
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
@@ -233,22 +233,7 @@
                 "path": "bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example_archive-root/Payload/Example.app",
                 "type": "com.apple.product-type.application"
             },
-            "search_paths": {
-                "includes": [
-                    "CoreUtilsObjC",
-                    {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
-                        "t": "g"
-                    }
-                ],
-                "quote_headers": [
-                    ".",
-                    {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
-                        "t": "g"
-                    }
-                ]
-            },
+            "search_paths": {},
             "swiftmodules": [],
             "test_host": null
         },
@@ -353,7 +338,7 @@
                         "t": "g"
                     }
                 ],
-                "quote_headers": [
+                "quote_includes": [
                     ".",
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
@@ -444,23 +429,7 @@
                 "path": "bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle_archive-root/ExampleObjcTests.xctest",
                 "type": "com.apple.product-type.bundle.unit-test"
             },
-            "search_paths": {
-                "includes": [
-                    "CoreUtilsObjC",
-                    {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
-                        "t": "g"
-                    }
-                ],
-                "quote_headers": [
-                    ".",
-                    {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
-                        "t": "g"
-                    },
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin"
-                ]
-            },
+            "search_paths": {},
             "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
         },
@@ -550,13 +519,12 @@
                         "t": "g"
                     }
                 ],
-                "quote_headers": [
+                "quote_includes": [
                     ".",
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
                         "t": "g"
-                    },
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin"
+                    }
                 ]
             },
             "swiftmodules": [],
@@ -642,23 +610,7 @@
                 "path": "bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle_archive-root/ExampleTests.xctest",
                 "type": "com.apple.product-type.bundle.unit-test"
             },
-            "search_paths": {
-                "includes": [
-                    "CoreUtilsObjC",
-                    {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
-                        "t": "g"
-                    }
-                ],
-                "quote_headers": [
-                    ".",
-                    {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
-                        "t": "g"
-                    },
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin"
-                ]
-            },
+            "search_paths": {},
             "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
         },
@@ -769,13 +721,12 @@
                         "t": "g"
                     }
                 ],
-                "quote_headers": [
+                "quote_includes": [
                     ".",
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
                         "t": "g"
-                    },
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin"
+                    }
                 ]
             },
             "swiftmodules": [
@@ -869,22 +820,7 @@
                 "path": "bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle_archive-root/ExampleUITests.xctest",
                 "type": "com.apple.product-type.bundle.ui-testing"
             },
-            "search_paths": {
-                "includes": [
-                    "CoreUtilsObjC",
-                    {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
-                        "t": "g"
-                    }
-                ],
-                "quote_headers": [
-                    ".",
-                    {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
-                        "t": "g"
-                    }
-                ]
-            },
+            "search_paths": {},
             "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
         },
@@ -1066,8 +1002,12 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {
-                "quote_headers": [
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin"
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+                        "t": "g"
+                    }
                 ]
             },
             "swiftmodules": [],
@@ -1160,7 +1100,7 @@
                         "t": "g"
                     }
                 ],
-                "quote_headers": [
+                "quote_includes": [
                     ".",
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",

--- a/test/fixtures/cc/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/project.xcodeproj/project.pbxproj
@@ -347,8 +347,8 @@
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = "EXTERNAL_SECRET_3=\\\"Goodbye\\\"";
 				HEADER_SEARCH_PATHS = (
-					"bazel-rules_xcodeproj/external/examples_cc_external/private",
-					"bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external/private",
+					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/examples_cc_external/private",
+					"$(PROJECT_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external/private",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
@@ -393,8 +393,9 @@
 				SWIFT_VERSION = 5;
 				TARGET_NAME = examples_cc_external__lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
-					"bazel-rules_xcodeproj/external/examples_cc_external",
-					"bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external",
+					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/examples_cc_external",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external",
+					"$(PROJECT_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external",
 				);
 			};
 			name = Debug;
@@ -463,7 +464,7 @@
 					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(TARGET_DEVICE_PLATFORM_NAME)",
 					"-L/usr/lib/swift",
 					"-filelist",
-					"test/fixtures/cc/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/examples/cc/tool/tool.LinkFileList,$(BUILD_DIR)",
+					"$(PROJECT_DIR)/test/fixtures/cc/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/examples/cc/tool/tool.LinkFileList,$(BUILD_DIR)",
 					"-ObjC",
 				);
 				PRODUCT_MODULE_NAME = _tool_;
@@ -474,10 +475,15 @@
 				SWIFT_VERSION = 5;
 				TARGET_NAME = tool;
 				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
-					"bazel-rules_xcodeproj/external/examples_cc_external",
-					"bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external",
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
+					"$(PROJECT_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
+					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/examples_cc_external",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external",
+					"$(PROJECT_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external",
+					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/bazel_tools",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/bazel_tools",
+					"$(PROJECT_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/bazel_tools",
 				);
 			};
 			name = Debug;
@@ -491,8 +497,8 @@
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = "SECRET_3=\\\"Hello\\\"";
 				HEADER_SEARCH_PATHS = (
-					examples/cc/lib/private,
-					"bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/examples/cc/lib/private",
+					"$(PROJECT_DIR)/examples/cc/lib/private",
+					"$(PROJECT_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/examples/cc/lib/private",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
@@ -537,8 +543,9 @@
 				SWIFT_VERSION = 5;
 				TARGET_NAME = examples_cc_lib_lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
+					"$(PROJECT_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
 				);
 			};
 			name = Debug;
@@ -593,8 +600,9 @@
 				SWIFT_VERSION = 5;
 				TARGET_NAME = examples_cc_lib2_lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
+					"$(PROJECT_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
 				);
 			};
 			name = Debug;

--- a/test/fixtures/cc/spec.json
+++ b/test/fixtures/cc/spec.json
@@ -96,7 +96,7 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {
-                "quote_headers": [
+                "quote_includes": [
                     ".",
                     {
                         "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
@@ -190,7 +190,7 @@
                         "t": "g"
                     }
                 ],
-                "quote_headers": [
+                "quote_includes": [
                     ".",
                     {
                         "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
@@ -286,7 +286,7 @@
                 "type": "com.apple.product-type.tool"
             },
             "search_paths": {
-                "quote_headers": [
+                "quote_includes": [
                     ".",
                     {
                         "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
@@ -298,6 +298,14 @@
                     },
                     {
                         "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external",
+                        "t": "g"
+                    },
+                    {
+                        "_": "bazel_tools",
+                        "t": "e"
+                    },
+                    {
+                        "_": "darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/bazel_tools",
                         "t": "g"
                     }
                 ]
@@ -397,7 +405,7 @@
                         "t": "g"
                     }
                 ],
-                "quote_headers": [
+                "quote_includes": [
                     {
                         "_": "examples_cc_external",
                         "t": "e"

--- a/test/fixtures/command_line/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/project.xcodeproj/project.pbxproj
@@ -232,8 +232,8 @@
 					"SECRET_2=\\\"World!\\\"",
 				);
 				HEADER_SEARCH_PATHS = (
-					"\"examples/command_line/lib/dir with space\"",
-					"\"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/dir with space\"",
+					"\"$(PROJECT_DIR)/examples/command_line/lib/dir with space\"",
+					"\"$(PROJECT_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/dir with space\"",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_CFLAGS = (
@@ -274,7 +274,7 @@
 					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(TARGET_DEVICE_PLATFORM_NAME)",
 					"-L/usr/lib/swift",
 					"-filelist",
-					"test/fixtures/command_line/project.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/examples/command_line/tool/tool.LinkFileList,$(BUILD_DIR)",
+					"$(PROJECT_DIR)/test/fixtures/command_line/project.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/examples/command_line/tool/tool.LinkFileList,$(BUILD_DIR)",
 					"-ObjC",
 				);
 				PRODUCT_MODULE_NAME = examples_command_line_tool_tool_library;
@@ -285,8 +285,9 @@
 				SWIFT_VERSION = 5;
 				TARGET_NAME = tool;
 				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
+					"$(PROJECT_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
 				);
 			};
 			name = Debug;
@@ -345,8 +346,9 @@
 				SWIFT_VERSION = 5;
 				TARGET_NAME = examples_command_line_lib_lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
+					"$(PROJECT_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
 				);
 			};
 			name = Debug;

--- a/test/fixtures/command_line/spec.json
+++ b/test/fixtures/command_line/spec.json
@@ -101,7 +101,7 @@
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {
-                "quote_headers": [
+                "quote_includes": [
                     ".",
                     {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
@@ -191,22 +191,7 @@
                 "path": "bazel-out/applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/tool/tool",
                 "type": "com.apple.product-type.tool"
             },
-            "search_paths": {
-                "includes": [
-                    "examples/command_line/lib/dir with space",
-                    {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/dir with space",
-                        "t": "g"
-                    }
-                ],
-                "quote_headers": [
-                    ".",
-                    {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
-                        "t": "g"
-                    }
-                ]
-            },
+            "search_paths": {},
             "swiftmodules": [],
             "test_host": null
         },
@@ -296,7 +281,7 @@
                         "t": "g"
                     }
                 ],
-                "quote_headers": [
+                "quote_includes": [
                     ".",
                     {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",

--- a/test/fixtures/generator/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/project.xcodeproj/project.pbxproj
@@ -1610,7 +1610,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"-filelist",
-					"test/fixtures/generator/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/tools/generator/tests.LinkFileList,$(BUILD_DIR)",
+					"$(PROJECT_DIR)/test/fixtures/generator/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/tools/generator/tests.LinkFileList,$(BUILD_DIR)",
 					"-ObjC",
 				);
 				PRODUCT_MODULE_NAME = tests;
@@ -1669,7 +1669,7 @@
 					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(TARGET_DEVICE_PLATFORM_NAME)",
 					"-L/usr/lib/swift",
 					"-filelist",
-					"test/fixtures/generator/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/tools/generator/generator.LinkFileList,$(BUILD_DIR)",
+					"$(PROJECT_DIR)/test/fixtures/generator/project.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-fastbuild-ST-1b9bd654f600/tools/generator/generator.LinkFileList,$(BUILD_DIR)",
 					"-ObjC",
 				);
 				PRODUCT_MODULE_NAME = _generator_;

--- a/tools/generator/src/FilePathResolver.swift
+++ b/tools/generator/src/FilePathResolver.swift
@@ -22,20 +22,35 @@ struct FilePathResolver: Equatable {
         return workspaceOutputPath + internalDirectoryName
     }
 
-    func resolve(_ filePath: FilePath, useBuildDir: Bool = false) -> Path {
+    func resolve(_ filePath: FilePath, useBuildDir: Bool = false, useProjectDir: Bool = true) -> Path {
         switch filePath.type {
         case .project:
-            return filePath.path
+            return "$(PROJECT_DIR)" + filePath.path
         case .external:
-            return externalDirectory + filePath.path
+            let path = externalDirectory + filePath.path
+            if useProjectDir && path.isRelative {
+                return "$(PROJECT_DIR)" + path
+            } else {
+                return path
+            }
         case .generated:
             if useBuildDir {
                 return "$(BUILD_DIR)/bazel-out" + filePath.path
             } else {
-                return generatedDirectory + filePath.path
+                let path = generatedDirectory + filePath.path
+                if useProjectDir && path.isRelative {
+                    return "$(PROJECT_DIR)" + path
+                } else {
+                    return path
+                }
             }
         case .internal:
-            return internalDirectory + filePath.path
+            let path = internalDirectory + filePath.path
+            if useProjectDir {
+                return "$(PROJECT_DIR)" + path
+            } else {
+                return path
+            }
         }
     }
 }

--- a/tools/generator/src/Generator+CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator+CreateFilesAndGroups.swift
@@ -206,7 +206,10 @@ extension Generator {
         for target in targets.values {
             let modulemaps = target.modulemaps
                 .filter { $0.type == .generated }
-                .map { "\(filePathResolver.resolve($0).string.quoted)\n" }
+                .map { """
+\(filePathResolver.resolve($0, useProjectDir: false).string.quoted)
+
+""" }
             generatedFiles.append(contentsOf: modulemaps)
         }
 

--- a/tools/generator/src/SearchPaths.swift
+++ b/tools/generator/src/SearchPaths.swift
@@ -1,9 +1,12 @@
 struct SearchPaths: Equatable {
-    let quoteHeaders: [FilePath]
+    let quoteIncludes: [FilePath]
     let includes: [FilePath]
 
-    init(quoteHeaders: [FilePath] = [], includes: [FilePath] = []) {
-        self.quoteHeaders = quoteHeaders
+    init(
+        quoteIncludes: [FilePath] = [],
+        includes: [FilePath] = []
+    ) {
+        self.quoteIncludes = quoteIncludes
         self.includes = includes
     }
 }
@@ -12,14 +15,14 @@ struct SearchPaths: Equatable {
 
 extension SearchPaths: Decodable {
     enum CodingKeys: String, CodingKey {
-        case quoteHeaders
+        case quoteIncludes
         case includes
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        quoteHeaders = try container.decodeFilePaths(.quoteHeaders)
+        quoteIncludes = try container.decodeFilePaths(.quoteIncludes)
         includes = try container.decodeFilePaths(.includes)
     }
 }

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -900,7 +900,7 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
                     "-L/usr/lib/swift",
                     "-filelist",
                     #"""
-"out/p.xcodeproj/rules_xcp/targets/a1b2c/A 2/A.LinkFileList,$(BUILD_DIR)"
+"$(PROJECT_DIR)/out/p.xcodeproj/rules_xcp/targets/a1b2c/A 2/A.LinkFileList,$(BUILD_DIR)"
 """#,
                 ],
                 "SDKROOT": "macosx",
@@ -910,7 +910,7 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
             "B 1": targets["B 1"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/B 1",
                 "OTHER_SWIFT_FLAGS": """
--Xcc -fmodule-map-file=a/module.modulemap
+-Xcc -fmodule-map-file=$(PROJECT_DIR)/a/module.modulemap
 """,
                 "SDKROOT": "macosx",
                 "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/x",
@@ -926,7 +926,7 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
                     "-L/usr/lib/swift",
                     "-filelist",
                     #"""
-"out/p.xcodeproj/rules_xcp/targets/a1b2c/B 2/B.LinkFileList,$(BUILD_DIR)"
+"$(PROJECT_DIR)/out/p.xcodeproj/rules_xcp/targets/a1b2c/B 2/B.LinkFileList,$(BUILD_DIR)"
 """#,
                 ],
                 "SDKROOT": "macosx",
@@ -945,7 +945,7 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
                     "-L/usr/lib/swift",
                     "-filelist",
                     #"""
-"out/p.xcodeproj/rules_xcp/targets/a1b2c/B 3/B3.LinkFileList,$(BUILD_DIR)"
+"$(PROJECT_DIR)/out/p.xcodeproj/rules_xcp/targets/a1b2c/B 3/B3.LinkFileList,$(BUILD_DIR)"
 """#,
                 ],
                 "SDKROOT": "macosx",
@@ -955,7 +955,7 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
             "C 1": targets["C 1"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/C 1",
                 "OTHER_SWIFT_FLAGS": """
--Xcc -fmodule-map-file=bazel-out/a/b/module.modulemap
+-Xcc -fmodule-map-file=$(PROJECT_DIR)/bazel-out/a/b/module.modulemap
 """,
                 "SDKROOT": "macosx",
                 "TARGET_NAME": targets["C 1"]!.name,
@@ -969,7 +969,7 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
                     "-L/usr/lib/swift",
                     "-filelist",
                     #"""
-"out/p.xcodeproj/rules_xcp/targets/a1b2c/C 2/d.LinkFileList,$(BUILD_DIR)"
+"$(PROJECT_DIR)/out/p.xcodeproj/rules_xcp/targets/a1b2c/C 2/d.LinkFileList,$(BUILD_DIR)"
 """#,
                 ],
                 "SDKROOT": "macosx",

--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -26,6 +26,25 @@ def file_path(file):
         return external_file_path(path)
     return project_file_path(path)
 
+def parsed_file_path(path):
+    """Coverts a file path string into a `FilePath` Swift DTO value.
+
+    Args:
+        path: A file path string.
+
+    Returns:
+        A value as returned from `file_path().
+    """
+
+    # These checks are less than ideal, but since it's a string we can't tell if
+    # they meant something else
+    if path.startswith("bazel-out/"):
+        return generated_file_path(path)
+    elif path.startswith("external/"):
+        return external_file_path(path)
+    else:
+        return project_file_path(path)
+
 def external_file_path(path):
     return struct(
         # Type: "e" == `.external`


### PR DESCRIPTION
Before this refactor we generally tried to calculate search paths, to ensure that we correctly identified the "external/" and "bazel-out/" directories without having to parse strings. This has the benefit of technically allowing the "external/" and "bazel-out/" directories to exist in the workspace.

There are some issues with this approach though. The main one being that custom rules that set search paths aren't accounted for properly. If we instead leverage the information in `CcInfo.compilation_context` we support all sorts of rules out of the box... but have to resort parsing strings.

We were already parsing the strings for the `local_includes`, and will need to for framework includes in the future. I believe the more generic code that should just work is worth giving up the ability to have "external/" and "bazel-out/" directories in the workspace.