### PR TITLE
Support `includes` in cc_library

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -72,7 +72,7 @@ def process_compiler_opts_test_suite(name):
             *,
             name,
             expected_build_settings,
-            expected_search_paths = {"quote_includes": [], "includes": []},
+            expected_search_paths = {"quote_includes": [], "includes": [], "system_includes": []},
             conlyopts = [],
             cxxopts = [],
             full_swiftcopts = [],
@@ -528,6 +528,8 @@ def process_compiler_opts_test_suite(name):
             "1/2/3",
             "-iquote",
             "0/9",
+            "-isystem",
+            "s1/s2",
         ],
         cxxopts = [
             "-iquote",
@@ -535,8 +537,10 @@ def process_compiler_opts_test_suite(name):
             "-Ix/y/z",
             "-I",
             "aa/bb",
+            "-isystem",
+            "s3/s4",
         ],
-        user_swiftcopts = ["-Xcc", "-Ic/d/e", "-Xcc", "-iquote4/5"],
+        user_swiftcopts = ["-Xcc", "-Ic/d/e", "-Xcc", "-iquote4/5", "-Xcc", "-isystems5/s6"],
         expected_build_settings = {},
         expected_search_paths = {
             "quote_includes": [
@@ -550,6 +554,11 @@ def process_compiler_opts_test_suite(name):
                 "1/2/3",
                 "aa/bb",
                 "c/d/e",
+            ],
+            "system_includes": [
+                "s1/s2",
+                "s3/s4",
+                "s5/s6",
             ],
         },
     )

--- a/tools/generator/src/Generator+SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator+SetTargetConfigurations.swift
@@ -61,6 +61,16 @@ Target "\(id)" not found in `pbxTargets`
                 )
             }
 
+            let systemIncludes = target.searchPaths.systemIncludes
+            if !systemIncludes.isEmpty {
+                try targetBuildSettings.prepend(
+                    onKey: "SYSTEM_HEADER_SEARCH_PATHS",
+                    systemIncludes.map { filePath in
+                        return filePathResolver.resolve(filePath).string.quoted
+                    }
+                )
+            }
+
             try targetBuildSettings.prepend(
                 onKey: "OTHER_SWIFT_FLAGS",
                 target.modulemaps

--- a/tools/generator/src/SearchPaths.swift
+++ b/tools/generator/src/SearchPaths.swift
@@ -2,15 +2,18 @@ struct SearchPaths: Equatable {
     let frameworkIncludes: [FilePath]
     let quoteIncludes: [FilePath]
     let includes: [FilePath]
+    let systemIncludes: [FilePath]
 
     init(
         frameworkIncludes: [FilePath] = [],
         quoteIncludes: [FilePath] = [],
-        includes: [FilePath] = []
+        includes: [FilePath] = [],
+        systemIncludes: [FilePath] = []
     ) {
         self.frameworkIncludes = frameworkIncludes
         self.quoteIncludes = quoteIncludes
         self.includes = includes
+        self.systemIncludes = systemIncludes
     }
 }
 
@@ -21,6 +24,7 @@ extension SearchPaths: Decodable {
         case frameworkIncludes
         case quoteIncludes
         case includes
+        case systemIncludes
     }
 
     init(from decoder: Decoder) throws {
@@ -29,6 +33,7 @@ extension SearchPaths: Decodable {
         frameworkIncludes = try container.decodeFilePaths(.frameworkIncludes)
         quoteIncludes = try container.decodeFilePaths(.quoteIncludes)
         includes = try container.decodeFilePaths(.includes)
+        systemIncludes = try container.decodeFilePaths(.systemIncludes)
     }
 }
 

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -710,6 +710,18 @@ def _process_target_linker_opts(*, ctx, build_settings):
         build_settings = build_settings,
     )
 
+def _process_target_includes(*, ctx, build_settings):
+    """Processes the includes for a target.
+
+    Args:
+        ctx: The aspect context.
+        build_settings: A mutable `dict` that will be updated with build
+            settings that are parsed from the target's includes.
+    """
+    includes = getattr(ctx.rule.attr, "includes", [])
+    if includes:
+        build_settings["HEADER_SEARCH_PATHS"] = includes
+
 # Utility
 
 def _expand_make_variables(*, ctx, values, attribute_name):
@@ -764,6 +776,10 @@ def process_opts(*, ctx, target, package_bin_dir, build_settings):
         build_settings = build_settings,
     )
     _process_target_linker_opts(
+        ctx = ctx,
+        build_settings = build_settings,
+    )
+    _process_target_includes(
         ctx = ctx,
         build_settings = build_settings,
     )

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -176,12 +176,13 @@ def _process_base_compiler_opts(*, opts, skip_opts, extra_processing = None):
 
     return unhandled_opts
 
-def create_opts_search_paths(quote_includes, includes):
+def create_opts_search_paths(quote_includes, includes, system_includes):
     """Creates a value representing search paths of a target.
 
     Args:
         quote_includes: A `list` of quote include paths (i.e `-iquote` values).
         includes: A `list` of include paths (i.e. `-I` values).
+        system_includes: A `list` of system include paths (i.e. `-isystem` values).
 
     Returns:
         A `struct` containing the `quote_includes` and `includes` fields
@@ -190,6 +191,7 @@ def create_opts_search_paths(quote_includes, includes):
     return struct(
         quote_includes = quote_includes,
         includes = includes,
+        system_includes = system_includes,
     )
 
 def merge_opts_search_paths(search_paths):
@@ -205,14 +207,17 @@ def merge_opts_search_paths(search_paths):
     """
     quote_includes = []
     includes = []
+    system_includes = []
 
     for search_path in search_paths:
         quote_includes.extend(search_path.quote_includes)
         includes.extend(search_path.includes)
+        system_includes.extend(search_path.system_includes)
 
     return create_opts_search_paths(
         quote_includes = uniq(quote_includes),
         includes = uniq(includes),
+        system_includes = uniq(system_includes),
     )
 
 def _process_conlyopts(opts):
@@ -234,8 +239,12 @@ def _process_conlyopts(opts):
     optimizations = []
     quote_includes = []
     includes = []
+    system_includes = []
 
     def process(opt, previous_opt):
+        if previous_opt == "-isystem":
+            system_includes.append(opt)
+            return True
         if previous_opt == "-iquote":
             quote_includes.append(opt)
             return True
@@ -245,6 +254,8 @@ def _process_conlyopts(opts):
 
         if opt.startswith("-O"):
             optimizations.append(opt)
+            return True
+        if opt == "-isystem":
             return True
         if opt == "-iquote":
             return True
@@ -269,6 +280,7 @@ def _process_conlyopts(opts):
     search_paths = create_opts_search_paths(
         quote_includes = uniq(quote_includes),
         includes = uniq(includes),
+        system_includes = uniq(system_includes),
     )
 
     return unhandled_opts, defines, optimizations, search_paths
@@ -294,8 +306,12 @@ def _process_cxxopts(opts, *, build_settings):
     optimizations = []
     quote_includes = []
     includes = []
+    system_includes = []
 
     def process(opt, previous_opt):
+        if previous_opt == "-isystem":
+            system_includes.append(opt)
+            return True
         if previous_opt == "-iquote":
             quote_includes.append(opt)
             return True
@@ -313,6 +329,8 @@ def _process_cxxopts(opts, *, build_settings):
             return True
         if opt.startswith("-stdlib="):
             build_settings["CLANG_CXX_LIBRARY"] = opt[8:]
+            return True
+        if opt == "-isystem":
             return True
         if opt == "-iquote":
             return True
@@ -337,6 +355,7 @@ def _process_cxxopts(opts, *, build_settings):
     search_paths = create_opts_search_paths(
         quote_includes = uniq(quote_includes),
         includes = uniq(includes),
+        system_includes = uniq(system_includes),
     )
 
     return unhandled_opts, defines, optimizations, search_paths
@@ -552,9 +571,13 @@ def _process_user_swiftcopts(opts):
 
     quote_includes = []
     includes = []
+    system_includes = []
 
     def process(opt, previous_opt):
         # TODO: handle the format "-Xcc -iquote -Xcc path"
+        if previous_opt == "-Xcc" and opt.startswith("-isystem"):
+            system_includes.append(opt[8:])
+            return True
         if previous_opt == "-Xcc" and opt.startswith("-iquote"):
             quote_includes.append(opt[7:])
             return True
@@ -575,6 +598,7 @@ def _process_user_swiftcopts(opts):
     search_paths = create_opts_search_paths(
         quote_includes = uniq(quote_includes),
         includes = uniq(includes),
+        system_includes = uniq(system_includes),
     )
 
     return search_paths
@@ -710,18 +734,6 @@ def _process_target_linker_opts(*, ctx, build_settings):
         build_settings = build_settings,
     )
 
-def _process_target_includes(*, ctx, build_settings):
-    """Processes the includes for a target.
-
-    Args:
-        ctx: The aspect context.
-        build_settings: A mutable `dict` that will be updated with build
-            settings that are parsed from the target's includes.
-    """
-    includes = getattr(ctx.rule.attr, "includes", [])
-    if includes:
-        build_settings["HEADER_SEARCH_PATHS"] = includes
-
 # Utility
 
 def _expand_make_variables(*, ctx, values, attribute_name):
@@ -776,10 +788,6 @@ def process_opts(*, ctx, target, package_bin_dir, build_settings):
         build_settings = build_settings,
     )
     _process_target_linker_opts(
-        ctx = ctx,
-        build_settings = build_settings,
-    )
-    _process_target_includes(
         ctx = ctx,
         build_settings = build_settings,
     )

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -915,6 +915,7 @@ def _process_resource_target(*, ctx, target, transitive_infos):
         opts_search_paths = create_opts_search_paths(
             quote_includes = [],
             includes = [],
+            system_includes = [],
         ),
     )
 
@@ -1017,6 +1018,7 @@ def _process_non_xcode_target(*, ctx, target, transitive_infos):
             opts_search_paths = create_opts_search_paths(
                 quote_includes = [],
                 includes = [],
+                system_includes = [],
             ),
         ),
         static_framework_files = static_framework_files,
@@ -1159,6 +1161,7 @@ def _skip_target(*, target, transitive_infos):
             opts_search_paths = create_opts_search_paths(
                 quote_includes = [],
                 includes = [],
+                system_includes = [],
             ),
         ),
         static_framework_files = depset(
@@ -1273,6 +1276,15 @@ def _process_search_paths(*, cc_info, objc, opts_search_paths):
                 file_path_to_dto(parsed_file_path(path))
                 for path in (compilation_context.includes.to_list() +
                              opts_search_paths.includes)
+            ],
+        )
+        set_if_true(
+            search_paths,
+            "system_includes",
+            [
+                file_path_to_dto(parsed_file_path(path))
+                for path in (compilation_context.system_includes.to_list() +
+                             opts_search_paths.system_includes)
             ],
         )
 


### PR DESCRIPTION
By specifying `SYSTEM_HEADER_SEARCH_PATHS` in Xcode build settings.

Partially addresses https://github.com/buildbuddy-io/rules_xcodeproj/issues/82.

Allows [Yams](https://github.com/jpsim/Yams) to compile.