### PR TITLE
Clean before Bazel Integration Tests

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -33,6 +33,7 @@ actions:
         branches:
           - "main"
     bazel_commands:
+      - "clean"
       - "test --config=workflows //:all_integration_tests"
 
   - name: Buildifier Lint


### PR DESCRIPTION
This temporarily works around a bug where Bazel doesn't pick up changes to a child workspace during the integration tests.

Related to https://github.com/buildbuddy-io/rules_xcodeproj/issues/190.