### PR TITLE
Upgrade `rules_bazel_integration_test` to use `bazel-contrib` release.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 # To update these lines, execute 
-# `bazel run @cgrindel_rules_bazel_integration_test//tools:update_deleted_packages`
+# `bazel run @bazel_contrib_rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=examples/cc/external,examples/command_line/external,examples/ios_app,examples/ios_app/CoreUtilsObjC,examples/ios_app/Example,examples/ios_app/ExampleObjcTests,examples/ios_app/ExampleResources,examples/ios_app/ExampleTests,examples/ios_app/ExampleUITests,examples/ios_app/TestingUtils,examples/ios_app/Utils,examples/ios_app/external,examples/ios_app/test/fixtures,examples/ios_app/third_party
 query --deleted_packages=examples/cc/external,examples/command_line/external,examples/ios_app,examples/ios_app/CoreUtilsObjC,examples/ios_app/Example,examples/ios_app/ExampleObjcTests,examples/ios_app/ExampleResources,examples/ios_app/ExampleTests,examples/ios_app/ExampleUITests,examples/ios_app/TestingUtils,examples/ios_app/Utils,examples/ios_app/external,examples/ios_app/test/fixtures,examples/ios_app/third_party
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 # To update these lines, execute 
-# `bazel run @bazel_contrib_rules_bazel_integration_test//tools:update_deleted_packages`
+# `bazel run @contrib_rules_bazel_integration_test//tools:update_deleted_packages`
 build --deleted_packages=examples/cc/external,examples/command_line/external,examples/ios_app,examples/ios_app/CoreUtilsObjC,examples/ios_app/Example,examples/ios_app/ExampleObjcTests,examples/ios_app/ExampleResources,examples/ios_app/ExampleTests,examples/ios_app/ExampleUITests,examples/ios_app/TestingUtils,examples/ios_app/Utils,examples/ios_app/external,examples/ios_app/test/fixtures,examples/ios_app/third_party
 query --deleted_packages=examples/cc/external,examples/command_line/external,examples/ios_app,examples/ios_app/CoreUtilsObjC,examples/ios_app/Example,examples/ios_app/ExampleObjcTests,examples/ios_app/ExampleResources,examples/ios_app/ExampleTests,examples/ios_app/ExampleUITests,examples/ios_app/TestingUtils,examples/ios_app/Utils,examples/ios_app/external,examples/ios_app/test/fixtures,examples/ios_app/third_party
 

--- a/BUILD
+++ b/BUILD
@@ -1,8 +1,8 @@
-load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "integration_test_utils",
 )
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 
 # Buildifier
 

--- a/BUILD
+++ b/BUILD
@@ -1,8 +1,8 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 load(
-    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "integration_test_utils",
 )
-load("@buildifier_prebuilt//:rules.bzl", "buildifier")
 
 # Buildifier
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,15 +106,15 @@ buildifier_prebuilt_register_toolchains()
 # Bazel Integration Test
 
 http_archive(
-    name = "cgrindel_rules_bazel_integration_test",
-    sha256 = "993dea93d67895c25a093b55102ae9005bc74eb5546031b71820a79b3788c190",
-    strip_prefix = "rules_bazel_integration_test-0.6.0",
+    name = "contrib_rules_bazel_integration_test",
+    sha256 = "ab9bbf776b5874f8a02f639fec2fbb3e3eefa4403cf861ae00d7c7e4d757f9ff",
+    strip_prefix = "rules_bazel_integration_test-0.6.2",
     urls = [
-        "http://github.com/cgrindel/rules_bazel_integration_test/archive/0.6.0.tar.gz",
+        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/v0.6.2.tar.gz",
     ],
 )
 
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 
@@ -124,7 +124,7 @@ bazel_starlib_dependencies()
 
 # Bazel Binaries for Bazel Integration Tests
 
-load("@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -114,7 +114,7 @@ http_archive(
     ],
 )
 
-load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:deps.bzl", "bazel_integration_test_rules_dependencies")
 
 bazel_integration_test_rules_dependencies()
 
@@ -124,7 +124,7 @@ bazel_starlib_dependencies()
 
 # Bazel Binaries for Bazel Integration Tests
 
-load("@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
+load("@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl", "bazel_binaries")
 load("//:bazel_versions.bzl", "SUPPORTED_BAZEL_VERSIONS")
 
 bazel_binaries(versions = SUPPORTED_BAZEL_VERSIONS)

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@cgrindel_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
     "integration_test_utils",
 )

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@bazel_contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
+    "@contrib_rules_bazel_integration_test//bazel_integration_test:defs.bzl",
     "bazel_integration_test",
     "integration_test_utils",
 )


### PR DESCRIPTION
Related to bazel-contrib/rules_bazel_integration_test#47.