### PR TITLE
Add `files` entries for folder-type file children

### DIFF
--- a/tools/generator/src/Generator+CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator+CreateFilesAndGroups.swift
@@ -178,10 +178,17 @@ extension Generator {
                     }
                 }
 
+                lastElement = element
+
                 // End early if we get back a file element. This can happen if
                 // a folder-like file is added.
                 if element is PBXFileReference { break }
-                lastElement = element
+            }
+
+            if fullFilePath != filePath {
+                // We need to add extra entries for file-like folders, to allow
+                // easy copying of resources
+                elements[fullFilePath] = lastElement
             }
         }
 

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -325,6 +325,9 @@ enum Fixtures {
             lastKnownFileType: "wrapper.framework",
             path: "Fram.framework"
         )
+        elements["a/Fram.framework/Fram"] = elements["a/Fram.framework"]!
+        elements["a/Fram.framework/Headers/Fram.h"] =
+            elements["a/Fram.framework"]!
 
         // a/module.modulemap
 
@@ -395,13 +398,14 @@ enum Fixtures {
             path: "z.mm"
         )
 
-        // Assets.xcassets/Contents.json
+        // Assets.xcassets
 
         elements["Assets.xcassets"] = PBXFileReference(
             sourceTree: .group,
             lastKnownFileType: "folder.assetcatalog",
             path: "Assets.xcassets"
         )
+        elements["Assets.xcassets/Contents.json"] = elements["Assets.xcassets"]!
 
         // `internal`/CompileStub.swift
 


### PR DESCRIPTION
Part of #75.

This makes it easier to copy resources when we have paths to all of the children but not the parent.