### PR TITLE
Fix escaping to patch directories that contain the word external

### DIFF
--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -1042,7 +1042,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(    *(\\w+ )?header \"(\\.\\.\\/)*)(((?!(bazel-out|external)).)*\")%\\1SRCROOT/\\4%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(    *(\\w+ )?header \"(\\.\\.)*)(((?!(\\/bazel-out\\/|\\/external\\/)).)*\")%\\1SRCROOT/\\4%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */ = {

--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -1042,7 +1042,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(    *(\\w+ )?header \"(\\.\\.)*)(((?!(\\/bazel-out\\/|\\/external\\/)).)*\")%\\1SRCROOT/\\4%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(\\s*(\\w+ )?header )(?!(\"\\.\\.(\\/\\.\\.)*\\/|\")(bazel-out|external)\\/)(\"(\\.\\.\\/)*)(.*\")%\\1\\6SRCROOT/\\8%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */ = {

--- a/test/fixtures/command_line/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/project.xcodeproj/project.pbxproj
@@ -692,7 +692,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(    *(\\w+ )?header \"(\\.\\.)*)(((?!(\\/bazel-out\\/|\\/external\\/)).)*\")%\\1SRCROOT/\\4%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(\\s*(\\w+ )?header )(?!(\"\\.\\.(\\/\\.\\.)*\\/|\")(bazel-out|external)\\/)(\"(\\.\\.\\/)*)(.*\")%\\1\\6SRCROOT/\\8%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */ = {

--- a/test/fixtures/command_line/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/project.xcodeproj/project.pbxproj
@@ -692,7 +692,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(    *(\\w+ )?header \"(\\.\\.\\/)*)(((?!(bazel-out|external)).)*\")%\\1SRCROOT/\\4%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(    *(\\w+ )?header \"(\\.\\.)*)(((?!(\\/bazel-out\\/|\\/external\\/)).)*\")%\\1SRCROOT/\\4%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */ = {

--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -327,7 +327,7 @@ set -eu
 while IFS= read -r input; do
   output="${input%.modulemap}.xcode.modulemap"
   perl -p -e \
-    's%^(    *(\w+ )?header "(\.\.)*)(((?!(\/bazel-out\/|\/external\/)).)*")%\1SRCROOT/\4%' \
+    's%^(\s*(\w+ )?header )(?!("\.\.(\/\.\.)*\/|")(bazel-out|external)\/)("(\.\.\/)*)(.*")%\1\6SRCROOT/\8%' \
     < "$input" \
     > "$output"
 done < "$SCRIPT_INPUT_FILE_LIST_0"

--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -327,7 +327,7 @@ set -eu
 while IFS= read -r input; do
   output="${input%.modulemap}.xcode.modulemap"
   perl -p -e \
-    's%^(    *(\w+ )?header "(\.\.\/)*)(((?!(bazel-out|external)).)*")%\1SRCROOT/\4%' \
+    's%^(    *(\w+ )?header "(\.\.)*)(((?!(\/bazel-out\/|\/external\/)).)*")%\1SRCROOT/\4%' \
     < "$input" \
     > "$output"
 done < "$SCRIPT_INPUT_FILE_LIST_0"

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1212,7 +1212,7 @@ set -eu
 while IFS= read -r input; do
   output="${input%.modulemap}.xcode.modulemap"
   perl -p -e \
-    's%^(    *(\w+ )?header "(\.\.)*)(((?!(\/bazel-out\/|\/external\/)).)*")%\1SRCROOT/\4%' \
+    's%^(\s*(\w+ )?header )(?!("\.\.(\/\.\.)*\/|")(bazel-out|external)\/)("(\.\.\/)*)(.*")%\1\6SRCROOT/\8%' \
     < "$input" \
     > "$output"
 done < "$SCRIPT_INPUT_FILE_LIST_0"

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1212,7 +1212,7 @@ set -eu
 while IFS= read -r input; do
   output="${input%.modulemap}.xcode.modulemap"
   perl -p -e \
-    's%^(    *(\w+ )?header "(\.\.\/)*)(((?!(bazel-out|external)).)*")%\1SRCROOT/\4%' \
+    's%^(    *(\w+ )?header "(\.\.)*)(((?!(\/bazel-out\/|\/external\/)).)*")%\1SRCROOT/\4%' \
     < "$input" \
     > "$output"
 done < "$SCRIPT_INPUT_FILE_LIST_0"


### PR DESCRIPTION
Follow-up to https://github.com/buildbuddy-io/rules_xcodeproj/pull/279.

I ran into a case where if you have a directory that contains the word `external`, it that wasn't being patched correctly, thus failing the compilation.

This PR fixes it and only excludes headers in directories that start with exactly `/bazel-out/` or `/external/` but not directories that contain `/toolexternal/` or `/externaltool/`, or have `/bazel-out/` or `/external/` later in the path. 