### PR TITLE
Fix over-collection of Xcode targets

### DIFF
--- a/examples/ios_app/TestingUtils/BUILD
+++ b/examples/ios_app/TestingUtils/BUILD
@@ -33,8 +33,11 @@ genrule(
         ":gen_Answer.swift",
     ],
     outs = ["TestingUtils.swift"],
-    cmd = """\
-echo "import Foundation" > $@
-cat $(SRCS) >> $@
-""",
+    cmd = "./$(location merger) $@ $(SRCS)",
+    tools = [":merger"],
+)
+
+sh_binary(
+    name = "merger",
+    srcs = ["merge.sh"],
 )

--- a/examples/ios_app/TestingUtils/merge.sh
+++ b/examples/ios_app/TestingUtils/merge.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+readonly output="$1"
+shift
+
+echo "import Foundation" > "$output"
+cat "$@" >> "$output"

--- a/xcodeproj/internal/default_input_file_attributes_aspect.bzl
+++ b/xcodeproj/internal/default_input_file_attributes_aspect.bzl
@@ -31,34 +31,46 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
     structured_resources = ()
     bundle_imports = ()
     if ctx.rule.kind == "cc_library":
+        xcode_targets = ("deps", "interface_deps")
         excluded = ("deps", "interface_deps", "win_def_file")
         hdrs = ("hdrs", "textual_hdrs")
     elif ctx.rule.kind == "objc_library":
+        xcode_targets = ("deps", "runtime_deps", "data")
         excluded = ("deps", "runtime_deps")
         non_arc_srcs = ("non_arc_srcs")
         hdrs = ("hdrs", "textual_hdrs")
         resources = ("data")
     elif ctx.rule.kind == "swift_library":
+        xcode_targets = ("deps", "private_deps", "data")
         excluded = ("deps", "private_deps")
         resources = ("data")
     elif (ctx.rule.kind == "apple_resource_group" or
           ctx.rule.kind == "apple_resource_bundle"):
+        xcode_targets = ("resources")
         excluded = ()
         resources = ("resources")
         structured_resources = ("structured_resources")
     elif ctx.rule.kind == "apple_bundle_import":
+        xcode_targets = ()
         excluded = ()
         bundle_imports = ("bundle_imports")
+    elif ctx.rule.kind == "genrule":
+        xcode_targets = ()
+        excluded = ("tools")
     elif AppleBundleInfo in target:
-        excluded = ["deps"]
+        xcode_targets = ["deps", "resources"]
+        excluded = ["deps", "extensions", "frameworks"]
         if _is_test_target(target):
+            xcode_targets.append("test_host")
             excluded.append("test_host")
         resources = ("resources")
     else:
+        xcode_targets = ("deps")
         excluded = ("deps")
 
     return [
         InputFileAttributesInfo(
+            xcode_targets = xcode_targets,
             excluded = excluded,
             non_arc_srcs = non_arc_srcs,
             srcs = srcs,

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -4,7 +4,6 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":collections.bzl", "flatten", "set_if_true")
 load(":files.bzl", "file_path", "file_path_to_dto", "join_paths_ignoring_empty")
 load(":logging.bzl", "warn")
-load(":providers.bzl", "InputFileAttributesInfo")
 
 # Utility
 
@@ -104,6 +103,7 @@ def _collect(
         *,
         ctx,
         target,
+        attrs_info,
         owner,
         additional_files = [],
         transitive_infos):
@@ -115,6 +115,7 @@ def _collect(
         owner: An optional string that has a unique identifier for `target`, if
             it owns the resources. Only targets that become Xcode targets should
             own resources.
+        attrs_info: The `InputFileAttributesInfo` for the target.
         additional_files: A `list` of `File`s to add to the inputs. This can
             be used to add files to the `generated` and `extra_files` fields
             (e.g. modulemaps or BUILD files).
@@ -139,7 +140,6 @@ def _collect(
             catagories. This also includes files of transitive dependencies
             that didn't create an Xcode target.
     """
-    attrs_info = target[InputFileAttributesInfo]
     output_files = target.files.to_list()
 
     srcs = []

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -11,13 +11,10 @@ rules, then you will use these providers to communicate between them.
 InputFileAttributesInfo = provider(
     "Specifies how input files of a target are collected.",
     fields = {
-        "other_collector": """\
-An optional lambda that is passed the target being processed and returns a
-`list` of `File`s that will end up in `InputFilesInfo.other`. If any of the
-files are generated, they will also end up in `InputFilesInfo.generated`.
-""",
         "excluded": """\
-A sequence of attribute names to not collect `File`s from.
+A sequence of attribute names to not collect `File`s from. This should generally
+be `deps` and `deps`-like attributes. The goal is to exclude attributes that
+have generated products (e.g. ".swiftmodule" or ".a" files) as outputs.
 """,
         "hdrs": """\
 A sequence of attribute names to collect `File`s from for the `hdrs`-like
@@ -42,6 +39,11 @@ A sequence of attribute names to collect `File`s from for
         "bundle_imports": """\
 A sequence of attribute names to collect `File`s from for `bundle_imports`-like
 attributes.
+""",
+        "xcode_targets": """\
+A sequence of attribute names to allow Xcode targets to propagate from. This
+will share a lot with the `excluded` sequence, but it will also include some
+additional attributes (e.g. `resources`).
 """,
     },
 )


### PR DESCRIPTION
Part of #100.

Before this change we would create Xcode targets and set dependencies to them along every rule attribute. This was partially a side effect of the changes in input collection that requires us to propagate the aspect along all attributes.

Now we only include transitive information for attributes that should create Xcode targets.