### PR TITLE
Use python3 instead of python for compatibility with newer versions of macOS

### DIFF
--- a/xcodeproj/internal/updater.template.sh
+++ b/xcodeproj/internal/updater.template.sh
@@ -15,7 +15,7 @@ for spec in "${specs[@]}"; do
   dest="$dir/spec.json"
 
   mkdir -p "$dir"
-  python -m json.tool "$spec" > "$dest"
+  python3 -m json.tool "$spec" > "$dest"
 done
 
 for installer in "${installers[@]}"; do


### PR DESCRIPTION
This was failing for me locally on macOS 12.3. I believe earlier versions of macOS also ship with `python3`, so hopefully it doesn't break for anyone else.