### PR TITLE
Fix resource targets that are included via `deps`

### DIFF
--- a/examples/ios_app/ExampleTests/BUILD
+++ b/examples/ios_app/ExampleTests/BUILD
@@ -14,11 +14,11 @@ swift_library(
     name = "ExampleTests.library",
     testonly = True,
     srcs = glob(["**/*.swift"]),
-    data = ["//ExampleResources"],
     module_name = "ExampleTests",
     tags = ["manual"],
     deps = [
         "//Example:Example.library",
+        "//ExampleResources",
         "//TestingUtils",
         "//Utils",
     ],

--- a/examples/ios_app/test/fixtures/spec.json
+++ b/examples/ios_app/test/fixtures/spec.json
@@ -976,8 +976,8 @@
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
             "dependencies": [
-                "//ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
                 "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
+                "//ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
                 "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
                 "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
             ],

--- a/xcodeproj/internal/default_input_file_attributes_aspect.bzl
+++ b/xcodeproj/internal/default_input_file_attributes_aspect.bzl
@@ -63,47 +63,47 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
     bundle_imports = ()
     if ctx.rule.kind == "cc_library":
         xcode_targets = {
-            "deps": target_type.compile,
-            "interface_deps": target_type.compile,
+            "deps": [target_type.compile, target_type.resources],
+            "interface_deps": [target_type.compile],
         }
         excluded = ("deps", "interface_deps", "win_def_file")
         hdrs = ("hdrs", "textual_hdrs")
         resources = {
-            "deps": target_type.compile,
-            "interface_deps": target_type.compile,
+            "deps": [target_type.compile, target_type.resources],
+            "interface_deps": [target_type.compile],
         }
     elif ctx.rule.kind == "objc_library":
         xcode_targets = {
-            "deps": target_type.compile,
-            "runtime_deps": target_type.compile,
-            "data": target_type.resources,
+            "deps": [target_type.compile, target_type.resources],
+            "runtime_deps": [target_type.compile],
+            "data": [target_type.resources],
         }
         excluded = ("deps", "runtime_deps")
         non_arc_srcs = ("non_arc_srcs")
         hdrs = ("hdrs", "textual_hdrs")
         pch = "pch"
         resources = {
-            "deps": target_type.compile,
-            "runtime_deps": target_type.compile,
-            "data": target_type.resources,
+            "deps": [target_type.compile, target_type.resources],
+            "runtime_deps": [target_type.compile],
+            "data": [target_type.resources],
         }
     elif ctx.rule.kind == "swift_library":
         xcode_targets = {
-            "deps": target_type.compile,
-            "private_deps": target_type.compile,
-            "data": target_type.resources,
+            "deps": [target_type.compile, target_type.resources],
+            "private_deps": [target_type.compile],
+            "data": [target_type.resources],
         }
         excluded = ("deps", "private_deps")
         resources = {
-            "deps": target_type.compile,
-            "private_deps": target_type.compile,
-            "data": target_type.resources,
+            "deps": [target_type.compile, target_type.resources],
+            "private_deps": [target_type.compile],
+            "data": [target_type.resources],
         }
     elif (ctx.rule.kind == "apple_resource_group" or
           ctx.rule.kind == "apple_resource_bundle"):
-        xcode_targets = {"resources": target_type.resources}
+        xcode_targets = {"resources": [target_type.resources]}
         excluded = ()
-        resources = {"resources": target_type.resources}
+        resources = {"resources": [target_type.resources]}
         structured_resources = ("structured_resources")
     elif ctx.rule.kind == "apple_bundle_import":
         xcode_targets = {}
@@ -114,21 +114,21 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
         excluded = ("tools")
     elif AppleBundleInfo in target:
         xcode_targets = {
-            "deps": target_type.compile,
-            "resources": target_type.resources,
+            "deps": [target_type.compile, target_type.resources],
+            "resources": [target_type.resources],
         }
         excluded = ["deps", "extensions", "frameworks"]
         if _is_test_target(target):
-            xcode_targets["test_host"] = target_type.compile
+            xcode_targets["test_host"] = [target_type.compile]
             excluded.append("test_host")
         resources = {
-            "deps": target_type.compile,
-            "resources": target_type.resources,
+            "deps": [target_type.compile, target_type.resources],
+            "resources": [target_type.resources],
         }
     else:
-        xcode_targets = {"deps": this_target_type}
+        xcode_targets = {"deps": [this_target_type, target_type.resources]}
         excluded = ("deps")
-        resources = {"deps": this_target_type}
+        resources = {"deps": [this_target_type, target_type.resources]}
 
     return [
         InputFileAttributesInfo(

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -40,7 +40,7 @@ def _collect_transitive_extra_files(info):
 def _should_include_transitive_resources(*, attrs_info, attr, info):
     return ((not info.target or not info.target.is_bundle) and
             (not attrs_info or
-             attrs_info.resources.get(attr) == info.target_type))
+             info.target_type in attrs_info.resources.get(attr, [None])))
 
 def _should_ignore_attr(attr, *, excluded_attrs):
     return (

--- a/xcodeproj/internal/resource_bundle_products.bzl
+++ b/xcodeproj/internal/resource_bundle_products.bzl
@@ -15,7 +15,7 @@ def _collect(
                 info.resource_bundles._unowned_products
                 for attr, info in transitive_infos
                 if (not attrs_info or
-                    attrs_info.xcode_targets.get(attr) == info.target_type)
+                    info.target_type in attrs_info.xcode_targets.get(attr, [None]))
             ],
         )
         owned_products = [
@@ -31,7 +31,7 @@ def _collect(
                 info.resource_bundles._unowned_products
                 for attr, info in transitive_infos
                 if (not attrs_info or
-                    attrs_info.xcode_targets.get(attr) == info.target_type)
+                    info.target_type in attrs_info.xcode_targets.get(attr, [None]))
             ],
         )
 

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -1182,7 +1182,7 @@ def _process_dependencies(*, attrs_info, transitive_infos):
             [info.target.id] if info.target else info.dependencies
             for attr, info in transitive_infos
             if (not attrs_info or
-                attrs_info.xcode_targets.get(attr) == info.target_type)
+                info.target_type in attrs_info.xcode_targets.get(attr, [None]))
         ])
     ]
 
@@ -1442,8 +1442,8 @@ def _process_target(*, ctx, target, transitive_infos):
             transitive = [
                 info.potential_target_merges
                 for attr, info in transitive_infos
-                if (processed_target.attrs_info.xcode_targets.get(attr) ==
-                    info.target_type)
+                if (info.target_type in
+                    processed_target.attrs_info.xcode_targets.get(attr, [None]))
             ],
         ),
         required_links = depset(
@@ -1451,8 +1451,8 @@ def _process_target(*, ctx, target, transitive_infos):
             transitive = [
                 info.required_links
                 for attr, info in transitive_infos
-                if (processed_target.attrs_info.xcode_targets.get(attr) ==
-                    info.target_type)
+                if (info.target_type in
+                    processed_target.attrs_info.xcode_targets.get(attr, [None]))
             ],
         ),
         resource_bundles = processed_target.resource_bundles,
@@ -1465,8 +1465,8 @@ def _process_target(*, ctx, target, transitive_infos):
             transitive = [
                 info.xcode_targets
                 for attr, info in transitive_infos
-                if (processed_target.attrs_info.xcode_targets.get(attr) ==
-                    info.target_type)
+                if (info.target_type in
+                    processed_target.attrs_info.xcode_targets.get(attr, [None]))
             ],
         ),
     )


### PR DESCRIPTION
Part of #80, #81, #103. 

This doesn't make sense, but it's clearly supported with rules_apple. This also is more fuel for me to eventually rewrite this in a way that fixes another resource completeness bug (#228).