### PR TITLE
Add `tvos_app` example

### DIFF
--- a/examples/tvos_app/BUILD
+++ b/examples/tvos_app/BUILD
@@ -1,0 +1,9 @@
+load("//xcodeproj:xcodeproj.bzl", "xcodeproj")
+load(":xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
+
+xcodeproj(
+    name = "xcodeproj",
+    project_name = "Command Line",
+    tags = ["manual"],
+    targets = XCODEPROJ_TARGETS,
+)

--- a/examples/tvos_app/BUILD
+++ b/examples/tvos_app/BUILD
@@ -3,7 +3,7 @@ load(":xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
 
 xcodeproj(
     name = "xcodeproj",
-    project_name = "Command Line",
+    project_name = "TvOS App",
     tags = ["manual"],
     targets = XCODEPROJ_TARGETS,
 )

--- a/examples/tvos_app/BUILD
+++ b/examples/tvos_app/BUILD
@@ -3,7 +3,7 @@ load(":xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
 
 xcodeproj(
     name = "xcodeproj",
-    project_name = "TvOS App",
+    project_name = "tvOS App",
     tags = ["manual"],
     targets = XCODEPROJ_TARGETS,
 )

--- a/examples/tvos_app/Example/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ]
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - App Store.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ]
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
@@ -1,0 +1,32 @@
+{
+  "assets" : [
+    {
+      "filename" : "App Icon - App Store.imagestack",
+      "idiom" : "tv",
+      "role" : "primary-app-icon",
+      "size" : "1280x768"
+    },
+    {
+      "filename" : "App Icon.imagestack",
+      "idiom" : "tv",
+      "role" : "primary-app-icon",
+      "size" : "400x240"
+    },
+    {
+      "filename" : "Top Shelf Image Wide.imageset",
+      "idiom" : "tv",
+      "role" : "top-shelf-image-wide",
+      "size" : "2320x720"
+    },
+    {
+      "filename" : "Top Shelf Image.imageset",
+      "idiom" : "tv",
+      "role" : "top-shelf-image",
+      "size" : "1920x720"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image Wide.imageset/Contents.json
@@ -1,0 +1,24 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "tv-marketing",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv-marketing",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
@@ -1,0 +1,24 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "tv-marketing",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "tv-marketing",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/Assets.xcassets/Contents.json
+++ b/examples/tvos_app/Example/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/Example/BUILD
+++ b/examples/tvos_app/Example/BUILD
@@ -1,0 +1,25 @@
+load("@build_bazel_rules_apple//apple:tvos.bzl", "tvos_application")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+# load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
+
+swift_library(
+    name = "Example.library",
+    srcs = glob(["**/*.swift"]),
+    # data = [":ExampleLibraryResourceGroup"] + select({
+    #     ":release_build": [],
+    #     "//conditions:default": [":PreviewContent"],
+    # }),
+    module_name = "Example",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+tvos_application(
+    name = "Example",
+    bundle_id = "io.buildbuddy.example",
+    bundle_name = "Example",
+    infoplists = ["Info.plist"],
+    minimum_os_version = "15.0",
+    visibility = ["//visibility:public"],
+    deps = [":Example.library"],
+)

--- a/examples/tvos_app/Example/BUILD
+++ b/examples/tvos_app/Example/BUILD
@@ -1,14 +1,9 @@
 load("@build_bazel_rules_apple//apple:tvos.bzl", "tvos_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-# load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
 
 swift_library(
     name = "Example.library",
     srcs = glob(["**/*.swift"]),
-    # data = [":ExampleLibraryResourceGroup"] + select({
-    #     ":release_build": [],
-    #     "//conditions:default": [":PreviewContent"],
-    # }),
     module_name = "Example",
     tags = ["manual"],
     visibility = ["//visibility:public"],

--- a/examples/tvos_app/Example/ContentView.swift
+++ b/examples/tvos_app/Example/ContentView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentView.swift
+//  Example
+//
+//  Created by Chuck Grindel on 4/8/22.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/examples/tvos_app/Example/ContentView.swift
+++ b/examples/tvos_app/Example/ContentView.swift
@@ -1,10 +1,3 @@
-//
-//  ContentView.swift
-//  Example
-//
-//  Created by Chuck Grindel on 4/8/22.
-//
-
 import SwiftUI
 
 struct ContentView: View {

--- a/examples/tvos_app/Example/ExampleApp.swift
+++ b/examples/tvos_app/Example/ExampleApp.swift
@@ -1,0 +1,17 @@
+//
+//  ExampleApp.swift
+//  Example
+//
+//  Created by Chuck Grindel on 4/8/22.
+//
+
+import SwiftUI
+
+@main
+struct ExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/examples/tvos_app/Example/ExampleApp.swift
+++ b/examples/tvos_app/Example/ExampleApp.swift
@@ -1,10 +1,3 @@
-//
-//  ExampleApp.swift
-//  Example
-//
-//  Created by Chuck Grindel on 4/8/22.
-//
-
 import SwiftUI
 
 @main

--- a/examples/tvos_app/Example/Info.plist
+++ b/examples/tvos_app/Example/Info.plist
@@ -1,0 +1,7 @@
+{
+  CFBundleIdentifier = "\${PRODUCT_BUNDLE_IDENTIFIER}";
+  CFBundleName = "\${PRODUCT_NAME}";
+  CFBundlePackageType = "APPL";
+  CFBundleShortVersionString = "1.0";
+  CFBundleVersion = "1.0";
+}

--- a/examples/tvos_app/Example/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/examples/tvos_app/Example/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/tvos_app/ExampleTests/BUILD
+++ b/examples/tvos_app/ExampleTests/BUILD
@@ -1,0 +1,19 @@
+load("@build_bazel_rules_apple//apple:tvos.bzl", "tvos_unit_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+tvos_unit_test(
+    name = "ExampleTests",
+    bundle_id = "io.buildbuddy.example.tests",
+    minimum_os_version = "15.0",
+    test_host = "//examples/tvos_app/Example",
+    visibility = ["//visibility:public"],
+    deps = [":ExampleTests.library"],
+)
+
+swift_library(
+    name = "ExampleTests.library",
+    testonly = True,
+    srcs = glob(["**/*.swift"]),
+    module_name = "ExampleTests",
+    tags = ["manual"],
+)

--- a/examples/tvos_app/ExampleTests/BUILD
+++ b/examples/tvos_app/ExampleTests/BUILD
@@ -5,6 +5,8 @@ tvos_unit_test(
     name = "ExampleTests",
     bundle_id = "io.buildbuddy.example.tests",
     minimum_os_version = "15.0",
+    # xctestrunner does not support tvOS. So, don't try to run this.
+    tags = ["manual"],
     test_host = "//examples/tvos_app/Example",
     visibility = ["//visibility:public"],
     deps = [":ExampleTests.library"],
@@ -16,4 +18,7 @@ swift_library(
     srcs = glob(["**/*.swift"]),
     module_name = "ExampleTests",
     tags = ["manual"],
+    deps = [
+        "//examples/tvos_app/Example:Example.library",
+    ],
 )

--- a/examples/tvos_app/ExampleTests/ExampleTests.swift
+++ b/examples/tvos_app/ExampleTests/ExampleTests.swift
@@ -1,5 +1,7 @@
 import XCTest
 
+@testable import Example
+
 class ExampleTests: XCTestCase {
     func testExample() throws {
         XCTAssertEqual("foo", "foo")

--- a/examples/tvos_app/ExampleTests/ExampleTests.swift
+++ b/examples/tvos_app/ExampleTests/ExampleTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+class ExampleTests: XCTestCase {
+    func testExample() throws {
+        XCTAssertEqual("foo", "foo")
+    }
+}

--- a/examples/tvos_app/ExampleUITests/BUILD
+++ b/examples/tvos_app/ExampleUITests/BUILD
@@ -1,0 +1,26 @@
+load("@build_bazel_rules_apple//apple:tvos.bzl", "tvos_ui_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+tvos_ui_test(
+    name = "ExampleUITests",
+    bundle_id = "io.buildbuddy.example.uitests",
+    minimum_os_version = "15.0",
+    # xctestrunner does not support tvOS. So, don't try to run this.
+    tags = ["manual"],
+    test_host = "//examples/tvos_app/Example",
+    visibility = ["//visibility:public"],
+    deps = [":ExampleUITests.library"],
+)
+
+swift_library(
+    name = "ExampleUITests.library",
+    testonly = True,
+    srcs = [":Sources"],
+    module_name = "ExampleUITests",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "Sources",
+    srcs = glob(["**/*.swift"]),
+)

--- a/examples/tvos_app/ExampleUITests/ExampleUITests.swift
+++ b/examples/tvos_app/ExampleUITests/ExampleUITests.swift
@@ -1,14 +1,6 @@
-//
-//  ExampleUITests.swift
-//  ExampleUITests
-//
-//  Created by Chuck Grindel on 4/8/22.
-//
-
 import XCTest
 
 class ExampleUITests: XCTestCase {
-
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.
 

--- a/examples/tvos_app/ExampleUITests/ExampleUITests.swift
+++ b/examples/tvos_app/ExampleUITests/ExampleUITests.swift
@@ -1,0 +1,42 @@
+//
+//  ExampleUITests.swift
+//  ExampleUITests
+//
+//  Created by Chuck Grindel on 4/8/22.
+//
+
+import XCTest
+
+class ExampleUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/examples/tvos_app/ExampleUITests/ExampleUITestsLaunchTests.swift
+++ b/examples/tvos_app/ExampleUITests/ExampleUITestsLaunchTests.swift
@@ -1,14 +1,6 @@
-//
-//  ExampleUITestsLaunchTests.swift
-//  ExampleUITests
-//
-//  Created by Chuck Grindel on 4/8/22.
-//
-
 import XCTest
 
 class ExampleUITestsLaunchTests: XCTestCase {
-
     override class var runsForEachTargetApplicationUIConfiguration: Bool {
         true
     }

--- a/examples/tvos_app/ExampleUITests/ExampleUITestsLaunchTests.swift
+++ b/examples/tvos_app/ExampleUITests/ExampleUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  ExampleUITestsLaunchTests.swift
+//  ExampleUITests
+//
+//  Created by Chuck Grindel on 4/8/22.
+//
+
+import XCTest
+
+class ExampleUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/examples/tvos_app/xcodeproj_targets.bzl
+++ b/examples/tvos_app/xcodeproj_targets.bzl
@@ -1,0 +1,7 @@
+"""Exposes targets used by `xcodeproj` to allow use in fixture tests."""
+
+XCODEPROJ_TARGETS = [
+    # TODO(chuck): FIX ME!
+    # "//examples/tvos_app/Example",
+    "//examples/tvos_app/ExampleTests",
+]

--- a/examples/tvos_app/xcodeproj_targets.bzl
+++ b/examples/tvos_app/xcodeproj_targets.bzl
@@ -1,7 +1,6 @@
 """Exposes targets used by `xcodeproj` to allow use in fixture tests."""
 
 XCODEPROJ_TARGETS = [
-    # TODO(chuck): FIX ME!
-    # "//examples/tvos_app/Example",
+    "//examples/tvos_app/Example",
     "//examples/tvos_app/ExampleTests",
 ]

--- a/examples/tvos_app/xcodeproj_targets.bzl
+++ b/examples/tvos_app/xcodeproj_targets.bzl
@@ -3,4 +3,5 @@
 XCODEPROJ_TARGETS = [
     "//examples/tvos_app/Example",
     "//examples/tvos_app/ExampleTests",
+    "//examples/tvos_app/ExampleUITests",
 ]

--- a/test/fixtures/fixtures.bzl
+++ b/test/fixtures/fixtures.bzl
@@ -4,6 +4,7 @@ FIXTURE_BASENAMES = [
     "cc",
     "command_line",
     "generator",
+    "tvos_app",
 ]
 
 _FIXTURE_PACKAGES = ["//test/fixtures/{}".format(b) for b in FIXTURE_BASENAMES]

--- a/test/fixtures/tvos_app/BUILD
+++ b/test/fixtures/tvos_app/BUILD
@@ -1,0 +1,6 @@
+load("//examples/tvos_app:xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
+load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
+
+xcodeproj_fixture(
+    targets = XCODEPROJ_TARGETS,
+)

--- a/test/fixtures/tvos_app/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/project.xcodeproj/project.pbxproj
@@ -26,9 +26,18 @@
 		3A2E1ED31DDF3DFE54C3CBC0 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5DD2BA71710A6E5D778D04 /* ExampleApp.swift */; };
 		7262F7CBE2364086A650E1ED /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B211B2D3B051C1CA3AC779 /* ContentView.swift */; };
 		9E4EA3D3C8C7E14B0E337CD9 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A398F7939B7B7C9EFFFFA4E /* ExampleTests.swift */; };
+		E970C3DAB32DDFB392AE4290 /* ExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D9616425B5B2F0F529FC4F /* ExampleUITestsLaunchTests.swift */; };
+		EA303565E85D06AE6E04AABB /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F4D595EBEEE256B7E8078D /* ExampleUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		03CF1F99C3E116A66D39DB7B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EAB95A4512529D4CB8BE5D4E;
+			remoteInfo = Example;
+		};
 		078E6A97773B9731CAA6A183 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
@@ -50,14 +59,25 @@
 			remoteGlobalIDString = 3064A34776444DE49627998E;
 			remoteInfo = "Bazel Generated Files";
 		};
+		9EA5AB932A9708D1A7667DFA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3064A34776444DE49627998E;
+			remoteInfo = "Bazel Generated Files";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		17D9616425B5B2F0F529FC4F /* ExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		332DA7D905FE78395F8B49AB /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F93BE1FCDA4A6A551947845 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		7164B79B755C61D70222D1BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		87E7ADC81C6FF328FCC38BB2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		8F5DD2BA71710A6E5D778D04 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
 		9A398F7939B7B7C9EFFFFA4E /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
+		A4F4D595EBEEE256B7E8078D /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
+		C2288FA66726CD35CFB04516 /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5E39D6F9D4DAE2C1137ABB0 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C6747EB9856511FCC8FC1432 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D1B211B2D3B051C1CA3AC779 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -103,8 +123,26 @@
 			children = (
 				C5E39D6F9D4DAE2C1137ABB0 /* Example.app */,
 				332DA7D905FE78395F8B49AB /* ExampleTests.xctest */,
+				C2288FA66726CD35CFB04516 /* ExampleUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		479E7EE8B154DD2392A481A3 /* ExampleUITests.__internal__.__test_bundle-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				87E7ADC81C6FF328FCC38BB2 /* Info.plist */,
+			);
+			path = "ExampleUITests.__internal__.__test_bundle-intermediates";
+			sourceTree = "<group>";
+		};
+		50AF604D6694C0AFE78B5F0C /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				A4F4D595EBEEE256B7E8078D /* ExampleUITests.swift */,
+				17D9616425B5B2F0F529FC4F /* ExampleUITestsLaunchTests.swift */,
+			);
+			path = ExampleUITests;
 			sourceTree = "<group>";
 		};
 		52922DC1C268A3FE9B5C3C38 /* Bazel External Repositories */ = {
@@ -121,6 +159,7 @@
 			children = (
 				C0DD6E10EF80391E5371DC8E /* Example */,
 				793FD6800571A5AD39D04A67 /* ExampleTests */,
+				50AF604D6694C0AFE78B5F0C /* ExampleUITests */,
 			);
 			path = tvos_app;
 			sourceTree = "<group>";
@@ -178,6 +217,7 @@
 			children = (
 				21185BF85FB3B73E9670C5EA /* Example */,
 				BE0736B2CB46DD6BD109459D /* ExampleTests */,
+				AEE8ED8D6BE2590281D08DE5 /* ExampleUITests */,
 			);
 			path = tvos_app;
 			sourceTree = "<group>";
@@ -199,6 +239,14 @@
 				C6747EB9856511FCC8FC1432 /* Info.plist */,
 			);
 			path = "Example-intermediates";
+			sourceTree = "<group>";
+		};
+		AEE8ED8D6BE2590281D08DE5 /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				479E7EE8B154DD2392A481A3 /* ExampleUITests.__internal__.__test_bundle-intermediates */,
+			);
+			path = ExampleUITests;
 			sourceTree = "<group>";
 		};
 		B99507E1F907E7A7CB415BE5 /* bin */ = {
@@ -237,6 +285,23 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		78E254055CF3D5252C84D79D /* ExampleUITests.__internal__.__test_bundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8E5F721E3B8848F625065067 /* Build configuration list for PBXNativeTarget "ExampleUITests.__internal__.__test_bundle" */;
+			buildPhases = (
+				AB298EF0B6EC715E492E0A39 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2C3EF0A78A1C6D3ED61F8B20 /* PBXTargetDependency */,
+				8090BAEEB7C7D714E55D865C /* PBXTargetDependency */,
+			);
+			name = ExampleUITests.__internal__.__test_bundle;
+			productName = ExampleUITests;
+			productReference = C2288FA66726CD35CFB04516 /* ExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		E5FC08BFA53D3AF04406D2BB /* ExampleTests.__internal__.__test_bundle */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = AC225E2F7B139CBF04D43ED2 /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */;
@@ -283,6 +348,11 @@
 					3064A34776444DE49627998E = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
+					78E254055CF3D5252C84D79D = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+						TestTargetID = EAB95A4512529D4CB8BE5D4E;
+					};
 					E5FC08BFA53D3AF04406D2BB = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -310,6 +380,7 @@
 				3064A34776444DE49627998E /* Bazel Generated Files */,
 				EAB95A4512529D4CB8BE5D4E /* Example */,
 				E5FC08BFA53D3AF04406D2BB /* ExampleTests.__internal__.__test_bundle */,
+				78E254055CF3D5252C84D79D /* ExampleUITests.__internal__.__test_bundle */,
 			);
 		};
 /* End PBXProject section */
@@ -396,14 +467,35 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AB298EF0B6EC715E492E0A39 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA303565E85D06AE6E04AABB /* ExampleUITests.swift in Sources */,
+				E970C3DAB32DDFB392AE4290 /* ExampleUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		2C3EF0A78A1C6D3ED61F8B20 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 3064A34776444DE49627998E /* Bazel Generated Files */;
+			targetProxy = 9EA5AB932A9708D1A7667DFA /* PBXContainerItemProxy */;
+		};
 		39159660DA50973079657E41 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Bazel Generated Files";
 			target = 3064A34776444DE49627998E /* Bazel Generated Files */;
 			targetProxy = 2221FA2FB6E417367EA947F0 /* PBXContainerItemProxy */;
+		};
+		8090BAEEB7C7D714E55D865C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Example;
+			target = EAB95A4512529D4CB8BE5D4E /* Example */;
+			targetProxy = 03CF1F99C3E116A66D39DB7B /* PBXContainerItemProxy */;
 		};
 		C418EED9BCE57CCDB9B6CA97 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -420,6 +512,62 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		1CFA568E03BB2DF51CD2716A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					DEBUG,
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.uitests;
+				PRODUCT_MODULE_NAME = ExampleUITests;
+				PRODUCT_NAME = ExampleUITests;
+				SDKROOT = appletvos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = ExampleUITests.__internal__.__test_bundle;
+				TEST_TARGET_NAME = Example;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+			};
+			name = Debug;
+		};
 		235020F26966A0B7CA3238B5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -577,6 +725,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				7C935235ACC6252AE6F5B6FF /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		8E5F721E3B8848F625065067 /* Build configuration list for PBXNativeTarget "ExampleUITests.__internal__.__test_bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1CFA568E03BB2DF51CD2716A /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/tvos_app/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/project.xcodeproj/project.pbxproj
@@ -16,9 +16,21 @@
 				700DDA896776846733B25577 /* Fix Info.plists */,
 			);
 			dependencies = (
+				1B345DF509A5588973BB937D /* PBXTargetDependency */,
 			);
 			name = "Bazel Generated Files";
 			productName = "Bazel Generated Files";
+		};
+		4C83CDF1E6003ECA397737DA /* Setup */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 7A993C65A3954B906466DAE9 /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildPhases = (
+				ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */,
+			);
+			dependencies = (
+			);
+			name = Setup;
+			productName = Setup;
 		};
 /* End PBXAggregateTarget section */
 
@@ -58,6 +70,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 3064A34776444DE49627998E;
 			remoteInfo = "Bazel Generated Files";
+		};
+		3993462F5254457CDA557859 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4C83CDF1E6003ECA397737DA;
+			remoteInfo = Setup;
 		};
 		9EA5AB932A9708D1A7667DFA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -348,6 +367,9 @@
 					3064A34776444DE49627998E = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
+					4C83CDF1E6003ECA397737DA = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
 					78E254055CF3D5252C84D79D = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -377,6 +399,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
+				4C83CDF1E6003ECA397737DA /* Setup */,
 				3064A34776444DE49627998E /* Bazel Generated Files */,
 				EAB95A4512529D4CB8BE5D4E /* Example */,
 				E5FC08BFA53D3AF04406D2BB /* ExampleTests.__internal__.__test_bundle */,
@@ -404,7 +427,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\ncd \"bazel-out\"\n\nrsync \\\n  --files-from \"$PROJECT_DIR/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.rsynclist\" \\\n  --chmod=u+w \\\n  -L \\\n  . \\\n  \"$BUILD_DIR/bazel-out\"\n\ncd \"$PROJECT_FILE_PATH/rules_xcodeproj\"\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf gen_dir\n\nln -sf \"$BUILD_DIR/bazel-out\" gen_dir\n";
+			shellScript = "set -eu\n\ncd \"bazel-out\"\n\nrsync \\\n  --files-from \"$PROJECT_DIR/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.rsynclist\" \\\n  --chmod=u+w \\\n  -L \\\n  . \\\n  \"$BUILD_DIR/bazel-out\"\n";
 			showEnvVarsInLog = 0;
 		};
 		700DDA896776846733B25577 /* Fix Info.plists */ = {
@@ -447,6 +470,22 @@
 			shellScript = "set -eu\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf \"$PROJECT_DIR/bazel-out\"\n\nPATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  ${BAZEL_PATH} \\\n  build \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/tvos_app:xcodeproj\n";
 			showEnvVarsInLog = 0;
 		};
+		ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Create Symlinks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"$PROJECT_FILE_PATH/rules_xcodeproj\"\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf gen_dir\n\nln -sf \"$BUILD_DIR/bazel-out\" gen_dir\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-rules_xcodeproj/external\" external\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -479,6 +518,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		1B345DF509A5588973BB937D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = 4C83CDF1E6003ECA397737DA /* Setup */;
+			targetProxy = 3993462F5254457CDA557859 /* PBXContainerItemProxy */;
+		};
 		2C3EF0A78A1C6D3ED61F8B20 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Bazel Generated Files";
@@ -627,6 +672,14 @@
 			};
 			name = Debug;
 		};
+		70E18BE128A25A1F96CAB0FE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				TARGET_NAME = Setup;
+			};
+			name = Debug;
+		};
 		7C935235ACC6252AE6F5B6FF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -648,7 +701,8 @@
 		ACE65DF71AEBC3D1DAF7EF52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BAZEL_PACKAGE_BIN_DIR = BazelGeneratedFiles;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				TARGET_NAME = GenerateBazelFiles;
 			};
 			name = Debug;
 		};
@@ -717,6 +771,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				EC20EA8CCDB6CBDE2D648F14 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		7A993C65A3954B906466DAE9 /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				70E18BE128A25A1F96CAB0FE /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/tvos_app/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/project.xcodeproj/project.pbxproj
@@ -1,0 +1,603 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		3064A34776444DE49627998E /* Bazel Generated Files */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 9EA7153333762DEA3558208C /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */;
+			buildPhases = (
+				8B6377F4DA6FAE3ED76C177A /* Generate Files */,
+				64D3406EB908D4BD044C581E /* Copy Files */,
+				700DDA896776846733B25577 /* Fix Info.plists */,
+			);
+			dependencies = (
+			);
+			name = "Bazel Generated Files";
+			productName = "Bazel Generated Files";
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		3A2E1ED31DDF3DFE54C3CBC0 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5DD2BA71710A6E5D778D04 /* ExampleApp.swift */; };
+		7262F7CBE2364086A650E1ED /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B211B2D3B051C1CA3AC779 /* ContentView.swift */; };
+		9E4EA3D3C8C7E14B0E337CD9 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A398F7939B7B7C9EFFFFA4E /* ExampleTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		078E6A97773B9731CAA6A183 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EAB95A4512529D4CB8BE5D4E;
+			remoteInfo = Example;
+		};
+		121C0F1755D40EF9E74DDC51 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3064A34776444DE49627998E;
+			remoteInfo = "Bazel Generated Files";
+		};
+		2221FA2FB6E417367EA947F0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90B40B411875CA87718F15D6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3064A34776444DE49627998E;
+			remoteInfo = "Bazel Generated Files";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		332DA7D905FE78395F8B49AB /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5F93BE1FCDA4A6A551947845 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		7164B79B755C61D70222D1BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		8F5DD2BA71710A6E5D778D04 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
+		9A398F7939B7B7C9EFFFFA4E /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
+		C5E39D6F9D4DAE2C1137ABB0 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6747EB9856511FCC8FC1432 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		D1B211B2D3B051C1CA3AC779 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		F3EE8A1F985D59D79066BF9C /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		21185BF85FB3B73E9670C5EA /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				A5089B5D7C89E56A64758135 /* Example-intermediates */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		22D63AE4A8E6D3194DC63EEA /* Bazel Generated Files */ = {
+			isa = PBXGroup;
+			children = (
+				5F57303056F621413493A62D /* applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6 */,
+			);
+			name = "Bazel Generated Files";
+			path = test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/gen_dir;
+			sourceTree = "<group>";
+		};
+		288B9239A6FC5370446C5FD5 /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				F3EE8A1F985D59D79066BF9C /* DefaultTestBundle.plist */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
+		3695C1B089A901CABEE1141B /* apple */ = {
+			isa = PBXGroup;
+			children = (
+				288B9239A6FC5370446C5FD5 /* testing */,
+			);
+			path = apple;
+			sourceTree = "<group>";
+		};
+		428D294EDDF4A41D530E1B84 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				C5E39D6F9D4DAE2C1137ABB0 /* Example.app */,
+				332DA7D905FE78395F8B49AB /* ExampleTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		52922DC1C268A3FE9B5C3C38 /* Bazel External Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				5877E1B0DA723A428072DE2A /* build_bazel_rules_apple */,
+			);
+			name = "Bazel External Repositories";
+			path = "bazel-rules_xcodeproj/external";
+			sourceTree = "<group>";
+		};
+		57B03B4B19A8CB1911AA5D73 /* tvos_app */ = {
+			isa = PBXGroup;
+			children = (
+				C0DD6E10EF80391E5371DC8E /* Example */,
+				793FD6800571A5AD39D04A67 /* ExampleTests */,
+			);
+			path = tvos_app;
+			sourceTree = "<group>";
+		};
+		5877E1B0DA723A428072DE2A /* build_bazel_rules_apple */ = {
+			isa = PBXGroup;
+			children = (
+				3695C1B089A901CABEE1141B /* apple */,
+			);
+			path = build_bazel_rules_apple;
+			sourceTree = "<group>";
+		};
+		5E3A6AF7F4D54FD8AC656E4D /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				57B03B4B19A8CB1911AA5D73 /* tvos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		5F57303056F621413493A62D /* applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6 */ = {
+			isa = PBXGroup;
+			children = (
+				B99507E1F907E7A7CB415BE5 /* bin */,
+			);
+			path = "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6";
+			sourceTree = "<group>";
+		};
+		7427A21F07B0024A81DB246B /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				81E922D5F65D8A7B9DB7F242 /* tvos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		7815C19C8CB3760DBF3E1BDE /* ExampleTests.__internal__.__test_bundle-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				7164B79B755C61D70222D1BA /* Info.plist */,
+			);
+			path = "ExampleTests.__internal__.__test_bundle-intermediates";
+			sourceTree = "<group>";
+		};
+		793FD6800571A5AD39D04A67 /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				9A398F7939B7B7C9EFFFFA4E /* ExampleTests.swift */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
+		81E922D5F65D8A7B9DB7F242 /* tvos_app */ = {
+			isa = PBXGroup;
+			children = (
+				21185BF85FB3B73E9670C5EA /* Example */,
+				BE0736B2CB46DD6BD109459D /* ExampleTests */,
+			);
+			path = tvos_app;
+			sourceTree = "<group>";
+		};
+		91B19B3116ADB8C8ECC2934E = {
+			isa = PBXGroup;
+			children = (
+				5E3A6AF7F4D54FD8AC656E4D /* examples */,
+				52922DC1C268A3FE9B5C3C38 /* Bazel External Repositories */,
+				22D63AE4A8E6D3194DC63EEA /* Bazel Generated Files */,
+				428D294EDDF4A41D530E1B84 /* Products */,
+				C66B8C06B79203E1B66DFCCF /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		A5089B5D7C89E56A64758135 /* Example-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				C6747EB9856511FCC8FC1432 /* Info.plist */,
+			);
+			path = "Example-intermediates";
+			sourceTree = "<group>";
+		};
+		B99507E1F907E7A7CB415BE5 /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				7427A21F07B0024A81DB246B /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
+		BE0736B2CB46DD6BD109459D /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				7815C19C8CB3760DBF3E1BDE /* ExampleTests.__internal__.__test_bundle-intermediates */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
+		C0DD6E10EF80391E5371DC8E /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				D1B211B2D3B051C1CA3AC779 /* ContentView.swift */,
+				8F5DD2BA71710A6E5D778D04 /* ExampleApp.swift */,
+				5F93BE1FCDA4A6A551947845 /* Info.plist */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		C66B8C06B79203E1B66DFCCF /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E5FC08BFA53D3AF04406D2BB /* ExampleTests.__internal__.__test_bundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AC225E2F7B139CBF04D43ED2 /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */;
+			buildPhases = (
+				2C6C62B973D3C57190D8211A /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C418EED9BCE57CCDB9B6CA97 /* PBXTargetDependency */,
+				DE2A9C64E8E8EC51BD29FC22 /* PBXTargetDependency */,
+			);
+			name = ExampleTests.__internal__.__test_bundle;
+			productName = ExampleTests;
+			productReference = 332DA7D905FE78395F8B49AB /* ExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		EAB95A4512529D4CB8BE5D4E /* Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 19C1A3DAF723B9973DBE381B /* Build configuration list for PBXNativeTarget "Example" */;
+			buildPhases = (
+				6315F36A6873172964A42F18 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				39159660DA50973079657E41 /* PBXTargetDependency */,
+			);
+			name = Example;
+			productName = Example;
+			productReference = C5E39D6F9D4DAE2C1137ABB0 /* Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		90B40B411875CA87718F15D6 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					3064A34776444DE49627998E = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					E5FC08BFA53D3AF04406D2BB = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+						TestTargetID = EAB95A4512529D4CB8BE5D4E;
+					};
+					EAB95A4512529D4CB8BE5D4E = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+				};
+			};
+			buildConfigurationList = 80BD425FBB172AF87565539B /* Build configuration list for PBXProject "project" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 91B19B3116ADB8C8ECC2934E;
+			productRefGroup = 428D294EDDF4A41D530E1B84 /* Products */;
+			projectDirPath = ../../..;
+			projectRoot = "";
+			targets = (
+				3064A34776444DE49627998E /* Bazel Generated Files */,
+				EAB95A4512529D4CB8BE5D4E /* Example */,
+				E5FC08BFA53D3AF04406D2BB /* ExampleTests.__internal__.__test_bundle */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		64D3406EB908D4BD044C581E /* Copy Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(PROJECT_DIR)/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Copy Files";
+			outputFileListPaths = (
+				"$(PROJECT_DIR)/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"bazel-out\"\n\nrsync \\\n  --files-from \"$PROJECT_DIR/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.rsynclist\" \\\n  --chmod=u+w \\\n  -L \\\n  . \\\n  \"$BUILD_DIR/bazel-out\"\n\ncd \"$PROJECT_FILE_PATH/rules_xcodeproj\"\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf gen_dir\n\nln -sf \"$BUILD_DIR/bazel-out\" gen_dir\n";
+			showEnvVarsInLog = 0;
+		};
+		700DDA896776846733B25577 /* Fix Info.plists */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(PROJECT_DIR)/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/infoplists.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Fix Info.plists";
+			outputFileListPaths = (
+				"$(PROJECT_DIR)/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8B6377F4DA6FAE3ED76C177A /* Generate Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate Files";
+			outputFileListPaths = (
+				"$(PROJECT_DIR)/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf \"$PROJECT_DIR/bazel-out\"\n\nPATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  ${BAZEL_PATH} \\\n  build \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/tvos_app:xcodeproj\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2C6C62B973D3C57190D8211A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9E4EA3D3C8C7E14B0E337CD9 /* ExampleTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6315F36A6873172964A42F18 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7262F7CBE2364086A650E1ED /* ContentView.swift in Sources */,
+				3A2E1ED31DDF3DFE54C3CBC0 /* ExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		39159660DA50973079657E41 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 3064A34776444DE49627998E /* Bazel Generated Files */;
+			targetProxy = 2221FA2FB6E417367EA947F0 /* PBXContainerItemProxy */;
+		};
+		C418EED9BCE57CCDB9B6CA97 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 3064A34776444DE49627998E /* Bazel Generated Files */;
+			targetProxy = 121C0F1755D40EF9E74DDC51 /* PBXContainerItemProxy */;
+		};
+		DE2A9C64E8E8EC51BD29FC22 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Example;
+			target = EAB95A4512529D4CB8BE5D4E /* Example */;
+			targetProxy = 078E6A97773B9731CAA6A183 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		235020F26966A0B7CA3238B5 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					DEBUG,
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.tests;
+				PRODUCT_MODULE_NAME = ExampleTests;
+				PRODUCT_NAME = ExampleTests;
+				SDKROOT = appletvos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example$(TARGET_BUILD_SUBPATH)";
+				TARGET_NAME = ExampleTests.__internal__.__test_bundle;
+				TEST_HOST = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example.app/Example";
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+			};
+			name = Debug;
+		};
+		7C935235ACC6252AE6F5B6FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BAZEL_PATH = bazel;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+		ACE65DF71AEBC3D1DAF7EF52 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_PACKAGE_BIN_DIR = BazelGeneratedFiles;
+			};
+			name = Debug;
+		};
+		EC20EA8CCDB6CBDE2D648F14 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					DEBUG,
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
+				PRODUCT_MODULE_NAME = Example;
+				PRODUCT_NAME = Example;
+				SDKROOT = appletvos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = Example;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		19C1A3DAF723B9973DBE381B /* Build configuration list for PBXNativeTarget "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EC20EA8CCDB6CBDE2D648F14 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		80BD425FBB172AF87565539B /* Build configuration list for PBXProject "project" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7C935235ACC6252AE6F5B6FF /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		9EA7153333762DEA3558208C /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ACE65DF71AEBC3D1DAF7EF52 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		AC225E2F7B139CBF04D43ED2 /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				235020F26966A0B7CA3238B5 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 90B40B411875CA87718F15D6 /* Project object */;
+}

--- a/test/fixtures/tvos_app/project.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/test/fixtures/tvos_app/project.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/test/fixtures/tvos_app/project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/test/fixtures/tvos_app/project.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/test/fixtures/tvos_app/project.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/test/fixtures/tvos_app/project.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -1,0 +1,2 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -1,2 +1,3 @@
 $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
 $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -1,2 +1,3 @@
 applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
 applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -1,0 +1,2 @@
+applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
+applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,2 +1,3 @@
 $(PROJECT_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
 $(PROJECT_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,0 +1,2 @@
+$(PROJECT_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
+$(PROJECT_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
+++ b/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
@@ -1,0 +1,2 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist

--- a/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
+++ b/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
@@ -1,2 +1,3 @@
 $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist
 $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist

--- a/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
+++ b/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
@@ -1,0 +1,2 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
+++ b/test/fixtures/tvos_app/project.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
@@ -1,2 +1,3 @@
 $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
 $(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/spec.json
+++ b/test/fixtures/tvos_app/spec.json
@@ -24,6 +24,10 @@
         {
             "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
             "t": "g"
+        },
+        {
+            "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist",
+            "t": "g"
         }
     ],
     "invalid_target_merges": [],
@@ -37,6 +41,10 @@
         "//examples/tvos_app/ExampleTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
         [
             "//examples/tvos_app/ExampleTests:ExampleTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
+        ],
+        "//examples/tvos_app/ExampleUITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+        [
+            "//examples/tvos_app/ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
         ]
     ],
     "targets": [
@@ -404,6 +412,187 @@
                     "t": "g"
                 }
             ],
+            "test_host": null
+        },
+        "//examples/tvos_app/ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "DEBUG",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.uitests",
+                "PRODUCT_MODULE_NAME": "_ExampleUITests_Stub",
+                "PRODUCT_NAME": "ExampleUITests",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+            "dependencies": [
+                "//examples/tvos_app/ExampleUITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+                "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
+            ],
+            "frameworks": [],
+            "info_plist": {
+                "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist",
+                "t": "g"
+            },
+            "inputs": {
+                "contains_generated_files": true
+            },
+            "is_swift": false,
+            "label": "//examples/tvos_app/ExampleUITests:ExampleUITests.__internal__.__test_bundle",
+            "links": [
+                {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/libExampleUITests.library.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "ExampleUITests.__internal__.__test_bundle",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "ExampleUITests",
+                "path": {
+                    "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle_archive-root/ExampleUITests.xctest",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.bundle.ui-testing"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
+        },
+        "//examples/tvos_app/ExampleUITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "ENABLE_TESTING_SEARCH_PATHS": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "DEBUG",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_MODULE_NAME": "ExampleUITests",
+                "PRODUCT_NAME": "ExampleUITests.library",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "examples/tvos_app/ExampleUITests/ExampleUITests.swift",
+                    "examples/tvos_app/ExampleUITests/ExampleUITestsLaunchTests.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//examples/tvos_app/ExampleUITests:ExampleUITests.library",
+            "links": [],
+            "modulemaps": [],
+            "name": "ExampleUITests.library",
+            "outputs": {
+                "swift_module": {
+                    "name": "ExampleUITests.swiftmodule",
+                    "swiftdoc": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftdoc",
+                    "swiftmodule": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "ExampleUITests.library",
+                "path": {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/libExampleUITests.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
             "test_host": null
         }
     ]

--- a/test/fixtures/tvos_app/spec.json
+++ b/test/fixtures/tvos_app/spec.json
@@ -1,0 +1,410 @@
+{
+    "build_settings": {
+        "ALWAYS_SEARCH_USER_PATHS": false,
+        "BAZEL_PATH": "bazel",
+        "CLANG_ENABLE_OBJC_ARC": true,
+        "CLANG_MODULES_AUTOLINK": false,
+        "COPY_PHASE_STRIP": false,
+        "CURRENT_PROJECT_VERSION": "1",
+        "MARKETING_VERSION": "1.0",
+        "ONLY_ACTIVE_ARCH": true,
+        "USE_HEADERMAP": false,
+        "VALIDATE_WORKSPACE": false
+    },
+    "extra_files": [
+        "examples/tvos_app/Example/Info.plist",
+        {
+            "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist",
+            "t": "g"
+        },
+        {
+            "_": "build_bazel_rules_apple/apple/testing/DefaultTestBundle.plist",
+            "t": "e"
+        },
+        {
+            "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
+            "t": "g"
+        }
+    ],
+    "invalid_target_merges": [],
+    "label": "//test/fixtures/tvos_app:xcodeproj",
+    "name": "project",
+    "target_merges": [
+        "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+        [
+            "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
+        ],
+        "//examples/tvos_app/ExampleTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+        [
+            "//examples/tvos_app/ExampleTests:ExampleTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
+        ]
+    ],
+    "targets": [
+        "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "DEBUG",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
+                "PRODUCT_MODULE_NAME": "_Example_Stub",
+                "PRODUCT_NAME": "Example",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+            "dependencies": [
+                "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
+            ],
+            "frameworks": [],
+            "info_plist": {
+                "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist",
+                "t": "g"
+            },
+            "inputs": {
+                "contains_generated_files": true
+            },
+            "is_swift": false,
+            "label": "//examples/tvos_app/Example:Example",
+            "links": [
+                {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/libExample.library.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "Example",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "Example",
+                "path": {
+                    "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example_archive-root/Payload/Example.app",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.application"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "DEBUG",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_MODULE_NAME": "Example",
+                "PRODUCT_NAME": "Example.library",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "examples/tvos_app/Example/ContentView.swift",
+                    "examples/tvos_app/Example/ExampleApp.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//examples/tvos_app/Example:Example.library",
+            "links": [],
+            "modulemaps": [],
+            "name": "Example.library",
+            "outputs": {
+                "swift_module": {
+                    "name": "Example.swiftmodule",
+                    "swiftdoc": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example.swiftdoc",
+                    "swiftmodule": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "Example.library",
+                "path": {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/libExample.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//examples/tvos_app/ExampleTests:ExampleTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "DEBUG",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.tests",
+                "PRODUCT_MODULE_NAME": "_ExampleTests_Stub",
+                "PRODUCT_NAME": "ExampleTests",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+            "dependencies": [
+                "//examples/tvos_app/ExampleTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+                "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
+            ],
+            "frameworks": [],
+            "info_plist": {
+                "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
+                "t": "g"
+            },
+            "inputs": {
+                "contains_generated_files": true
+            },
+            "is_swift": false,
+            "label": "//examples/tvos_app/ExampleTests:ExampleTests.__internal__.__test_bundle",
+            "links": [
+                {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/libExampleTests.library.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "ExampleTests.__internal__.__test_bundle",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "ExampleTests",
+                "path": {
+                    "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle_archive-root/ExampleTests.xctest",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.bundle.unit-test"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
+        },
+        "//examples/tvos_app/ExampleTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "ENABLE_TESTING_SEARCH_PATHS": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "DEBUG",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_MODULE_NAME": "ExampleTests",
+                "PRODUCT_NAME": "ExampleTests.library",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
+            "dependencies": [
+                "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "examples/tvos_app/ExampleTests/ExampleTests.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//examples/tvos_app/ExampleTests:ExampleTests.library",
+            "links": [],
+            "modulemaps": [],
+            "name": "ExampleTests.library",
+            "outputs": {
+                "swift_module": {
+                    "name": "ExampleTests.swiftmodule",
+                    "swiftdoc": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftdoc",
+                    "swiftmodule": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "ExampleTests.library",
+                "path": {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/libExampleTests.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [
+                {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example.swiftmodule",
+                    "t": "g"
+                }
+            ],
+            "test_host": null
+        }
+    ]
+}

--- a/xcodeproj/internal/targets.bzl
+++ b/xcodeproj/internal/targets.bzl
@@ -7,6 +7,7 @@ load(
     "AppleResourceInfo",
     "IosXcTestBundleInfo",
     "MacosXcTestBundleInfo",
+    "TvosXcTestBundleInfo",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 
@@ -50,7 +51,8 @@ def _is_test_bundle(target, deps):
         return False
     return (
         _is_test_bundle_with_provider(target, deps, IosXcTestBundleInfo) or
-        _is_test_bundle_with_provider(target, deps, MacosXcTestBundleInfo)
+        _is_test_bundle_with_provider(target, deps, MacosXcTestBundleInfo) or
+        _is_test_bundle_with_provider(target, deps, TvosXcTestBundleInfo)
     )
 
 def _should_become_xcode_target(target):


### PR DESCRIPTION
Related to #95.

- Added `tvos_app` example.
- Added `TvosXcTestBundleInfo` support to `targets.is_test_bundle()`.
- Added fixtures for `tvos_app`.