### PR TITLE
Parse user-provided copts for Swift

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -536,17 +536,20 @@ def process_compiler_opts_test_suite(name):
             "-I",
             "aa/bb",
         ],
+        user_swiftcopts = ["-Xcc", "-Ic/d/e", "-Xcc", "-iquote4/5"],
         expected_build_settings = {},
         expected_search_paths = {
             "quote_includes": [
                 "a/b/c",
                 "0/9",
                 "y/z",
+                "4/5",
             ],
             "includes": [
                 "x/y/z",
                 "1/2/3",
                 "aa/bb",
+                "c/d/e",
             ],
         },
     )

--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -15,7 +15,8 @@ def _process_compiler_opts_test_impl(ctx):
     search_paths = process_compiler_opts(
         conlyopts = ctx.attr.conlyopts,
         cxxopts = ctx.attr.cxxopts,
-        swiftcopts = ctx.attr.swiftcopts,
+        full_swiftcopts = ctx.attr.full_swiftcopts,
+        user_swiftcopts = ctx.attr.user_swiftcopts,
         package_bin_dir = ctx.attr.package_bin_dir,
         build_settings = build_settings,
     )
@@ -53,7 +54,8 @@ process_compiler_opts_test = unittest.make(
         "expected_build_settings": attr.string_dict(mandatory = True),
         "expected_search_paths": attr.string(mandatory = True),
         "package_bin_dir": attr.string(mandatory = True),
-        "swiftcopts": attr.string_list(mandatory = True),
+        "full_swiftcopts": attr.string_list(mandatory = True),
+        "user_swiftcopts": attr.string_list(mandatory = True),
     },
 )
 
@@ -73,14 +75,16 @@ def process_compiler_opts_test_suite(name):
             expected_search_paths = {"quote_includes": [], "includes": []},
             conlyopts = [],
             cxxopts = [],
-            swiftcopts = [],
+            full_swiftcopts = [],
+            user_swiftcopts = [],
             package_bin_dir = ""):
         test_names.append(name)
         process_compiler_opts_test(
             name = name,
             conlyopts = conlyopts,
             cxxopts = cxxopts,
-            swiftcopts = swiftcopts,
+            full_swiftcopts = full_swiftcopts,
+            user_swiftcopts = user_swiftcopts,
             package_bin_dir = package_bin_dir,
             expected_build_settings = stringify_dict(expected_build_settings),
             expected_search_paths = json.encode(expected_search_paths),
@@ -91,7 +95,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_integration".format(name),
-        swiftcopts = [
+        full_swiftcopts = [
             "-target",
             "arm64-apple-ios15.0-simulator",
             "-sdk",
@@ -134,6 +138,7 @@ def process_compiler_opts_test_suite(name):
             "examples/xcode_like/ExampleUITests/ExampleUITests.swift",
             "examples/xcode_like/ExampleUITests/ExampleUITestsLaunchTests.swift",
         ],
+        user_swiftcopts = [],
         expected_build_settings = {
             "ENABLE_TESTABILITY": "True",
             "APPLICATION_EXTENSION_API_ONLY": "True",
@@ -146,7 +151,8 @@ def process_compiler_opts_test_suite(name):
         name = "{}_empty".format(name),
         conlyopts = [],
         cxxopts = [],
-        swiftcopts = [],
+        full_swiftcopts = [],
+        user_swiftcopts = [],
         expected_build_settings = {},
     )
 
@@ -219,7 +225,7 @@ def process_compiler_opts_test_suite(name):
             "-passthrough",
             "-mios-simulator-version-min=14.0",
         ],
-        swiftcopts = [
+        full_swiftcopts = [
             "-output-file-map",
             "path",
             "-passthrough",
@@ -317,7 +323,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_option-enable-testing".format(name),
-        swiftcopts = ["-enable-testing"],
+        full_swiftcopts = ["-enable-testing"],
         expected_build_settings = {
             "ENABLE_TESTABILITY": "True",
         },
@@ -327,7 +333,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_option-application-extension".format(name),
-        swiftcopts = ["-application-extension"],
+        full_swiftcopts = ["-application-extension"],
         expected_build_settings = {
             "APPLICATION_EXTENSION_API_ONLY": "True",
         },
@@ -392,7 +398,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_defines".format(name),
-        swiftcopts = [
+        full_swiftcopts = [
             "-DDEBUG",
             "-DBAZEL",
             "-DDEBUG",
@@ -407,7 +413,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_multiple_swift_compilation_modes".format(name),
-        swiftcopts = [
+        full_swiftcopts = [
             "-wmo",
             "-no-whole-module-optimization",
         ],
@@ -418,7 +424,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_option-incremental".format(name),
-        swiftcopts = ["-incremental"],
+        full_swiftcopts = ["-incremental"],
         expected_build_settings = {
             "SWIFT_COMPILATION_MODE": "singlefile",
         },
@@ -426,7 +432,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_option-whole-module-optimization".format(name),
-        swiftcopts = ["-whole-module-optimization"],
+        full_swiftcopts = ["-whole-module-optimization"],
         expected_build_settings = {
             "SWIFT_COMPILATION_MODE": "wholemodule",
         },
@@ -434,7 +440,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_option-wmo".format(name),
-        swiftcopts = ["-wmo"],
+        full_swiftcopts = ["-wmo"],
         expected_build_settings = {
             "SWIFT_COMPILATION_MODE": "wholemodule",
         },
@@ -442,7 +448,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_option-no-whole-module-optimization".format(name),
-        swiftcopts = ["-no-whole-module-optimization"],
+        full_swiftcopts = ["-no-whole-module-optimization"],
         expected_build_settings = {
             "SWIFT_COMPILATION_MODE": "singlefile",
         },
@@ -452,7 +458,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_generated_header".format(name),
-        swiftcopts = [
+        full_swiftcopts = [
             "-emit-objc-header-path",
             "a/b/c/TestingUtils-Custom.h",
         ],
@@ -466,7 +472,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_multiple_swift_optimization_levels".format(name),
-        swiftcopts = [
+        full_swiftcopts = [
             "-Osize",
             "-Onone",
             "-O",
@@ -478,7 +484,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_option-Onone".format(name),
-        swiftcopts = ["-Onone"],
+        full_swiftcopts = ["-Onone"],
         expected_build_settings = {
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
         },
@@ -486,7 +492,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_option-O".format(name),
-        swiftcopts = ["-O"],
+        full_swiftcopts = ["-O"],
         expected_build_settings = {
             "SWIFT_OPTIMIZATION_LEVEL": "-O",
         },
@@ -494,7 +500,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_option-Osize".format(name),
-        swiftcopts = ["-Osize"],
+        full_swiftcopts = ["-Osize"],
         expected_build_settings = {
             "SWIFT_OPTIMIZATION_LEVEL": "-Osize",
         },
@@ -504,7 +510,7 @@ def process_compiler_opts_test_suite(name):
 
     _add_test(
         name = "{}_swift_option-swift-version".format(name),
-        swiftcopts = ["-swift-version=42"],
+        full_swiftcopts = ["-swift-version=42"],
         expected_build_settings = {
             "SWIFT_VERSION": "42",
         },

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -522,12 +522,13 @@ def _process_user_swiftcopts(opts):
     includes = []
 
     def process(opt, previous_opt):
-        if opt.startswith("-iquote") and previous_opt == "-Xcc":
+        if previous_opt == "-Xcc" and opt.startswith("-iquote"):
             quote_includes.append(opt[7:])
             return True
-        if opt.startswith("-I") and previous_opt == "-Xcc":
+        if previous_opt == "-Xcc" and opt.startswith("-I"):
             includes.append(opt[2:])
             return True
+
         if opt == "-Xcc":
             return True
         return False
@@ -577,7 +578,7 @@ def _process_compiler_opts(
         cxxopts = cxxopts,
         build_settings = build_settings,
     )
-    full_swiftcopts = _process_full_swiftcopts(
+    swiftcopts = _process_full_swiftcopts(
         full_swiftcopts,
         package_bin_dir = package_bin_dir,
         build_settings = build_settings,
@@ -602,7 +603,7 @@ def _process_compiler_opts(
     set_if_true(
         build_settings,
         "OTHER_SWIFT_FLAGS",
-        " ".join(full_swiftcopts),
+        " ".join(swiftcopts),
     )
 
     return merge_opts_search_paths([conly_search_paths, cxx_search_paths, swift_search_paths])

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -106,9 +106,16 @@ def _get_unprocessed_compiler_opts(*, ctx, target):
 
     # TODO: Handle perfileopts somehow?
 
+    rule_copts = []
+    user_swiftcopts = []
     if SwiftInfo in target:
         # Rule level swiftcopts are included in action.argv below
-        rule_copts = []
+        user_swiftcopts = getattr(ctx.rule.attr, "copts", [])
+        user_swiftcopts = _expand_make_variables(
+            ctx = ctx,
+            values = user_swiftcopts,
+            attribute_name = "copts",
+        )
     elif CcInfo in target:
         rule_copts = getattr(ctx.rule.attr, "copts", [])
         rule_copts = _expand_make_variables(
@@ -116,8 +123,7 @@ def _get_unprocessed_compiler_opts(*, ctx, target):
             values = rule_copts,
             attribute_name = "copts",
         )
-    else:
-        rule_copts = []
+        
 
     raw_swiftcopts = []
     for action in target.actions:
@@ -131,6 +137,7 @@ def _get_unprocessed_compiler_opts(*, ctx, target):
         base_copts + cpp.copts + cpp.conlyopts + rule_copts,
         base_cxxopts + cpp.copts + cpp.cxxopts + rule_copts,
         raw_swiftcopts,
+        user_swiftcopts,
     )
 
 def _process_base_compiler_opts(*, opts, skip_opts, extra_processing = None):
@@ -190,10 +197,10 @@ def merge_opts_search_paths(search_paths):
     """Merges a `list` of search paths into a single set set of search paths.
 
     Args:
-        search_paths: A `list` of values returned from `_create_search_paths()`.
+        search_paths: A `list` of values returned from `create_opts_search_paths()`.
 
     Returns:
-        A value returned from `_create_search_paths()`, with the search paths
+        A value returned from `create_opts_search_paths()`, with the search paths
         provided to it being the merged and deduplicated values from
         `search_paths`.
     """
@@ -221,7 +228,7 @@ def _process_conlyopts(opts):
         *   A `list` of unhandled C compiler options.
         *   A `list` of defines parsed.
         *   A `list` of C compiler optimization levels parsed.
-        *   A value returned by `_create_search_paths()` with the parsed search
+        *   A value returned by `create_opts_search_paths()` with the parsed search
             paths.
     """
     defines = []
@@ -416,7 +423,7 @@ def _process_copts(*, conlyopts, cxxopts, build_settings):
         merge_opts_search_paths([conly_search_paths, cxx_search_paths]),
     )
 
-def _process_swiftcopts(opts, *, package_bin_dir, build_settings):
+def _process_full_swiftcopts(opts, package_bin_dir, build_settings):
     """Processes Swift compiler options.
 
     Args:
@@ -501,11 +508,47 @@ under {}""".format(opt, package_bin_dir))
 
     return unhandled_opts
 
+def _process_user_swiftcopts(opts):
+    """Processes user-provided Swift compiler options.
+
+    Args:
+        opts: A `list` of Swift compiler options.
+
+    Returns:
+        A `list` of search paths.
+    """
+
+    quote_includes = []
+    includes = []
+
+    def process(opt, previous_opt):
+        # TODO: how to we handle `-Xcc -I -Xcc path`?
+        if opt.startswith("-iquote"):
+            includes.append(opt[7:])
+            return True
+        if opt.startswith("-I"):
+            includes.append(opt[2:])
+            return True
+
+    unhandled_opts = _process_base_compiler_opts(
+        opts = opts,
+        skip_opts = {},
+        extra_processing = process,
+    )
+
+    search_paths = create_opts_search_paths(
+        quote_includes = uniq(quote_includes),
+        includes = uniq(includes),
+    )
+
+    return search_paths # TODO: how do we handle unhandled_opts here?
+
 def _process_compiler_opts(
         *,
         conlyopts,
         cxxopts,
         swiftcopts,
+        user_swiftcopts,
         package_bin_dir,
         build_settings):
     """Processes compiler options.
@@ -526,15 +569,18 @@ def _process_compiler_opts(
         *   `quotes_includes`: A `list` of quote include paths parsed.
         *   `includes`: A `list` of include paths parsed.
     """
-    conlyopts, cxxopts, search_paths = _process_copts(
+    conlyopts, cxxopts, c_search_paths = _process_copts(
         conlyopts = conlyopts,
         cxxopts = cxxopts,
         build_settings = build_settings,
     )
-    swiftcopts = _process_swiftcopts(
+    swiftcopts = _process_full_swiftcopts(
         swiftcopts,
         package_bin_dir = package_bin_dir,
         build_settings = build_settings,
+    )
+    swift_search_paths = _process_user_swiftcopts(
+        user_swiftcopts,
     )
 
     # TODO: Split out `WARNING_CFLAGS`? (Must maintain order, and only ones that apply to both c and cxx)
@@ -556,7 +602,7 @@ def _process_compiler_opts(
         " ".join(swiftcopts),
     )
 
-    return search_paths
+    return merge_opts_search_paths([c_search_paths, swift_search_paths])
 
 def _process_target_compiler_opts(
         *,
@@ -580,7 +626,7 @@ def _process_target_compiler_opts(
         *   `quotes_includes`: A `list` of quote include paths parsed.
         *   `includes`: A `list` of include paths parsed.
     """
-    conlyopts, cxxopts, swiftcopts = _get_unprocessed_compiler_opts(
+    conlyopts, cxxopts, swiftcopts, user_swiftcopts = _get_unprocessed_compiler_opts(
         ctx = ctx,
         target = target,
     )
@@ -588,6 +634,7 @@ def _process_target_compiler_opts(
         conlyopts = conlyopts,
         cxxopts = cxxopts,
         swiftcopts = swiftcopts,
+        user_swiftcopts = user_swiftcopts,
         package_bin_dir = package_bin_dir,
         build_settings = build_settings,
     )

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -123,7 +123,6 @@ def _get_unprocessed_compiler_opts(*, ctx, target):
             values = user_copts,
             attribute_name = "copts",
         )
-        
 
     raw_swiftcopts = []
     for action in target.actions:
@@ -531,10 +530,11 @@ def _process_user_swiftcopts(opts):
             return True
         if opt == "-Xcc":
             return True
+        return False
 
-    _ = _process_base_compiler_opts(
+    _process_base_compiler_opts(
         opts = opts,
-        skip_opts = {}, # Empty in order to process all user opts.
+        skip_opts = {},  # Empty in order to process all user opts.
         extra_processing = process,
     )
 

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -524,7 +524,7 @@ def _process_user_swiftcopts(opts):
 
     def process(opt, previous_opt):
         if opt.startswith("-iquote") and previous_opt == "-Xcc":
-            includes.append(opt[7:])
+            quote_includes.append(opt[7:])
             return True
         if opt.startswith("-I") and previous_opt == "-Xcc":
             includes.append(opt[2:])

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -423,7 +423,7 @@ def _process_copts(*, conlyopts, cxxopts, build_settings):
         merge_opts_search_paths([conly_search_paths, cxx_search_paths]),
     )
 
-def _process_full_swiftcopts(opts, package_bin_dir, build_settings):
+def _process_full_swiftcopts(opts, *, package_bin_dir, build_settings):
     """Processes Swift compiler options.
 
     Args:
@@ -547,7 +547,7 @@ def _process_compiler_opts(
         *,
         conlyopts,
         cxxopts,
-        swiftcopts,
+        full_swiftcopts,
         user_swiftcopts,
         package_bin_dir,
         build_settings):
@@ -626,14 +626,14 @@ def _process_target_compiler_opts(
         *   `quotes_includes`: A `list` of quote include paths parsed.
         *   `includes`: A `list` of include paths parsed.
     """
-    conlyopts, cxxopts, swiftcopts, user_swiftcopts = _get_unprocessed_compiler_opts(
+    conlyopts, cxxopts, full_swiftcopts, user_swiftcopts = _get_unprocessed_compiler_opts(
         ctx = ctx,
         target = target,
     )
     return _process_compiler_opts(
         conlyopts = conlyopts,
         cxxopts = cxxopts,
-        swiftcopts = swiftcopts,
+        full_swiftcopts = full_swiftcopts,
         user_swiftcopts = user_swiftcopts,
         package_bin_dir = package_bin_dir,
         build_settings = build_settings,

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -423,8 +423,37 @@ def _process_copts(*, conlyopts, cxxopts, build_settings):
         cxx_search_paths,
     )
 
-def _process_full_swiftcopts(opts, *, package_bin_dir, build_settings):
+def _process_swiftopts(full_swiftcopts, user_swiftcopts, *, package_bin_dir, build_settings):
     """Processes Swift compiler options.
+
+    Args:
+        full_swiftcopts: A `list` of Swift compiler options.
+        user_swiftcopts: A `list` of user-provided Swift compiler options.
+        package_bin_dir: The package directory for the target within
+            `ctx.bin_dir`.
+        build_settings: A mutable `dict` that will be updated with build
+            settings that are parsed from `opts`.
+
+    Returns:
+        A `tuple` containing two elements:
+
+        *   A `list` of unhandled Swift compiler options.
+        *   A value returned by `_create_search_paths()` with the parsed search
+            paths.
+    """
+    swiftcopts = _process_full_swiftcopts(
+        full_swiftcopts,
+        package_bin_dir = package_bin_dir,
+        build_settings = build_settings,
+    )
+
+    swift_search_paths = _process_user_swiftcopts(
+        user_swiftcopts,
+    )
+    return swiftcopts, swift_search_paths
+
+def _process_full_swiftcopts(opts, *, package_bin_dir, build_settings):
+    """Processes the full Swift compiler options (including Bazel ones).
 
     Args:
         opts: A `list` of Swift compiler options.
@@ -578,13 +607,11 @@ def _process_compiler_opts(
         cxxopts = cxxopts,
         build_settings = build_settings,
     )
-    swiftcopts = _process_full_swiftcopts(
+    swiftcopts, swift_search_paths = _process_swiftopts(
         full_swiftcopts,
+        user_swiftcopts,
         package_bin_dir = package_bin_dir,
         build_settings = build_settings,
-    )
-    swift_search_paths = _process_user_swiftcopts(
-        user_swiftcopts,
     )
 
     # TODO: Split out `WARNING_CFLAGS`? (Must maintain order, and only ones that apply to both c and cxx)

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -543,6 +543,9 @@ def _process_user_swiftcopts(opts):
     Args:
         opts: A `list` of Swift compiler options.
 
+    Note: any flag processed here needs to be filtered from
+        processing in `_process_full_swiftcopts()`.
+
     Returns:
         A `list` of search paths.
     """
@@ -551,6 +554,7 @@ def _process_user_swiftcopts(opts):
     includes = []
 
     def process(opt, previous_opt):
+        # TODO: handle the format "-Xcc -iquote -Xcc path"
         if previous_opt == "-Xcc" and opt.startswith("-iquote"):
             quote_includes.append(opt[7:])
             return True


### PR DESCRIPTION
This PR fixes an issue where `copts` for Swift code are not collected correctly and can cause build failures. Still very much a WIP, but feedback welcome!