### PR TITLE
Add support for `PBXVariantGroup` to `File`

### DIFF
--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -105,9 +105,9 @@ Product for target "\(id)" not found
         }
 
         guard
-            let generatedFileList = files.first(
-                where: { $0.key == .internal(generatedFileListPath) }
-            )?.value.reference
+            let generatedFileList = files
+                .first(where: { $0.key == .internal(generatedFileListPath) })?
+                .value.fileElement
         else {
             throw PreconditionError(message: "generatedFileList not in `files`")
         }
@@ -190,7 +190,7 @@ File "\(headerFile.filePath)" not found
 """)
             }
             let pbxBuildFile = PBXBuildFile(
-                file: file.reference,
+                file: file.fileElement,
                 settings: headerFile.settings
             )
             pbxProj.add(object: pbxBuildFile)
@@ -232,7 +232,7 @@ File "\(sourceFile.filePath)" not found
 """)
             }
             let pbxBuildFile = PBXBuildFile(
-                file: file.reference,
+                file: file.fileElement,
                 settings: sourceFile.settings
             )
             pbxProj.add(object: pbxBuildFile)
@@ -300,12 +300,12 @@ cp "${SCRIPT_INPUT_FILE_0}" "${SCRIPT_OUTPUT_FILE_0}"
 Framework with file path "\(filePath)" not found
 """)
             }
-            guard let reference = framework.reference else {
+            guard let fileElement = framework.fileElement else {
                 throw PreconditionError(message: """
-Framework with file path "\(filePath)" had nil PBXFileReference
+Framework with file path "\(filePath)" had nil PBXFileElement
 """)
             }
-            let pbxBuildFile = PBXBuildFile(file: reference)
+            let pbxBuildFile = PBXBuildFile(file: fileElement)
             pbxProj.add(object: pbxBuildFile)
             return pbxBuildFile
         }
@@ -332,18 +332,18 @@ Framework with file path "\(filePath)" had nil PBXFileReference
             return nil
         }
 
-        func fileReference(filePath: FilePath) throws -> PBXFileReference {
+        func fileElement(filePath: FilePath) throws -> PBXFileElement {
             guard let resource = files[filePath] else {
                 throw PreconditionError(message: """
 Resource with file path "\(filePath)" not found
 """)
             }
-            guard let reference = resource.reference else {
+            guard let fileElement = resource.fileElement else {
                 throw PreconditionError(message: """
-Resource with file path "\(filePath)" had nil PBXFileReference
+Resource with file path "\(filePath)" had nil PBXFileElement
 """)
             }
-            return reference
+            return fileElement
         }
 
         func productReference(path: Path) throws -> PBXFileReference {
@@ -355,18 +355,18 @@ Resource bundle product reference with path "\(path)" not found
             return reference
         }
 
-        func buildFile(reference: PBXFileReference) -> PBXBuildFile {
-            let pbxBuildFile = PBXBuildFile(file: reference)
+        func buildFile(fileElement: PBXFileElement) -> PBXBuildFile {
+            let pbxBuildFile = PBXBuildFile(file: fileElement)
             pbxProj.add(object: pbxBuildFile)
             return pbxBuildFile
         }
 
-        let nonProductResources = try inputs.resources.map(fileReference)
+        let nonProductResources = try inputs.resources.map(fileElement)
         let produceResources = try resourceBundles.map(productReference)
-        let references = Set(nonProductResources + produceResources)
+        let fileElements = Set(nonProductResources + produceResources)
 
         let buildPhase = PBXResourcesBuildPhase(
-            files: references.map(buildFile).sortedLocalizedStandard()
+            files: fileElements.map(buildFile).sortedLocalizedStandard()
         )
         pbxProj.add(object: buildPhase)
 
@@ -389,13 +389,13 @@ Resource bundle product reference with path "\(path)" not found
 Framework with file path "\(filePath)" not found
 """)
             }
-            guard let reference = framework.reference else {
+            guard let fileElement = framework.fileElement else {
                 throw PreconditionError(message: """
-Framework with file path "\(filePath)" had nil PBXFileReference
+Framework with file path "\(filePath)" had nil PBXFileElement
 """)
             }
             let pbxBuildFile = PBXBuildFile(
-                file: reference,
+                file: fileElement,
                 settings: [
                     "ATTRIBUTES": ["CodeSignOnCopy", "RemoveHeadersOnCopy"],
                 ]

--- a/tools/generator/src/Generator+WriteXcodeProj.swift
+++ b/tools/generator/src/Generator+WriteXcodeProj.swift
@@ -14,9 +14,13 @@ extension Generator {
         let internalOutputPath = outputPath + internalDirectoryName
 
         for (filePath, file) in files.filter(\.key.isInternal) {
+            guard case let .reference(_, content) = file else {
+                continue
+            }
+            
             let path = internalOutputPath + filePath.path
             try path.parent().mkpath()
-            try path.write(file.content)
+            try path.write(content)
         }
     }
 }

--- a/tools/generator/src/Sorting.swift
+++ b/tools/generator/src/Sorting.swift
@@ -3,6 +3,9 @@ import XcodeProj
 private extension PBXFileElement {
     var sortOrder: Int {
         switch self {
+        case is PBXVariantGroup:
+            // Localized containers should be treated as files
+            return 0
         case is PBXGroup:
             return -1
         default:

--- a/tools/generator/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generator/test/CreateFilesAndGroupsTests.swift
@@ -34,16 +34,16 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         )
 
         let expectedFiles: [FilePath: File] = [
-            "a.swift": File(reference: PBXFileReference(
+            "a.swift": .reference(PBXFileReference(
                 sourceTree: .group,
                 lastKnownFileType: "sourcecode.swift",
                 path: "a.swift"
             )),
         ]
-        expectedPBXProj.add(object: expectedFiles["a.swift"]!.reference!)
+        expectedPBXProj.add(object: expectedFiles["a.swift"]!.fileElement!)
 
         let expectedRootElements: [PBXFileElement] = [
-            expectedFiles["a.swift"]!.reference!,
+            expectedFiles["a.swift"]!.fileElement!,
         ]
         expectedMainGroup.addChildren(expectedRootElements)
 

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -540,36 +540,32 @@ enum Fixtures {
                 content = ""
             }
             
-            files[filePath] = File(reference: reference, content: content)
+            files[filePath] = .reference(reference, content: content)
         }
 
         // LinkFileLists
 
-        files[.internal("targets/a1b2c/A 2/A.LinkFileList")] = File(
-            reference: nil,
-            content: """
+        files[.internal("targets/a1b2c/A 2/A.LinkFileList")] =
+            .nonReferencedContent("""
 a/c.a
 z/A.a
 
 """)
 
-        files[.internal("targets/a1b2c/B 2/B.LinkFileList")] = File(
-            reference: nil,
-            content: """
+        files[.internal("targets/a1b2c/B 2/B.LinkFileList")] =
+            .nonReferencedContent("""
 a/b.framework
 
 """)
 
-        files[.internal("targets/a1b2c/B 3/B3.LinkFileList")] = File(
-            reference: nil,
-            content: """
+        files[.internal("targets/a1b2c/B 3/B3.LinkFileList")] =
+            .nonReferencedContent("""
 a/b.framework
 
 """)
 
-        files[.internal("targets/a1b2c/C 2/d.LinkFileList")] = File(
-            reference: nil,
-            content: """
+        files[.internal("targets/a1b2c/C 2/d.LinkFileList")] =
+            .nonReferencedContent("""
 a/c.a
 
 """)
@@ -742,7 +738,7 @@ a/c.a
             return buildFiles
         }
 
-        let elements = files.mapValues(\.reference)
+        let elements = files.mapValues(\.fileElement)
 
         let buildPhases: [TargetID: [PBXBuildPhase]] = [
             "A 1": [
@@ -964,7 +960,7 @@ a/c.a
         let shellScript = PBXShellScriptBuildPhase(
             outputFileListPaths: [
                 files[.internal("generated.xcfilelist")]!
-                    .reference!
+                    .fileElement!
                     .projectRelativePath(in: pbxProj)
                     .string,
             ],


### PR DESCRIPTION
`PBXVariantGroup` is used to hold localized files. For resource bundling we need to copy these references instead of the `PBXFileReference` inside of them.

We don't have anything that creates `PBXVariantGroup`s yet, but that is coming soon in a PR to support localized files.