### PR TITLE
Ensure the same env variables are being used during indexing

### DIFF
--- a/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/project.xcodeproj/project.pbxproj
@@ -1021,7 +1021,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf \"$PROJECT_DIR/bazel-out\"\n\nPATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  ${BAZEL_PATH} \\\n  build \\\n  --output_groups=generated_inputs \\\n  //test/fixtures:fixture\n";
+			shellScript = "set -eu\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf \"$PROJECT_DIR/bazel-out\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  ${BAZEL_PATH} \\\n  build \\\n  --output_groups=generated_inputs \\\n  //test/fixtures:fixture\n";
 			showEnvVarsInLog = 0;
 		};
 		C977250D6EB972BF2FF38593 /* Fix Modulemaps */ = {
@@ -1574,7 +1574,10 @@
 		70E18BE128A25A1F96CAB0FE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = Setup;
 			};
 			name = Debug;
@@ -1670,7 +1673,10 @@
 		ACE65DF71AEBC3D1DAF7EF52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = GenerateBazelFiles;
 			};
 			name = Debug;

--- a/test/fixtures/cc/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/project.xcodeproj/project.pbxproj
@@ -434,7 +434,10 @@
 		70E18BE128A25A1F96CAB0FE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = Setup;
 			};
 			name = Debug;

--- a/test/fixtures/command_line/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/project.xcodeproj/project.pbxproj
@@ -637,7 +637,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf \"$PROJECT_DIR/bazel-out\"\n\nPATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  ${BAZEL_PATH} \\\n  build \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/command_line:xcodeproj\n";
+			shellScript = "set -eu\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf \"$PROJECT_DIR/bazel-out\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  ${BAZEL_PATH} \\\n  build \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/command_line:xcodeproj\n";
 			showEnvVarsInLog = 0;
 		};
 		8B6A1F2475BB65156F63CE12 /* Copy Swift Generated Header */ = {
@@ -951,7 +951,10 @@
 		70E18BE128A25A1F96CAB0FE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = Setup;
 			};
 			name = Debug;
@@ -1037,7 +1040,10 @@
 		ACE65DF71AEBC3D1DAF7EF52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = GenerateBazelFiles;
 			};
 			name = Debug;

--- a/test/fixtures/generator/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/project.xcodeproj/project.pbxproj
@@ -1827,7 +1827,10 @@
 		70E18BE128A25A1F96CAB0FE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = Setup;
 			};
 			name = Debug;

--- a/test/fixtures/tvos_app/project.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/project.xcodeproj/project.pbxproj
@@ -467,7 +467,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf \"$PROJECT_DIR/bazel-out\"\n\nPATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  ${BAZEL_PATH} \\\n  build \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/tvos_app:xcodeproj\n";
+			shellScript = "set -eu\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf \"$PROJECT_DIR/bazel-out\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  ${BAZEL_PATH} \\\n  build \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/tvos_app:xcodeproj\n";
 			showEnvVarsInLog = 0;
 		};
 		ECDF8E3FB28F2FB706B4D395 /* Create Symlinks */ = {
@@ -677,7 +677,10 @@
 		70E18BE128A25A1F96CAB0FE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = Setup;
 			};
 			name = Debug;
@@ -703,7 +706,10 @@
 		ACE65DF71AEBC3D1DAF7EF52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
 				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = GenerateBazelFiles;
 			};
 			name = Debug;

--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -2,6 +2,18 @@ import PathKit
 import XcodeProj
 
 extension Generator {
+    // Xcode likes this list as a string, and apparently in reverse
+    static let allPlatforms = """
+watchsimulator \
+watchos \
+macosx \
+iphonesimulator \
+iphoneos \
+driverkit \
+appletvsimulator \
+appletvos
+"""
+
     static func addTargets(
         in pbxProj: PBXProj,
         for disambiguatedTargets: [TargetID: DisambiguatedTarget],
@@ -116,7 +128,10 @@ Product for target "\(id)" not found in `products`
         let debugConfiguration = XCBuildConfiguration(
             name: "Debug",
             buildSettings: [
+                "ALLOW_TARGET_PLATFORM_SPECIALIZATION": true,
                 "BAZEL_PACKAGE_BIN_DIR": "rules_xcodeproj",
+                "SUPPORTED_PLATFORMS": allPlatforms,
+                "SUPPORTS_MACCATALYST": true,
                 "TARGET_NAME": "Setup",
             ]
         )
@@ -185,7 +200,10 @@ ln -sfn "\#(
         let debugConfiguration = XCBuildConfiguration(
             name: "Debug",
             buildSettings: [
+                "ALLOW_TARGET_PLATFORM_SPECIALIZATION": true,
                 "BAZEL_PACKAGE_BIN_DIR": "rules_xcodeproj",
+                "SUPPORTED_PLATFORMS": allPlatforms,
+                "SUPPORTS_MACCATALYST": true,
                 "TARGET_NAME": "GenerateBazelFiles",
             ]
         )
@@ -218,7 +236,11 @@ rm -rf "$PROJECT_DIR/\(filePathResolver.generatedDirectory)"
             shellScript: #"""
 set -eu
 \#(removeWorkspaceBazelOut)
-PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
+env -i \
+  DEVELOPER_DIR="$DEVELOPER_DIR" \
+  HOME="$HOME" \
+  PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
+  USER="$USER" \
   ${BAZEL_PATH} \
   build \
   --output_groups=generated_inputs \

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1093,10 +1093,24 @@ bazel-out/a/c.a
 
         let pbxProject = pbxProj.rootObject!
 
+        let allPlatforms = """
+watchsimulator \
+watchos \
+macosx \
+iphonesimulator \
+iphoneos \
+driverkit \
+appletvsimulator \
+appletvos
+"""
+
         let setupDebugConfiguration = XCBuildConfiguration(
             name: "Debug",
             buildSettings: [
+                "ALLOW_TARGET_PLATFORM_SPECIALIZATION": true,
                 "BAZEL_PACKAGE_BIN_DIR": "rules_xcodeproj",
+                "SUPPORTED_PLATFORMS": allPlatforms,
+                "SUPPORTS_MACCATALYST": true,
                 "TARGET_NAME": "Setup",
             ]
         )
@@ -1148,7 +1162,10 @@ ln -sfn "\#(
         let generateFilesDebugConfiguration = XCBuildConfiguration(
             name: "Debug",
             buildSettings: [
+                "ALLOW_TARGET_PLATFORM_SPECIALIZATION": true,
                 "BAZEL_PACKAGE_BIN_DIR": "rules_xcodeproj",
+                "SUPPORTED_PLATFORMS": allPlatforms,
+                "SUPPORTS_MACCATALYST": true,
                 "TARGET_NAME": "GenerateBazelFiles",
             ]
         )
@@ -1167,7 +1184,11 @@ ln -sfn "\#(
             shellScript: #"""
 set -eu
 
-PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
+env -i \
+  DEVELOPER_DIR="$DEVELOPER_DIR" \
+  HOME="$HOME" \
+  PATH="${PATH//\/usr\/local\/bin//opt/homebrew/bin:/usr/local/bin}" \
+  USER="$USER" \
   ${BAZEL_PATH} \
   build \
   --output_groups=generated_inputs \


### PR DESCRIPTION
This change both limits the numbers of env variables being passed to `bazel build` as well as fixes an issue where the Run Scripts would get different selected platforms depending on if it was a regular build or an index build, by saying that the run scripts support all platforms.