### PR TITLE
Pre-generate files during initial project creation

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -12,7 +12,6 @@ gh-md-toc --hide-header --hide-footer --start-depth=1
 * [My Xcode project seems to be of of sync with my Bazel project\. What should I do?](#my-xcode-project-seems-to-be-of-of-sync-with-my-bazel-project-what-should-i-do)
 * [When I open my Xcode project, the Bazel Generated Files folder in the project navigator is red\. How do I fix this?](#when-i-open-my-xcode-project-the-bazel-generated-files-folder-in-the-project-navigator-is-red-how-do-i-fix-this)
 
-
 ## My Xcode project seems to be of of sync with my Bazel project. What should I do?
 
 The generated Xcode project includes scripts to synchronize select Bazel
@@ -20,13 +19,18 @@ generated files (e.g. `Info.plist`) with Xcode. Perform the following steps to
 synchronize these file:
 
 1. Open the Xcode project: `xed path/to/MyApp.xcodeproj`.
-2. Select the `Bazel Generated Files` scheme (Menu: `Product` > `Scheme` > `Bazel Generated Files`).
-3. Execute the build for the the `Bazel Generated Files` scheme (Menu: `Product` > `Build`).
-4. Close Xcode.
-5. Open the Xcode project: `xed path/to/MyApp.xcodeproj`.
+2. Select the `Bazel Generated Files` scheme (Menu: `Product` > `Scheme` >
+   `Bazel Generated Files`).
+3. Build the `Bazel Generated Files` scheme (Menu: `Product` > `Build`).
+4. If items under the `Bazel Generated Files` group in the Project navigator are
+   red, close and re-open the project.
 
-## When I open my Xcode project, the `Bazel Generated Files` folder in the project navigator is red. How do I fix this?
+All targets that depend on generates files depend on the `Bazel Generated Files`
+target, so building any of those targets will also synchronize Xcode.
 
-If Xcode shows project navigator items in red, it usually means that they are not present. You
-merely need to synchronize the files with your Bazel project by following [these
-steps](#my-xcode-project-seems-to-be-of-of-sync-with-my-bazel-project-what-should-i-do).
+## When I open my Xcode project, the `Bazel Generated Files` group in the Project navigator is red. How do I fix this?
+
+If Xcode shows Project navigator items in red, it usually means that they are
+not present. You merely need to synchronize the files with your Bazel project by
+following
+[these steps](#my-xcode-project-seems-to-be-of-of-sync-with-my-bazel-project-what-should-i-do).

--- a/xcodeproj/internal/fixtures.bzl
+++ b/xcodeproj/internal/fixtures.bzl
@@ -76,11 +76,6 @@ _update_fixtures = rule(
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
-        "_installer_template": attr.label(
-            allow_single_file = True,
-            executable = False,
-            default = Label("//xcodeproj/internal:installer.template.sh"),
-        ),
         "_updater_template": attr.label(
             allow_single_file = True,
             default = ":updater.template.sh",


### PR DESCRIPTION
To make initial experiences nicer, we now run the `Bazel Generated Files` scheme as part of initial project creation. This won't be run each time the project is generated, only if the `gen_dir` isn't found.

To disable this behavior, you can set `pre_generate_files = False` on your `xcodeproj` target. In that case, it will only run the `Setup` scheme, which will ensure that Xcode behaves nicely once the generated files are created, without having to close and re-open the project.

Longer term we might want to reduce the number of files pre-generated, as this step might take a long time. Also, Build with Bazel might have different requirements.