### PR TITLE
When executing integration tests, ignore any generated Xcode projects in the child workspace

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -33,7 +33,7 @@ bazel_integration_test(
         ["ios_app/**/*"],
         exclude = [
             "ios_app/bazel-*",
-            # Ignore any Xcode projects that may have been manually generated.
+            # Ignore any Xcode projects that may have been manually generated
             "ios_app/*.xcodeproj/**",
         ],
     ) + [

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -29,7 +29,14 @@ bazel_integration_test(
     additional_env_inherit = ["DEVELOPER_DIR"],
     bazel_version = CURRENT_BAZEL_VERSION,
     test_runner = ":ios_app_test_runner",
-    workspace_files = integration_test_utils.glob_workspace_files("ios_app") + [
+    workspace_files = glob(
+        ["ios_app/**/*"],
+        exclude = [
+            "ios_app/bazel-*",
+            # Ignore any Xcode projects that may have been manually generated.
+            "ios_app/*.xcodeproj/**",
+        ],
+    ) + [
         "//:local_repository_files",
     ],
     workspace_path = "ios_app",


### PR DESCRIPTION
Closes #182.

