### PR TITLE
Associate transitive `XcodeProjInfo` with the attribute it came from

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -146,13 +146,16 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md
         hdrs = depset(hdrs),
         generated = depset(
             generated,
-            transitive = [info.inputs.generated for info in transitive_infos],
+            transitive = [
+                info.inputs.generated
+                for _, info in transitive_infos
+            ],
         ),
         extra_files = depset(
             extra_files,
             transitive = flatten([
                 _collect_transitive_extra_files(info)
-                for info in transitive_infos
+                for _, info in transitive_infos
             ]),
         ),
     )
@@ -179,13 +182,13 @@ def _merge(inputs = None, *, transitive_infos):
         generated = depset(
             transitive = ([inputs.generated] if inputs else []) + [
                 info.inputs.generated
-                for info in transitive_infos
+                for _, info in transitive_infos
             ],
         ),
         extra_files = depset(
             transitive = ([inputs.extra_files] if inputs else []) + [
                 info.inputs.extra_files
-                for info in transitive_infos
+                for _, info in transitive_infos
             ],
         ),
     )

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -910,17 +910,17 @@ def _skip_target(*, transitive_infos):
         linker_inputs = depset(
             transitive = [
                 info.linker_inputs
-                for info in transitive_infos
+                for _, info in transitive_infos
             ],
         ),
         potential_target_merges = depset(
             transitive = [
                 info.potential_target_merges
-                for info in transitive_infos
+                for _, info in transitive_infos
             ],
         ),
         required_links = depset(
-            transitive = [info.required_links for info in transitive_infos],
+            transitive = [info.required_links for _, info in transitive_infos],
         ),
         search_paths = _process_search_paths(
             cc_info = None,
@@ -931,7 +931,7 @@ def _skip_target(*, transitive_infos):
         ),
         target = None,
         xcode_targets = depset(
-            transitive = [info.xcode_targets for info in transitive_infos],
+            transitive = [info.xcode_targets for _, info in transitive_infos],
         ),
     )
 
@@ -942,7 +942,7 @@ def _process_dependencies(*, transitive_infos):
             # We pass on the next level of dependencies if the previous target
             # didn't create an Xcode target.
             [info.target.id] if info.target else info.dependencies
-            for info in transitive_infos
+            for _, info in transitive_infos
         ])
     ]
 
@@ -954,7 +954,7 @@ def _process_defines(
         transitive_infos,
         build_settings):
     transitive_cc_defines = []
-    for info in transitive_infos:
+    for _, info in transitive_infos:
         transitive_defines = info.defines
         transitive_cc_defines.extend(transitive_defines.cc_defines)
 
@@ -1166,18 +1166,18 @@ def _process_target(*, ctx, target, transitive_infos):
             processed_target.potential_target_merges,
             transitive = [
                 info.potential_target_merges
-                for info in transitive_infos
+                for _, info in transitive_infos
             ],
         ),
         required_links = depset(
             processed_target.required_links,
-            transitive = [info.required_links for info in transitive_infos],
+            transitive = [info.required_links for _, info in transitive_infos],
         ),
         search_paths = processed_target.search_paths,
         target = processed_target.target,
         xcode_targets = depset(
             processed_target.xcode_targets,
-            transitive = [info.xcode_targets for info in transitive_infos],
+            transitive = [info.xcode_targets for _, info in transitive_infos],
         ),
     )
 

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -182,7 +182,9 @@ def _xcodeproj_impl(ctx):
         for dep in ctx.attr.targets
         if XcodeProjInfo in dep
     ]
-    inputs = input_files.merge(transitive_infos = infos)
+    inputs = input_files.merge(
+        transitive_infos = [(None, info) for info in infos],
+    )
 
     spec_file = _write_json_spec(
         ctx = ctx,

--- a/xcodeproj/internal/xcodeproj_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_aspect.bzl
@@ -27,9 +27,9 @@ def _transitive_infos(*, ctx):
         if type(dep) == "list":
             for dep in dep:
                 if type(dep) == "Target" and XcodeProjInfo in dep:
-                    transitive_infos.append(dep[XcodeProjInfo])
+                    transitive_infos.append((attr, dep[XcodeProjInfo]))
         elif type(dep) == "Target" and XcodeProjInfo in dep:
-            transitive_infos.append(dep[XcodeProjInfo])
+            transitive_infos.append((attr, dep[XcodeProjInfo]))
 
     return transitive_infos
 


### PR DESCRIPTION
This will be used soon to limit which dependencies become Xcode targets, which fixes issues with code generation rules.