### PR TITLE
Refactor test bundle detection to `targets.bzl`

### DIFF
--- a/test/internal/targets/BUILD.bazel
+++ b/test/internal/targets/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":is_test_bundle_tests.bzl", "is_test_bundle_test_suite")
+
+is_test_bundle_test_suite(name = "is_test_bundle")

--- a/test/internal/targets/is_test_bundle_tests.bzl
+++ b/test/internal/targets/is_test_bundle_tests.bzl
@@ -1,0 +1,91 @@
+"""Tests for targets.is_test_bundle"""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "IosXcTestBundleInfo",
+    "MacosXcTestBundleInfo",
+)
+
+# buildifier: disable=bzl-visibility
+load("//xcodeproj/internal:targets.bzl", "targets")
+
+def _is_test_bundle_for_ios_test_bundle_test(ctx):
+    env = unittest.begin(ctx)
+
+    target = {IosXcTestBundleInfo: IosXcTestBundleInfo()}
+    dep = {IosXcTestBundleInfo: IosXcTestBundleInfo()}
+    deps = [dep]
+
+    actual = targets.is_test_bundle(target, deps)
+    asserts.true(env, actual)
+
+    return unittest.end(env)
+
+is_test_bundle_for_ios_test_bundle_test = unittest.make(_is_test_bundle_for_ios_test_bundle_test)
+
+def _is_test_bundle_for_macos_test_bundel_test(ctx):
+    env = unittest.begin(ctx)
+
+    target = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
+    dep = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
+    deps = [dep]
+
+    actual = targets.is_test_bundle(target, deps)
+    asserts.true(env, actual)
+
+    return unittest.end(env)
+
+is_test_bundle_for_macos_test_bundel_test = unittest.make(_is_test_bundle_for_macos_test_bundel_test)
+
+def _is_test_bundle_has_provider_but_not_dep_test(ctx):
+    env = unittest.begin(ctx)
+
+    target = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
+    dep = {}
+    deps = [dep]
+
+    actual = targets.is_test_bundle(target, deps)
+    asserts.false(env, actual)
+
+    return unittest.end(env)
+
+is_test_bundle_has_provider_but_not_dep_test = unittest.make(_is_test_bundle_has_provider_but_not_dep_test)
+
+def _is_test_bundle_does_not_have_provider_test(ctx):
+    env = unittest.begin(ctx)
+
+    target = {}
+    dep = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
+    deps = [dep]
+
+    actual = targets.is_test_bundle(target, deps)
+    asserts.false(env, actual)
+
+    return unittest.end(env)
+
+is_test_bundle_does_not_have_provider_test = unittest.make(_is_test_bundle_does_not_have_provider_test)
+
+def _is_test_bundle_more_than_one_dep_test(ctx):
+    env = unittest.begin(ctx)
+
+    target = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
+    dep = {MacosXcTestBundleInfo: MacosXcTestBundleInfo()}
+    deps = [dep, dep]
+
+    actual = targets.is_test_bundle(target, deps)
+    asserts.false(env, actual)
+
+    return unittest.end(env)
+
+is_test_bundle_more_than_one_dep_test = unittest.make(_is_test_bundle_more_than_one_dep_test)
+
+def is_test_bundle_test_suite(name):
+    return unittest.suite(
+        name,
+        is_test_bundle_for_ios_test_bundle_test,
+        is_test_bundle_for_macos_test_bundel_test,
+        is_test_bundle_has_provider_but_not_dep_test,
+        is_test_bundle_does_not_have_provider_test,
+        is_test_bundle_more_than_one_dep_test,
+    )

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -8,8 +8,6 @@ load(
     "AppleFrameworkImportInfo",
     "AppleResourceBundleInfo",
     "AppleResourceInfo",
-    "IosXcTestBundleInfo",
-    "MacosXcTestBundleInfo",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
@@ -36,6 +34,7 @@ load(
     "target_type",
 )
 load(":resource_bundle_products.bzl", "resource_bundle_products")
+load(":targets.bzl", "targets")
 
 # Configuration
 
@@ -1135,16 +1134,9 @@ def _should_skip_target(*, ctx, target):
     """
 
     # TODO: Find a way to detect TestEnvironment instead
-    return (
-        (
-            IosXcTestBundleInfo in target and
-            len(ctx.rule.attr.deps) == 1 and
-            IosXcTestBundleInfo in ctx.rule.attr.deps[0]
-        ) or (
-            MacosXcTestBundleInfo in target and
-            len(ctx.rule.attr.deps) == 1 and
-            MacosXcTestBundleInfo in ctx.rule.attr.deps[0]
-        )
+    return targets.is_test_bundle(
+        target = target,
+        deps = getattr(ctx.rule.attr, "deps", None),
     )
 
 def _target_info_fields(

--- a/xcodeproj/internal/targets.bzl
+++ b/xcodeproj/internal/targets.bzl
@@ -1,0 +1,52 @@
+"""API for Inspecting and Acting on Targets"""
+
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "IosXcTestBundleInfo",
+    "MacosXcTestBundleInfo",
+)
+
+def _is_test_bundle_with_provider(target, deps, bundle_provider):
+    """Determines whether the target is a test bundle target that provides the specified bundle provider.
+
+    Apple test bundle targets will provide a test bundle provider and will have
+    a single dep that also provides the provider.
+
+    Args:
+        target: The `Target` to evaluate.
+        deps: The `list` of depdencies for the target as returned by
+              `ctx.rule.attr.deps`.
+        bundle_provider: A bundle provider type (e.g
+                         `IosXcTestBundleInfo`, `MacosXcTestBundleInfo`).
+
+    Returns:
+        A `bool` indicating whether the target is a test bundle provider of the
+        specified provider.
+    """
+    return (
+        bundle_provider in target and
+        len(deps) == 1 and
+        bundle_provider in deps[0]
+    )
+
+def _is_test_bundle(target, deps):
+    """Determines whether the specified target is an Apple test bundle target.
+
+    Args:
+        target: The `Target` to evaluate.
+        deps: The `list` of depdencies for the target as returned by
+              `ctx.rule.attr.deps`.
+
+    Returns:
+        A `bool` indicating whether the target is an Apple test bundle target.
+    """
+    if deps == None:
+        return False
+    return (
+        _is_test_bundle_with_provider(target, deps, IosXcTestBundleInfo) or
+        _is_test_bundle_with_provider(target, deps, MacosXcTestBundleInfo)
+    )
+
+targets = struct(
+    is_test_bundle = _is_test_bundle,
+)

--- a/xcodeproj/internal/targets.bzl
+++ b/xcodeproj/internal/targets.bzl
@@ -14,10 +14,10 @@ def _is_test_bundle_with_provider(target, deps, bundle_provider):
 
     Args:
         target: The `Target` to evaluate.
-        deps: The `list` of depdencies for the target as returned by
-              `ctx.rule.attr.deps`.
+        deps: The `list` of dependencies for the target as returned by
+            `ctx.rule.attr.deps`.
         bundle_provider: A bundle provider type (e.g
-                         `IosXcTestBundleInfo`, `MacosXcTestBundleInfo`).
+            `IosXcTestBundleInfo`, `MacosXcTestBundleInfo`).
 
     Returns:
         A `bool` indicating whether the target is a test bundle provider of the
@@ -34,8 +34,8 @@ def _is_test_bundle(target, deps):
 
     Args:
         target: The `Target` to evaluate.
-        deps: The `list` of depdencies for the target as returned by
-              `ctx.rule.attr.deps`.
+        deps: The `list` of dependencies for the target as returned by
+            `ctx.rule.attr.deps`.
 
     Returns:
         A `bool` indicating whether the target is an Apple test bundle target.


### PR DESCRIPTION
Related to #136.

- Added `targets.bzl` to encapsulate API for inspecting and acting upon a target. The hope is to move some additional functionality from target.bzl to this API.
- Implemented `targets.is_test_bundle()` to encapsulate the logic for detecting a test bundle target.