### PR TITLE
Fix external link for targets without generated files

### DIFF
--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -17,9 +17,21 @@
 				700DDA896776846733B25577 /* Fix Info.plists */,
 			);
 			dependencies = (
+				1B345DF509A5588973BB937D /* PBXTargetDependency */,
 			);
 			name = "Bazel Generated Files";
 			productName = "Bazel Generated Files";
+		};
+		4C83CDF1E6003ECA397737DA /* Setup */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 7A993C65A3954B906466DAE9 /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildPhases = (
+				ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */,
+			);
+			dependencies = (
+			);
+			name = Setup;
+			productName = Setup;
 		};
 /* End PBXAggregateTarget section */
 
@@ -129,6 +141,20 @@
 			remoteGlobalIDString = EAB95A4512529D4CB8BE5D4E;
 			remoteInfo = Example;
 		};
+		3993462F5254457CDA557859 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
+		6063D017FF0BD630301C7ACD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
 		6CCFBB6244E6F79BBAE14283 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
@@ -163,6 +189,27 @@
 			proxyType = 1;
 			remoteGlobalIDString = 3064A34776444DE49627998E;
 			remoteInfo = "Bazel Generated Files";
+		};
+		B5BCC52B1C8F3D238D44B3DE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
+		CD1DB8EBFA62947054E6732D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
+		E275EBB8F2B713CCBEE713C3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
 		};
 		E58F4A1E1F92E1E2F5570ED4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -600,6 +647,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				6ACE625F4F25204D4C86FD12 /* PBXTargetDependency */,
 				B44F3488B8861B13B6BE0333 /* PBXTargetDependency */,
 			);
 			name = Utils;
@@ -652,6 +700,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				360BF3C47D5AB0E0FDCC3C7C /* PBXTargetDependency */,
 			);
 			name = ExampleResources;
 			productName = ExampleResources;
@@ -687,6 +736,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				B41237FB14D060AB32765EA3 /* PBXTargetDependency */,
 			);
 			name = ExternalResources;
 			productName = ExternalResources;
@@ -744,6 +794,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				D6D03542DD975303D63600AD /* PBXTargetDependency */,
 			);
 			name = CoreUtilsObjC;
 			productName = CoreUtilsObjC;
@@ -761,6 +812,9 @@
 				LastUpgradeCheck = 1320;
 				TargetAttributes = {
 					3064A34776444DE49627998E = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					4C83CDF1E6003ECA397737DA = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
 					682FCD8AED9E378997DB28CB = {
@@ -818,6 +872,7 @@
 			projectDirPath = ../..;
 			projectRoot = "";
 			targets = (
+				4C83CDF1E6003ECA397737DA /* Setup */,
 				3064A34776444DE49627998E /* Bazel Generated Files */,
 				F735F4A9CFBBEB3F09580C52 /* CoreUtilsObjC */,
 				EAB95A4512529D4CB8BE5D4E /* Example */,
@@ -987,7 +1042,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(    *(\\w+ )?header \"(\\.\\.\\/)*)(((?!(bazel-out|external)).)*\")%\\1SRCROOT/\\4%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-ios_app/external\" external\n";
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(    *(\\w+ )?header \"(\\.\\.\\/)*)(((?!(bazel-out|external)).)*\")%\\1SRCROOT/\\4%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Create Symlinks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-ios_app/external\" external\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1060,6 +1131,12 @@
 			target = 8B1A49AD77FC1690CB9AE556 /* TestingUtils */;
 			targetProxy = 7ADFECF50878167CF6071A82 /* PBXContainerItemProxy */;
 		};
+		1B345DF509A5588973BB937D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 3993462F5254457CDA557859 /* PBXContainerItemProxy */;
+		};
 		21627D3581B6ADD9906D176D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Example;
@@ -1071,6 +1148,12 @@
 			name = "Bazel Generated Files";
 			target = 3064A34776444DE49627998E /* Bazel Generated Files */;
 			targetProxy = 9EA5AB932A9708D1A7667DFA /* PBXContainerItemProxy */;
+		};
+		360BF3C47D5AB0E0FDCC3C7C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = CD1DB8EBFA62947054E6732D /* PBXContainerItemProxy */;
 		};
 		39159660DA50973079657E41 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1096,6 +1179,12 @@
 			target = 9782FF51889CEA3AB3A4FF47 /* ExampleResources */;
 			targetProxy = 1BAA0BC5AA1CBCF8600437AB /* PBXContainerItemProxy */;
 		};
+		6ACE625F4F25204D4C86FD12 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = B5BCC52B1C8F3D238D44B3DE /* PBXContainerItemProxy */;
+		};
 		7E14CF57C8FA9BF9043A9A53 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Utils;
@@ -1113,6 +1202,12 @@
 			name = "Bazel Generated Files";
 			target = 3064A34776444DE49627998E /* Bazel Generated Files */;
 			targetProxy = 17EEC780925E742F008C20DE /* PBXContainerItemProxy */;
+		};
+		B41237FB14D060AB32765EA3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 6063D017FF0BD630301C7ACD /* PBXContainerItemProxy */;
 		};
 		B44F3488B8861B13B6BE0333 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1149,6 +1244,12 @@
 			name = ExampleResources;
 			target = 9782FF51889CEA3AB3A4FF47 /* ExampleResources */;
 			targetProxy = 15400836A743F9AC2A0E4C5F /* PBXContainerItemProxy */;
+		};
+		D6D03542DD975303D63600AD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = E275EBB8F2B713CCBEE713C3 /* PBXContainerItemProxy */;
 		};
 		DE2A9C64E8E8EC51BD29FC22 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1464,6 +1565,14 @@
 			};
 			name = Debug;
 		};
+		70E18BE128A25A1F96CAB0FE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				TARGET_NAME = Setup;
+			};
+			name = Debug;
+		};
 		7C935235ACC6252AE6F5B6FF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1554,7 +1663,8 @@
 		ACE65DF71AEBC3D1DAF7EF52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BAZEL_PACKAGE_BIN_DIR = BazelGeneratedFiles;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				TARGET_NAME = GenerateBazelFiles;
 			};
 			name = Debug;
 		};
@@ -1740,6 +1850,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6494BAE58154BF84E3AF60D9 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		7A993C65A3954B906466DAE9 /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				70E18BE128A25A1F96CAB0FE /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/cc/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/project.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 55;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		4C83CDF1E6003ECA397737DA /* Setup */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 7A993C65A3954B906466DAE9 /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildPhases = (
+				ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */,
+			);
+			dependencies = (
+			);
+			name = Setup;
+			productName = Setup;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		46272773FEE292F97F7598E0 /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 7CE856EC2CE9B541065D14B0 /* lib.c */; };
 		5B4F5A0F99FCFB768BB56235 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C91EE0C5078D0455B44BD9D /* main.c */; };
@@ -23,6 +37,20 @@
 			remoteGlobalIDString = 5FB682B564422D3823A3C78C;
 			remoteInfo = "//examples/cc/lib2:lib_impl";
 		};
+		35B40FF81A9E3993FA0CD638 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
+		54242AD20E704B0C25595827 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
 		6A32CAF498672EF63B16DD4B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
@@ -30,12 +58,26 @@
 			remoteGlobalIDString = 219A963F11BAD0FDD3F6CC45;
 			remoteInfo = "@examples_cc_external//:lib_impl";
 		};
+		76EDD912384A58963236FA8F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
 		9EE1DCA574790AB33F7520C7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 58402704FF804AD3AC11716D;
 			remoteInfo = "//examples/cc/lib:lib_impl";
+		};
+		C370E256DAC18E3226CF8940 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -176,6 +218,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				7B4C1873591B3296EBC53731 /* PBXTargetDependency */,
 			);
 			name = "@examples_cc_external//:lib_impl";
 			productName = lib_impl;
@@ -191,6 +234,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				CB6EF51946C986AA8DE43DF4 /* PBXTargetDependency */,
 			);
 			name = "//examples/cc/lib:lib_impl";
 			productName = lib_impl;
@@ -206,6 +250,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				08CACBBBC829A41D1BB36D23 /* PBXTargetDependency */,
 			);
 			name = "//examples/cc/lib2:lib_impl";
 			productName = lib_impl;
@@ -221,6 +266,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				06D4406A09F773986DEF04EC /* PBXTargetDependency */,
 				9291054CE01A8D81DA27A7DC /* PBXTargetDependency */,
 				52901E7121F038C779EDD27D /* PBXTargetDependency */,
 				65B2861201C7585D568CFC70 /* PBXTargetDependency */,
@@ -243,6 +289,9 @@
 					219A963F11BAD0FDD3F6CC45 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
+					};
+					4C83CDF1E6003ECA397737DA = {
+						CreatedOnToolsVersion = 13.2.1;
 					};
 					58402704FF804AD3AC11716D = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -271,6 +320,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
+				4C83CDF1E6003ECA397737DA /* Setup */,
 				219A963F11BAD0FDD3F6CC45 /* @examples_cc_external//:lib_impl */,
 				58402704FF804AD3AC11716D /* //examples/cc/lib:lib_impl */,
 				5FB682B564422D3823A3C78C /* //examples/cc/lib2:lib_impl */,
@@ -278,6 +328,25 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Create Symlinks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-rules_xcodeproj/external\" external\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		3886896FF296EE4041EFDFDD /* Sources */ = {
@@ -317,6 +386,18 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		06D4406A09F773986DEF04EC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 54242AD20E704B0C25595827 /* PBXContainerItemProxy */;
+		};
+		08CACBBBC829A41D1BB36D23 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = C370E256DAC18E3226CF8940 /* PBXContainerItemProxy */;
+		};
 		52901E7121F038C779EDD27D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "//examples/cc/lib:lib_impl";
@@ -329,15 +410,35 @@
 			target = 5FB682B564422D3823A3C78C /* //examples/cc/lib2:lib_impl */;
 			targetProxy = 0ADF60CADB649C1DBFF171DA /* PBXContainerItemProxy */;
 		};
+		7B4C1873591B3296EBC53731 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 35B40FF81A9E3993FA0CD638 /* PBXContainerItemProxy */;
+		};
 		9291054CE01A8D81DA27A7DC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "@examples_cc_external//:lib_impl";
 			target = 219A963F11BAD0FDD3F6CC45 /* @examples_cc_external//:lib_impl */;
 			targetProxy = 6A32CAF498672EF63B16DD4B /* PBXContainerItemProxy */;
 		};
+		CB6EF51946C986AA8DE43DF4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 76EDD912384A58963236FA8F /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		70E18BE128A25A1F96CAB0FE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				TARGET_NAME = Setup;
+			};
+			name = Debug;
+		};
 		74237F30610FC68FC69D29AF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -596,6 +697,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D59388014CAA34F648FDB911 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		7A993C65A3954B906466DAE9 /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				70E18BE128A25A1F96CAB0FE /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/command_line/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/project.xcodeproj/project.pbxproj
@@ -17,9 +17,21 @@
 				700DDA896776846733B25577 /* Fix Info.plists */,
 			);
 			dependencies = (
+				1B345DF509A5588973BB937D /* PBXTargetDependency */,
 			);
 			name = "Bazel Generated Files";
 			productName = "Bazel Generated Files";
+		};
+		4C83CDF1E6003ECA397737DA /* Setup */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 7A993C65A3954B906466DAE9 /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildPhases = (
+				ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */,
+			);
+			dependencies = (
+			);
+			name = Setup;
+			productName = Setup;
 		};
 /* End PBXAggregateTarget section */
 
@@ -35,6 +47,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		3993462F5254457CDA557859 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
+		3AB55A92EF0F00C52BC836A5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
+		54242AD20E704B0C25595827 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
 		74D659156810290F200548BC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
@@ -76,6 +109,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 3064A34776444DE49627998E;
 			remoteInfo = "Bazel Generated Files";
+		};
+		CAD0371AD3535594C93105C5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
 		};
 		ED86F7583B438439F3EBE4D5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -431,6 +471,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				E4A4DF69A70952247C8266DD /* PBXTargetDependency */,
 			);
 			name = "lib_impl (macOS 11.0)";
 			productName = lib_impl;
@@ -446,6 +487,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				EFD5724650C13500FB0C6634 /* PBXTargetDependency */,
 			);
 			name = "lib_impl (macOS 12.0)";
 			productName = lib_impl;
@@ -461,6 +503,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				06D4406A09F773986DEF04EC /* PBXTargetDependency */,
 				1CAAA20952A9D831D1BB7D52 /* PBXTargetDependency */,
 			);
 			name = tool;
@@ -483,6 +526,9 @@
 						LastSwiftMigration = 1320;
 					};
 					3064A34776444DE49627998E = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					4C83CDF1E6003ECA397737DA = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
 					4E173AA8FBFD84DF9DFA5258 = {
@@ -520,6 +566,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
+				4C83CDF1E6003ECA397737DA /* Setup */,
 				3064A34776444DE49627998E /* Bazel Generated Files */,
 				DD562DFDF26C59CEE576D62A /* lib_impl (macOS 11.0) */,
 				EB567C262EC7066F128D4E5A /* lib_impl (macOS 12.0) */,
@@ -645,7 +692,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(    *(\\w+ )?header \"(\\.\\.\\/)*)(((?!(bazel-out|external)).)*\")%\\1SRCROOT/\\4%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-rules_xcodeproj/external\" external\n";
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(    *(\\w+ )?header \"(\\.\\.\\/)*)(((?!(bazel-out|external)).)*\")%\\1SRCROOT/\\4%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Create Symlinks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-rules_xcodeproj/external\" external\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -704,6 +767,18 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		06D4406A09F773986DEF04EC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 54242AD20E704B0C25595827 /* PBXContainerItemProxy */;
+		};
+		1B345DF509A5588973BB937D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 3993462F5254457CDA557859 /* PBXContainerItemProxy */;
+		};
 		1CAAA20952A9D831D1BB7D52 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "lib_swift (macOS 12.0)";
@@ -734,11 +809,23 @@
 			target = 3064A34776444DE49627998E /* Bazel Generated Files */;
 			targetProxy = AC390F6510EEB05553F4D5AF /* PBXContainerItemProxy */;
 		};
+		E4A4DF69A70952247C8266DD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 3AB55A92EF0F00C52BC836A5 /* PBXContainerItemProxy */;
+		};
 		EAEAF060E08AE3A9EF9D261D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "lib_impl (macOS 11.0)";
 			target = DD562DFDF26C59CEE576D62A /* lib_impl (macOS 11.0) */;
 			targetProxy = 7658A6351C0304CED1E71F65 /* PBXContainerItemProxy */;
+		};
+		EFD5724650C13500FB0C6634 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = CAD0371AD3535594C93105C5 /* PBXContainerItemProxy */;
 		};
 		F64FCACD0E814DDC1F40A137 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -859,6 +946,14 @@
 			};
 			name = Debug;
 		};
+		70E18BE128A25A1F96CAB0FE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				TARGET_NAME = Setup;
+			};
+			name = Debug;
+		};
 		7C935235ACC6252AE6F5B6FF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -939,7 +1034,8 @@
 		ACE65DF71AEBC3D1DAF7EF52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BAZEL_PACKAGE_BIN_DIR = BazelGeneratedFiles;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				TARGET_NAME = GenerateBazelFiles;
 			};
 			name = Debug;
 		};
@@ -1158,6 +1254,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				6FC6D25E6B1F3FBCE9139EB6 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		7A993C65A3954B906466DAE9 /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				70E18BE128A25A1F96CAB0FE /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/generator/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/project.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 55;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		4C83CDF1E6003ECA397737DA /* Setup */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 7A993C65A3954B906466DAE9 /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildPhases = (
+				ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */,
+			);
+			dependencies = (
+			);
+			name = Setup;
+			productName = Setup;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		02182EDE6FDB241C2434DF8A /* XCScheme+TestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D351EBF697F74A32355EC048 /* XCScheme+TestItem.swift */; };
 		073D09171A88A0A4D802AA1E /* XcodeProj+CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = F84AD628C1B10FBFD1555866 /* XcodeProj+CustomDump.swift */; };
@@ -187,6 +201,20 @@
 			remoteGlobalIDString = 70659DDDA9D45D295FB4BEC1;
 			remoteInfo = generator.library;
 		};
+		176719C09A438C7A8A72BC44 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
+		220CCD2F23DEDC12BE450798 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
 		2F1610D67BFD419CE8F4FC2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
@@ -200,6 +228,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 3CA32B55F719FFAD80B057A6;
 			remoteInfo = PathKit;
+		};
+		385DBF1C49F252CBFB6E9E31 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
+		4C698D8446701FD1B0847AD7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
 		};
 		63844F62E0929050BA34F3B5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -215,12 +257,26 @@
 			remoteGlobalIDString = 3CA32B55F719FFAD80B057A6;
 			remoteInfo = PathKit;
 		};
+		8A4D0B10425F4055033DE9AA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
 		B08F87FF3DD343994245C253 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = D05B05A5C01B711C89655AF9;
 			remoteInfo = CustomDump;
+		};
+		BB56B08A06A234129717CD2A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
 		};
 		BCB7F7B87E3481A51E1E0AC2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -235,6 +291,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 6418E36295EA4236B83448C1;
 			remoteInfo = XCTestDynamicOverlay;
+		};
+		E1C737EE7089FC55CA8DC891 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
+		};
+		FA45368B58DC163DBAD0FCF9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -930,6 +1000,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				A6E0C27691962907ECCFDEFB /* PBXTargetDependency */,
 				953C6A279C85A182679C2745 /* PBXTargetDependency */,
 				E4686BB163EAA7CE10107566 /* PBXTargetDependency */,
 			);
@@ -947,6 +1018,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				B72EB52FA546697DBDB3B8C9 /* PBXTargetDependency */,
 			);
 			name = PathKit;
 			productName = PathKit;
@@ -962,6 +1034,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				B04CB994B956D43EC072CC4F /* PBXTargetDependency */,
 				A2F934863BF8FD0FC8435C49 /* PBXTargetDependency */,
 				23B8BE7B798704FE6E934116 /* PBXTargetDependency */,
 			);
@@ -979,6 +1052,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				9F0476E7A640C3B4F701C41B /* PBXTargetDependency */,
 			);
 			name = XCTestDynamicOverlay;
 			productName = XCTestDynamicOverlay;
@@ -994,6 +1068,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				CCD21E2C1B8DEFA0EA8A0F33 /* PBXTargetDependency */,
 				1031E46C8AB82E81D3627092 /* PBXTargetDependency */,
 				88759EF1E37EB5DF0D7CA0A0 /* PBXTargetDependency */,
 			);
@@ -1011,6 +1086,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				09655CCD3B832A0870752739 /* PBXTargetDependency */,
 			);
 			name = AEXML;
 			productName = AEXML;
@@ -1026,6 +1102,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				CA37C2726719A9D7D44C3F94 /* PBXTargetDependency */,
 				CD3D8B1B2E46932B246E26C5 /* PBXTargetDependency */,
 			);
 			name = generator;
@@ -1042,6 +1119,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				8DFF568BC582C27C90BAEB98 /* PBXTargetDependency */,
 				7D1203C9CD3F5D3A0DB504E8 /* PBXTargetDependency */,
 			);
 			name = CustomDump;
@@ -1070,6 +1148,9 @@
 					478B039DAAF0CD2DBD2D7226 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
+					};
+					4C83CDF1E6003ECA397737DA = {
+						CreatedOnToolsVersion = 13.2.1;
 					};
 					6418E36295EA4236B83448C1 = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -1106,6 +1187,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
+				4C83CDF1E6003ECA397737DA /* Setup */,
 				7ED2FBB8D0DD634C2391CB9E /* AEXML */,
 				D05B05A5C01B711C89655AF9 /* CustomDump */,
 				B3E25219A26AE795DACA89CA /* generator */,
@@ -1117,6 +1199,25 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Create Symlinks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-rules_xcodeproj/external\" external\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		12070C4B3C9001FDA7B695DE /* Sources */ = {
@@ -1348,6 +1449,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		09655CCD3B832A0870752739 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = BB56B08A06A234129717CD2A /* PBXContainerItemProxy */;
+		};
 		1031E46C8AB82E81D3627092 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PathKit;
@@ -1372,17 +1479,59 @@
 			target = 478B039DAAF0CD2DBD2D7226 /* XcodeProj */;
 			targetProxy = 2F1610D67BFD419CE8F4FC2D /* PBXContainerItemProxy */;
 		};
+		8DFF568BC582C27C90BAEB98 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 385DBF1C49F252CBFB6E9E31 /* PBXContainerItemProxy */;
+		};
 		953C6A279C85A182679C2745 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CustomDump;
 			target = D05B05A5C01B711C89655AF9 /* CustomDump */;
 			targetProxy = B08F87FF3DD343994245C253 /* PBXContainerItemProxy */;
 		};
+		9F0476E7A640C3B4F701C41B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 4C698D8446701FD1B0847AD7 /* PBXContainerItemProxy */;
+		};
 		A2F934863BF8FD0FC8435C49 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = AEXML;
 			target = 7ED2FBB8D0DD634C2391CB9E /* AEXML */;
 			targetProxy = 63844F62E0929050BA34F3B5 /* PBXContainerItemProxy */;
+		};
+		A6E0C27691962907ECCFDEFB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 176719C09A438C7A8A72BC44 /* PBXContainerItemProxy */;
+		};
+		B04CB994B956D43EC072CC4F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = E1C737EE7089FC55CA8DC891 /* PBXContainerItemProxy */;
+		};
+		B72EB52FA546697DBDB3B8C9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 220CCD2F23DEDC12BE450798 /* PBXContainerItemProxy */;
+		};
+		CA37C2726719A9D7D44C3F94 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 8A4D0B10425F4055033DE9AA /* PBXContainerItemProxy */;
+		};
+		CCD21E2C1B8DEFA0EA8A0F33 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = FA45368B58DC163DBAD0FCF9 /* PBXContainerItemProxy */;
 		};
 		CD3D8B1B2E46932B246E26C5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1670,6 +1819,14 @@
 			};
 			name = Debug;
 		};
+		70E18BE128A25A1F96CAB0FE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				TARGET_NAME = Setup;
+			};
+			name = Debug;
+		};
 		7C935235ACC6252AE6F5B6FF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1880,6 +2037,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				5F76F81196D7882A29429FD9 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		7A993C65A3954B906466DAE9 /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				70E18BE128A25A1F96CAB0FE /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;


### PR DESCRIPTION
We need the external symlink for our search paths to external repo headers to work. Before this change we would only create the symlink as part of the Bazel Generated Files target. Now we have a new target that runs before all other targets that ensures that the symlinks exist.

Ideally this would only run if the symlinks didn't exist, but Xcode doesn't support the Input Files being symlinks, so it always runs. Thankfully it's super fast.