### PR TITLE
Add `watchos_app` example

### DIFF
--- a/examples/watchos_app/BUILD
+++ b/examples/watchos_app/BUILD
@@ -1,0 +1,9 @@
+load("//xcodeproj:xcodeproj.bzl", "xcodeproj")
+load(":xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
+
+xcodeproj(
+    name = "xcodeproj",
+    project_name = "WatchOS App",
+    tags = ["manual"],
+    targets = XCODEPROJ_TARGETS,
+)

--- a/examples/watchos_app/Example/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/watchos_app/Example/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/watchos_app/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/watchos_app/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/watchos_app/Example/Assets.xcassets/Contents.json
+++ b/examples/watchos_app/Example/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/watchos_app/Example/BUILD
+++ b/examples/watchos_app/Example/BUILD
@@ -1,0 +1,52 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+config_setting(
+    name = "release_build",
+    values = {
+        "compilation_mode": "opt",
+    },
+)
+
+ios_application(
+    name = "Example",
+    app_icons = glob(["Assets.xcassets/AppIcon.appiconset/**"]),
+    bundle_id = "io.buildbuddy.example",
+    bundle_name = "Example",
+    families = ["iphone"],
+    infoplists = [":Info.plist"],
+    minimum_os_version = "15.0",
+    resources = [":ExampleResourceGroup"],
+    visibility = ["//visibility:public"],
+    # TODO(chuck): FIX ME!
+    # watch_application = "//examples/watchos_app/ExampleWatchKitApp",
+    deps = [":Example.library"],
+)
+
+apple_resource_group(
+    name = "ExampleResourceGroup",
+    resources = glob(
+        [
+            "Assets.xcassets/**",
+        ],
+        exclude = ["Assets.xcassets/AppIcon.appiconset/**"],
+    ),
+)
+
+swift_library(
+    name = "Example.library",
+    srcs = glob(["**/*.swift"]),
+    data = select({
+        ":release_build": [],
+        "//conditions:default": [":PreviewContent"],
+    }),
+    module_name = "Example",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "PreviewContent",
+    srcs = glob(["PreviewContent/**"]),
+)

--- a/examples/watchos_app/Example/BUILD
+++ b/examples/watchos_app/Example/BUILD
@@ -19,8 +19,7 @@ ios_application(
     minimum_os_version = "15.0",
     resources = [":ExampleResourceGroup"],
     visibility = ["//visibility:public"],
-    # TODO(chuck): FIX ME!
-    # watch_application = "//examples/watchos_app/ExampleWatchKitApp",
+    watch_application = "//examples/watchos_app/ExampleWatchKitApp",
     deps = [":Example.library"],
 )
 

--- a/examples/watchos_app/Example/ContentView.swift
+++ b/examples/watchos_app/Example/ContentView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/examples/watchos_app/Example/ExampleApp.swift
+++ b/examples/watchos_app/Example/ExampleApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct ExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/examples/watchos_app/Example/Info.plist
+++ b/examples/watchos_app/Example/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+</dict>
+</plist>

--- a/examples/watchos_app/Example/PreviewContent/PreviewAssets.xcassets/Contents.json
+++ b/examples/watchos_app/Example/PreviewContent/PreviewAssets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/watchos_app/ExampleTests/BUILD
+++ b/examples/watchos_app/ExampleTests/BUILD
@@ -1,0 +1,22 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+ios_unit_test(
+    name = "ExampleTests",
+    bundle_id = "io.buildbuddy.example.tests",
+    minimum_os_version = "15.0",
+    test_host = "//examples/watchos_app/Example",
+    visibility = ["//visibility:public"],
+    deps = [":ExampleTests.library"],
+)
+
+swift_library(
+    name = "ExampleTests.library",
+    testonly = True,
+    srcs = glob(["**/*.swift"]),
+    module_name = "ExampleTests",
+    tags = ["manual"],
+    deps = [
+        "//examples/watchos_app/Example:Example.library",
+    ],
+)

--- a/examples/watchos_app/ExampleTests/ExampleTests.swift
+++ b/examples/watchos_app/ExampleTests/ExampleTests.swift
@@ -1,0 +1,27 @@
+@testable import Example
+import XCTest
+
+class ExampleTests: XCTestCase {
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+}

--- a/examples/watchos_app/ExampleUITests/BUILD
+++ b/examples/watchos_app/ExampleUITests/BUILD
@@ -1,0 +1,24 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_ui_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+ios_ui_test(
+    name = "ExampleUITests",
+    bundle_id = "io.buildbuddy.example.uitests",
+    minimum_os_version = "15.0",
+    test_host = "//examples/watchos_app/Example",
+    visibility = ["//visibility:public"],
+    deps = [":ExampleUITests.library"],
+)
+
+swift_library(
+    name = "ExampleUITests.library",
+    testonly = True,
+    srcs = [":Sources"],
+    module_name = "ExampleUITests",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "Sources",
+    srcs = glob(["**/*.swift"]),
+)

--- a/examples/watchos_app/ExampleUITests/ExampleUITests.swift
+++ b/examples/watchos_app/ExampleUITests/ExampleUITests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+class ExampleUITests: XCTestCase {
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/examples/watchos_app/ExampleUITests/ExampleUITestsLaunchTests.swift
+++ b/examples/watchos_app/ExampleUITests/ExampleUITestsLaunchTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+class ExampleUITestsLaunchTests: XCTestCase {
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/examples/watchos_app/ExampleUITests/ExampleUITestsLaunchTests.swift
+++ b/examples/watchos_app/ExampleUITests/ExampleUITestsLaunchTests.swift
@@ -1,10 +1,6 @@
 import XCTest
 
 class ExampleUITestsLaunchTests: XCTestCase {
-    override class var runsForEachTargetApplicationUIConfiguration: Bool {
-        true
-    }
-
     override func setUpWithError() throws {
         continueAfterFailure = false
     }

--- a/examples/watchos_app/ExampleWatchKitApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,109 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "24x24",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "27.5x27.5",
+      "subtype" : "42mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "notificationCenter",
+      "scale" : "2x",
+      "size" : "33x33",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "40x40",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "44x44",
+      "subtype" : "40mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "46x46",
+      "subtype" : "41mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "50x50",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "appLauncher",
+      "scale" : "2x",
+      "size" : "51x51",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "86x86",
+      "subtype" : "38mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "98x98",
+      "subtype" : "42mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "108x108",
+      "subtype" : "44mm"
+    },
+    {
+      "idiom" : "watch",
+      "role" : "quickLook",
+      "scale" : "2x",
+      "size" : "117x117",
+      "subtype" : "45mm"
+    },
+    {
+      "idiom" : "watch-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitApp/Assets.xcassets/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitApp/BUILD
+++ b/examples/watchos_app/ExampleWatchKitApp/BUILD
@@ -8,6 +8,7 @@ watchos_application(
     infoplists = [":Info.plist"],
     minimum_os_version = "7.0",
     version = "//examples/watchos_app/ExampleWatchKitExtension:Version",
+    visibility = ["//examples/watchos_app:__subpackages__"],
 )
 
 filegroup(

--- a/examples/watchos_app/ExampleWatchKitApp/BUILD
+++ b/examples/watchos_app/ExampleWatchKitApp/BUILD
@@ -1,0 +1,16 @@
+load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_application")
+
+watchos_application(
+    name = "ExampleWatchKitApp",
+    app_icons = ["AppIcon.xcassets"],
+    bundle_id = "io.buildbuddy.example.watch",
+    extension = "//examples/watchos_app/ExampleWatchKitExtension",
+    infoplists = [":Info.plist"],
+    minimum_os_version = "7.0",
+    version = "//examples/watchos_app/ExampleWatchKitExtension:Version",
+)
+
+filegroup(
+    name = "AppIcon.xcassets",
+    srcs = glob(["Assets.xcassets/AppIcon.appiconset/**"]),
+)

--- a/examples/watchos_app/ExampleWatchKitApp/Info.plist
+++ b/examples/watchos_app/ExampleWatchKitApp/Info.plist
@@ -12,17 +12,14 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionAttributes</key>
-		<dict>
-			<key>WKAppBundleIdentifier</key>
-			<string>io.buildbuddy.example.watch</string>
-		</dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.watchkit</string>
-	</dict>
-	<key>WKExtensionDelegateClassName</key>
-	<string>ExtensionDelegate</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>io.buildbuddy.example</string>
+	<key>WKWatchKitApp</key>
+	<true/>
 </dict>
 </plist>

--- a/examples/watchos_app/ExampleWatchKitAppTests/BUILD
+++ b/examples/watchos_app/ExampleWatchKitAppTests/BUILD
@@ -1,0 +1,21 @@
+load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_unit_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+watchos_unit_test(
+    name = "ExampleWatchKitAppTests",
+    minimum_os_version = "7.0",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+    deps = [":ExampleWatchKitAppTests.library"],
+)
+
+swift_library(
+    name = "ExampleWatchKitAppTests.library",
+    testonly = True,
+    srcs = glob(["**/*.swift"]),
+    module_name = "ExampleWatchKitAppTests",
+    tags = ["manual"],
+    deps = [
+        "//examples/watchos_app/ExampleWatchKitExtension:ExampleWatchKitExtension.library",
+    ],
+)

--- a/examples/watchos_app/ExampleWatchKitAppTests/Example_WatchKit_AppTests.swift
+++ b/examples/watchos_app/ExampleWatchKitAppTests/Example_WatchKit_AppTests.swift
@@ -1,0 +1,27 @@
+@testable import Example_WatchKit_Extension
+import XCTest
+
+class Example_WatchKit_AppTests: XCTestCase {
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+}

--- a/examples/watchos_app/ExampleWatchKitAppTests/Example_WatchKit_AppTests.swift
+++ b/examples/watchos_app/ExampleWatchKitAppTests/Example_WatchKit_AppTests.swift
@@ -1,4 +1,4 @@
-@testable import Example_WatchKit_Extension
+@testable import ExampleWatchKitExtension
 import XCTest
 
 class Example_WatchKit_AppTests: XCTestCase {

--- a/examples/watchos_app/ExampleWatchKitAppUITests/BUILD
+++ b/examples/watchos_app/ExampleWatchKitAppUITests/BUILD
@@ -1,0 +1,24 @@
+load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_ui_test")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+watchos_ui_test(
+    name = "ExampleWatchKitAppUITests",
+    minimum_os_version = "7.0",
+    tags = ["manual"],
+    test_host = "//examples/watchos_app/ExampleWatchKitApp",
+    visibility = ["//visibility:public"],
+    deps = [":ExampleWatchKitAppUITests.library"],
+)
+
+swift_library(
+    name = "ExampleWatchKitAppUITests.library",
+    testonly = True,
+    srcs = [":Sources"],
+    module_name = "ExampleUITests",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "Sources",
+    srcs = glob(["**/*.swift"]),
+)

--- a/examples/watchos_app/ExampleWatchKitAppUITests/Example_WatchKit_AppUITests.swift
+++ b/examples/watchos_app/ExampleWatchKitAppUITests/Example_WatchKit_AppUITests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+class Example_WatchKit_AppUITests: XCTestCase {
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/examples/watchos_app/ExampleWatchKitAppUITests/Example_WatchKit_AppUITestsLaunchTests.swift
+++ b/examples/watchos_app/ExampleWatchKitAppUITests/Example_WatchKit_AppUITestsLaunchTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+class Example_WatchKit_AppUITestsLaunchTests: XCTestCase {
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/Contents.json
@@ -1,0 +1,53 @@
+{
+  "assets" : [
+    {
+      "filename" : "Circular.imageset",
+      "idiom" : "watch",
+      "role" : "circular"
+    },
+    {
+      "filename" : "Extra Large.imageset",
+      "idiom" : "watch",
+      "role" : "extra-large"
+    },
+    {
+      "filename" : "Graphic Bezel.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-bezel"
+    },
+    {
+      "filename" : "Graphic Circular.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-circular"
+    },
+    {
+      "filename" : "Graphic Corner.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-corner"
+    },
+    {
+      "filename" : "Graphic Extra Large.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-extra-large"
+    },
+    {
+      "filename" : "Graphic Large Rectangular.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-large-rectangular"
+    },
+    {
+      "filename" : "Modular.imageset",
+      "idiom" : "watch",
+      "role" : "modular"
+    },
+    {
+      "filename" : "Utilitarian.imageset",
+      "idiom" : "watch",
+      "role" : "utilitarian"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/Contents.json
@@ -6,32 +6,32 @@
       "role" : "circular"
     },
     {
-      "filename" : "Extra Large.imageset",
+      "filename" : "ExtraLarge.imageset",
       "idiom" : "watch",
       "role" : "extra-large"
     },
     {
-      "filename" : "Graphic Bezel.imageset",
+      "filename" : "GraphicBezel.imageset",
       "idiom" : "watch",
       "role" : "graphic-bezel"
     },
     {
-      "filename" : "Graphic Circular.imageset",
+      "filename" : "GraphicCircular.imageset",
       "idiom" : "watch",
       "role" : "graphic-circular"
     },
     {
-      "filename" : "Graphic Corner.imageset",
+      "filename" : "GraphicCorner.imageset",
       "idiom" : "watch",
       "role" : "graphic-corner"
     },
     {
-      "filename" : "Graphic Extra Large.imageset",
+      "filename" : "GraphicExtraLarge.imageset",
       "idiom" : "watch",
       "role" : "graphic-extra-large"
     },
     {
-      "filename" : "Graphic Large Rectangular.imageset",
+      "filename" : "GraphicLargeRectangular.imageset",
       "idiom" : "watch",
       "role" : "graphic-large-rectangular"
     },

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/ExtraLarge.imageset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/ExtraLarge.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/GraphicBezel.imageset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/GraphicBezel.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/GraphicCircular.imageset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/GraphicCircular.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/GraphicCorner.imageset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/GraphicCorner.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/GraphicExtraLarge.imageset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/GraphicExtraLarge.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/GraphicLargeRectangular.imageset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/GraphicLargeRectangular.imageset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
@@ -1,0 +1,25 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "auto-scaling" : "auto"
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/BUILD
+++ b/examples/watchos_app/ExampleWatchKitExtension/BUILD
@@ -1,0 +1,52 @@
+load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
+load("@build_bazel_rules_apple//apple:versioning.bzl", "apple_bundle_version")
+load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_extension")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+config_setting(
+    name = "release_build",
+    values = {
+        "compilation_mode": "opt",
+    },
+)
+
+apple_bundle_version(
+    name = "Version",
+    build_version = "1.0",
+)
+
+watchos_extension(
+    name = "ExampleWatchKitExtension",
+    bundle_id = "io.buildbuddy.example.Example.watchkitapp.extension",
+    infoplists = [":Info.plist"],
+    minimum_os_version = "7.0",
+    resources = [":ResourceGroup"],
+    version = ":Version",
+    visibility = ["//visibility:public"],
+    deps = [":ExampleWatchKitExtension.library"],
+)
+
+apple_resource_group(
+    name = "ResourceGroup",
+    resources = glob(
+        ["Assets.xcassets/**"],
+        exclude = ["Assets.xcassets/AppIcon.appiconset/**"],
+    ),
+)
+
+swift_library(
+    name = "ExampleWatchKitExtension.library",
+    srcs = glob(["**/*.swift"]),
+    data = select({
+        ":release_build": [],
+        "//conditions:default": [":PreviewContent"],
+    }),
+    module_name = "ExampleWatchKitExtension",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "PreviewContent",
+    srcs = glob(["PreviewContent/**"]),
+)

--- a/examples/watchos_app/ExampleWatchKitExtension/BUILD
+++ b/examples/watchos_app/ExampleWatchKitExtension/BUILD
@@ -44,7 +44,7 @@ swift_library(
     }),
     module_name = "ExampleWatchKitExtension",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = ["//examples/watchos_app:__subpackages__"],
 )
 
 filegroup(

--- a/examples/watchos_app/ExampleWatchKitExtension/BUILD
+++ b/examples/watchos_app/ExampleWatchKitExtension/BUILD
@@ -13,11 +13,12 @@ config_setting(
 apple_bundle_version(
     name = "Version",
     build_version = "1.0",
+    visibility = ["//examples/watchos_app:__subpackages__"],
 )
 
 watchos_extension(
     name = "ExampleWatchKitExtension",
-    bundle_id = "io.buildbuddy.example.Example.watchkitapp.extension",
+    bundle_id = "io.buildbuddy.example.watch.extension",
     infoplists = [":Info.plist"],
     minimum_os_version = "7.0",
     resources = [":ResourceGroup"],

--- a/examples/watchos_app/ExampleWatchKitExtension/BUILD
+++ b/examples/watchos_app/ExampleWatchKitExtension/BUILD
@@ -29,10 +29,7 @@ watchos_extension(
 
 apple_resource_group(
     name = "ResourceGroup",
-    resources = glob(
-        ["Assets.xcassets/**"],
-        exclude = ["Assets.xcassets/AppIcon.appiconset/**"],
-    ),
+    resources = glob(["Assets.xcassets/**"]),
 )
 
 swift_library(

--- a/examples/watchos_app/ExampleWatchKitExtension/ComplicationController.swift
+++ b/examples/watchos_app/ExampleWatchKitExtension/ComplicationController.swift
@@ -1,0 +1,50 @@
+import ClockKit
+
+class ComplicationController: NSObject, CLKComplicationDataSource {
+    // MARK: - Complication Configuration
+
+    func getComplicationDescriptors(handler: @escaping ([CLKComplicationDescriptor]) -> Void) {
+        let descriptors = [
+            CLKComplicationDescriptor(identifier: "complication", displayName: "Example", supportedFamilies: CLKComplicationFamily.allCases),
+            // Multiple complication support can be added here with more descriptors
+        ]
+
+        // Call the handler with the currently supported complication descriptors
+        handler(descriptors)
+    }
+
+    func handleSharedComplicationDescriptors(_: [CLKComplicationDescriptor]) {
+        // Do any necessary work to support these newly shared complication descriptors
+    }
+
+    // MARK: - Timeline Configuration
+
+    func getTimelineEndDate(for _: CLKComplication, withHandler handler: @escaping (Date?) -> Void) {
+        // Call the handler with the last entry date you can currently provide or nil if you can't support future timelines
+        handler(nil)
+    }
+
+    func getPrivacyBehavior(for _: CLKComplication, withHandler handler: @escaping (CLKComplicationPrivacyBehavior) -> Void) {
+        // Call the handler with your desired behavior when the device is locked
+        handler(.showOnLockScreen)
+    }
+
+    // MARK: - Timeline Population
+
+    func getCurrentTimelineEntry(for _: CLKComplication, withHandler handler: @escaping (CLKComplicationTimelineEntry?) -> Void) {
+        // Call the handler with the current timeline entry
+        handler(nil)
+    }
+
+    func getTimelineEntries(for _: CLKComplication, after _: Date, limit _: Int, withHandler handler: @escaping ([CLKComplicationTimelineEntry]?) -> Void) {
+        // Call the handler with the timeline entries after the given date
+        handler(nil)
+    }
+
+    // MARK: - Sample Templates
+
+    func getLocalizableSampleTemplate(for _: CLKComplication, withHandler handler: @escaping (CLKComplicationTemplate?) -> Void) {
+        // This method will be called once per supported complication, and the results will be cached
+        handler(nil)
+    }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/ContentView.swift
+++ b/examples/watchos_app/ExampleWatchKitExtension/ContentView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, World!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/ExampleApp.swift
+++ b/examples/watchos_app/ExampleWatchKitExtension/ExampleApp.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+@main
+struct ExampleApp: App {
+    @SceneBuilder var body: some Scene {
+        WindowGroup {
+            NavigationView {
+                ContentView()
+            }
+        }
+
+        WKNotificationScene(controller: NotificationController.self, category: "myCategory")
+    }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/Info.plist
+++ b/examples/watchos_app/ExampleWatchKitExtension/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>io.buildbuddy.example.Example.watchkitapp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+</dict>
+</plist>

--- a/examples/watchos_app/ExampleWatchKitExtension/NotificationController.swift
+++ b/examples/watchos_app/ExampleWatchKitExtension/NotificationController.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import UserNotifications
+import WatchKit
+
+class NotificationController: WKUserNotificationHostingController<NotificationView> {
+    override var body: NotificationView {
+        return NotificationView()
+    }
+
+    override func willActivate() {
+        // This method is called when watch view controller is about to be visible to user
+        super.willActivate()
+    }
+
+    override func didDeactivate() {
+        // This method is called when watch view controller is no longer visible
+        super.didDeactivate()
+    }
+
+    override func didReceive(_: UNNotification) {
+        // This method is called when a notification needs to be presented.
+        // Implement it if you use a dynamic notification interface.
+        // Populate your dynamic notification interface as quickly as possible.
+    }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/NotificationView.swift
+++ b/examples/watchos_app/ExampleWatchKitExtension/NotificationView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct NotificationView: View {
+    var body: some View {
+        Text("Hello, World!")
+    }
+}
+
+struct NotificationView_Previews: PreviewProvider {
+    static var previews: some View {
+        NotificationView()
+    }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/PreviewContent/PreviewAssets.xcassets/Contents.json
+++ b/examples/watchos_app/ExampleWatchKitExtension/PreviewContent/PreviewAssets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/examples/watchos_app/ExampleWatchKitExtension/PushNotificationPayload.apns
+++ b/examples/watchos_app/ExampleWatchKitExtension/PushNotificationPayload.apns
@@ -1,0 +1,20 @@
+{
+    "aps": {
+        "alert": {
+            "body": "Test message",
+            "title": "Optional title",
+            "subtitle": "Optional subtitle"
+        },
+        "category": "myCategory",
+        "thread-id": "5280"
+    },
+    
+    "WatchKit Simulator Actions": [
+        {
+            "title": "First Button",
+            "identifier": "firstButtonAction"
+        }
+    ],
+    
+    "customKey": "Use this file to define a testing payload for your notifications. The aps dictionary specifies the category, alert text and title. The WatchKit Simulator Actions array can provide info for one or more action buttons in addition to the standard Dismiss button. Any other top level keys are custom payload. If you have multiple such JSON files in your project, you'll be able to select them when choosing to debug the notification interface of your Watch App."
+}

--- a/examples/watchos_app/xcodeproj_targets.bzl
+++ b/examples/watchos_app/xcodeproj_targets.bzl
@@ -1,0 +1,11 @@
+"""Exposes targets used by `xcodeproj` to allow use in fixture tests."""
+
+XCODEPROJ_TARGETS = [
+    "//examples/watchos_app/Example",
+    "//examples/watchos_app/ExampleTests",
+    "//examples/watchos_app/ExampleUITests",
+    "//examples/watchos_app/ExampleWatchKitApp",
+    "//examples/watchos_app/ExampleWatchKitAppTests",
+    "//examples/watchos_app/ExampleWatchKitAppUITests",
+    "//examples/watchos_app/ExampleWatchKitExtension",
+]

--- a/xcodeproj/internal/targets.bzl
+++ b/xcodeproj/internal/targets.bzl
@@ -8,6 +8,7 @@ load(
     "IosXcTestBundleInfo",
     "MacosXcTestBundleInfo",
     "TvosXcTestBundleInfo",
+    "WatchosXcTestBundleInfo",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 
@@ -52,7 +53,8 @@ def _is_test_bundle(target, deps):
     return (
         _is_test_bundle_with_provider(target, deps, IosXcTestBundleInfo) or
         _is_test_bundle_with_provider(target, deps, MacosXcTestBundleInfo) or
-        _is_test_bundle_with_provider(target, deps, TvosXcTestBundleInfo)
+        _is_test_bundle_with_provider(target, deps, TvosXcTestBundleInfo) or
+        _is_test_bundle_with_provider(target, deps, WatchosXcTestBundleInfo)
     )
 
 def _should_become_xcode_target(target):


### PR DESCRIPTION
Related to #95.

- Added example that includes an iOS app with a corresponding watchOS app.
- Updated `targets.is_test_bundle` to support `WatchosXcTestBundleInfo`.