### PR TITLE
Add `uniq()` function

### DIFF
--- a/xcodeproj/internal/collections.bzl
+++ b/xcodeproj/internal/collections.bzl
@@ -7,3 +7,16 @@ def flatten(seq):
         for sub_seq in seq
         for item in sub_seq
     ]
+
+def uniq(seq):
+    """Returns a list of unique elements in `seq`.
+
+    Requires all the elements to be hashable.
+
+    Args:
+        seq: A sequence to filter.
+
+    Returns:
+        A new `list` with all unique elements from `seq`.
+    """
+    return {x: None for x in seq}.keys()

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -4,6 +4,7 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain")
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(":build_settings.bzl", "set_if_true")
+load(":collections.bzl", "uniq")
 
 # C and C++ compiler flags that we don't want to propagate to Xcode.
 # The values are the number of flags to skip, 1 being the flag itself, 2 being
@@ -205,8 +206,8 @@ def merge_opts_search_paths(search_paths):
         includes.extend(search_path.includes)
 
     return create_opts_search_paths(
-        quote_includes = {x: None for x in quote_includes}.keys(),
-        includes = {x: None for x in includes}.keys(),
+        quote_includes = uniq(quote_includes),
+        includes = uniq(includes),
     )
 
 def _process_conlyopts(opts):
@@ -254,8 +255,8 @@ def _process_conlyopts(opts):
     )
 
     search_paths = create_opts_search_paths(
-        quote_includes = {x: None for x in quote_includes}.keys(),
-        includes = {x: None for x in includes}.keys(),
+        quote_includes = uniq(quote_includes),
+        includes = uniq(includes),
     )
 
     return unhandled_opts, optimizations, search_paths
@@ -315,8 +316,8 @@ def _process_cxxopts(*, opts, build_settings):
     )
 
     search_paths = create_opts_search_paths(
-        quote_includes = {x: None for x in quote_includes}.keys(),
-        includes = {x: None for x in includes}.keys(),
+        quote_includes = uniq(quote_includes),
+        includes = uniq(includes),
     )
 
     return unhandled_opts, optimizations, search_paths
@@ -450,7 +451,7 @@ def _process_swiftcopts(*, opts, build_settings):
         build_settings,
         "SWIFT_ACTIVE_COMPILATION_CONDITIONS",
         # Eliminate duplicates
-        " ".join({x: None for x in defines}.keys()),
+        " ".join(uniq(defines)),
     )
 
     return unhandled_opts

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -14,7 +14,7 @@ load(
     "get_targeted_device_family",
     "set_if_true",
 )
-load(":collections.bzl", "flatten")
+load(":collections.bzl", "flatten", "uniq")
 load(
     ":files.bzl",
     "external_file_path",
@@ -1079,7 +1079,7 @@ def _process_defines(
         )
 
         # Remove duplicates
-        setting = reversed({x: None for x in reversed(setting)}.keys())
+        setting = reversed(uniq(reversed(setting)))
 
         set_if_true(build_settings, "GCC_PREPROCESSOR_DEFINITIONS", setting)
 
@@ -1237,8 +1237,8 @@ def _process_modulemaps(*, swift_info):
     # Different modules might be defined in the same modulemap file, so we need
     # to deduplicate them.
     return struct(
-        file_paths = {x: None for x in modulemap_file_paths}.keys(),
-        files = {x: None for x in modulemap_files}.keys(),
+        file_paths = uniq(modulemap_file_paths),
+        files = uniq(modulemap_files),
     )
 
 def _process_swiftmodules(*, swift_info):


### PR DESCRIPTION
This is basically the same as skylib's version, except it doesn't have the `list()` wrapper. When https://github.com/bazelbuild/bazel-skylib/blob/8334f938c1574ef6f1f7a38a03550a31df65274e/lib/collections.bzl#L64-L65 is addressed, we should move to that version.