### PR TITLE
Improve diff on `createdFiles`

### DIFF
--- a/tools/generator/src/FilePath.swift
+++ b/tools/generator/src/FilePath.swift
@@ -62,6 +62,36 @@ extension FilePath {
     }
 }
 
+
+// MARK: Comparable
+
+extension FilePath: Comparable {
+    static func < (lhs: FilePath, rhs: FilePath) -> Bool {
+        guard lhs.path == rhs.path else {
+            return lhs.path < rhs.path
+        }
+        guard lhs.type == rhs.type else {
+            return lhs.type < rhs.type
+        }
+        return lhs.isFolder
+    }
+}
+
+extension FilePath.PathType: Comparable {
+    static func < (lhs: FilePath.PathType, rhs: FilePath.PathType) -> Bool {
+        return lhs.sortKey < rhs.sortKey
+    }
+
+    private var sortKey: Int {
+        switch self {
+        case .project: return 0
+        case .external: return 1
+        case .generated: return 2
+        case .internal: return 3
+        }
+    }
+}
+
 // MARK: Operators
 
 func +(lhs: FilePath, rhs: String) -> FilePath {

--- a/tools/generator/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generator/test/CreateFilesAndGroupsTests.swift
@@ -148,8 +148,29 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(createdRootElements, expectedRootElements)
-        XCTAssertNoDifference(createdFiles, expectedFiles)
+        XCTAssertNoDifference(
+            createdFiles.map(KeyAndValue.init).sorted(),
+            expectedFiles.map(KeyAndValue.init).sorted()
+        )
 
         XCTAssertNoDifference(pbxProj, expectedPBXProj)
+    }
+}
+
+struct KeyAndValue<Key, Value> {
+    let key: Key
+    let value: Value
+
+    init(key: Key, value: Value) {
+        self.key = key
+        self.value = value
+    }
+}
+
+extension KeyAndValue: Equatable where Key: Equatable, Value: Equatable {}
+extension KeyAndValue: Hashable where Key: Hashable, Value: Hashable {}
+extension KeyAndValue: Comparable where Key: Comparable, Value: Equatable {
+    static func < (lhs: KeyAndValue, rhs: KeyAndValue) -> Bool {
+        return lhs.key < rhs.key
     }
 }


### PR DESCRIPTION
We shouldn't need to create the intermediate struct and sort, but currently `CustomDump` mixes up values and keys, making the diff output unreadable. This is at least parsable now when there is a diff failure here.