### PR TITLE
Perform merge detection in Starlark

### DIFF
--- a/examples/ios_app/test/fixtures/spec.json
+++ b/examples/ios_app/test/fixtures/spec.json
@@ -163,9 +163,10 @@
             "t": "g"
         }
     ],
+    "invalid_target_merges": [],
     "label": "//test/fixtures:fixture",
     "name": "project",
-    "potential_target_merges": [
+    "target_merges": [
         "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
         [
             "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
@@ -182,21 +183,6 @@
         [
             "//ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
         ]
-    ],
-    "required_links": [
-        {
-            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/libUtils.a",
-            "t": "g"
-        },
-        {
-            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/libCoreUtilsObjC.a",
-            "t": "g"
-        },
-        "third_party/ExampleFramework.framework/ExampleFramework",
-        {
-            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/libTestingUtils.a",
-            "t": "g"
-        }
     ],
     "targets": [
         "//CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",

--- a/test/fixtures/cc/spec.json
+++ b/test/fixtures/cc/spec.json
@@ -18,10 +18,10 @@
             "t": "e"
         }
     ],
+    "invalid_target_merges": [],
     "label": "//test/fixtures/cc:xcodeproj",
     "name": "project",
-    "potential_target_merges": [],
-    "required_links": [],
+    "target_merges": [],
     "targets": [
         "//examples/cc/lib2:lib_impl darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
         {

--- a/test/fixtures/command_line/spec.json
+++ b/test/fixtures/command_line/spec.json
@@ -19,23 +19,14 @@
         "examples/command_line/lib/dir with space/lib.h",
         "examples/command_line/tool/Info.plist"
     ],
+    "invalid_target_merges": [],
     "label": "//test/fixtures/command_line:xcodeproj",
     "name": "project",
-    "potential_target_merges": [
+    "target_merges": [
         "//examples/command_line/tool:tool.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57",
         [
             "//examples/command_line/tool:tool applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57"
         ]
-    ],
-    "required_links": [
-        {
-            "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/liblib_swift.a",
-            "t": "g"
-        },
-        {
-            "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/liblib_impl.a",
-            "t": "g"
-        }
     ],
     "targets": [
         "//examples/command_line/lib:lib_impl macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57",

--- a/test/fixtures/generator/spec.json
+++ b/test/fixtures/generator/spec.json
@@ -12,43 +12,19 @@
         "VALIDATE_WORKSPACE": false
     },
     "extra_files": [],
-    "label": "//test/fixtures/generator:xcodeproj",
-    "name": "project",
-    "potential_target_merges": [
-        "//tools/generator/test:tests.library darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
-        [
-            "//tools/generator/test:tests darwin_x86_64-fastbuild-ST-d53d69b6b8c1"
-        ],
+    "invalid_target_merges": [
         "//tools/generator:generator.library darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
         [
             "//tools/generator:generator darwin_x86_64-fastbuild-ST-d53d69b6b8c1"
         ]
     ],
-    "required_links": [
-        {
-            "_": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1/bin/external/com_github_kylef_pathkit/libPathKit.a",
-            "t": "g"
-        },
-        {
-            "_": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1/bin/external/com_github_tadija_aexml/libAEXML.a",
-            "t": "g"
-        },
-        {
-            "_": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
-            "t": "g"
-        },
-        {
-            "_": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a",
-            "t": "g"
-        },
-        {
-            "_": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
-            "t": "g"
-        },
-        {
-            "_": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1/bin/tools/generator/libgenerator.library.a",
-            "t": "g"
-        }
+    "label": "//test/fixtures/generator:xcodeproj",
+    "name": "project",
+    "target_merges": [
+        "//tools/generator/test:tests.library darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
+        [
+            "//tools/generator/test:tests darwin_x86_64-fastbuild-ST-d53d69b6b8c1"
+        ]
     ],
     "targets": [
         "//tools/generator/test:tests darwin_x86_64-fastbuild-ST-d53d69b6b8c1",

--- a/tools/generator/src/DTO.swift
+++ b/tools/generator/src/DTO.swift
@@ -6,8 +6,8 @@ struct Project: Equatable, Decodable {
     let label: String
     let buildSettings: [String: BuildSetting]
     var targets: [TargetID: Target]
-    let potentialTargetMerges: [TargetID: Set<TargetID>]
-    let requiredLinks: Set<FilePath>
+    let targetMerges: [TargetID: Set<TargetID>]
+    let invalidTargetMerges: [TargetID: Set<TargetID>]
     let extraFiles: Set<FilePath>
 }
 

--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -13,9 +13,8 @@ struct Environment {
 
     let processTargetMerges: (
         _ targets: inout [TargetID: Target],
-        _ potentialTargetMerges: [TargetID: Set<TargetID>],
-        _ requiredLinks: Set<FilePath>
-    ) throws -> [InvalidMerge]
+        _ targetMerges: [TargetID: Set<TargetID>]
+    ) throws -> Void
 
     let createFilesAndGroups: (
         _ pbxProj: PBXProj,

--- a/tools/generator/src/Generator+ProcessTargetMerges.swift
+++ b/tools/generator/src/Generator+ProcessTargetMerges.swift
@@ -19,36 +19,18 @@ extension Generator {
     ///
     /// - Parameters:
     ///   - targets: The universe of targets. These will be edited in place.
-    ///   - potentialTargetMerges: A dictionary mapping target ids of targets
+    ///   - targetMerges: A dictionary mapping target ids of targets
     ///     that should be merged to the target ids of the target they should
     ///     be merged into.
-    ///   - requiredLinks: A set of paths that are linked into top level
-    ///     targets. If any of the targets to be merged produce one of these
-    ///     paths, then that merge won't happen and will be returned as invalid.
-    ///
-    /// - Returns: An array of `InvalidMerge` structs for any merges that
-    ///   couldn't be performed.
     static func processTargetMerges(
         targets: inout [TargetID: Target],
-        potentialTargetMerges: [TargetID: Set<TargetID>],
-        requiredLinks: Set<FilePath>
-    ) throws -> [InvalidMerge] {
-        var validTargetMerges = potentialTargetMerges
-        var invalidMerges: [InvalidMerge] = []
-        for (source, destinations) in potentialTargetMerges {
+        targetMerges: [TargetID: Set<TargetID>]
+    ) throws {
+        for (source, destinations) in targetMerges {
             guard let merging = targets[source] else {
                 throw PreconditionError(message: """
-`potentialTargetMerges.key` (\(source)) references target that doesn't exist
+`targetMerges.key` (\(source)) references target that doesn't exist
 """)
-            }
-
-            guard !requiredLinks.contains(merging.product.path) else {
-                validTargetMerges.removeValue(forKey: source)
-                invalidMerges.append(.init(
-                    source: source,
-                    destinations: destinations
-                ))
-                continue
             }
 
             for destination in destinations {
@@ -104,12 +86,10 @@ exist
         for (id, target) in targets {
             // Dependencies
             for dependency in target.dependencies {
-                if validTargetMerges[dependency] != nil {
+                if targetMerges[dependency] != nil {
                     targets[id]!.dependencies.remove(dependency)
                 }
             }
         }
-
-        return invalidMerges
     }
 }

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -51,21 +51,17 @@ class Generator {
         let mainGroup: PBXGroup = pbxProject.mainGroup
 
         var targets = project.targets
-        let invalidMerges = try environment.processTargetMerges(
-            &targets,
-            project.potentialTargetMerges,
-            project.requiredLinks
-        )
+        try environment.processTargetMerges(&targets, project.targetMerges)
 
-        for invalidMerge in invalidMerges {
-            guard let srcTarget = targets[invalidMerge.source] else {
+        for (src, destinations) in project.invalidTargetMerges {
+            guard let srcTarget = targets[src] else {
                 throw PreconditionError(
                     message: """
-Source target "\(invalidMerge.source)" not found in `targets`
+Source target "\(src)" not found in `targets`
 """)
             }
-            for destination in invalidMerge.destinations {
-                guard let desTarget = targets[destination] else {
+            for destination in destinations {
+                guard let destTarget = targets[destination] else {
                     throw PreconditionError(message: """
 Destination target "\(destination)" not found in `targets`
 """)
@@ -73,8 +69,8 @@ Destination target "\(destination)" not found in `targets`
                 logger.logWarning("""
 Was unable to merge "\(srcTarget.label) \
 (\(srcTarget.configuration))" into \
-"\(desTarget.label) \
-(\(desTarget.configuration))"
+"\(destTarget.label) \
+(\(destTarget.configuration))"
 """)
             }
         }

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -14,8 +14,8 @@ enum Fixtures {
             "ONLY_ACTIVE_ARCH": .bool(true),
         ],
         targets: targets,
-        potentialTargetMerges: [:],
-        requiredLinks: [],
+        targetMerges: [:],
+        invalidTargetMerges: [:],
         extraFiles: [
             .generated("a1b2c/bin/t.c"),
             .generated("a/b/module.modulemap"),

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -14,8 +14,8 @@ final class GeneratorTests: XCTestCase {
             label: "//a/P:xcodeproj",
             buildSettings: [:],
             targets: Fixtures.targets,
-            potentialTargetMerges: [:],
-            requiredLinks: [],
+            targetMerges: [:],
+            invalidTargetMerges: ["Y": ["Z"]],
             extraFiles: []
         )
 
@@ -105,29 +105,24 @@ final class GeneratorTests: XCTestCase {
 
         struct ProcessTargetMergesCalled: Equatable {
             let targets: [TargetID: Target]
-            let potentialTargetMerges: [TargetID: Set<TargetID>]
-            let requiredLinks: Set<FilePath>
+            let targetMerges: [TargetID: Set<TargetID>]
         }
 
         var processTargetMergesCalled: [ProcessTargetMergesCalled] = []
         func processTargetMerges(
             targets: inout [TargetID: Target],
-            potentialTargetMerges: [TargetID: Set<TargetID>],
-            requiredLinks: Set<FilePath>
-        ) throws -> [InvalidMerge] {
+            targetMerges: [TargetID: Set<TargetID>]
+        ) throws -> Void {
             processTargetMergesCalled.append(.init(
                 targets: targets,
-                potentialTargetMerges: potentialTargetMerges,
-                requiredLinks: requiredLinks
+                targetMerges: targetMerges
             ))
             targets = mergedTargets
-            return [InvalidMerge(source: "Y", destinations: ["Z"])]
         }
 
         let expectedProcessTargetMergesCalled = [ProcessTargetMergesCalled(
             targets: project.targets,
-            potentialTargetMerges: project.potentialTargetMerges,
-            requiredLinks: project.requiredLinks
+            targetMerges: project.targetMerges
         )]
         expectedMessagesLogged.append(StubLogger.MessageLogged(.warning, """
  Was unable to merge "//:Y (a1b2c)" into "//:Z (1a2b3)"

--- a/tools/generator/test/ProcessTargetMergesTests.swift
+++ b/tools/generator/test/ProcessTargetMergesTests.swift
@@ -9,35 +9,30 @@ final class TargetMergingTests: XCTestCase {
         // Arrange
 
         var targets = Fixtures.targets
-        let potentialTargetMerges: [TargetID: Set<TargetID>] = [:]
-        let requiredLinks = Set<FilePath>()
+        let targetMerges: [TargetID: Set<TargetID>] = [:]
 
         let expectedTargets = Fixtures.targets
-        let expectedInvalidMerges: [InvalidMerge] = []
 
         // Act
 
-        let invalidMerges = try Generator.processTargetMerges(
+        try Generator.processTargetMerges(
             targets: &targets,
-            potentialTargetMerges: potentialTargetMerges,
-            requiredLinks: requiredLinks
+            targetMerges: targetMerges
         )
 
         // Assert
 
         XCTAssertNoDifference(targets, expectedTargets)
-        XCTAssertNoDifference(invalidMerges, expectedInvalidMerges)
     }
 
     func test_merges_without_required_links() throws {
         // Arrange
 
         var targets = Fixtures.targets
-        let potentialTargetMerges: [TargetID: Set<TargetID>] = [
+        let targetMerges: [TargetID: Set<TargetID>] = [
             "A 1": ["A 2"],
             "B 1": ["B 2", "B 3"],
         ]
-        let requiredLinks = Set<FilePath>()
 
         var expectedTargets = targets
         expectedTargets.removeValue(forKey: "A 1")
@@ -95,96 +90,16 @@ final class TargetMergingTests: XCTestCase {
             // Inherited "B 1"'s "A 1" dependency and changed it to "A 2"
             dependencies: ["A 2"]
         )
-        let expectedInvalidMerges: [InvalidMerge] = []
 
         // Act
 
-        let invalidMerges = try Generator.processTargetMerges(
+        try Generator.processTargetMerges(
             targets: &targets,
-            potentialTargetMerges: potentialTargetMerges,
-            requiredLinks: requiredLinks
+            targetMerges: targetMerges
         )
 
         // Assert
 
         XCTAssertNoDifference(targets, expectedTargets)
-        XCTAssertNoDifference(invalidMerges, expectedInvalidMerges)
-    }
-
-    func test_merges_with_required_links() throws {
-        // Arrange
-
-        var targets = Fixtures.targets
-        // "B 2" having a link on "A 1" is a problem for Xcode, as both
-        // "A 1" and a merged "A 2" would have to exist, and have the same
-        // "PRODUCT_MODULE_NAME", which breaks indexing
-        targets["B 2"] = Target.mock(
-            packageBinDir: targets["B 2"]!.packageBinDir,
-            product: targets["B 2"]!.product,
-            isSwift: targets["B 2"]!.isSwift,
-            frameworks: targets["B 2"]!.frameworks,
-            modulemaps: targets["B 2"]!.modulemaps,
-            swiftmodules: targets["B 2"]!.swiftmodules,
-            resourceBundles: targets["B 2"]!.resourceBundles,
-            inputs: targets["B 2"]!.inputs,
-            links: [
-                .generated("z/A.a"),
-                .generated("a/b.framework"),
-            ],
-            dependencies: targets["B 2"]!.dependencies
-        )
-        let potentialTargetMerges: [TargetID: Set<TargetID>] = [
-            "A 1": ["A 2"],
-            "B 1": ["B 2", "B 3"],
-        ]
-        let requiredLinks: Set<FilePath> = [.generated("z/A.a")]
-
-        var expectedTargets = targets
-        expectedTargets.removeValue(forKey: "B 1")
-        expectedTargets["B 2"] = Target.mock(
-            packageBinDir: targets["B 1"]!.packageBinDir,
-            product: targets["B 2"]!.product,
-            isSwift: targets["B 1"]!.isSwift,
-            frameworks: targets["B 2"]!.frameworks,
-            modulemaps: targets["B 1"]!.modulemaps,
-            swiftmodules: targets["B 1"]!.swiftmodules,
-            resourceBundles: targets["B 2"]!.resourceBundles,
-            inputs: targets["B 2"]!.inputs.merging(targets["B 1"]!.inputs),
-            // Removed "B 1"'s product
-            links: [.generated("z/A.a")],
-            // Inherited "B 1"'s dependencies
-            dependencies: ["A 1", "A 2"]
-        )
-        expectedTargets["B 3"] = Target.mock(
-            packageBinDir: targets["B 1"]!.packageBinDir,
-            product: targets["B 3"]!.product,
-            isSwift: targets["B 1"]!.isSwift,
-            testHost: "A 2",
-            frameworks: targets["B 3"]!.frameworks,
-            modulemaps: targets["B 1"]!.modulemaps,
-            swiftmodules: targets["B 1"]!.swiftmodules,
-            resourceBundles: targets["B 3"]!.resourceBundles,
-            inputs: targets["B 3"]!.inputs.merging(targets["B 1"]!.inputs),
-            // Removed "B 1"'s product
-            links: ["a/StaticFram.framework/StaticFram"],
-            // Inherited "B 1"'s dependencies
-            dependencies: ["A 1", "A 2"]
-        )
-        let expectedInvalidMerges = [
-            InvalidMerge(source: "A 1", destinations: ["A 2"]),
-        ]
-
-        // Act
-
-        let invalidMerges = try Generator.processTargetMerges(
-            targets: &targets,
-            potentialTargetMerges: potentialTargetMerges,
-            requiredLinks: requiredLinks
-        )
-
-        // Assert
-
-        XCTAssertNoDifference(targets, expectedTargets)
-        XCTAssertNoDifference(invalidMerges, expectedInvalidMerges)
     }
 }

--- a/xcodeproj/internal/flattened_key_values.bzl
+++ b/xcodeproj/internal/flattened_key_values.bzl
@@ -28,7 +28,7 @@ Expected the iterable to have an even number of items. length: {len}\
 
     return key_values
 
-def _to_list(key_values_dict, sort = True):
+def _to_list(key_values_dict, *, sort = True):
     """Converts a `dict` to a flattened key-value `list`.
 
     Args:
@@ -47,7 +47,8 @@ def _to_list(key_values_dict, sort = True):
 
     iterable = []
     for key in keys:
-        iterable.extend([key, key_values_dict[key]])
+        iterable.append(key)
+        iterable.append(key_values_dict[key])
     return iterable
 
 def _sort(iterable):


### PR DESCRIPTION
There is no need to send over the large `required_links` over to the generator, since we have all of the information in Starlark to perform the merge. We still send the invalid merges to the generator for better warning reporting.