### PR TITLE
Don't blow away `gen_dir` on each install

### DIFF
--- a/xcodeproj/internal/installer.template.sh
+++ b/xcodeproj/internal/installer.template.sh
@@ -16,6 +16,7 @@ rsync \
   --exclude=project.xcworkspace \
   --exclude=xcuserdata \
   --exclude=xcshareddata/xcschemes \
+  --exclude=rules_xcodeproj/gen_dir \
   --delete \
   "$src/" "$dest/"
 


### PR DESCRIPTION
If we don't do this, Xcode shows generated files as unreachable until after the symlink is created again and the project is reopened.