### PR TITLE
Handle -application-extension copt

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -111,6 +111,7 @@ def process_compiler_opts_test_suite(name):
             "-Xfrontend",
             "-serialize-debugging-options",
             "-enable-testing",
+            "-application-extension",
             "weird",
             "-gline-tables-only",
             "-Xwrapped-swift=-debug-prefix-pwd-is-dot",
@@ -135,6 +136,7 @@ def process_compiler_opts_test_suite(name):
         ],
         expected_build_settings = {
             "ENABLE_TESTABILITY": "True",
+            "APPLICATION_EXTENSION_API_ONLY": "True",
             "OTHER_SWIFT_FLAGS": "weird -unhandled",
             "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
         },
@@ -318,6 +320,16 @@ def process_compiler_opts_test_suite(name):
         swiftcopts = ["-enable-testing"],
         expected_build_settings = {
             "ENABLE_TESTABILITY": "True",
+        },
+    )
+
+    ## APPLICATION_EXTENSION_API_ONLY
+
+    _add_test(
+        name = "{}_swift_option-application-extension".format(name),
+        swiftcopts = ["-application-extension"],
+        expected_build_settings = {
+            "APPLICATION_EXTENSION_API_ONLY": "True",
         },
     )
 

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -458,6 +458,9 @@ under {}""".format(opt, package_bin_dir))
         if opt == "-enable-testing":
             build_settings["ENABLE_TESTABILITY"] = True
             return True
+        if opt == "-application-extension":
+            build_settings["APPLICATION_EXTENSION_API_ONLY"] = True
+            return True
         compilation_mode = _SWIFT_COMPILATION_MODE_OPTS.get(opt, "")
         if compilation_mode:
             build_settings["SWIFT_COMPILATION_MODE"] = compilation_mode


### PR DESCRIPTION
If you pass `-application-extension` to `copts`, it's now handled correctly.