### PR TITLE
Fix non-generated build setting paths

### DIFF
--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -1159,7 +1159,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/CoreUtilsObjC",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
@@ -1205,7 +1205,7 @@
 				TARGET_NAME = Utils;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
 				);
 			};
 			name = Debug;
@@ -1299,7 +1299,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/CoreUtilsObjC",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
 				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -1348,7 +1348,7 @@
 				PRODUCT_NAME = ExampleTests;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG AWESOME";
-				SWIFT_INCLUDE_PATHS = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -1358,7 +1358,7 @@
 				TEST_HOST = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example.app/Example";
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
 				);
 			};
 			name = Debug;
@@ -1431,7 +1431,7 @@
 				TARGET_NAME = TestingUtils;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
 				);
 			};
 			name = Debug;
@@ -1467,7 +1467,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/CoreUtilsObjC",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
@@ -1513,7 +1513,7 @@
 				TARGET_NAME = CoreUtilsObjC;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
 				);
 			};
 			name = Debug;
@@ -1539,7 +1539,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/CoreUtilsObjC",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
 				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -1599,7 +1599,7 @@
 				TARGET_NAME = Example;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
 				);
 			};
 			name = Debug;
@@ -1620,7 +1620,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/CoreUtilsObjC",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
 				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -1678,7 +1678,7 @@
 				TEST_HOST = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example.app/Example";
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin",
 				);
 			};
 			name = Debug;

--- a/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/modulemaps.fixed.xcfilelist
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/modulemaps.fixed.xcfilelist
@@ -1,3 +1,3 @@
-$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.xcode.modulemap
-$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swift.xcode.modulemap
-$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.xcode.modulemap
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.xcode.modulemap
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swift.xcode.modulemap
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.xcode.modulemap

--- a/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/modulemaps.xcfilelist
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/rules_xcodeproj/modulemaps.xcfilelist
@@ -1,3 +1,3 @@
-$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap
-$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swift.modulemap
-$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swift.modulemap
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.modulemap

--- a/test/fixtures/cc/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/project.xcodeproj/project.pbxproj
@@ -390,7 +390,7 @@
 				TARGET_NAME = lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
 				);
 			};
 			name = Debug;
@@ -473,11 +473,11 @@
 				TARGET_NAME = tool;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
 					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/examples_cc_external",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external",
 					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/bazel_tools",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/bazel_tools",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/bazel_tools",
 				);
 			};
 			name = Debug;
@@ -493,7 +493,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/examples/cc/lib/private",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/examples/cc/lib/private",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/examples/cc/lib/private",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
@@ -539,7 +539,7 @@
 				TARGET_NAME = lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin",
 				);
 			};
 			name = Debug;
@@ -555,7 +555,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/examples_cc_external/private",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external/private",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external/private",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
@@ -601,7 +601,7 @@
 				TARGET_NAME = lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/examples_cc_external",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/examples_cc_external",
 				);
 			};
 			name = Debug;

--- a/test/fixtures/command_line/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/project.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 				TARGET_NAME = lib_swift;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
+					"$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
 				);
 			};
 			name = Debug;
@@ -522,9 +522,9 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"\"$(PROJECT_DIR)/examples/command_line/lib/dir with space\"",
-					"\"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/dir with space\"",
+					"\"$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/dir with space\"",
 					"$(PROJECT_DIR)/examples/command_line/lib/private",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/private",
+					"$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/private",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_CFLAGS = (
@@ -577,7 +577,7 @@
 				TARGET_NAME = tool;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
+					"$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
 				);
 			};
 			name = Debug;
@@ -638,7 +638,7 @@
 				TARGET_NAME = lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)",
-					"$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
+					"$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin",
 				);
 			};
 			name = Debug;

--- a/test/fixtures/command_line/project.xcodeproj/rules_xcodeproj/modulemaps.fixed.xcfilelist
+++ b/test/fixtures/command_line/project.xcodeproj/rules_xcodeproj/modulemaps.fixed.xcfilelist
@@ -1,1 +1,1 @@
-$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap

--- a/test/fixtures/command_line/project.xcodeproj/rules_xcodeproj/modulemaps.xcfilelist
+++ b/test/fixtures/command_line/project.xcodeproj/rules_xcodeproj/modulemaps.xcfilelist
@@ -1,1 +1,1 @@
-$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/lib_impl.swift.modulemap
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/lib_impl.swift.modulemap

--- a/test/fixtures/generator/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/project.xcodeproj/project.pbxproj
@@ -1447,7 +1447,7 @@
 				PRODUCT_NAME = XcodeProj;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -1564,7 +1564,7 @@
 				PRODUCT_NAME = tests;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_swift_custom_dump";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/tools/generator $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_swift_custom_dump";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -1748,7 +1748,7 @@
 				PRODUCT_NAME = generator.library;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_tuist_xcodeproj";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -1804,7 +1804,7 @@
 				PRODUCT_NAME = CustomDump;
 				SDKROOT = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-fastbuild-ST-1b9bd654f600/bin/external/com_github_pointfreeco_xctest_dynamic_overlay";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;

--- a/tools/generator/src/FilePathResolver.swift
+++ b/tools/generator/src/FilePathResolver.swift
@@ -24,7 +24,7 @@ struct FilePathResolver: Equatable {
 
     func resolve(
         _ filePath: FilePath,
-        useBuildDir: Bool = false,
+        useBuildDir: Bool = true,
         useOriginalGeneratedFiles: Bool = false,
         useScriptVariables: Bool = false
     ) -> Path {

--- a/tools/generator/src/Generator+SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator+SetTargetConfigurations.swift
@@ -65,12 +65,7 @@ Target "\(id)" not found in `pbxTargets`
                 onKey: "OTHER_SWIFT_FLAGS",
                 target.modulemaps
                     .map { filePath -> String in
-                        var modulemap = filePathResolver
-                            // Header resolution is based on this path, so we
-                            // need to have it rooted in `$(BUILD_DIR)` instead
-                            // of `gen_dir`, otherwise it can't find the
-                            // `SRCROOT` symlink
-                            .resolve(filePath, useBuildDir: true)
+                        var modulemap = filePathResolver.resolve(filePath)
 
                         if filePath.type == .generated {
                             modulemap.replaceExtension("xcode.modulemap")
@@ -115,7 +110,11 @@ Target "\(id)" not found in `pbxTargets`
             buildSettings["TARGET_NAME"] = target.name
 
             if let infoPlist = target.infoPlist {
-              let infoPlistPath = filePathResolver.resolve(infoPlist).string.quoted
+              let infoPlistPath = filePathResolver
+                    // We need to use `gen_dir` instead of `$(BUILD_DIR)` here
+                    // to match the project navigator
+                    .resolve(infoPlist, useBuildDir: false)
+                    .string.quoted
               buildSettings["INFOPLIST_FILE"] = infoPlistPath
             } else {
               buildSettings["GENERATE_INFOPLIST_FILE"] = true

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -600,7 +600,7 @@ enum Fixtures {
 
         // xcfilelists
 
-        let genDir = "$(PROJECT_FILE_PATH)/\(internalDirectoryName)/gen_dir"
+        let genDir = "$(BUILD_DIR)/bazel-out"
 
         files[.internal("generated.xcfilelist")] = .nonReferencedContent("""
 \(generatedDirectory)/a/b/module.modulemap
@@ -610,8 +610,8 @@ enum Fixtures {
 
         files[.internal("generated.copied.xcfilelist")] = .nonReferencedContent(
 """
-\(genDir)/a/b/module.modulemap
-\(genDir)/a1b2c/bin/t.c
+$(PROJECT_FILE_PATH)/\(internalDirectoryName)/gen_dir/a/b/module.modulemap
+$(PROJECT_FILE_PATH)/\(internalDirectoryName)/gen_dir/a1b2c/bin/t.c
 
 """)
 
@@ -1248,9 +1248,7 @@ ln -sfn "\#(
 """#,
                 ],
                 "SDKROOT": "macosx",
-                "SWIFT_INCLUDE_PATHS": """
-$(PROJECT_FILE_PATH)/rules_xcp/gen_dir/x
-""",
+                "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/x",
                 "TARGET_NAME": targets["A 2"]!.name,
             ]) { $1 },
             "B 1": targets["B 1"]!.buildSettings.asDictionary.merging([
@@ -1260,9 +1258,7 @@ $(PROJECT_FILE_PATH)/rules_xcp/gen_dir/x
 -Xcc -fmodule-map-file=$(PROJECT_DIR)/a/module.modulemap
 """,
                 "SDKROOT": "macosx",
-                "SWIFT_INCLUDE_PATHS": """
-$(PROJECT_FILE_PATH)/rules_xcp/gen_dir/x
-""",
+                "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/x",
                 "TARGET_NAME": targets["B 1"]!.name,
             ]) { $1 },
             "B 2": targets["B 2"]!.buildSettings.asDictionary.merging([


### PR DESCRIPTION
For targets that don't depend on `Bazel Generated Files`, the `gen_dir` symlink might not be created yet, so search paths need to be based on `$(BUILD_DIR)` instead.