### PR TITLE
Filter resource targets better

### DIFF
--- a/examples/ios_app/Example/BUILD
+++ b/examples/ios_app/Example/BUILD
@@ -37,7 +37,7 @@ apple_resource_group(
 swift_library(
     name = "Example.library",
     srcs = glob(["**/*.swift"]),
-    data = ["//ExampleResources"] + select({
+    data = [":ExampleLibraryResourceGroup"] + select({
         ":release_build": [],
         "//conditions:default": [":PreviewContent"],
     }),
@@ -49,6 +49,11 @@ swift_library(
         "//third_party:ExampleFramework",
         "@examples_ios_app_external//:ExternalFramework",
     ],
+)
+
+apple_resource_group(
+    name = "ExampleLibraryResourceGroup",
+    resources = ["//ExampleResources"],
 )
 
 filegroup(

--- a/examples/ios_app/ExampleResources/BUILD
+++ b/examples/ios_app/ExampleResources/BUILD
@@ -1,10 +1,16 @@
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_bundle")
+load(":dep_resources_collector.bzl", "dep_resources_collector")
 
 apple_resource_bundle(
     name = "ExampleResources",
     bundle_id = "com.example.resources",
     infoplists = ["Info.plist"],
-    resources = glob(["Assets.xcassets/**"]),
+    resources = glob(["Assets.xcassets/**"]) + [":deps_txt"],
     structured_resources = ["nested/hello.txt"],
     visibility = ["//visibility:public"],
+)
+
+dep_resources_collector(
+    name = "deps_txt",
+    deps = ["//Utils"],
 )

--- a/examples/ios_app/ExampleResources/dep_resources_collector.bzl
+++ b/examples/ios_app/ExampleResources/dep_resources_collector.bzl
@@ -1,0 +1,49 @@
+"""An example aspect to exercise Xcode target selection."""
+
+# buildifier: disable=bzl-visibility
+load("@build_bazel_rules_apple//apple/internal:resources.bzl", "resources")
+
+DepCollectorInfo = provider(
+    "Collects names of transitive dependencies of a target",
+    fields = {"dep_names": "The names of transitive dependencies."},
+)
+
+def _deps_aspect_impl(_target, ctx):
+    return [
+        DepCollectorInfo(
+            dep_names = depset(
+                [ctx.rule.attr.name],
+                transitive = [
+                    dep[DepCollectorInfo].dep_names
+                    for dep in getattr(ctx.rule.attr, "deps", [])
+                ],
+            ),
+        ),
+    ]
+
+_deps_aspect = aspect(
+    implementation = _deps_aspect_impl,
+    attr_aspects = ["*"],
+)
+
+def _dep_resources_collector_impl(ctx):
+    all_deps = depset(
+        transitive = [dep[DepCollectorInfo].dep_names for dep in ctx.attr.deps],
+    ).to_list()
+
+    output = ctx.actions.declare_file("deps.txt")
+    ctx.actions.run_shell(
+        outputs = [output],
+        command = "echo '{}' > {}".format("\n".join(all_deps), output.path),
+    )
+
+    return resources.bucketize(resources = [output])
+
+dep_resources_collector = rule(
+    implementation = _dep_resources_collector_impl,
+    attrs = {
+        "deps": attr.label_list(
+            aspects = [_deps_aspect],
+        ),
+    },
+)

--- a/examples/ios_app/test/fixtures/spec.json
+++ b/examples/ios_app/test/fixtures/spec.json
@@ -11,7 +11,6 @@
         "USE_HEADERMAP": false
     },
     "extra_files": [
-        "ExampleResources/Info.plist",
         "third_party/ExampleFramework.framework/ExampleFramework",
         "third_party/ExampleFramework.framework/Headers/Bar.h",
         "third_party/ExampleFramework.framework/Headers/ExampleFramework.h",
@@ -106,6 +105,7 @@
             "_": "examples_ios_app_external/ExternalFramework.framework/_CodeSignature/CodeResources",
             "t": "e"
         },
+        "ExampleResources/Info.plist",
         {
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
             "t": "g"

--- a/xcodeproj/internal/default_input_file_attributes_aspect.bzl
+++ b/xcodeproj/internal/default_input_file_attributes_aspect.bzl
@@ -1,9 +1,37 @@
 """Implementation of the `default_input_file_attributes_aspect` aspect."""
 
-load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo")
-load(":providers.bzl", "InputFileAttributesInfo")
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleBundleInfo",
+    "AppleResourceBundleInfo",
+    "AppleResourceInfo",
+)
+load(":providers.bzl", "InputFileAttributesInfo", "target_type")
 
 # Utility
+
+def _get_target_type(*, ctx, target):
+    if ctx.rule.kind == "apple_resource_group":
+        return target_type.resources
+
+    # Top-level bundles
+    if AppleBundleInfo in target:
+        return target_type.compile
+
+    # Resources
+    if AppleResourceBundleInfo in target or AppleResourceInfo in target:
+        return target_type.resources
+
+    # Libraries
+    if CcInfo in target:
+        return target_type.compile
+
+    # Command-line tools
+    executable = target[DefaultInfo].files_to_run.executable
+    if executable and not executable.is_source:
+        return target_type.compile
+
+    return None
 
 def _is_test_target(target):
     """Returns whether the given target is for test purposes or not."""
@@ -20,6 +48,8 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
     if InputFileAttributesInfo in target:
         return []
 
+    this_target_type = _get_target_type(ctx = ctx, target = target)
+
     if CcInfo in target:
         srcs = ("srcs")
     else:
@@ -27,49 +57,80 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
 
     non_arc_srcs = ()
     hdrs = ()
-    resources = ()
+    resources = {}
     structured_resources = ()
     bundle_imports = ()
     if ctx.rule.kind == "cc_library":
-        xcode_targets = ("deps", "interface_deps")
+        xcode_targets = {
+            "deps": target_type.compile,
+            "interface_deps": target_type.compile,
+        }
         excluded = ("deps", "interface_deps", "win_def_file")
         hdrs = ("hdrs", "textual_hdrs")
+        resources = {
+            "deps": target_type.compile,
+            "interface_deps": target_type.compile,
+        }
     elif ctx.rule.kind == "objc_library":
-        xcode_targets = ("deps", "runtime_deps", "data")
+        xcode_targets = {
+            "deps": target_type.compile,
+            "runtime_deps": target_type.compile,
+            "data": target_type.resources,
+        }
         excluded = ("deps", "runtime_deps")
         non_arc_srcs = ("non_arc_srcs")
         hdrs = ("hdrs", "textual_hdrs")
-        resources = ("data")
+        resources = {
+            "deps": target_type.compile,
+            "runtime_deps": target_type.compile,
+            "data": target_type.resources,
+        }
     elif ctx.rule.kind == "swift_library":
-        xcode_targets = ("deps", "private_deps", "data")
+        xcode_targets = {
+            "deps": target_type.compile,
+            "private_deps": target_type.compile,
+            "data": target_type.resources,
+        }
         excluded = ("deps", "private_deps")
-        resources = ("data")
+        resources = {
+            "deps": target_type.compile,
+            "private_deps": target_type.compile,
+            "data": target_type.resources,
+        }
     elif (ctx.rule.kind == "apple_resource_group" or
           ctx.rule.kind == "apple_resource_bundle"):
-        xcode_targets = ("resources")
+        xcode_targets = {"resources": target_type.resources}
         excluded = ()
-        resources = ("resources")
+        resources = {"resources": target_type.resources}
         structured_resources = ("structured_resources")
     elif ctx.rule.kind == "apple_bundle_import":
-        xcode_targets = ()
+        xcode_targets = {}
         excluded = ()
         bundle_imports = ("bundle_imports")
     elif ctx.rule.kind == "genrule":
-        xcode_targets = ()
+        xcode_targets = {}
         excluded = ("tools")
     elif AppleBundleInfo in target:
-        xcode_targets = ["deps", "resources"]
+        xcode_targets = {
+            "deps": target_type.compile,
+            "resources": target_type.resources,
+        }
         excluded = ["deps", "extensions", "frameworks"]
         if _is_test_target(target):
-            xcode_targets.append("test_host")
+            xcode_targets["test_host"] = target_type.compile
             excluded.append("test_host")
-        resources = ("resources")
+        resources = {
+            "deps": target_type.compile,
+            "resources": target_type.resources,
+        }
     else:
-        xcode_targets = ("deps")
+        xcode_targets = {"deps": this_target_type}
         excluded = ("deps")
+        resources = {"deps": this_target_type}
 
     return [
         InputFileAttributesInfo(
+            target_type = this_target_type,
             xcode_targets = xcode_targets,
             excluded = excluded,
             non_arc_srcs = non_arc_srcs,

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -11,6 +11,10 @@ rules, then you will use these providers to communicate between them.
 InputFileAttributesInfo = provider(
     "Specifies how input files of a target are collected.",
     fields = {
+        "bundle_imports": """\
+A sequence of attribute names to collect `File`s from for `bundle_imports`-like
+attributes.
+""",
         "excluded": """\
 A sequence of attribute names to not collect `File`s from. This should generally
 be `deps` and `deps`-like attributes. The goal is to exclude attributes that
@@ -36,16 +40,18 @@ attributes.
 A sequence of attribute names to collect `File`s from for
 `structured_resources`-like attributes.
 """,
-        "bundle_imports": """\
-A sequence of attribute names to collect `File`s from for `bundle_imports`-like
-attributes.
-""",
+        "target_type": "See `XcodeProjInfo.target_type`.",
         "xcode_targets": """\
-A sequence of attribute names to allow Xcode targets to propagate from. This
-will share a lot with the `excluded` sequence, but it will also include some
-additional attributes (e.g. `resources`).
+A `dict` mapping attribute names to target type strings (i.e. "resource" or
+"compile"). Only Xcode targets from the specified attributes with the specified
+target type are allowed to propagate.
 """,
     },
+)
+
+target_type = struct(
+    compile = "compile",
+    resources = "resources",
 )
 
 XcodeProjInfo = provider(
@@ -86,6 +92,11 @@ paths of any target that depends on this target.
         "target": """\
 A `struct` that contains information about the current target that is
 potentially needed by the dependent targets.
+""",
+        "target_type": """\
+A string that categorizes the type of the current target. This will be one of
+"compile", "resources", or `None`. Even if this target doesn't produce an Xcode
+target, it can still have a non-`None` value for this field.
 """,
         "xcode_targets": """\
 A `depset` of partial json `dict` strings (e.g. a single '"Key": "Value"'

--- a/xcodeproj/internal/resource_bundle_products.bzl
+++ b/xcodeproj/internal/resource_bundle_products.bzl
@@ -5,12 +5,15 @@ def _collect(
         bundle_path = None,
         owner,
         is_consuming_bundle,
+        attrs_info,
         transitive_infos):
     if owner:
         transitive_unowned_products = depset(
             transitive = [
                 info.resource_bundles._unowned_products
-                for _, info in transitive_infos
+                for attr, info in transitive_infos
+                if (not attrs_info or
+                    attrs_info.xcode_targets.get(attr) == info.target_type)
             ],
         )
         owned_products = [
@@ -24,7 +27,9 @@ def _collect(
             [bundle_path] if bundle_path else None,
             transitive = [
                 info.resource_bundles._unowned_products
-                for _, info in transitive_infos
+                for attr, info in transitive_infos
+                if (not attrs_info or
+                    attrs_info.xcode_targets.get(attr) == info.target_type)
             ],
         )
 

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -183,6 +183,7 @@ def _xcodeproj_impl(ctx):
         if XcodeProjInfo in dep
     ]
     inputs = input_files.merge(
+        attrs_info = None,
         transitive_infos = [(None, info) for info in infos],
     )
 


### PR DESCRIPTION
While this prevents some extra Xcode targets from being created when they aren't wanted, it has an issue logged in https://github.com/buildbuddy-io/rules_xcodeproj/issues/228.