### PR TITLE
Remove color diagnostics setting from parsed opts

### DIFF
--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -1190,7 +1190,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1207,7 +1206,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1264,7 +1262,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1281,7 +1278,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1334,7 +1330,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1351,7 +1346,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1420,7 +1414,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1437,7 +1430,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1505,7 +1497,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1522,7 +1513,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1583,7 +1573,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1600,7 +1589,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1661,7 +1649,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1678,7 +1665,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",

--- a/examples/ios_app/test/fixtures/spec.json
+++ b/examples/ios_app/test/fixtures/spec.json
@@ -195,7 +195,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -212,7 +211,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -300,7 +298,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -317,7 +314,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -434,7 +430,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -451,7 +446,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -564,7 +558,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -581,7 +574,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -675,7 +667,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -692,7 +683,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -830,7 +820,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -847,7 +836,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -939,7 +927,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -956,7 +943,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -1083,7 +1069,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -1100,7 +1085,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -1188,7 +1172,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -1205,7 +1188,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -1283,7 +1265,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -1300,7 +1281,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -1385,7 +1365,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -1402,7 +1381,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",

--- a/test/fixtures/cc/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/project.xcodeproj/project.pbxproj
@@ -351,7 +351,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -368,7 +367,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -428,7 +426,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -445,7 +442,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -502,7 +498,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -519,7 +514,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -564,7 +558,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -581,7 +574,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",

--- a/test/fixtures/cc/spec.json
+++ b/test/fixtures/cc/spec.json
@@ -33,7 +33,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -50,7 +49,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -127,7 +125,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -144,7 +141,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -225,7 +221,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -242,7 +237,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -353,7 +347,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -370,7 +363,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",

--- a/test/fixtures/command_line/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/project.xcodeproj/project.pbxproj
@@ -766,7 +766,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -783,7 +782,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -827,7 +825,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -844,7 +841,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -907,7 +903,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -924,7 +919,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -985,7 +979,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1002,7 +995,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1054,7 +1046,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1071,7 +1062,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1119,7 +1109,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1136,7 +1125,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",

--- a/test/fixtures/command_line/spec.json
+++ b/test/fixtures/command_line/spec.json
@@ -61,7 +61,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -78,7 +77,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -169,7 +167,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -186,7 +183,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -287,7 +283,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -304,7 +299,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -380,7 +374,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -397,7 +390,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -474,7 +466,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -491,7 +482,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -584,7 +574,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -601,7 +590,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -691,7 +679,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -708,7 +695,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -793,7 +779,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -810,7 +795,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",

--- a/test/fixtures/generator/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/project.xcodeproj/project.pbxproj
@@ -1413,7 +1413,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1430,7 +1429,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1470,7 +1468,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1487,7 +1484,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1527,7 +1523,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1544,7 +1539,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1589,7 +1583,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1606,7 +1599,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1642,7 +1634,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1659,7 +1650,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1720,7 +1710,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1737,7 +1726,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1777,7 +1765,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1794,7 +1781,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1834,7 +1820,6 @@
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",
@@ -1851,7 +1836,6 @@
 				OTHER_CPLUSPLUSFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
 					"-fstack-protector",
-					"-fcolor-diagnostics",
 					"-Wall",
 					"-Wthread-safety",
 					"-Wself-assign",

--- a/test/fixtures/generator/spec.json
+++ b/test/fixtures/generator/spec.json
@@ -35,7 +35,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -52,7 +51,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -145,7 +143,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -162,7 +159,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -274,7 +270,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -291,7 +286,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -374,7 +368,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -391,7 +384,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -506,7 +498,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -523,7 +514,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -599,7 +589,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -616,7 +605,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -795,7 +783,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -812,7 +799,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -888,7 +874,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -905,7 +890,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -997,7 +981,6 @@
                 "OTHER_CFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",
@@ -1014,7 +997,6 @@
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-D_FORTIFY_SOURCE=1",
                     "-fstack-protector",
-                    "-fcolor-diagnostics",
                     "-Wall",
                     "-Wthread-safety",
                     "-Wself-assign",

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -8,6 +8,7 @@ load(":collections.bzl", "set_if_true", "uniq")
 # The values are the number of flags to skip, 1 being the flag itself, 2 being
 # another flag right after it, etc.
 _CC_SKIP_OPTS = {
+    "-fcolor-diagnostics": 1,
     "-isysroot": 2,
     "-mios-simulator-version-min": 1,
     "-miphoneos-version-min": 1,


### PR DESCRIPTION
Leaving this flag in causes weird ascii escape sequences in the build output.