### PR TITLE
Use an enum for `Platform.os`

### DIFF
--- a/examples/ios_app/test/fixtures/spec.json
+++ b/examples/ios_app/test/fixtures/spec.json
@@ -195,7 +195,6 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "PRODUCT_MODULE_NAME": "_Example_",
                 "PRODUCT_NAME": "Example",
-                "SDKROOT": "iphoneos",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5",
                 "TARGETED_DEVICE_FAMILY": "1"
@@ -222,7 +221,7 @@
                 "arch": "x86_64",
                 "environment": "Simulator",
                 "minimum_os_version": "15.0",
-                "os": "iOS"
+                "os": "ios"
             },
             "product": {
                 "name": "Example",
@@ -292,7 +291,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "Example",
                 "PRODUCT_NAME": "Example.library",
-                "SDKROOT": "iphoneos",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -334,7 +332,7 @@
                 "arch": "x86_64",
                 "environment": "Simulator",
                 "minimum_os_version": "15.0",
-                "os": "iOS"
+                "os": "ios"
             },
             "product": {
                 "name": "Example.library",
@@ -406,7 +404,6 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.tests",
                 "PRODUCT_MODULE_NAME": "_ExampleTests_",
                 "PRODUCT_NAME": "ExampleTests",
-                "SDKROOT": "iphoneos",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5",
                 "TARGETED_DEVICE_FAMILY": "1,2"
@@ -433,7 +430,7 @@
                 "arch": "x86_64",
                 "environment": "Simulator",
                 "minimum_os_version": "15.0",
-                "os": "iOS"
+                "os": "ios"
             },
             "product": {
                 "name": "ExampleTests",
@@ -504,7 +501,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "ExampleTests",
                 "PRODUCT_NAME": "ExampleTests.library",
-                "SDKROOT": "iphoneos",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG AWESOME",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -547,7 +543,7 @@
                 "arch": "x86_64",
                 "environment": "Simulator",
                 "minimum_os_version": "15.0",
-                "os": "iOS"
+                "os": "ios"
             },
             "product": {
                 "name": "ExampleTests.library",
@@ -628,7 +624,6 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.uitests",
                 "PRODUCT_MODULE_NAME": "_ExampleUITests_",
                 "PRODUCT_NAME": "ExampleUITests",
-                "SDKROOT": "iphoneos",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5",
                 "TARGETED_DEVICE_FAMILY": "1,2"
@@ -654,7 +649,7 @@
                 "arch": "x86_64",
                 "environment": "Simulator",
                 "minimum_os_version": "15.0",
-                "os": "iOS"
+                "os": "ios"
             },
             "product": {
                 "name": "ExampleUITests",
@@ -725,7 +720,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "ExampleUITests",
                 "PRODUCT_NAME": "ExampleUITests.library",
-                "SDKROOT": "iphoneos",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -756,7 +750,7 @@
                 "arch": "x86_64",
                 "environment": "Simulator",
                 "minimum_os_version": "15.0",
-                "os": "iOS"
+                "os": "ios"
             },
             "product": {
                 "name": "ExampleUITests.library",
@@ -812,7 +806,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "TestingUtils",
                 "PRODUCT_NAME": "TestingUtils",
-                "SDKROOT": "iphoneos",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG AWESOME",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -845,7 +838,7 @@
                 "arch": "x86_64",
                 "environment": "Simulator",
                 "minimum_os_version": "15.0",
-                "os": "iOS"
+                "os": "ios"
             },
             "product": {
                 "name": "TestingUtils",
@@ -900,7 +893,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "Utils",
                 "PRODUCT_NAME": "Utils",
-                "SDKROOT": "iphoneos",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -928,7 +920,7 @@
                 "arch": "x86_64",
                 "environment": "Simulator",
                 "minimum_os_version": "15.0",
-                "os": "iOS"
+                "os": "ios"
             },
             "product": {
                 "name": "Utils",

--- a/test/fixtures/cc/spec.json
+++ b/test/fixtures/cc/spec.json
@@ -60,7 +60,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "examples_cc_lib2_lib_impl",
                 "PRODUCT_NAME": "lib_impl",
-                "SDKROOT": "macosx",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -84,7 +83,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "lib_impl",
@@ -149,7 +148,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "examples_cc_lib_lib_impl",
                 "PRODUCT_NAME": "lib_impl",
-                "SDKROOT": "macosx",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -171,7 +169,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "lib_impl",
@@ -237,7 +235,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "_tool_",
                 "PRODUCT_NAME": "tool",
-                "SDKROOT": "macosx",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -264,7 +261,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "tool",

--- a/test/fixtures/command_line/spec.json
+++ b/test/fixtures/command_line/spec.json
@@ -71,7 +71,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "examples_command_line_lib_lib_impl",
                 "PRODUCT_NAME": "lib_impl",
-                "SDKROOT": "macosx",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -93,7 +92,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "12.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "lib_impl",
@@ -160,7 +159,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "_tool_",
                 "PRODUCT_NAME": "tool",
-                "SDKROOT": "macosx",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -184,7 +182,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "12.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "tool",
@@ -258,7 +256,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "examples_command_line_tool_tool_library",
                 "PRODUCT_NAME": "tool.library",
-                "SDKROOT": "macosx",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -281,7 +278,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "12.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "tool.library",

--- a/test/fixtures/generator/spec.json
+++ b/test/fixtures/generator/spec.json
@@ -75,7 +75,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "_generator_",
                 "PRODUCT_NAME": "generator",
-                "SDKROOT": "macosx",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -99,7 +98,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "generator",
@@ -154,7 +153,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "generator",
                 "PRODUCT_NAME": "generator.library",
-                "SDKROOT": "macosx",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -212,7 +210,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "generator.library",
@@ -281,7 +279,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "_tests_",
                 "PRODUCT_NAME": "tests",
-                "SDKROOT": "macosx",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
@@ -308,7 +305,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "tests",
@@ -364,7 +361,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "tests",
                 "PRODUCT_NAME": "tests.library",
-                "SDKROOT": "macosx",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -410,7 +406,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "tests.library",
@@ -490,7 +486,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "PathKit",
                 "PRODUCT_NAME": "PathKit",
-                "SDKROOT": "macosx",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -522,7 +517,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "PathKit",
@@ -577,7 +572,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "CustomDump",
                 "PRODUCT_NAME": "CustomDump",
-                "SDKROOT": "macosx",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -707,7 +701,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "CustomDump",
@@ -767,7 +761,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "XCTestDynamicOverlay",
                 "PRODUCT_NAME": "XCTestDynamicOverlay",
-                "SDKROOT": "macosx",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -799,7 +792,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "XCTestDynamicOverlay",
@@ -854,7 +847,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "AEXML",
                 "PRODUCT_NAME": "AEXML",
-                "SDKROOT": "macosx",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -902,7 +894,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "AEXML",
@@ -957,7 +949,6 @@
                 ],
                 "PRODUCT_MODULE_NAME": "XcodeProj",
                 "PRODUCT_NAME": "XcodeProj",
-                "SDKROOT": "macosx",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -1368,7 +1359,7 @@
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "11.0",
-                "os": "macOS"
+                "os": "macos"
             },
             "product": {
                 "name": "XcodeProj",

--- a/test/internal/platform/generate_platform_information_tests.bzl
+++ b/test/internal/platform/generate_platform_information_tests.bzl
@@ -91,10 +91,9 @@ def generate_platform_information_test_suite(name):
             "arch": "wild",
             "environment": "Simulator",
             "minimum_os_version": "12.0",
-            "os": "tvOS",
+            "os": "tvos",
         },
         expected_build_settings = {
-            "SDKROOT": "appletvos",
             "TVOS_DEPLOYMENT_TARGET": "12.0",
         },
     )
@@ -109,11 +108,10 @@ def generate_platform_information_test_suite(name):
             "arch": "x86_64",
             "environment": "Simulator",
             "minimum_os_version": "11.0",
-            "os": "iOS",
+            "os": "ios",
         },
         expected_build_settings = {
             "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
-            "SDKROOT": "iphoneos",
         },
     )
 
@@ -128,11 +126,10 @@ def generate_platform_information_test_suite(name):
         expected_platform_dict = {
             "arch": "arm64",
             "minimum_os_version": "12.1",
-            "os": "macOS",
+            "os": "macos",
         },
         expected_build_settings = {
             "MACOSX_DEPLOYMENT_TARGET": "12.1",
-            "SDKROOT": "macosx",
         },
     )
 

--- a/tools/generator/src/DTO.swift
+++ b/tools/generator/src/DTO.swift
@@ -36,7 +36,14 @@ struct Product: Equatable, Decodable {
 }
 
 struct Platform: Equatable, Decodable {
-    let os: String
+    enum OS: String, Decodable {
+        case macOS = "macos"
+        case iOS = "ios"
+        case tvOS = "tvos"
+        case watchOS = "watchos"
+    }
+
+    let os: OS
     let arch: String
     let minimumOsVersion: String
     let environment: String?

--- a/tools/generator/src/Generator+DisambiguateTargets.swift
+++ b/tools/generator/src/Generator+DisambiguateTargets.swift
@@ -85,7 +85,7 @@ struct ProductTypeComponents {
     /// `add(target:)`, there will be an entry in `oses`.
     /// `OperatingSystemComponents.add(target)` will have been called for each
     /// `Target`.
-    var oses: [String: OperatingSystemComponents] = [:]
+    var oses: [Platform.OS: OperatingSystemComponents] = [:]
 
     /// Adds another `Target` into consideration for `distinguishers()`.
     mutating func add(target: Target) {
@@ -181,7 +181,7 @@ struct OperatingSystemComponents {
             var components: [String] = []
 
             if forceDistinguisher {
-                components.append(platform.os)
+                components.append(platform.os.prettyName)
             }
 
             components.append(Target.prettyConfiguration(target.configuration))
@@ -194,7 +194,7 @@ struct OperatingSystemComponents {
                 components.append(platform.arch)
             }
             if forceDistinguisher || minimumVersions.count > 1 {
-                components.append(platform.os)
+                components.append(platform.os.prettyName)
             }
             if minimumVersions.count > 1 {
                 components.append(platform.minimumOsVersion)
@@ -237,6 +237,17 @@ private extension Target {
             platform.minimumOsVersion,
             platform.environment ?? "Device"
         ].joined(separator: "-")
+    }
+}
+
+private extension Platform.OS {
+    var prettyName: String {
+        switch self {
+        case .macOS: return "macOS"
+        case .iOS: return "iOS"
+        case .watchOS: return "watchOS"
+        case .tvOS: return "tvOS"
+        }
     }
 }
 

--- a/tools/generator/src/Generator+SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator+SetTargetConfigurations.swift
@@ -74,7 +74,7 @@ Target "\(id)" not found in `pbxTargets`.
             var buildSettings = targetBuildSettings.asDictionary
             
             buildSettings["BAZEL_PACKAGE_BIN_DIR"] = target.packageBinDir.string
-
+            buildSettings["SDKROOT"] = target.platform.os.sdkRoot
             buildSettings["TARGET_NAME"] = target.name
 
             let swiftmodules = target.swiftmodules
@@ -209,6 +209,18 @@ packageBinDir is in unexpected format: \(packageBinDir)
         components = ["targets"] + components + ["\(name).LinkFileList"]
 
         return .internal(Path(components: components))
+    }
+}
+
+
+private extension Platform.OS {
+    var sdkRoot: String {
+        switch self {
+        case .macOS: return "macosx"
+        case .iOS: return "iphoneos"
+        case .watchOS: return "watchos"
+        case .tvOS: return "appletvos"
+        }
     }
 }
 

--- a/tools/generator/test/DisambiguateTargetsTests.swift
+++ b/tools/generator/test/DisambiguateTargetsTests.swift
@@ -46,7 +46,7 @@ final class DisambiguateTargetsTests: XCTestCase {
         let targets: [TargetID: Target] = [
             "A 1": Target.mock(
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.0",
                     environment: nil
@@ -55,7 +55,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             ),
             "A 2": Target.mock(
                 platform: .init(
-                    os: "watchOS",
+                    os: .watchOS,
                     arch: "arm64",
                     minimumOsVersion: "8.0",
                     environment: nil
@@ -94,7 +94,7 @@ final class DisambiguateTargetsTests: XCTestCase {
         let targets: [TargetID: Target] = [
             "A 1": Target.mock(
                 platform: .init(
-                    os: "macOS",
+                    os: .macOS,
                     arch: "arm64",
                     minimumOsVersion: "12.0",
                     environment: nil
@@ -103,7 +103,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             ),
             "A 2": Target.mock(
                 platform: .init(
-                    os: "macOS",
+                    os: .macOS,
                     arch: "x86_64",
                     minimumOsVersion: "12.0",
                     environment: nil
@@ -142,7 +142,7 @@ final class DisambiguateTargetsTests: XCTestCase {
         let targets: [TargetID: Target] = [
             "A 1": Target.mock(
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: nil
@@ -151,7 +151,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             ),
             "A 2": Target.mock(
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "13.2",
                     environment: nil
@@ -190,7 +190,7 @@ final class DisambiguateTargetsTests: XCTestCase {
         let targets: [TargetID: Target] = [
             "A 1": Target.mock(
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: nil
@@ -199,7 +199,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             ),
             "A 2": Target.mock(
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: "Simulator"
@@ -238,7 +238,7 @@ final class DisambiguateTargetsTests: XCTestCase {
         let targets: [TargetID: Target] = [
             "A 1": Target.mock(
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: nil
@@ -247,7 +247,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             ),
             "A 2": Target.mock(
                 platform: .init(
-                    os: "macOS",
+                    os: .macOS,
                     arch: "x86_64",
                     minimumOsVersion: "12.0",
                     environment: nil
@@ -286,7 +286,7 @@ final class DisambiguateTargetsTests: XCTestCase {
         let targets: [TargetID: Target] = [
             "A 1": Target.mock(
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: nil
@@ -295,7 +295,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             ),
             "A 2": Target.mock(
                 platform: .init(
-                    os: "macOS",
+                    os: .macOS,
                     arch: "arm64",
                     minimumOsVersion: "11.2",
                     environment: nil
@@ -304,7 +304,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             ),
             "A 3": Target.mock(
                 platform: .init(
-                    os: "macOS",
+                    os: .macOS,
                     arch: "arm64",
                     minimumOsVersion: "11.2",
                     environment: nil
@@ -345,7 +345,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             "A 1": Target.mock(
                 configuration: "1",
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: nil
@@ -355,7 +355,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             "A 2": Target.mock(
                 configuration: "2",
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: nil
@@ -395,7 +395,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             "A 1": Target.mock(
                 configuration: "1",
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: nil
@@ -405,7 +405,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             "A 2": Target.mock(
                 configuration: "2",
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: nil
@@ -415,7 +415,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             "A 3": Target.mock(
                 configuration: "2",
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: nil
@@ -456,7 +456,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             "A 1": Target.mock(
                 configuration: "1",
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: nil
@@ -466,7 +466,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             "A 2": Target.mock(
                 configuration: "2",
                 platform: .init(
-                    os: "iOS",
+                    os: .iOS,
                     arch: "arm64",
                     minimumOsVersion: "15.1",
                     environment: nil
@@ -476,7 +476,7 @@ final class DisambiguateTargetsTests: XCTestCase {
             "A 3": Target.mock(
                 configuration: "2",
                 platform: .init(
-                    os: "macOS",
+                    os: .macOS,
                     arch: "arm64",
                     minimumOsVersion: "12.0",
                     environment: nil

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -93,12 +93,24 @@ enum Fixtures {
         ),
         "E1": Target.mock(
             packageBinDir: "bazel-out/a1b2c/bin/E1",
+            platform: .init(
+                os: .watchOS,
+                arch: "x86_64",
+                minimumOsVersion: "9.1",
+                environment: nil
+            ),
             product: .init(type: .staticLibrary, name: "E1", path: "e1/E.a"),
             isSwift: true,
             inputs: .init(srcs: [.external("a_repo/a.swift")])
         ),
         "E2": Target.mock(
             packageBinDir: "bazel-out/a1b2c/bin/E2",
+            platform: .init(
+                os: .tvOS,
+                arch: "arm64",
+                minimumOsVersion: "9.1",
+                environment: nil
+            ),
             product: .init(type: .staticLibrary, name: "E2", path: "e2/E.a"),
             isSwift: true,
             inputs: .init(srcs: [.external("another_repo/b.swift")])
@@ -854,6 +866,7 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
         let buildSettings: [TargetID: [String: Any]] = [
             "A 1": targets["A 1"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/A 1",
+                "SDKROOT": "macosx",
                 "TARGET_NAME": targets["A 1"]!.name,
             ]) { $1 },
             "A 2": targets["A 2"]!.buildSettings.asDictionary.merging([
@@ -864,6 +877,7 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
 "out/p.xcodeproj/rules_xcp/targets/a1b2c/A 2/A.LinkFileList,$(BUILD_DIR)"
 """#,
                 ],
+                "SDKROOT": "macosx",
                 "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/x",
                 "TARGET_NAME": targets["A 2"]!.name,
             ]) { $1 },
@@ -872,6 +886,7 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
                 "OTHER_SWIFT_FLAGS": """
 -Xcc -fmodule-map-file=a/module.modulemap
 """,
+                "SDKROOT": "macosx",
                 "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/x",
                 "TARGET_NAME": targets["B 1"]!.name,
             ]) { $1 },
@@ -884,6 +899,7 @@ PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
 "out/p.xcodeproj/rules_xcp/targets/a1b2c/B 2/B.LinkFileList,$(BUILD_DIR)"
 """#,
                 ],
+                "SDKROOT": "macosx",
                 "TARGET_BUILD_DIR": """
 $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
 """,
@@ -898,6 +914,7 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
 "out/p.xcodeproj/rules_xcp/targets/a1b2c/B 3/B3.LinkFileList,$(BUILD_DIR)"
 """#,
                 ],
+                "SDKROOT": "macosx",
                 "TARGET_NAME": targets["B 3"]!.name,
                 "TEST_TARGET_NAME": pbxTargets["A 2"]!.name,
             ]) { $1 },
@@ -906,6 +923,7 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
                 "OTHER_SWIFT_FLAGS": """
 -Xcc -fmodule-map-file=bazel-out/a/b/module.modulemap
 """,
+                "SDKROOT": "macosx",
                 "TARGET_NAME": targets["C 1"]!.name,
             ]) { $1 },
             "C 2": targets["C 2"]!.buildSettings.asDictionary.merging([
@@ -916,14 +934,17 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
 "out/p.xcodeproj/rules_xcp/targets/a1b2c/C 2/d.LinkFileList,$(BUILD_DIR)"
 """#,
                 ],
+                "SDKROOT": "macosx",
                 "TARGET_NAME": targets["C 2"]!.name,
             ]) { $1 },
             "E1": targets["E1"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/E1",
+                "SDKROOT": "watchos",
                 "TARGET_NAME": targets["E1"]!.name,
             ]) { $1 },
             "E2": targets["E2"]!.buildSettings.asDictionary.merging([
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/E2",
+                "SDKROOT": "appletvos",
                 "TARGET_NAME": targets["E2"]!.name,
             ]) { $1 },
         ]

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -25,7 +25,7 @@ extension Target {
             configuration: configuration,
             packageBinDir: packageBinDir,
             platform: platform ?? Platform(
-                os: "macOS",
+                os: .macOS,
                 arch: "arm64",
                 minimumOsVersion: "12.0",
                 environment: nil

--- a/xcodeproj/internal/platform.bzl
+++ b/xcodeproj/internal/platform.bzl
@@ -3,22 +3,8 @@
 _DEPLOYMENT_TARGET_KEY = {
     apple_common.platform_type.ios: "IPHONEOS_DEPLOYMENT_TARGET",
     apple_common.platform_type.macos: "MACOSX_DEPLOYMENT_TARGET",
-    apple_common.platform_type.tvos: "TVOS_DEPLOYMENT_TARGET",
     apple_common.platform_type.watchos: "WATCHOS_DEPLOYMENT_TARGET",
-}
-
-_PRETTY_OS = {
-    apple_common.platform_type.ios: "iOS",
-    apple_common.platform_type.macos: "macOS",
-    apple_common.platform_type.tvos: "tvOS",
-    apple_common.platform_type.watchos: "watchOS",
-}
-
-_SDK_ROOT = {
-    apple_common.platform_type.ios: "iphoneos",
-    apple_common.platform_type.macos: "macosx",
-    apple_common.platform_type.tvos: "appletvos",
-    apple_common.platform_type.watchos: "watchos",
+    apple_common.platform_type.tvos: "TVOS_DEPLOYMENT_TARGET",
 }
 
 def _generate_platform_information(
@@ -51,14 +37,13 @@ def _generate_platform_information(
         fail("Currently you must build for simulator when generating a project")
 
     platform_dict = {
-        "os": _PRETTY_OS[platform_type],
+        "os": str(platform_type),
         "arch": arch,
         "minimum_os_version": minimum_os_version,
     }
     if not is_device:
         platform_dict["environment"] = "Simulator"
 
-    build_settings["SDKROOT"] = _SDK_ROOT[platform_type]
     build_settings[_DEPLOYMENT_TARGET_KEY[platform_type]] = (
         minimum_deployment_os_version if minimum_deployment_os_version else minimum_os_version
     )


### PR DESCRIPTION
There is some logic we will want to do based on the platform, so this is better than the pretty name we were getting before.