### PR TITLE
Fix generated files target dependency detection

### DIFF
--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -57,6 +57,13 @@
 			remoteGlobalIDString = EAB95A4512529D4CB8BE5D4E;
 			remoteInfo = Example;
 		};
+		05F71069DEEAD35A2A289575 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3064A34776444DE49627998E;
+			remoteInfo = "Bazel Generated Files";
+		};
 		078E6A97773B9731CAA6A183 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
@@ -147,6 +154,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 8B1A49AD77FC1690CB9AE556;
 			remoteInfo = TestingUtils;
+		};
+		9EA5AB932A9708D1A7667DFA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3064A34776444DE49627998E;
+			remoteInfo = "Bazel Generated Files";
 		};
 		E58F4A1E1F92E1E2F5570ED4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -598,6 +612,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				2C3EF0A78A1C6D3ED61F8B20 /* PBXTargetDependency */,
 				8090BAEEB7C7D714E55D865C /* PBXTargetDependency */,
 				B9E875CC0E0CE82EAE0D68E4 /* PBXTargetDependency */,
 			);
@@ -648,6 +663,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				BA07896B61B9027F0533AC69 /* PBXTargetDependency */,
 				21627D3581B6ADD9906D176D /* PBXTargetDependency */,
 				B83AE2FC96D66AE4CB710137 /* PBXTargetDependency */,
 				545A036FD772496B7255F60D /* PBXTargetDependency */,
@@ -1024,6 +1040,12 @@
 			target = EAB95A4512529D4CB8BE5D4E /* Example */;
 			targetProxy = 3846663A93CA92FEEE314085 /* PBXContainerItemProxy */;
 		};
+		2C3EF0A78A1C6D3ED61F8B20 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 3064A34776444DE49627998E /* Bazel Generated Files */;
+			targetProxy = 9EA5AB932A9708D1A7667DFA /* PBXContainerItemProxy */;
+		};
 		39159660DA50973079657E41 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Bazel Generated Files";
@@ -1083,6 +1105,12 @@
 			name = ExternalResources;
 			target = A92585AB652F9F937D1D19A2 /* ExternalResources */;
 			targetProxy = 6CCFBB6244E6F79BBAE14283 /* PBXContainerItemProxy */;
+		};
+		BA07896B61B9027F0533AC69 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 3064A34776444DE49627998E /* Bazel Generated Files */;
+			targetProxy = 05F71069DEEAD35A2A289575 /* PBXContainerItemProxy */;
 		};
 		C418EED9BCE57CCDB9B6CA97 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/examples/ios_app/test/fixtures/spec.json
+++ b/examples/ios_app/test/fixtures/spec.json
@@ -357,6 +357,7 @@
                 "t": "g"
             },
             "inputs": {
+                "contains_generated_files": true,
                 "resources": [
                     {
                         "_": "examples_ios_app_external/bundles/Utils.bundle",
@@ -464,6 +465,7 @@
             "frameworks": [],
             "info_plist": null,
             "inputs": {
+                "contains_generated_files": true,
                 "srcs": [
                     "Example/ContentView.swift",
                     "Example/ExampleApp.swift"
@@ -596,6 +598,7 @@
                 "t": "g"
             },
             "inputs": {
+                "contains_generated_files": true,
                 "resources": [
                     {
                         "_": "examples_ios_app_external/bundles/Utils.bundle",
@@ -845,7 +848,9 @@
                 "_": "applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
             },
-            "inputs": {},
+            "inputs": {
+                "contains_generated_files": true
+            },
             "is_swift": false,
             "label": "//ExampleTests:ExampleTests.__internal__.__test_bundle",
             "links": [
@@ -937,6 +942,7 @@
             "frameworks": [],
             "info_plist": null,
             "inputs": {
+                "contains_generated_files": true,
                 "srcs": [
                     "ExampleTests/ExampleTests.swift"
                 ]
@@ -1080,7 +1086,9 @@
                 "_": "applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
             },
-            "inputs": {},
+            "inputs": {
+                "contains_generated_files": true
+            },
             "is_swift": false,
             "label": "//ExampleUITests:ExampleUITests.__internal__.__test_bundle",
             "links": [
@@ -1257,6 +1265,7 @@
             "frameworks": [],
             "info_plist": null,
             "inputs": {
+                "contains_generated_files": true,
                 "srcs": [
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swift",

--- a/test/fixtures/command_line/spec.json
+++ b/test/fixtures/command_line/spec.json
@@ -182,6 +182,7 @@
             "frameworks": [],
             "info_plist": null,
             "inputs": {
+                "contains_generated_files": true,
                 "srcs": [
                     "examples/command_line/lib/lib.swift"
                 ]

--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -86,8 +86,7 @@ Product for target "\(id)" not found in `products`
             pbxTargets[id] = pbxTarget
 
             if
-                target.inputs.containsGeneratedFiles
-                    || target.modulemaps.containsGeneratedFiles,
+                target.inputs.containsGeneratedFiles,
                 let generatedFilesTarget = generatedFilesTarget
             {
                 _ = try pbxTarget.addDependency(target: generatedFilesTarget)
@@ -539,11 +538,6 @@ private struct SourceFile: Hashable {
 }
 
 extension Inputs {
-    var containsGeneratedFiles: Bool {
-        return srcs.containsGeneratedFiles
-            || nonArcSrcs.containsGeneratedFiles
-    }
-
     var containsSourceFiles: Bool {
         return !(srcs.isEmpty && nonArcSrcs.isEmpty)
     }

--- a/tools/generator/src/Inputs.swift
+++ b/tools/generator/src/Inputs.swift
@@ -3,17 +3,20 @@ struct Inputs: Equatable {
     var nonArcSrcs: Set<FilePath>
     var hdrs: Set<FilePath>
     var resources: Set<FilePath>
+    var containsGeneratedFiles: Bool
 
     init(
         srcs: Set<FilePath> = [],
         nonArcSrcs: Set<FilePath> = [],
         hdrs: Set<FilePath> = [],
-        resources: Set<FilePath> = []
+        resources: Set<FilePath> = [],
+        containsGeneratedFiles: Bool = false
     ) {
         self.srcs = srcs
         self.nonArcSrcs = nonArcSrcs
         self.hdrs = hdrs
         self.resources = resources
+        self.containsGeneratedFiles = containsGeneratedFiles
     }
 }
 
@@ -23,6 +26,8 @@ extension Inputs {
         nonArcSrcs.formUnion(other.nonArcSrcs)
         hdrs.formUnion(other.hdrs)
         resources.formUnion(other.resources)
+        containsGeneratedFiles = containsGeneratedFiles
+            || other.containsGeneratedFiles
     }
 
     func union(_ other: Inputs) -> Inputs {
@@ -49,6 +54,7 @@ extension Inputs: Decodable {
         case nonArcSrcs
         case hdrs
         case resources
+        case containsGeneratedFiles
     }
 
     init(from decoder: Decoder) throws {
@@ -58,6 +64,10 @@ extension Inputs: Decodable {
         nonArcSrcs = try container.decodeFilePaths(.nonArcSrcs)
         hdrs = try container.decodeFilePaths(.hdrs)
         resources = try container.decodeFilePaths(.resources)
+        containsGeneratedFiles = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .containsGeneratedFiles
+        ) ?? false
     }
 }
 

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -103,7 +103,11 @@ enum Fixtures {
             packageBinDir: "bazel-out/a1b2c/bin/C 1",
             product: .init(type: .staticLibrary, name: "c", path: "a/c.a"),
             modulemaps: [.generated("a/b/module.modulemap")],
-            inputs: .init(srcs: ["a/b/c.m"], hdrs: ["a/b/c.h"])
+            inputs: .init(
+                srcs: ["a/b/c.m"],
+                hdrs: ["a/b/c.h"],
+                containsGeneratedFiles: true
+            )
         ),
         "C 2": Target.mock(
             packageBinDir: "bazel-out/a1b2c/bin/C 2",

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -257,6 +257,7 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md
                 if _should_include_transitive_resources(info = info)
             ],
         ),
+        contains_generated_files = bool(generated),
         generated = depset(
             generated,
             transitive = [
@@ -372,6 +373,12 @@ def _to_dto(inputs, *, is_bundle, avoid_infos):
                 if owner not in avoid_owners
             ],
         )
+
+    set_if_true(
+        ret,
+        "contains_generated_files",
+        inputs.contains_generated_files,
+    )
 
     return ret
 


### PR DESCRIPTION
As we add new inputs, such as we did with the Info.plist, it was easy to forget to update the logic around adding the Bazel Generated Files target dependency. Since we have all of the information we need in `input_files.to_dto()`, I've moved the logic there so we will automatically catch these dependencies in the future.