### PR TITLE
Set `-framework` and `-weak_framework` for SDKs

### DIFF
--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -1216,6 +1216,13 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					SwiftUI,
+					"-ObjC",
+				);
 				PRODUCT_MODULE_NAME = Utils;
 				PRODUCT_NAME = Utils;
 				SDKROOT = iphoneos;
@@ -1355,6 +1362,10 @@
 				OTHER_LDFLAGS = (
 					"-filelist",
 					"$(PROJECT_DIR)/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleTests/ExampleTests.__internal__.__test_bundle.LinkFileList,$(BUILD_DIR)",
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					SwiftUI,
 					"-ObjC",
 				);
 				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(PROJECT_DIR)/third_party/ExampleFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(PROJECT_DIR)/bazel-ios_app/external/examples_ios_app_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/TestingUtils/TestingUtils.swift.xcode.modulemap -Fthird_party -Fexternal/examples_ios_app_external";
@@ -1434,6 +1445,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined";
 				PRODUCT_MODULE_NAME = TestingUtils;
 				PRODUCT_NAME = TestingUtils;
@@ -1515,6 +1527,13 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					SwiftUI,
+					"-ObjC",
+				);
 				PRODUCT_MODULE_NAME = CoreUtils;
 				PRODUCT_NAME = CoreUtilsObjC;
 				SDKROOT = iphoneos;
@@ -1591,6 +1610,10 @@
 				OTHER_LDFLAGS = (
 					"-filelist",
 					"$(PROJECT_DIR)/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/Example/Example.LinkFileList,$(BUILD_DIR)",
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					SwiftUI,
 					"-ObjC",
 				);
 				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(PROJECT_DIR)/third_party/ExampleFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(PROJECT_DIR)/bazel-ios_app/external/examples_ios_app_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC/CoreUtilsObjC.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Utils/Utils.swift.xcode.modulemap -Fthird_party -Fexternal/examples_ios_app_external";
@@ -1667,6 +1690,10 @@
 					"-L/usr/lib/swift",
 					"-filelist",
 					"$(PROJECT_DIR)/test/fixtures/project.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList,$(BUILD_DIR)",
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					SwiftUI,
 					"-ObjC",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.objctests;

--- a/examples/ios_app/test/fixtures/spec.json
+++ b/examples/ios_app/test/fixtures/spec.json
@@ -221,6 +221,13 @@
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
                 ],
+                "OTHER_LDFLAGS": [
+                    "-framework",
+                    "Foundation",
+                    "-weak_framework",
+                    "SwiftUI",
+                    "-ObjC"
+                ],
                 "PRODUCT_MODULE_NAME": "CoreUtils",
                 "PRODUCT_NAME": "CoreUtilsObjC",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
@@ -449,6 +456,13 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-framework",
+                    "Foundation",
+                    "-weak_framework",
+                    "SwiftUI",
+                    "-ObjC"
                 ],
                 "OTHER_SWIFT_FLAGS": "-Fthird_party -Fexternal/examples_ios_app_external",
                 "PRODUCT_MODULE_NAME": "Example",
@@ -681,6 +695,13 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-framework",
+                    "Foundation",
+                    "-weak_framework",
+                    "SwiftUI",
+                    "-ObjC"
                 ],
                 "PRODUCT_MODULE_NAME": "ExampleObjcTests",
                 "PRODUCT_NAME": "ExampleObjcTests.library",
@@ -937,6 +958,13 @@
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
                 ],
+                "OTHER_LDFLAGS": [
+                    "-framework",
+                    "Foundation",
+                    "-weak_framework",
+                    "SwiftUI",
+                    "-ObjC"
+                ],
                 "OTHER_SWIFT_FLAGS": "-Fthird_party -Fexternal/examples_ios_app_external",
                 "PRODUCT_MODULE_NAME": "ExampleTests",
                 "PRODUCT_NAME": "ExampleTests.library",
@@ -1176,6 +1204,9 @@
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
                 ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
                 "PRODUCT_MODULE_NAME": "ExampleUITests",
                 "PRODUCT_NAME": "ExampleUITests.library",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1266,6 +1297,9 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
                 ],
                 "PRODUCT_MODULE_NAME": "TestingUtils",
                 "PRODUCT_NAME": "TestingUtils",
@@ -1363,6 +1397,13 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-framework",
+                    "Foundation",
+                    "-weak_framework",
+                    "SwiftUI",
+                    "-ObjC"
                 ],
                 "PRODUCT_MODULE_NAME": "Utils",
                 "PRODUCT_NAME": "Utils",

--- a/examples/ios_app/third_party/BUILD
+++ b/examples/ios_app/third_party/BUILD
@@ -9,5 +9,7 @@ apple_static_framework_import(
         ["ExampleFramework.framework/**"],
         exclude = ["**/.*"],
     ),
+    sdk_frameworks = ["Foundation"],
     visibility = ["//visibility:public"],
+    weak_sdk_frameworks = ["SwiftUI"],
 )

--- a/test/fixtures/cc/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/project.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = lib_impl;
 				SDKROOT = macosx;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -516,6 +517,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = lib_impl;
 				SDKROOT = macosx;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -573,6 +575,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = lib_impl;
 				SDKROOT = macosx;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";

--- a/test/fixtures/cc/spec.json
+++ b/test/fixtures/cc/spec.json
@@ -59,6 +59,9 @@
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
                 ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
                 "PRODUCT_NAME": "lib_impl",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -145,6 +148,9 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
                 ],
                 "PRODUCT_NAME": "lib_impl",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
@@ -357,6 +363,9 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
                 ],
                 "PRODUCT_NAME": "lib_impl",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",

--- a/test/fixtures/command_line/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/project.xcodeproj/project.pbxproj
@@ -790,6 +790,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = lib_impl;
 				SDKROOT = macosx;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -844,6 +845,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = lib_impl;
 				SDKROOT = macosx;
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
@@ -917,6 +919,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap";
 				PRODUCT_MODULE_NAME = LibSwift;
 				PRODUCT_NAME = lib_swift;
@@ -1050,6 +1053,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-fastbuild-ST-f2aadcfcab57/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap";
 				PRODUCT_MODULE_NAME = LibSwift;
 				PRODUCT_NAME = lib_swift;

--- a/test/fixtures/command_line/spec.json
+++ b/test/fixtures/command_line/spec.json
@@ -184,6 +184,9 @@
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
                 ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
                 "PRODUCT_MODULE_NAME": "LibSwiftTestsLib",
                 "PRODUCT_NAME": "LibSwiftTestsLib",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -295,6 +298,9 @@
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
                 ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
                 "PRODUCT_NAME": "lib_impl",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -380,6 +386,9 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
                 ],
                 "PRODUCT_NAME": "lib_impl",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
@@ -467,6 +476,9 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
                 ],
                 "PRODUCT_MODULE_NAME": "LibSwift",
                 "PRODUCT_NAME": "lib_swift",
@@ -570,6 +582,9 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
                 ],
                 "PRODUCT_MODULE_NAME": "LibSwift",
                 "PRODUCT_NAME": "lib_swift",
@@ -763,6 +778,9 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
                 ],
                 "PRODUCT_NAME": "tool.library",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",

--- a/test/fixtures/generator/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/project.xcodeproj/project.pbxproj
@@ -1439,6 +1439,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined";
 				PRODUCT_MODULE_NAME = XcodeProj;
 				PRODUCT_NAME = XcodeProj;
@@ -1492,6 +1493,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined";
 				PRODUCT_MODULE_NAME = XCTestDynamicOverlay;
 				PRODUCT_NAME = XCTestDynamicOverlay;
@@ -1603,6 +1605,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined";
 				PRODUCT_MODULE_NAME = PathKit;
 				PRODUCT_NAME = PathKit;
@@ -1725,6 +1728,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined";
 				PRODUCT_MODULE_NAME = generator;
 				PRODUCT_NAME = generator.library;
@@ -1778,6 +1782,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined";
 				PRODUCT_MODULE_NAME = CustomDump;
 				PRODUCT_NAME = CustomDump;
@@ -1831,6 +1836,7 @@
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
 				);
+				OTHER_LDFLAGS = "-ObjC";
 				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined";
 				PRODUCT_MODULE_NAME = AEXML;
 				PRODUCT_NAME = AEXML;

--- a/test/fixtures/generator/spec.json
+++ b/test/fixtures/generator/spec.json
@@ -166,6 +166,9 @@
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
                 ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
                 "PRODUCT_MODULE_NAME": "tests",
                 "PRODUCT_NAME": "tests.library",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -385,6 +388,9 @@
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
                 ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
                 "PRODUCT_MODULE_NAME": "generator",
                 "PRODUCT_NAME": "generator.library",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -512,6 +518,9 @@
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
                 ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
                 "PRODUCT_MODULE_NAME": "PathKit",
                 "PRODUCT_NAME": "PathKit",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -599,6 +608,9 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
                 ],
                 "PRODUCT_MODULE_NAME": "CustomDump",
                 "PRODUCT_NAME": "CustomDump",
@@ -791,6 +803,9 @@
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
                 ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
                 "PRODUCT_MODULE_NAME": "XCTestDynamicOverlay",
                 "PRODUCT_NAME": "XCTestDynamicOverlay",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -878,6 +893,9 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
                 ],
                 "PRODUCT_MODULE_NAME": "AEXML",
                 "PRODUCT_NAME": "AEXML",
@@ -982,6 +1000,9 @@
                     "-pthread",
                     "-no-canonical-prefixes",
                     "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
                 ],
                 "PRODUCT_MODULE_NAME": "XcodeProj",
                 "PRODUCT_NAME": "XcodeProj",

--- a/tools/generator/src/Generator+ProcessTargetMerges.swift
+++ b/tools/generator/src/Generator+ProcessTargetMerges.swift
@@ -57,11 +57,10 @@ exist
                 // Merge build settings
                 merged.buildSettings["PRODUCT_MODULE_NAME"] =
                     merging.buildSettings["PRODUCT_MODULE_NAME"]
-                merged.buildSettings["GCC_PREPROCESSOR_DEFINITIONS"] =
-                    merging.buildSettings["GCC_PREPROCESSOR_DEFINITIONS"]
-                merged.buildSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] =
-                    merging.buildSettings["SWIFT_ACTIVE_COMPILATION_CONDITIONS"]
-                merged.buildSettings.merge(merging.buildSettings) { l, _ in l }
+                
+                let productName = merged.buildSettings["PRODUCT_NAME"]
+                merged.buildSettings.merge(merging.buildSettings) { _, r in r }
+                merged.buildSettings["PRODUCT_NAME"] = productName
 
                 // Update search paths
                 merged.searchPaths = merging.searchPaths

--- a/tools/generator/test/ProcessTargetMergesTests.swift
+++ b/tools/generator/test/ProcessTargetMergesTests.swift
@@ -44,9 +44,8 @@ final class TargetMergingTests: XCTestCase {
             buildSettings: [
                 // Inherited "A 1"s `PRODUCT_MODULE_NAME`
                 "PRODUCT_MODULE_NAME": .string("A"),
-                // Keep "A 2"'s version of `T`
-                "T": .string("43"),
-                // Inherited "A 1"'s `Y`
+                // Inherited "A 1"'s `T`, `Y`, `Z`
+                "T": .string("42"),
                 "Y": .bool(true),
                 "Z": .string("0")
             ],


### PR DESCRIPTION
Part of #69, #71, and #77.

This adds support for `apple_static_framework_import`'s `sdk_frameworks` and `weak_sdk_frameworks` attributes.