### PR TITLE
Add `bazel` option to `build_mode` and force `dbg` for it

### DIFF
--- a/examples/ios_app/test/fixtures/BUILD
+++ b/examples/ios_app/test/fixtures/BUILD
@@ -17,6 +17,7 @@ update_fixtures(
     name = "update",
     tags = ["manual"],
     targets = [
+        ":fixture_bwb",
         ":fixture_bwx",
     ],
 )
@@ -24,6 +25,7 @@ update_fixtures(
 xcodeproj_test_suite(
     name = "xcodeproj",
     fixture_tests = [
+        xcodeproj_tests.from_fixture("//test/fixtures:fixture_bwb"),
         xcodeproj_tests.from_fixture("//test/fixtures:fixture_bwx"),
     ],
 )

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1,0 +1,1971 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		1264E098850804E77CE82093 /* Bazel Generated Files */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */;
+			buildPhases = (
+				CA47126A96DBA220099058F9 /* Generate Files */,
+				3BBBE88C0B5DFE50E861D039 /* Copy Files */,
+				C39544D2D57030E1F850014D /* Fix Modulemaps */,
+				C1BCE66C756D6574AE7961FF /* Fix Info.plists */,
+			);
+			dependencies = (
+				A375E057D32BEDDB980E23C5 /* PBXTargetDependency */,
+			);
+			name = "Bazel Generated Files";
+			productName = "Bazel Generated Files";
+		};
+		ECAFAC2323528A3317A7C9F2 /* Setup */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildPhases = (
+				48F6FA82818C0DE2760C55C0 /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = Setup;
+			productName = Setup;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		0CF1BE2D8A4589480BD6924D /* ExampleResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6511618DDE522A59792EF4D3 /* ExampleResources.bundle */; };
+		0F510D645C2D0A80BE763732 /* nested in Resources */ = {isa = PBXBuildFile; fileRef = B97C2835F125F69B2FDF8477 /* nested */; };
+		22B1B599528FD2D6ED98FF27 /* PreviewAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EF7A41BCADD5C386F325375B /* PreviewAssets.xcassets */; };
+		2986C89FC23EC9DAC3580D49 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = ECC63D78B0A2D399B5E493C5 /* Localizable.strings */; };
+		32284BD8DB742D84E539B8EB /* TestingUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BF5455514D7692884FB81F /* TestingUtils.swift */; };
+		3EB86573BC23DBD28DB4092D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B75CC91156E9D2337A9933AE /* Assets.xcassets */; };
+		4BFD859F1371C86D02DB25A1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADB9E176B3AB4F6354A1167 /* ContentView.swift */; };
+		550BA6FCF1894C7DFA32D1E3 /* ExternalFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA542B31DC88C70950011E86 /* ExternalFramework.framework */; };
+		64E83EFE14E692EFF2065C42 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1F2546A475C2CA76D8E89436 /* Assets.xcassets */; };
+		6A97C8EA8F4607A20FA6E3C2 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D027F83636D3D6C6ABBF375F /* ExampleTests.swift */; };
+		6B192A693F6E888F64E4D471 /* ExternalFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BA542B31DC88C70950011E86 /* ExternalFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7821060CBE02370F404D084C /* Utils.bundle in Resources */ = {isa = PBXBuildFile; fileRef = E9ED685D3A056C10F6A99CCD /* Utils.bundle */; };
+		8827E174961A52D2C88CF0C9 /* ExampleObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1945E01AD98FE05054F33AE5 /* ExampleObjcTests.m */; };
+		8D706D038CC2FAFCCA51D5A5 /* Answers.m in Sources */ = {isa = PBXBuildFile; fileRef = 28F5833510B6D7BECA9E9B7B /* Answers.m */; };
+		A29169FF12586786795BC72E /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BDA5C3FF5C9611B6DF55D3C /* ExampleUITests.swift */; };
+		A47B89A7830CBA5505845985 /* nested in Resources */ = {isa = PBXBuildFile; fileRef = 4BE5211604948E91881C4479 /* nested */; };
+		AF706BBB5E91814A308DFAED /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C6DFECB6D814B2CE3ADA51CD /* Assets.xcassets */; };
+		B054C3F6BAFAFA0604A3B413 /* Foo.m in Sources */ = {isa = PBXBuildFile; fileRef = DE684C8B8336D55C43040D1E /* Foo.m */; };
+		C908762178E1810512145D56 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC51A4085F05FC61686E7785 /* ExampleApp.swift */; };
+		CAE032E92796B6D1EFE0E452 /* ExternalResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 1176BC2C3AA9DF30F9244647 /* ExternalResources.bundle */; };
+		D184C3C5A13941F3D1470F16 /* ExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B6FAB2FF4A94053E4D470E /* ExampleUITestsLaunchTests.swift */; };
+		D44BA76178425EBF4A0F8B40 /* ExampleFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3D27BBBDD5DEF87214D8019 /* ExampleFramework.framework */; };
+		E890FC6A268E85A3E10BD648 /* nested in Resources */ = {isa = PBXBuildFile; fileRef = 62BA266605A71726F9EF2A78 /* nested */; };
+		F01312AFF4DEADA1852E81BD /* ExampleResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6511618DDE522A59792EF4D3 /* ExampleResources.bundle */; };
+		F66C7C4EE117AEFAA8D41FC2 /* Utils.bundle in Resources */ = {isa = PBXBuildFile; fileRef = E9ED685D3A056C10F6A99CCD /* Utils.bundle */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0F71FB02423BEEE76DFEE7A7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1264E098850804E77CE82093;
+			remoteInfo = "Bazel Generated Files";
+		};
+		12BBDEF891F9CEDDBCF66227 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		253F301DFAC4DBD74F463E32 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F175A7E1019A952CA7F66BBC;
+			remoteInfo = TestingUtils;
+		};
+		40C4645E155842FBD47B3D44 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 95C60B89B988FCC45A4A0562;
+			remoteInfo = ExampleResources;
+		};
+		4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		73935C723008807A2920DC10 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1264E098850804E77CE82093;
+			remoteInfo = "Bazel Generated Files";
+		};
+		7DC9F0A22A7B1E5E310197D9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 34820134F30D904FFA06D27A;
+			remoteInfo = Utils;
+		};
+		7EDBC9AA0948CBD61D742C1D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DEF15AA97EC0FE28A9A97CAA;
+			remoteInfo = Example;
+		};
+		80B7F7FC096EA6B5D2CEF6A4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		8AFCF859AE8A8F088DB4EF97 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0BCC9DD063CA52172B904538;
+			remoteInfo = ExternalResources;
+		};
+		97350A84E43A3D97DB7FF16B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 64AE6000A6317B9C077F3B1E;
+			remoteInfo = CoreUtilsObjC;
+		};
+		9AF12B3279FCACB57125FEC0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		9B5B4C5E0C8D4797ADCE6AB2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 34820134F30D904FFA06D27A;
+			remoteInfo = Utils;
+		};
+		9C436E7C1FA11504B50D86B5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F175A7E1019A952CA7F66BBC;
+			remoteInfo = TestingUtils;
+		};
+		A0F480345DF9DC369DA636A3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DEF15AA97EC0FE28A9A97CAA;
+			remoteInfo = Example;
+		};
+		A236A391B1795EC1AD621FA5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 34820134F30D904FFA06D27A;
+			remoteInfo = Utils;
+		};
+		B29F6183C154822D72EC2305 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1264E098850804E77CE82093;
+			remoteInfo = "Bazel Generated Files";
+		};
+		CC375C8586CC07711829D641 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		DE2ABDC3A4020CEAD5FB18F6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 95C60B89B988FCC45A4A0562;
+			remoteInfo = ExampleResources;
+		};
+		EBD0C87C46CE3A0065D73AA0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DEF15AA97EC0FE28A9A97CAA;
+			remoteInfo = Example;
+		};
+		FA89BC6DF686E165E775357E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1264E098850804E77CE82093;
+			remoteInfo = "Bazel Generated Files";
+		};
+		FB75881099C5283F0B88B414 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1264E098850804E77CE82093;
+			remoteInfo = "Bazel Generated Files";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		833364064E1457AC6C05CD5F /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				6B192A693F6E888F64E4D471 /* ExternalFramework.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		04B6B48EA76D2EFBD56BD67C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		05CED94736B3F5BB8E2E87B5 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		0B4615EBFB02A2D6C5B1045D /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		0BDA5C3FF5C9611B6DF55D3C /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
+		1104D414730D2DC8DC9DD9E9 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		1176BC2C3AA9DF30F9244647 /* ExternalResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExternalResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		119F88A7D863C38938114348 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		1945E01AD98FE05054F33AE5 /* ExampleObjcTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExampleObjcTests.m; sourceTree = "<group>"; };
+		1E9DF944F8F0B62634A3A29D /* Utils.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Utils.swift.modulemap; sourceTree = "<group>"; };
+		1F2546A475C2CA76D8E89436 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		26BF5455514D7692884FB81F /* TestingUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingUtils.swift; sourceTree = "<group>"; };
+		2824DA1BE9B4A537598FEFE0 /* CoreUtilsObjC.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = CoreUtilsObjC.swift.modulemap; sourceTree = "<group>"; };
+		28F5833510B6D7BECA9E9B7B /* Answers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Answers.m; sourceTree = "<group>"; };
+		2E9AA98CF71EC1A8ADA8FC12 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		3044751746014D22D03BB28E /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		328731FD80DB31CAF28DA35F /* Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
+		41E087EFF7DB4B31F84CEF5F /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		44C19A56FE797949930D145D /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4574E57BDC516B7338E600E4 /* Greeting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Greeting.swift; sourceTree = "<group>"; };
+		46A804416537B31F7C6B6E0E /* Answers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Answers.h; sourceTree = "<group>"; };
+		48F0B3D39D176B90AE9F2C8A /* Answer.swift.stencil */ = {isa = PBXFileReference; path = Answer.swift.stencil; sourceTree = "<group>"; };
+		4BE5211604948E91881C4479 /* nested */ = {isa = PBXFileReference; lastKnownFileType = folder; path = nested; sourceTree = "<group>"; };
+		502D073C9606AB022280231A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		51D8E16C7D64BCE16C6B4C9E /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		5510BC5BFFC471231BB2C8E0 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		55E65A7323E456CDEBA791E6 /* Greeting.swift.stencil */ = {isa = PBXFileReference; path = Greeting.swift.stencil; sourceTree = "<group>"; };
+		577BC07B4F6E580BDB13B5B1 /* CoreUtils.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreUtils.pch; sourceTree = "<group>"; };
+		5951CDD4ACEF57EA1B00FCBD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		5BA479F9D7617A5A5E99F50F /* Answer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Answer.swift; sourceTree = "<group>"; };
+		62BA266605A71726F9EF2A78 /* nested */ = {isa = PBXFileReference; lastKnownFileType = folder; path = nested; sourceTree = "<group>"; };
+		6511618DDE522A59792EF4D3 /* ExampleResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		823A0A913DE6BBF3286D06E6 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		86B6FAB2FF4A94053E4D470E /* ExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		8ADB9E176B3AB4F6354A1167 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		8F8B001AB6315D99F13FAC92 /* libCoreUtilsObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCoreUtilsObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		9BF5CE4ADD5163F5308F8626 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		9D61CBAFE2C78BDC7960D5A4 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		A619B11AC2106BAC08FA7DB0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		AA8B40F3394AF193E0043C9C /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
+		ADE221FC6902DE7F5C1351D9 /* TestingUtils.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = TestingUtils.swift.modulemap; sourceTree = "<group>"; };
+		B236D472E2B01203C379DE61 /* Foo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Foo.h; sourceTree = "<group>"; };
+		B75CC91156E9D2337A9933AE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B97C2835F125F69B2FDF8477 /* nested */ = {isa = PBXFileReference; lastKnownFileType = folder; path = nested; sourceTree = "<group>"; };
+		BA542B31DC88C70950011E86 /* ExternalFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExternalFramework.framework; sourceTree = "<group>"; };
+		C6DFECB6D814B2CE3ADA51CD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		CC8E3F6E9A6B44248BD06712 /* libUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		D027F83636D3D6C6ABBF375F /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
+		D165E542DE0036D69F5A152B /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		D227CE711F51FF221F83B7EA /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DC51A4085F05FC61686E7785 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
+		DE684C8B8336D55C43040D1E /* Foo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Foo.m; sourceTree = "<group>"; };
+		E470DDDC0990D96A685DB11C /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E87C46A394A10BD8A57D4ED8 /* ExampleObjcTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleObjcTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		E889785B64BCD36A9414A7E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		E9ED685D3A056C10F6A99CCD /* Utils.bundle */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Utils.bundle; sourceTree = "<group>"; };
+		EF7A41BCADD5C386F325375B /* PreviewAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = PreviewAssets.xcassets; sourceTree = "<group>"; };
+		F3D27BBBDD5DEF87214D8019 /* ExampleFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExampleFramework.framework; sourceTree = "<group>"; };
+		F7A2777E8293F6B63DA51836 /* libTestingUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTestingUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6E426D209568E509FBE28076 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D44BA76178425EBF4A0F8B40 /* ExampleFramework.framework in Frameworks */,
+				550BA6FCF1894C7DFA32D1E3 /* ExternalFramework.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		015833302CCE3B39492E505C /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				05263B83DB00469A09376A41 /* Example */,
+				B2E8F73B09FAE1D96221D163 /* ExampleObjcTests */,
+				9579B99A3C258FA1A007F4BC /* ExampleTests */,
+				FA1090BD952F1CB85A896C2B /* ExampleUITests */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
+		05263B83DB00469A09376A41 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				585AD694A7FC50DCE514B6E2 /* Example-intermediates */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		0FA8CC4F83F67E8D17E56EF6 /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				05CED94736B3F5BB8E2E87B5 /* BUILD */,
+				0BDA5C3FF5C9611B6DF55D3C /* ExampleUITests.swift */,
+				86B6FAB2FF4A94053E4D470E /* ExampleUITestsLaunchTests.swift */,
+			);
+			path = ExampleUITests;
+			sourceTree = "<group>";
+		};
+		1B8846860A494D5FC82D2072 /* PreviewContent */ = {
+			isa = PBXGroup;
+			children = (
+				EF7A41BCADD5C386F325375B /* PreviewAssets.xcassets */,
+			);
+			path = PreviewContent;
+			sourceTree = "<group>";
+		};
+		1F75B84D472E4F903E58A310 /* apple */ = {
+			isa = PBXGroup;
+			children = (
+				B90C93321F57509ADC051F9E /* testing */,
+			);
+			path = apple;
+			sourceTree = "<group>";
+		};
+		26F6241897488113A6E6DF7E /* CoreUtilsObjC */ = {
+			isa = PBXGroup;
+			children = (
+				2824DA1BE9B4A537598FEFE0 /* CoreUtilsObjC.swift.modulemap */,
+			);
+			path = CoreUtilsObjC;
+			sourceTree = "<group>";
+		};
+		4B8D264F33AE796A840E2C58 /* ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5 */ = {
+			isa = PBXGroup;
+			children = (
+				E98176885CA3B557090F3116 /* bin */,
+			);
+			path = "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5";
+			sourceTree = "<group>";
+		};
+		56B81B9C9A0209D46CB5AB83 /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				9D61CBAFE2C78BDC7960D5A4 /* BUILD */,
+				D027F83636D3D6C6ABBF375F /* ExampleTests.swift */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
+		585AD694A7FC50DCE514B6E2 /* Example-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				5951CDD4ACEF57EA1B00FCBD /* Info.plist */,
+			);
+			path = "Example-intermediates";
+			sourceTree = "<group>";
+		};
+		593E7C82FAAD94A7E6A04318 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D227CE711F51FF221F83B7EA /* Example.app */,
+				E87C46A394A10BD8A57D4ED8 /* ExampleObjcTests.xctest */,
+				6511618DDE522A59792EF4D3 /* ExampleResources.bundle */,
+				E470DDDC0990D96A685DB11C /* ExampleTests.xctest */,
+				44C19A56FE797949930D145D /* ExampleUITests.xctest */,
+				1176BC2C3AA9DF30F9244647 /* ExternalResources.bundle */,
+				8F8B001AB6315D99F13FAC92 /* libCoreUtilsObjC.a */,
+				F7A2777E8293F6B63DA51836 /* libTestingUtils.a */,
+				CC8E3F6E9A6B44248BD06712 /* libUtils.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		68510571C1C2FF91C893A79F /* ExampleResources */ = {
+			isa = PBXGroup;
+			children = (
+				4BE5211604948E91881C4479 /* nested */,
+				C6DFECB6D814B2CE3ADA51CD /* Assets.xcassets */,
+				119F88A7D863C38938114348 /* BUILD */,
+				9BF5CE4ADD5163F5308F8626 /* Info.plist */,
+			);
+			path = ExampleResources;
+			sourceTree = "<group>";
+		};
+		76B13F571D6D3879354C22DB /* ExampleObjcTests.__internal__.__test_bundle-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				502D073C9606AB022280231A /* Info.plist */,
+			);
+			path = "ExampleObjcTests.__internal__.__test_bundle-intermediates";
+			sourceTree = "<group>";
+		};
+		8559ED6752C798E87266A14E /* TestingUtils */ = {
+			isa = PBXGroup;
+			children = (
+				48F0B3D39D176B90AE9F2C8A /* Answer.swift.stencil */,
+				1104D414730D2DC8DC9DD9E9 /* BUILD */,
+				55E65A7323E456CDEBA791E6 /* Greeting.swift.stencil */,
+			);
+			path = TestingUtils;
+			sourceTree = "<group>";
+		};
+		8B51180584C4B20657E58D58 /* ExampleUITests.__internal__.__test_bundle-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				04B6B48EA76D2EFBD56BD67C /* Info.plist */,
+			);
+			path = "ExampleUITests.__internal__.__test_bundle-intermediates";
+			sourceTree = "<group>";
+		};
+		8EE3DCB9E9E0C79809FF9CE4 /* CoreUtilsObjC */ = {
+			isa = PBXGroup;
+			children = (
+				9B8FF1BA82EC92DF07BD8250 /* CoreUtils */,
+				28F5833510B6D7BECA9E9B7B /* Answers.m */,
+				41E087EFF7DB4B31F84CEF5F /* BUILD */,
+			);
+			path = CoreUtilsObjC;
+			sourceTree = "<group>";
+		};
+		93C53778407416F526CE86B2 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				B97C2835F125F69B2FDF8477 /* nested */,
+				1B8846860A494D5FC82D2072 /* PreviewContent */,
+				1F2546A475C2CA76D8E89436 /* Assets.xcassets */,
+				3044751746014D22D03BB28E /* BUILD */,
+				8ADB9E176B3AB4F6354A1167 /* ContentView.swift */,
+				DC51A4085F05FC61686E7785 /* ExampleApp.swift */,
+				A619B11AC2106BAC08FA7DB0 /* Info.plist */,
+				ECC63D78B0A2D399B5E493C5 /* Localizable.strings */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		9579B99A3C258FA1A007F4BC /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				9F4FB04D8BB2753A6AC57C77 /* ExampleTests.__internal__.__test_bundle-intermediates */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
+		9811D2ED915829A1A7881AFD /* Bazel External Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				DEDBB9862662A833DD5D663E /* build_bazel_rules_apple */,
+				BEFC18878DC5748769CC7D24 /* examples_ios_app_external */,
+			);
+			name = "Bazel External Repositories";
+			path = "bazel-ios_app/external";
+			sourceTree = "<group>";
+		};
+		9B8FF1BA82EC92DF07BD8250 /* CoreUtils */ = {
+			isa = PBXGroup;
+			children = (
+				46A804416537B31F7C6B6E0E /* Answers.h */,
+				577BC07B4F6E580BDB13B5B1 /* CoreUtils.pch */,
+			);
+			path = CoreUtils;
+			sourceTree = "<group>";
+		};
+		9C0169A2AF37D79DA14893D5 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				1E9DF944F8F0B62634A3A29D /* Utils.swift.modulemap */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		9F4FB04D8BB2753A6AC57C77 /* ExampleTests.__internal__.__test_bundle-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				E889785B64BCD36A9414A7E2 /* Info.plist */,
+			);
+			path = "ExampleTests.__internal__.__test_bundle-intermediates";
+			sourceTree = "<group>";
+		};
+		A9C67847D8308E4F16002948 /* TestingUtils */ = {
+			isa = PBXGroup;
+			children = (
+				5BA479F9D7617A5A5E99F50F /* Answer.swift */,
+				4574E57BDC516B7338E600E4 /* Greeting.swift */,
+				26BF5455514D7692884FB81F /* TestingUtils.swift */,
+				ADE221FC6902DE7F5C1351D9 /* TestingUtils.swift.modulemap */,
+			);
+			path = TestingUtils;
+			sourceTree = "<group>";
+		};
+		B2E8F73B09FAE1D96221D163 /* ExampleObjcTests */ = {
+			isa = PBXGroup;
+			children = (
+				76B13F571D6D3879354C22DB /* ExampleObjcTests.__internal__.__test_bundle-intermediates */,
+			);
+			path = ExampleObjcTests;
+			sourceTree = "<group>";
+		};
+		B5E6B29C1FEA4108FE0C81E6 /* third_party */ = {
+			isa = PBXGroup;
+			children = (
+				51D8E16C7D64BCE16C6B4C9E /* BUILD */,
+				F3D27BBBDD5DEF87214D8019 /* ExampleFramework.framework */,
+			);
+			path = third_party;
+			sourceTree = "<group>";
+		};
+		B90C93321F57509ADC051F9E /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				AA8B40F3394AF193E0043C9C /* DefaultTestBundle.plist */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
+		BEFC18878DC5748769CC7D24 /* examples_ios_app_external */ = {
+			isa = PBXGroup;
+			children = (
+				FBC89523643D5EE6D05828A9 /* bundles */,
+				62BA266605A71726F9EF2A78 /* nested */,
+				B75CC91156E9D2337A9933AE /* Assets.xcassets */,
+				BA542B31DC88C70950011E86 /* ExternalFramework.framework */,
+				2E9AA98CF71EC1A8ADA8FC12 /* Info.plist */,
+			);
+			path = examples_ios_app_external;
+			sourceTree = "<group>";
+		};
+		C047AF1D451C7E165914273D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C407A8E68D8C611448A3E699 /* Bazel Generated Files */ = {
+			isa = PBXGroup;
+			children = (
+				D87F56E482CD46A15E91DC70 /* applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5 */,
+				4B8D264F33AE796A840E2C58 /* ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5 */,
+			);
+			name = "Bazel Generated Files";
+			path = test/fixtures/bwb.xcodeproj/rules_xcodeproj/gen_dir;
+			sourceTree = "<group>";
+		};
+		D87F56E482CD46A15E91DC70 /* applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5 */ = {
+			isa = PBXGroup;
+			children = (
+				015833302CCE3B39492E505C /* bin */,
+			);
+			path = "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5";
+			sourceTree = "<group>";
+		};
+		DEDBB9862662A833DD5D663E /* build_bazel_rules_apple */ = {
+			isa = PBXGroup;
+			children = (
+				1F75B84D472E4F903E58A310 /* apple */,
+			);
+			path = build_bazel_rules_apple;
+			sourceTree = "<group>";
+		};
+		E0A6E74E3EC30503D4296461 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				5510BC5BFFC471231BB2C8E0 /* BUILD */,
+				B236D472E2B01203C379DE61 /* Foo.h */,
+				DE684C8B8336D55C43040D1E /* Foo.m */,
+				328731FD80DB31CAF28DA35F /* Utils.h */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		E98176885CA3B557090F3116 /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				26F6241897488113A6E6DF7E /* CoreUtilsObjC */,
+				A9C67847D8308E4F16002948 /* TestingUtils */,
+				9C0169A2AF37D79DA14893D5 /* Utils */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
+		EC6FEE5AC277A3FEEA95510A = {
+			isa = PBXGroup;
+			children = (
+				8EE3DCB9E9E0C79809FF9CE4 /* CoreUtilsObjC */,
+				93C53778407416F526CE86B2 /* Example */,
+				F4C29C5B5E612CC17B03B1C0 /* ExampleObjcTests */,
+				68510571C1C2FF91C893A79F /* ExampleResources */,
+				56B81B9C9A0209D46CB5AB83 /* ExampleTests */,
+				0FA8CC4F83F67E8D17E56EF6 /* ExampleUITests */,
+				8559ED6752C798E87266A14E /* TestingUtils */,
+				B5E6B29C1FEA4108FE0C81E6 /* third_party */,
+				E0A6E74E3EC30503D4296461 /* Utils */,
+				9811D2ED915829A1A7881AFD /* Bazel External Repositories */,
+				C407A8E68D8C611448A3E699 /* Bazel Generated Files */,
+				593E7C82FAAD94A7E6A04318 /* Products */,
+				C047AF1D451C7E165914273D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		F4C29C5B5E612CC17B03B1C0 /* ExampleObjcTests */ = {
+			isa = PBXGroup;
+			children = (
+				D165E542DE0036D69F5A152B /* BUILD */,
+				1945E01AD98FE05054F33AE5 /* ExampleObjcTests.m */,
+			);
+			path = ExampleObjcTests;
+			sourceTree = "<group>";
+		};
+		FA1090BD952F1CB85A896C2B /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				8B51180584C4B20657E58D58 /* ExampleUITests.__internal__.__test_bundle-intermediates */,
+			);
+			path = ExampleUITests;
+			sourceTree = "<group>";
+		};
+		FBC89523643D5EE6D05828A9 /* bundles */ = {
+			isa = PBXGroup;
+			children = (
+				E9ED685D3A056C10F6A99CCD /* Utils.bundle */,
+			);
+			path = bundles;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0BCC9DD063CA52172B904538 /* ExternalResources */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 718996D25ADEC97990FB5EE2 /* Build configuration list for PBXNativeTarget "ExternalResources" */;
+			buildPhases = (
+				0C2A6DA00BEF7BC0E7BB6E43 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A15F1A249509401D0B74005A /* PBXTargetDependency */,
+			);
+			name = ExternalResources;
+			productName = ExternalResources;
+			productReference = 1176BC2C3AA9DF30F9244647 /* ExternalResources.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		34820134F30D904FFA06D27A /* Utils */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B7B2838D5E51E99F559A42AC /* Build configuration list for PBXNativeTarget "Utils" */;
+			buildPhases = (
+				8FCBD3348EC5C739AA46D20E /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0FD2BFD3DDD85BFE6D5269C5 /* PBXTargetDependency */,
+				525486294F10747C8F6172F4 /* PBXTargetDependency */,
+			);
+			name = Utils;
+			productName = Utils;
+			productReference = CC8E3F6E9A6B44248BD06712 /* libUtils.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		64AE6000A6317B9C077F3B1E /* CoreUtilsObjC */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DF09ED80A9EE83EB12D74F22 /* Build configuration list for PBXNativeTarget "CoreUtilsObjC" */;
+			buildPhases = (
+				5182F34D39B2072D740E29D8 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EB99382E68EB53291BF54D3F /* PBXTargetDependency */,
+			);
+			name = CoreUtilsObjC;
+			productName = CoreUtilsObjC;
+			productReference = 8F8B001AB6315D99F13FAC92 /* libCoreUtilsObjC.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		7E5DFA29686635FDE423D8F4 /* ExampleObjcTests.__internal__.__test_bundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 53A92863D0432EBEC28036A6 /* Build configuration list for PBXNativeTarget "ExampleObjcTests.__internal__.__test_bundle" */;
+			buildPhases = (
+				988EFF4231814E9B47348FF1 /* Sources */,
+				494FE470F6BCEA2182DCC18D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				191F9026661B68825A423330 /* PBXTargetDependency */,
+				C7F459DED8FA911CD017E629 /* PBXTargetDependency */,
+				4340DE112FCC7EC33567A231 /* PBXTargetDependency */,
+				6CF6D5E9860D81504C950316 /* PBXTargetDependency */,
+			);
+			name = ExampleObjcTests.__internal__.__test_bundle;
+			productName = ExampleObjcTests;
+			productReference = E87C46A394A10BD8A57D4ED8 /* ExampleObjcTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		95C60B89B988FCC45A4A0562 /* ExampleResources */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2DA2E74A7235D7B2754DAB9F /* Build configuration list for PBXNativeTarget "ExampleResources" */;
+			buildPhases = (
+				5B09A56B41DE4C1FAE9B69EE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BC25428763663CB2C98EAB87 /* PBXTargetDependency */,
+			);
+			name = ExampleResources;
+			productName = ExampleResources;
+			productReference = 6511618DDE522A59792EF4D3 /* ExampleResources.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		BBF4D59A51801FF17E35E34E /* ExampleUITests.__internal__.__test_bundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4146445A590327AFBC6ECD1E /* Build configuration list for PBXNativeTarget "ExampleUITests.__internal__.__test_bundle" */;
+			buildPhases = (
+				75999A4F6D73EAE88A550D8B /* Sources */,
+				656C2986983FE4A0D487DE30 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2E6EA1FEE98746DEE423C1E9 /* PBXTargetDependency */,
+				4D0DFDD11CB698CEA15C699E /* PBXTargetDependency */,
+				4759CE70D5CD08547DBA3195 /* PBXTargetDependency */,
+			);
+			name = ExampleUITests.__internal__.__test_bundle;
+			productName = ExampleUITests;
+			productReference = 44C19A56FE797949930D145D /* ExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		D133FDFF63F008FDDB07BE99 /* ExampleTests.__internal__.__test_bundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8D7CAA9B63F689C04C435E90 /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */;
+			buildPhases = (
+				8E9A15D36D0A0B335579D589 /* Sources */,
+				448B4D3AD69A707A956D8277 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C2D1B7F2CA0445827922D05C /* PBXTargetDependency */,
+				F670F941F6741D0D3E7AC4A3 /* PBXTargetDependency */,
+				DC91293E0A2166D8365173A5 /* PBXTargetDependency */,
+				C2C1C85130B75A2A4AA73509 /* PBXTargetDependency */,
+				D32ED35208CAB32B6C2A56B3 /* PBXTargetDependency */,
+			);
+			name = ExampleTests.__internal__.__test_bundle;
+			productName = ExampleTests;
+			productReference = E470DDDC0990D96A685DB11C /* ExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		DEF15AA97EC0FE28A9A97CAA /* Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4E80458017EA17FB5B672FEB /* Build configuration list for PBXNativeTarget "Example" */;
+			buildPhases = (
+				F94B766A6F00B6427D27F290 /* Sources */,
+				6E426D209568E509FBE28076 /* Frameworks */,
+				96226B776237F3E91363C74E /* Resources */,
+				833364064E1457AC6C05CD5F /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2AE8FD8829F7134BE519ADAC /* PBXTargetDependency */,
+				E4CC90D212BA2CFA0249920B /* PBXTargetDependency */,
+				4D0F270A9C4875B0F9EFA648 /* PBXTargetDependency */,
+			);
+			name = Example;
+			productName = Example;
+			productReference = D227CE711F51FF221F83B7EA /* Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+		F175A7E1019A952CA7F66BBC /* TestingUtils */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DE5A272B1E91CD2127D39E3C /* Build configuration list for PBXNativeTarget "TestingUtils" */;
+			buildPhases = (
+				58F5AB439EA84217B9B89516 /* Sources */,
+				3D4CFD8FC03BCBC4496FF968 /* Copy Swift Generated Header */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A369504133B5C51B55717635 /* PBXTargetDependency */,
+			);
+			name = TestingUtils;
+			productName = TestingUtils;
+			productReference = F7A2777E8293F6B63DA51836 /* libTestingUtils.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0805833D09730531AD081697 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					0BCC9DD063CA52172B904538 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					1264E098850804E77CE82093 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					34820134F30D904FFA06D27A = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					64AE6000A6317B9C077F3B1E = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					7E5DFA29686635FDE423D8F4 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
+					};
+					95C60B89B988FCC45A4A0562 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					BBF4D59A51801FF17E35E34E = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
+					};
+					D133FDFF63F008FDDB07BE99 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
+					};
+					DEF15AA97EC0FE28A9A97CAA = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					ECAFAC2323528A3317A7C9F2 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					F175A7E1019A952CA7F66BBC = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+				};
+			};
+			buildConfigurationList = 669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				es,
+				Base,
+			);
+			mainGroup = EC6FEE5AC277A3FEEA95510A;
+			productRefGroup = 593E7C82FAAD94A7E6A04318 /* Products */;
+			projectDirPath = ../..;
+			projectRoot = "";
+			targets = (
+				ECAFAC2323528A3317A7C9F2 /* Setup */,
+				1264E098850804E77CE82093 /* Bazel Generated Files */,
+				64AE6000A6317B9C077F3B1E /* CoreUtilsObjC */,
+				DEF15AA97EC0FE28A9A97CAA /* Example */,
+				7E5DFA29686635FDE423D8F4 /* ExampleObjcTests.__internal__.__test_bundle */,
+				95C60B89B988FCC45A4A0562 /* ExampleResources */,
+				D133FDFF63F008FDDB07BE99 /* ExampleTests.__internal__.__test_bundle */,
+				BBF4D59A51801FF17E35E34E /* ExampleUITests.__internal__.__test_bundle */,
+				0BCC9DD063CA52172B904538 /* ExternalResources */,
+				F175A7E1019A952CA7F66BBC /* TestingUtils */,
+				34820134F30D904FFA06D27A /* Utils */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		0C2A6DA00BEF7BC0E7BB6E43 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3EB86573BC23DBD28DB4092D /* Assets.xcassets in Resources */,
+				E890FC6A268E85A3E10BD648 /* nested in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		448B4D3AD69A707A956D8277 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F01312AFF4DEADA1852E81BD /* ExampleResources.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		494FE470F6BCEA2182DCC18D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7821060CBE02370F404D084C /* Utils.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B09A56B41DE4C1FAE9B69EE /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AF706BBB5E91814A308DFAED /* Assets.xcassets in Resources */,
+				A47B89A7830CBA5505845985 /* nested in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		656C2986983FE4A0D487DE30 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CAE032E92796B6D1EFE0E452 /* ExternalResources.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		96226B776237F3E91363C74E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				64E83EFE14E692EFF2065C42 /* Assets.xcassets in Resources */,
+				0CF1BE2D8A4589480BD6924D /* ExampleResources.bundle in Resources */,
+				2986C89FC23EC9DAC3580D49 /* Localizable.strings in Resources */,
+				0F510D645C2D0A80BE763732 /* nested in Resources */,
+				22B1B599528FD2D6ED98FF27 /* PreviewAssets.xcassets in Resources */,
+				F66C7C4EE117AEFAA8D41FC2 /* Utils.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3BBBE88C0B5DFE50E861D039 /* Copy Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/generated.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Copy Files";
+			outputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/generated.copied.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"bazel-out\"\n\nrsync \\\n  --files-from \"$PROJECT_FILE_PATH/rules_xcodeproj/generated.rsynclist\" \\\n  --chmod=u+w \\\n  -L \\\n  . \\\n  \"$BUILD_DIR/bazel-out\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3D4CFD8FC03BCBC4496FF968 /* Copy Swift Generated Header */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(DERIVED_FILE_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			name = "Copy Swift Generated Header";
+			outputPaths = (
+				"$(CONFIGURATION_BUILD_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		48F6FA82818C0DE2760C55C0 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"$PROJECT_FILE_PATH/rules_xcodeproj\"\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf gen_dir\n\nln -sf \"$BUILD_DIR/bazel-out\" gen_dir\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-ios_app/external\" external\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$PROJECT_FILE_PATH/rules_xcodeproj/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
+			showEnvVarsInLog = 0;
+		};
+		C1BCE66C756D6574AE7961FF /* Fix Info.plists */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/infoplists.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Fix Info.plists";
+			outputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/infoplists.fixed.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C39544D2D57030E1F850014D /* Fix Modulemaps */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/modulemaps.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Fix Modulemaps";
+			outputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/modulemaps.fixed.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(\\s*(\\w+ )?header )(?!(\"\\.\\.(\\/\\.\\.)*\\/|\")(bazel-out|external)\\/)(\"(\\.\\.\\/)*)(.*\")%\\1\\6SRCROOT/\\8%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CA47126A96DBA220099058F9 /* Generate Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate Files";
+			outputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/generated.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf \"$PROJECT_DIR/bazel-out\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  ${BAZEL_PATH} \\\n  build \\\n  --output_groups=generated_inputs \\\n  //test/fixtures:fixture_bwb\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5182F34D39B2072D740E29D8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8D706D038CC2FAFCCA51D5A5 /* Answers.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		58F5AB439EA84217B9B89516 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				32284BD8DB742D84E539B8EB /* TestingUtils.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		75999A4F6D73EAE88A550D8B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A29169FF12586786795BC72E /* ExampleUITests.swift in Sources */,
+				D184C3C5A13941F3D1470F16 /* ExampleUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8E9A15D36D0A0B335579D589 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6A97C8EA8F4607A20FA6E3C2 /* ExampleTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8FCBD3348EC5C739AA46D20E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B054C3F6BAFAFA0604A3B413 /* Foo.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		988EFF4231814E9B47348FF1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8827E174961A52D2C88CF0C9 /* ExampleObjcTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F94B766A6F00B6427D27F290 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4BFD859F1371C86D02DB25A1 /* ContentView.swift in Sources */,
+				C908762178E1810512145D56 /* ExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0FD2BFD3DDD85BFE6D5269C5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 12BBDEF891F9CEDDBCF66227 /* PBXContainerItemProxy */;
+		};
+		191F9026661B68825A423330 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
+			targetProxy = FB75881099C5283F0B88B414 /* PBXContainerItemProxy */;
+		};
+		2AE8FD8829F7134BE519ADAC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
+			targetProxy = FA89BC6DF686E165E775357E /* PBXContainerItemProxy */;
+		};
+		2E6EA1FEE98746DEE423C1E9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
+			targetProxy = B29F6183C154822D72EC2305 /* PBXContainerItemProxy */;
+		};
+		4340DE112FCC7EC33567A231 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = TestingUtils;
+			target = F175A7E1019A952CA7F66BBC /* TestingUtils */;
+			targetProxy = 9C436E7C1FA11504B50D86B5 /* PBXContainerItemProxy */;
+		};
+		4759CE70D5CD08547DBA3195 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ExternalResources;
+			target = 0BCC9DD063CA52172B904538 /* ExternalResources */;
+			targetProxy = 8AFCF859AE8A8F088DB4EF97 /* PBXContainerItemProxy */;
+		};
+		4D0DFDD11CB698CEA15C699E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Example;
+			target = DEF15AA97EC0FE28A9A97CAA /* Example */;
+			targetProxy = EBD0C87C46CE3A0065D73AA0 /* PBXContainerItemProxy */;
+		};
+		4D0F270A9C4875B0F9EFA648 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Utils;
+			target = 34820134F30D904FFA06D27A /* Utils */;
+			targetProxy = A236A391B1795EC1AD621FA5 /* PBXContainerItemProxy */;
+		};
+		525486294F10747C8F6172F4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CoreUtilsObjC;
+			target = 64AE6000A6317B9C077F3B1E /* CoreUtilsObjC */;
+			targetProxy = 97350A84E43A3D97DB7FF16B /* PBXContainerItemProxy */;
+		};
+		6CF6D5E9860D81504C950316 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Utils;
+			target = 34820134F30D904FFA06D27A /* Utils */;
+			targetProxy = 7DC9F0A22A7B1E5E310197D9 /* PBXContainerItemProxy */;
+		};
+		A15F1A249509401D0B74005A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = CC375C8586CC07711829D641 /* PBXContainerItemProxy */;
+		};
+		A369504133B5C51B55717635 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
+			targetProxy = 73935C723008807A2920DC10 /* PBXContainerItemProxy */;
+		};
+		A375E057D32BEDDB980E23C5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */;
+		};
+		BC25428763663CB2C98EAB87 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 80B7F7FC096EA6B5D2CEF6A4 /* PBXContainerItemProxy */;
+		};
+		C2C1C85130B75A2A4AA73509 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = TestingUtils;
+			target = F175A7E1019A952CA7F66BBC /* TestingUtils */;
+			targetProxy = 253F301DFAC4DBD74F463E32 /* PBXContainerItemProxy */;
+		};
+		C2D1B7F2CA0445827922D05C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
+			targetProxy = 0F71FB02423BEEE76DFEE7A7 /* PBXContainerItemProxy */;
+		};
+		C7F459DED8FA911CD017E629 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Example;
+			target = DEF15AA97EC0FE28A9A97CAA /* Example */;
+			targetProxy = A0F480345DF9DC369DA636A3 /* PBXContainerItemProxy */;
+		};
+		D32ED35208CAB32B6C2A56B3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Utils;
+			target = 34820134F30D904FFA06D27A /* Utils */;
+			targetProxy = 9B5B4C5E0C8D4797ADCE6AB2 /* PBXContainerItemProxy */;
+		};
+		DC91293E0A2166D8365173A5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ExampleResources;
+			target = 95C60B89B988FCC45A4A0562 /* ExampleResources */;
+			targetProxy = 40C4645E155842FBD47B3D44 /* PBXContainerItemProxy */;
+		};
+		E4CC90D212BA2CFA0249920B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ExampleResources;
+			target = 95C60B89B988FCC45A4A0562 /* ExampleResources */;
+			targetProxy = DE2ABDC3A4020CEAD5FB18F6 /* PBXContainerItemProxy */;
+		};
+		EB99382E68EB53291BF54D3F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 9AF12B3279FCACB57125FEC0 /* PBXContainerItemProxy */;
+		};
+		F670F941F6741D0D3E7AC4A3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Example;
+			target = DEF15AA97EC0FE28A9A97CAA /* Example */;
+			targetProxy = 7EDBC9AA0948CBD61D742C1D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		ECC63D78B0A2D399B5E493C5 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				823A0A913DE6BBF3286D06E6 /* en */,
+				0B4615EBFB02A2D6C5B1045D /* es */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		0193F01B729A6692D7D3472B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_ENABLE_MODULES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/third_party",
+					"$(PROJECT_DIR)/bazel-ios_app/external/examples_ios_app_external",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+					AWESOME,
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/CoreUtilsObjC",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
+				);
+				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = (
+					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(TARGET_DEVICE_PLATFORM_NAME)",
+					"-L/usr/lib/swift",
+					"-filelist",
+					"$(PROJECT_FILE_PATH)/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList,$(BUILD_DIR)",
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					SwiftUI,
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.objctests;
+				PRODUCT_MODULE_NAME = ExampleObjcTests;
+				PRODUCT_NAME = ExampleObjcTests;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = iphonesimulator;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example$(TARGET_BUILD_SUBPATH)";
+				TARGET_NAME = ExampleObjcTests.__internal__.__test_bundle;
+				TEST_HOST = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example.app/Example";
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+				);
+			};
+			name = Debug;
+		};
+		1930030923086D364CC3127B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+					AWESOME,
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_MODULE_NAME = TestingUtils;
+				PRODUCT_NAME = TestingUtils;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = iphonesimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG AWESOME";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "SwiftAPI/TestingUtils-Swift.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = TestingUtils;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+				);
+			};
+			name = Debug;
+		};
+		394CCE329FB879734646BC3A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.uitests;
+				PRODUCT_MODULE_NAME = ExampleUITests;
+				PRODUCT_NAME = ExampleUITests;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = iphonesimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGET_NAME = ExampleUITests.__internal__.__test_bundle;
+				TEST_TARGET_NAME = Example;
+			};
+			name = Debug;
+		};
+		4A234614294618D445060F03 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = Setup;
+			};
+			name = Debug;
+		};
+		71CDD5A48E2EA7B78D29CDD7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/external/examples_ios_app_external";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.resources.external;
+				PRODUCT_NAME = ExternalResources;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = iphonesimulator;
+				TARGET_NAME = ExternalResources;
+			};
+			name = Debug;
+		};
+		958FA2D1FA128C21904CB40E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = GenerateBazelFiles;
+			};
+			name = Debug;
+		};
+		9A5566483B61F9D10CB67C4D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/third_party",
+					"$(PROJECT_DIR)/bazel-ios_app/external/examples_ios_app_external",
+				);
+				GCC_PREFIX_HEADER = "$(PROJECT_DIR)/CoreUtilsObjC/CoreUtils/CoreUtils.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/CoreUtilsObjC",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					SwiftUI,
+					"-ObjC",
+				);
+				PRODUCT_MODULE_NAME = CoreUtils;
+				PRODUCT_NAME = CoreUtilsObjC;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = iphonesimulator;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = CoreUtilsObjC;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+				);
+			};
+			name = Debug;
+		};
+		A56BEE637DA1B6A442624451 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/third_party",
+					"$(PROJECT_DIR)/bazel-ios_app/external/examples_ios_app_external",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/CoreUtilsObjC",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					SwiftUI,
+					"-ObjC",
+				);
+				PRODUCT_MODULE_NAME = Utils;
+				PRODUCT_NAME = Utils;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = iphonesimulator;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = Utils;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+				);
+			};
+			name = Debug;
+		};
+		B0892EE2AB907B40AA4EB960 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BAZEL_PATH = bazel;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
+				COPY_PHASE_STRIP = NO;
+				ONLY_ACTIVE_ARCH = YES;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+		E645B2A9F20A6B6E4422D78A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleResources";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.resources;
+				PRODUCT_NAME = ExampleResources;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = iphonesimulator;
+				TARGET_NAME = ExampleResources;
+			};
+			name = Debug;
+		};
+		ED022D7827FA072088152A34 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/third_party",
+					"$(PROJECT_DIR)/bazel-ios_app/external/examples_ios_app_external",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/CoreUtilsObjC",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
+				);
+				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.xcode.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = (
+					"-filelist",
+					"$(PROJECT_FILE_PATH)/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/Example/Example.LinkFileList,$(BUILD_DIR)",
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					SwiftUI,
+					"-ObjC",
+				);
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(PROJECT_DIR)/third_party/ExampleFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(PROJECT_DIR)/bazel-ios_app/external/examples_ios_app_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/CoreUtilsObjC.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/Utils.swift.xcode.modulemap -g -Fthird_party -Fexternal/examples_ios_app_external";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
+				PRODUCT_MODULE_NAME = Example;
+				PRODUCT_NAME = Example;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = iphonesimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGETED_DEVICE_FAMILY = 1;
+				TARGET_NAME = Example;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+				);
+			};
+			name = Debug;
+		};
+		F4B8552398B786F68242064D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/third_party",
+					"$(PROJECT_DIR)/bazel-ios_app/external/examples_ios_app_external",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+					AWESOME,
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/CoreUtilsObjC",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
+				);
+				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = (
+					"-filelist",
+					"$(PROJECT_FILE_PATH)/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/ExampleTests/ExampleTests.__internal__.__test_bundle.LinkFileList,$(BUILD_DIR)",
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					SwiftUI,
+					"-ObjC",
+				);
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(PROJECT_DIR)/third_party/ExampleFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(PROJECT_DIR)/bazel-ios_app/external/examples_ios_app_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/CoreUtilsObjC.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/Utils.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift.xcode.modulemap -g -Fthird_party -Fexternal/examples_ios_app_external";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.tests;
+				PRODUCT_MODULE_NAME = ExampleTests;
+				PRODUCT_NAME = ExampleTests;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = iphonesimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG AWESOME";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example$(TARGET_BUILD_SUBPATH)";
+				TARGET_NAME = ExampleTests.__internal__.__test_bundle;
+				TEST_HOST = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example.app/Example";
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+				);
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				958FA2D1FA128C21904CB40E /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		2DA2E74A7235D7B2754DAB9F /* Build configuration list for PBXNativeTarget "ExampleResources" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E645B2A9F20A6B6E4422D78A /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		4146445A590327AFBC6ECD1E /* Build configuration list for PBXNativeTarget "ExampleUITests.__internal__.__test_bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				394CCE329FB879734646BC3A /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		4E80458017EA17FB5B672FEB /* Build configuration list for PBXNativeTarget "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ED022D7827FA072088152A34 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		53A92863D0432EBEC28036A6 /* Build configuration list for PBXNativeTarget "ExampleObjcTests.__internal__.__test_bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0193F01B729A6692D7D3472B /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B0892EE2AB907B40AA4EB960 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		718996D25ADEC97990FB5EE2 /* Build configuration list for PBXNativeTarget "ExternalResources" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				71CDD5A48E2EA7B78D29CDD7 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A234614294618D445060F03 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		8D7CAA9B63F689C04C435E90 /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F4B8552398B786F68242064D /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		B7B2838D5E51E99F559A42AC /* Build configuration list for PBXNativeTarget "Utils" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A56BEE637DA1B6A442624451 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		DE5A272B1E91CD2127D39E3C /* Build configuration list for PBXNativeTarget "TestingUtils" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1930030923086D364CC3127B /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		DF09ED80A9EE83EB12D74F22 /* Build configuration list for PBXNativeTarget "CoreUtilsObjC" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A5566483B61F9D10CB67C4D /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0805833D09730531AD081697 /* Project object */;
+}

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -1,0 +1,10 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/Answer.swift
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/Greeting.swift
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift.modulemap
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/Utils.swift.modulemap

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -1,0 +1,10 @@
+applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.plist
+applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
+applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist
+ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap
+ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/Answer.swift
+ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/Greeting.swift
+ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift
+ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift.modulemap
+ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/Utils.swift.modulemap

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,0 +1,10 @@
+$(PROJECT_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.plist
+$(PROJECT_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap
+$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/Answer.swift
+$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/Greeting.swift
+$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift
+$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift.modulemap
+$(PROJECT_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/Utils.swift.modulemap

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
@@ -1,0 +1,4 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.xcode.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
@@ -1,0 +1,4 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/modulemaps.fixed.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/modulemaps.fixed.xcfilelist
@@ -1,0 +1,3 @@
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/CoreUtilsObjC.swift.xcode.modulemap
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift.xcode.modulemap
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/Utils.swift.xcode.modulemap

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/modulemaps.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/modulemaps.xcfilelist
@@ -1,0 +1,3 @@
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift.modulemap
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/Utils.swift.modulemap

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/Example/Example.LinkFileList
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/Example/Example.LinkFileList
@@ -1,0 +1,2 @@
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/libCoreUtilsObjC.a
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/libUtils.a

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList
@@ -1,0 +1,1 @@
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/libTestingUtils.a

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/ExampleTests/ExampleTests.__internal__.__test_bundle.LinkFileList
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/ExampleTests/ExampleTests.__internal__.__test_bundle.LinkFileList
@@ -1,0 +1,1 @@
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/libTestingUtils.a

--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -1,0 +1,1571 @@
+{
+    "build_settings": {
+        "ALWAYS_SEARCH_USER_PATHS": false,
+        "BAZEL_PATH": "bazel",
+        "CLANG_ENABLE_OBJC_ARC": true,
+        "CLANG_MODULES_AUTOLINK": false,
+        "COPY_PHASE_STRIP": false,
+        "ONLY_ACTIVE_ARCH": true,
+        "USE_HEADERMAP": false,
+        "VALIDATE_WORKSPACE": false
+    },
+    "extra_files": [
+        "third_party/BUILD",
+        "third_party/ExampleFramework.framework/ExampleFramework",
+        "third_party/ExampleFramework.framework/Headers/Bar.h",
+        "third_party/ExampleFramework.framework/Headers/ExampleFramework.h",
+        "third_party/ExampleFramework.framework/Info.plist",
+        "third_party/ExampleFramework.framework/Modules/module.modulemap",
+        "third_party/ExampleFramework.framework/_CodeSignature/CodeDirectory",
+        "third_party/ExampleFramework.framework/_CodeSignature/CodeRequirements",
+        "third_party/ExampleFramework.framework/_CodeSignature/CodeRequirements-1",
+        "third_party/ExampleFramework.framework/_CodeSignature/CodeResources",
+        "third_party/ExampleFramework.framework/_CodeSignature/CodeSignature",
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/ExternalFramework",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Headers/ExternalFramework-Swift.h",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Info.plist",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/Project/arm64-apple-ios-simulator.swiftsourceinfo",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/Project/arm64.swiftsourceinfo",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/Project/x86_64-apple-ios-simulator.swiftsourceinfo",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/Project/x86_64.swiftsourceinfo",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/arm64-apple-ios-simulator.swiftdoc",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/arm64-apple-ios-simulator.swiftinterface",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/arm64-apple-ios-simulator.swiftmodule",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/arm64.swiftdoc",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/arm64.swiftinterface",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/arm64.swiftmodule",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64-apple-ios-simulator.swiftdoc",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64-apple-ios-simulator.swiftinterface",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftdoc",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftinterface",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/Modules/module.modulemap",
+            "t": "e"
+        },
+        {
+            "_": "examples_ios_app_external/ExternalFramework.framework/_CodeSignature/CodeResources",
+            "t": "e"
+        },
+        "CoreUtilsObjC/BUILD",
+        "Utils/BUILD",
+        "ExampleResources/BUILD",
+        "ExampleResources/Info.plist",
+        "Example/BUILD",
+        {
+            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
+            "t": "g"
+        },
+        {
+            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/Utils.swift.modulemap",
+            "t": "g"
+        },
+        "Example/Assets.xcassets/AppIcon.appiconset/Contents.json",
+        "Example/Assets.xcassets/AppIcon.appiconset/ios_2x_icon-1.png",
+        "Example/Assets.xcassets/AppIcon.appiconset/ios_2x_icon.png",
+        "Example/Assets.xcassets/AppIcon.appiconset/ios_3x_icon.png",
+        "Example/Assets.xcassets/AppIcon.appiconset/ios_store_icon.png",
+        "Example/Assets.xcassets/AppIcon.appiconset/ipad_1x_icon.png",
+        "Example/Assets.xcassets/AppIcon.appiconset/ipad_2x_icon.png",
+        "Example/Assets.xcassets/AppIcon.appiconset/ipadpro_2x_icon.png",
+        "Example/Info.plist",
+        {
+            "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.plist",
+            "t": "g"
+        },
+        "TestingUtils/BUILD",
+        "TestingUtils/Greeting.swift.stencil",
+        "TestingUtils/Answer.swift.stencil",
+        {
+            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/Greeting.swift",
+            "t": "g"
+        },
+        {
+            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/Answer.swift",
+            "t": "g"
+        },
+        "ExampleTests/BUILD",
+        {
+            "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift.modulemap",
+            "t": "g"
+        },
+        {
+            "_": "build_bazel_rules_apple/apple/testing/DefaultTestBundle.plist",
+            "t": "e"
+        },
+        {
+            "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
+            "t": "g"
+        },
+        "ExampleObjcTests/BUILD",
+        {
+            "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist",
+            "t": "g"
+        },
+        {
+            "_": "examples_ios_app_external/Info.plist",
+            "t": "e"
+        },
+        "ExampleUITests/BUILD",
+        {
+            "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist",
+            "t": "g"
+        }
+    ],
+    "invalid_target_merges": [],
+    "label": "//test/fixtures:fixture_bwb",
+    "name": "bwb",
+    "target_merges": [
+        "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        [
+            "//Example:Example applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+        ],
+        "//ExampleObjcTests:ExampleObjcTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        [
+            "//ExampleObjcTests:ExampleObjcTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+        ],
+        "//ExampleTests:ExampleTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        [
+            "//ExampleTests:ExampleTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+        ],
+        "//ExampleUITests:ExampleUITests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        [
+            "//ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+        ]
+    ],
+    "targets": [
+        "//CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-framework",
+                    "Foundation",
+                    "-weak_framework",
+                    "SwiftUI",
+                    "-ObjC"
+                ],
+                "PRODUCT_MODULE_NAME": "CoreUtils",
+                "PRODUCT_NAME": "CoreUtilsObjC",
+                "SUPPORTED_PLATFORMS": "iphonesimulator",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "hdrs": [
+                    "CoreUtilsObjC/CoreUtils/Answers.h"
+                ],
+                "pch": "CoreUtilsObjC/CoreUtils/CoreUtils.pch",
+                "srcs": [
+                    "CoreUtilsObjC/Answers.m"
+                ]
+            },
+            "is_swift": false,
+            "label": "//CoreUtilsObjC:CoreUtilsObjC",
+            "links": [],
+            "modulemaps": [],
+            "name": "CoreUtilsObjC",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "CoreUtilsObjC",
+                "path": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/libCoreUtilsObjC.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "framework_includes": [
+                    "third_party",
+                    {
+                        "_": "examples_ios_app_external",
+                        "t": "e"
+                    }
+                ],
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//Example:Example applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
+                "PRODUCT_MODULE_NAME": "_Example_Stub",
+                "PRODUCT_NAME": "Example",
+                "SUPPORTED_PLATFORMS": "iphonesimulator",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TARGETED_DEVICE_FAMILY": "1"
+            },
+            "configuration": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [
+                "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+            ],
+            "frameworks": [
+                {
+                    "_": "examples_ios_app_external/ExternalFramework.framework",
+                    "t": "e"
+                }
+            ],
+            "info_plist": {
+                "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.plist",
+                "t": "g"
+            },
+            "inputs": {
+                "contains_generated_files": true,
+                "resources": [
+                    {
+                        "_": "examples_ios_app_external/bundles/Utils.bundle",
+                        "f": true,
+                        "t": "e"
+                    },
+                    "Example/PreviewContent/PreviewAssets.xcassets/Contents.json",
+                    "Example/PreviewContent/PreviewAssets.xcassets/rules_xcodeproj.imageset/Contents.json",
+                    "Example/PreviewContent/PreviewAssets.xcassets/rules_xcodeproj.imageset/rules_xcodeproj.png",
+                    "Example/Assets.xcassets/Contents.json",
+                    "Example/en.lproj/Localizable.strings",
+                    "Example/es.lproj/Localizable.strings",
+                    {
+                        "_": "Example/nested",
+                        "f": true
+                    }
+                ]
+            },
+            "is_swift": false,
+            "label": "//Example:Example",
+            "links": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/libUtils.a",
+                    "t": "g"
+                },
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/libCoreUtilsObjC.a",
+                    "t": "g"
+                },
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/libExample.library.a",
+                    "t": "g"
+                },
+                "third_party/ExampleFramework.framework/ExampleFramework"
+            ],
+            "modulemaps": [],
+            "name": "Example",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "Example",
+                "path": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example_archive-root/Payload/Example.app",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.application"
+            },
+            "resource_bundles": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleResources/ExampleResources.bundle",
+                    "t": "g"
+                }
+            ],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-framework",
+                    "Foundation",
+                    "-weak_framework",
+                    "SwiftUI",
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g -Fthird_party -Fexternal/examples_ios_app_external",
+                "PRODUCT_MODULE_NAME": "Example",
+                "PRODUCT_NAME": "Example.library",
+                "SUPPORTED_PLATFORMS": "iphonesimulator",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [
+                "//ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+                "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "contains_generated_files": true,
+                "srcs": [
+                    "Example/ContentView.swift",
+                    "Example/ExampleApp.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//Example:Example.library",
+            "links": [],
+            "modulemaps": [
+                "third_party/ExampleFramework.framework/Modules/module.modulemap",
+                {
+                    "_": "examples_ios_app_external/ExternalFramework.framework/Modules/module.modulemap",
+                    "t": "e"
+                },
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
+                    "t": "g"
+                },
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/Utils.swift.modulemap",
+                    "t": "g"
+                }
+            ],
+            "name": "Example.library",
+            "outputs": {
+                "swift_module": {
+                    "name": "Example.swiftmodule",
+                    "swiftdoc": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example.swiftdoc",
+                    "swiftmodule": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "Example.library",
+                "path": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/libExample.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "framework_includes": [
+                    "third_party",
+                    {
+                        "_": "examples_ios_app_external",
+                        "t": "e"
+                    }
+                ],
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//ExampleObjcTests:ExampleObjcTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.objctests",
+                "PRODUCT_MODULE_NAME": "_ExampleObjcTests_Stub",
+                "PRODUCT_NAME": "ExampleObjcTests",
+                "SUPPORTED_PLATFORMS": "iphonesimulator",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TARGETED_DEVICE_FAMILY": "1,2"
+            },
+            "configuration": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [
+                "//ExampleObjcTests:ExampleObjcTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+                "//Example:Example applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+            ],
+            "frameworks": [],
+            "info_plist": {
+                "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist",
+                "t": "g"
+            },
+            "inputs": {
+                "contains_generated_files": true,
+                "resources": [
+                    {
+                        "_": "examples_ios_app_external/bundles/Utils.bundle",
+                        "f": true,
+                        "t": "e"
+                    }
+                ]
+            },
+            "is_swift": false,
+            "label": "//ExampleObjcTests:ExampleObjcTests.__internal__.__test_bundle",
+            "links": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/libExampleObjcTests.library.a",
+                    "t": "g"
+                },
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/libTestingUtils.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "ExampleObjcTests.__internal__.__test_bundle",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "ExampleObjcTests",
+                "path": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle_archive-root/ExampleObjcTests.xctest",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.bundle.unit-test"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": "//Example:Example applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+        },
+        "//ExampleObjcTests:ExampleObjcTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "CLANG_ENABLE_MODULES": true,
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTING_SEARCH_PATHS": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\"",
+                    "AWESOME"
+                ],
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-framework",
+                    "Foundation",
+                    "-weak_framework",
+                    "SwiftUI",
+                    "-ObjC"
+                ],
+                "PRODUCT_MODULE_NAME": "ExampleObjcTests",
+                "PRODUCT_NAME": "ExampleObjcTests.library",
+                "SUPPORTED_PLATFORMS": "iphonesimulator",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [
+                "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+                "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+                "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "ExampleObjcTests/ExampleObjcTests.m"
+                ]
+            },
+            "is_swift": false,
+            "label": "//ExampleObjcTests:ExampleObjcTests.library",
+            "links": [],
+            "modulemaps": [],
+            "name": "ExampleObjcTests.library",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "ExampleObjcTests.library",
+                "path": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/libExampleObjcTests.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "framework_includes": [
+                    "third_party",
+                    {
+                        "_": "examples_ios_app_external",
+                        "t": "e"
+                    }
+                ],
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "GENERATE_INFOPLIST_FILE": true,
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "PRODUCT_BUNDLE_IDENTIFIER": "com.example.resources",
+                "PRODUCT_NAME": "ExampleResources",
+                "SUPPORTED_PLATFORMS": "iphonesimulator"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "resources": [
+                    "ExampleResources/Assets.xcassets/Contents.json",
+                    "ExampleResources/Assets.xcassets/rules_xcodeproj.imageset/Contents.json",
+                    "ExampleResources/Assets.xcassets/rules_xcodeproj.imageset/rules_xcodeproj.png",
+                    {
+                        "_": "ExampleResources/nested",
+                        "f": true
+                    }
+                ]
+            },
+            "is_swift": false,
+            "label": "//ExampleResources:ExampleResources",
+            "links": [],
+            "modulemaps": [],
+            "name": "ExampleResources",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleResources",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "ExampleResources",
+                "path": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleResources/ExampleResources.bundle",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.bundle"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//ExampleTests:ExampleTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.tests",
+                "PRODUCT_MODULE_NAME": "_ExampleTests_Stub",
+                "PRODUCT_NAME": "ExampleTests",
+                "SUPPORTED_PLATFORMS": "iphonesimulator",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TARGETED_DEVICE_FAMILY": "1,2"
+            },
+            "configuration": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [
+                "//ExampleTests:ExampleTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+                "//Example:Example applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+            ],
+            "frameworks": [],
+            "info_plist": {
+                "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
+                "t": "g"
+            },
+            "inputs": {
+                "contains_generated_files": true
+            },
+            "is_swift": false,
+            "label": "//ExampleTests:ExampleTests.__internal__.__test_bundle",
+            "links": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/libTestingUtils.a",
+                    "t": "g"
+                },
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/libExampleTests.library.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "ExampleTests.__internal__.__test_bundle",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "ExampleTests",
+                "path": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle_archive-root/ExampleTests.xctest",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.bundle.unit-test"
+            },
+            "resource_bundles": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleResources/ExampleResources.bundle",
+                    "t": "g"
+                }
+            ],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": "//Example:Example applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+        },
+        "//ExampleTests:ExampleTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "ENABLE_TESTING_SEARCH_PATHS": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\"",
+                    "AWESOME"
+                ],
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-framework",
+                    "Foundation",
+                    "-weak_framework",
+                    "SwiftUI",
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g -Fthird_party -Fexternal/examples_ios_app_external",
+                "PRODUCT_MODULE_NAME": "ExampleTests",
+                "PRODUCT_NAME": "ExampleTests.library",
+                "SUPPORTED_PLATFORMS": "iphonesimulator",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG AWESOME",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [
+                "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+                "//ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+                "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+                "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "contains_generated_files": true,
+                "srcs": [
+                    "ExampleTests/ExampleTests.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//ExampleTests:ExampleTests.library",
+            "links": [],
+            "modulemaps": [
+                "third_party/ExampleFramework.framework/Modules/module.modulemap",
+                {
+                    "_": "examples_ios_app_external/ExternalFramework.framework/Modules/module.modulemap",
+                    "t": "e"
+                },
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
+                    "t": "g"
+                },
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/Utils.swift.modulemap",
+                    "t": "g"
+                },
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift.modulemap",
+                    "t": "g"
+                }
+            ],
+            "name": "ExampleTests.library",
+            "outputs": {
+                "swift_module": {
+                    "name": "ExampleTests.swiftmodule",
+                    "swiftdoc": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.swiftdoc",
+                    "swiftmodule": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "ExampleTests.library",
+                "path": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/libExampleTests.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "framework_includes": [
+                    "third_party",
+                    {
+                        "_": "examples_ios_app_external",
+                        "t": "e"
+                    }
+                ],
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swiftmodule",
+                    "t": "g"
+                }
+            ],
+            "test_host": null
+        },
+        "//ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.uitests",
+                "PRODUCT_MODULE_NAME": "_ExampleUITests_Stub",
+                "PRODUCT_NAME": "ExampleUITests",
+                "SUPPORTED_PLATFORMS": "iphonesimulator",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TARGETED_DEVICE_FAMILY": "1,2"
+            },
+            "configuration": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [
+                "//ExampleUITests:ExampleUITests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+                "//Example:Example applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+            ],
+            "frameworks": [],
+            "info_plist": {
+                "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist",
+                "t": "g"
+            },
+            "inputs": {
+                "contains_generated_files": true
+            },
+            "is_swift": false,
+            "label": "//ExampleUITests:ExampleUITests.__internal__.__test_bundle",
+            "links": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/libExampleUITests.library.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "ExampleUITests.__internal__.__test_bundle",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "ExampleUITests",
+                "path": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle_archive-root/ExampleUITests.xctest",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.bundle.ui-testing"
+            },
+            "resource_bundles": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/external/examples_ios_app_external/ExternalResources.bundle",
+                    "t": "g"
+                }
+            ],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": "//Example:Example applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+        },
+        "//ExampleUITests:ExampleUITests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "ENABLE_TESTING_SEARCH_PATHS": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "ExampleUITests",
+                "PRODUCT_NAME": "ExampleUITests.library",
+                "SUPPORTED_PLATFORMS": "iphonesimulator",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [
+                "@examples_ios_app_external//:ExternalResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "ExampleUITests/ExampleUITests.swift",
+                    "ExampleUITests/ExampleUITestsLaunchTests.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//ExampleUITests:ExampleUITests.library",
+            "links": [],
+            "modulemaps": [],
+            "name": "ExampleUITests.library",
+            "outputs": {
+                "swift_module": {
+                    "name": "ExampleUITests.swiftmodule",
+                    "swiftdoc": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.swiftdoc",
+                    "swiftmodule": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "ExampleUITests.library",
+                "path": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/libExampleUITests.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "ENABLE_TESTING_SEARCH_PATHS": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\"",
+                    "AWESOME"
+                ],
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "TestingUtils",
+                "PRODUCT_NAME": "TestingUtils",
+                "SUPPORTED_PLATFORMS": "iphonesimulator",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG AWESOME",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "SwiftAPI/TestingUtils-Swift.h",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "contains_generated_files": true,
+                "srcs": [
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swift",
+                        "t": "g"
+                    }
+                ]
+            },
+            "is_swift": true,
+            "label": "//TestingUtils:TestingUtils",
+            "links": [],
+            "modulemaps": [],
+            "name": "TestingUtils",
+            "outputs": {
+                "swift_module": {
+                    "name": "TestingUtils.swiftmodule",
+                    "swiftdoc": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swiftdoc",
+                    "swiftmodule": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/TestingUtils.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "TestingUtils",
+                "path": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/TestingUtils/libTestingUtils.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-framework",
+                    "Foundation",
+                    "-weak_framework",
+                    "SwiftUI",
+                    "-ObjC"
+                ],
+                "PRODUCT_MODULE_NAME": "Utils",
+                "PRODUCT_NAME": "Utils",
+                "SUPPORTED_PLATFORMS": "iphonesimulator",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [
+                "//CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "hdrs": [
+                    "Utils/Foo.h",
+                    "Utils/Utils.h"
+                ],
+                "srcs": [
+                    "Utils/Foo.m"
+                ]
+            },
+            "is_swift": false,
+            "label": "//Utils:Utils",
+            "links": [],
+            "modulemaps": [],
+            "name": "Utils",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "Utils",
+                "path": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Utils/libUtils.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "framework_includes": [
+                    "third_party",
+                    {
+                        "_": "examples_ios_app_external",
+                        "t": "e"
+                    }
+                ],
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "@examples_ios_app_external//:ExternalResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+        {
+            "build_settings": {
+                "GENERATE_INFOPLIST_FILE": true,
+                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
+                "PRODUCT_BUNDLE_IDENTIFIER": "com.example.resources.external",
+                "PRODUCT_NAME": "ExternalResources",
+                "SUPPORTED_PLATFORMS": "iphonesimulator"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "resources": [
+                    {
+                        "_": "examples_ios_app_external/Assets.xcassets/Contents.json",
+                        "t": "e"
+                    },
+                    {
+                        "_": "examples_ios_app_external/Assets.xcassets/rules_xcodeproj.imageset/Contents.json",
+                        "t": "e"
+                    },
+                    {
+                        "_": "examples_ios_app_external/Assets.xcassets/rules_xcodeproj.imageset/rules_xcodeproj.png",
+                        "t": "e"
+                    },
+                    {
+                        "_": "examples_ios_app_external/nested",
+                        "f": true,
+                        "t": "e"
+                    }
+                ]
+            },
+            "is_swift": false,
+            "label": "@examples_ios_app_external//:ExternalResources",
+            "links": [],
+            "modulemaps": [],
+            "name": "ExternalResources",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/external/examples_ios_app_external",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "ios"
+            },
+            "product": {
+                "name": "ExternalResources",
+                "path": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/external/examples_ios_app_external/ExternalResources.bundle",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.bundle"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        }
+    ]
+}

--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -1,0 +1,762 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		ECAFAC2323528A3317A7C9F2 /* Setup */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildPhases = (
+				48F6FA82818C0DE2760C55C0 /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = Setup;
+			productName = Setup;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		9F8860D106D9ABB10483EA7A /* private.h in Sources */ = {isa = PBXBuildFile; fileRef = 941A754D1FBB5ACD78B4C755 /* private.h */; };
+		CD2AA10AC79D5924E155E574 /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = FB80EF95C89684721EBBDC35 /* lib.c */; };
+		CFDEFD32F9576B104A39894D /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 9411DCDC5C6F92122299107F /* main.c */; };
+		D770DE28E597BAF74254AFCB /* private.h in Sources */ = {isa = PBXBuildFile; fileRef = 8D73636373B8CDD4BE62C0A5 /* private.h */; };
+		D8961DA25CBC1AF0367FBA37 /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 26866FEDF67CD3FA66FFAB17 /* lib.c */; };
+		FC39DB0614B0AB5B5A2DF90E /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = FB0F020B344E60F89B31265D /* lib.c */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		1AB65E1F649B115C62DA830F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E180851AE3E1EEC8C4944F10;
+			remoteInfo = "//examples/cc/lib:lib_impl";
+		};
+		20B4384B1C553426B14F3544 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 373A62571D2CA8826AD4F92C;
+			remoteInfo = "//examples/cc/lib2:lib_impl";
+		};
+		2D50AC8D57F94038C0E530C9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0CEAA3455274D4DE9B4B82BF;
+			remoteInfo = "@examples_cc_external//:lib_impl";
+		};
+		424240DD0AE59FE97B422D1D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		45C913AA706FEBB282C879FE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		C1B43F49D4D864FB0617CC74 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		E00C142BC7B2630EB00776C1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		18ACCC7CF536A344E76584C2 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
+		1FA9CAC061B4F491CEBDF60A /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		26866FEDF67CD3FA66FFAB17 /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
+		2F2B12BDC30B75C3CD2012BD /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CEC67C55F51736AB9F17063 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		82E8E5D354CD9B769C1DD508 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
+		8D73636373B8CDD4BE62C0A5 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
+		8EEF31F83F9AF990435CC135 /* tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tool; sourceTree = BUILT_PRODUCTS_DIR; };
+		9411DCDC5C6F92122299107F /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		941A754D1FBB5ACD78B4C755 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
+		CDA701F96A5177E4188BEA69 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E179886B32A8D20BA0FD517F /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		F360F9D030E464AA774319E0 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
+		FB0F020B344E60F89B31265D /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
+		FB80EF95C89684721EBBDC35 /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		2D3DFF4472B24F4AD7FC4D86 /* examples_cc_external */ = {
+			isa = PBXGroup;
+			children = (
+				E612587DC09602FB8217B300 /* private */,
+				26866FEDF67CD3FA66FFAB17 /* lib.c */,
+				F360F9D030E464AA774319E0 /* lib.h */,
+			);
+			path = examples_cc_external;
+			sourceTree = "<group>";
+		};
+		538988851287F65BCA835B1D /* cc */ = {
+			isa = PBXGroup;
+			children = (
+				FDC330C37DD1DC9F623083BB /* lib */,
+				DF54345C65AB17E1D19AD454 /* lib2 */,
+				B81CB5A85E717306A9EDAE07 /* tool */,
+			);
+			path = cc;
+			sourceTree = "<group>";
+		};
+		579D7C5094A2D9E435BA8012 /* private */ = {
+			isa = PBXGroup;
+			children = (
+				8D73636373B8CDD4BE62C0A5 /* private.h */,
+			);
+			path = private;
+			sourceTree = "<group>";
+		};
+		593E7C82FAAD94A7E6A04318 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */,
+				CDA701F96A5177E4188BEA69 /* liblib_impl.a */,
+				5CEC67C55F51736AB9F17063 /* liblib_impl.a */,
+				8EEF31F83F9AF990435CC135 /* tool */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9811D2ED915829A1A7881AFD /* Bazel External Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				2D3DFF4472B24F4AD7FC4D86 /* examples_cc_external */,
+			);
+			name = "Bazel External Repositories";
+			path = "bazel-rules_xcodeproj/external";
+			sourceTree = "<group>";
+		};
+		B81CB5A85E717306A9EDAE07 /* tool */ = {
+			isa = PBXGroup;
+			children = (
+				2F2B12BDC30B75C3CD2012BD /* BUILD */,
+				9411DCDC5C6F92122299107F /* main.c */,
+			);
+			path = tool;
+			sourceTree = "<group>";
+		};
+		BB34C210E2A56E7B96B81F9A /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				538988851287F65BCA835B1D /* cc */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		C047AF1D451C7E165914273D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		DF54345C65AB17E1D19AD454 /* lib2 */ = {
+			isa = PBXGroup;
+			children = (
+				E179886B32A8D20BA0FD517F /* BUILD */,
+				FB0F020B344E60F89B31265D /* lib.c */,
+				18ACCC7CF536A344E76584C2 /* lib.h */,
+			);
+			path = lib2;
+			sourceTree = "<group>";
+		};
+		E612587DC09602FB8217B300 /* private */ = {
+			isa = PBXGroup;
+			children = (
+				941A754D1FBB5ACD78B4C755 /* private.h */,
+			);
+			path = private;
+			sourceTree = "<group>";
+		};
+		EC6FEE5AC277A3FEEA95510A = {
+			isa = PBXGroup;
+			children = (
+				BB34C210E2A56E7B96B81F9A /* examples */,
+				9811D2ED915829A1A7881AFD /* Bazel External Repositories */,
+				593E7C82FAAD94A7E6A04318 /* Products */,
+				C047AF1D451C7E165914273D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		FDC330C37DD1DC9F623083BB /* lib */ = {
+			isa = PBXGroup;
+			children = (
+				579D7C5094A2D9E435BA8012 /* private */,
+				1FA9CAC061B4F491CEBDF60A /* BUILD */,
+				FB80EF95C89684721EBBDC35 /* lib.c */,
+				82E8E5D354CD9B769C1DD508 /* lib.h */,
+			);
+			path = lib;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		0CEAA3455274D4DE9B4B82BF /* @examples_cc_external//:lib_impl */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6B35C64B72AF438AAA80E099 /* Build configuration list for PBXNativeTarget "@examples_cc_external//:lib_impl" */;
+			buildPhases = (
+				0320E1BD9F7CC13B8A051A33 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5B98370B1DD907C97C40A27B /* PBXTargetDependency */,
+			);
+			name = "@examples_cc_external//:lib_impl";
+			productName = lib_impl;
+			productReference = 3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		27EDD304E889980DC176FF62 /* tool */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D146AD00BEF0EE94F6F1E2AD /* Build configuration list for PBXNativeTarget "tool" */;
+			buildPhases = (
+				72C6D01265A3ACBB4140607C /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				856400D21DBDB4EC4EC06977 /* PBXTargetDependency */,
+				09E3E376134BB6CCC0CBAD31 /* PBXTargetDependency */,
+				7B9C45B4ECC722806B78A989 /* PBXTargetDependency */,
+				5072A54D92BD54F162C06B45 /* PBXTargetDependency */,
+			);
+			name = tool;
+			productName = tool;
+			productReference = 8EEF31F83F9AF990435CC135 /* tool */;
+			productType = "com.apple.product-type.tool";
+		};
+		373A62571D2CA8826AD4F92C /* //examples/cc/lib2:lib_impl */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CC32E30C4447E4F98912299A /* Build configuration list for PBXNativeTarget "//examples/cc/lib2:lib_impl" */;
+			buildPhases = (
+				31E865B4B67E6E7FC42468E1 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				540B454076EFF73BC2DE85EA /* PBXTargetDependency */,
+			);
+			name = "//examples/cc/lib2:lib_impl";
+			productName = lib_impl;
+			productReference = 5CEC67C55F51736AB9F17063 /* liblib_impl.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		E180851AE3E1EEC8C4944F10 /* //examples/cc/lib:lib_impl */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 52314820FE23152C79C94D1E /* Build configuration list for PBXNativeTarget "//examples/cc/lib:lib_impl" */;
+			buildPhases = (
+				5F6E740F936730CFEDAF6F7E /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				96604C2752858851BD010B11 /* PBXTargetDependency */,
+			);
+			name = "//examples/cc/lib:lib_impl";
+			productName = lib_impl;
+			productReference = CDA701F96A5177E4188BEA69 /* liblib_impl.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0805833D09730531AD081697 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					0CEAA3455274D4DE9B4B82BF = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					27EDD304E889980DC176FF62 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					373A62571D2CA8826AD4F92C = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					E180851AE3E1EEC8C4944F10 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					ECAFAC2323528A3317A7C9F2 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+				};
+			};
+			buildConfigurationList = 669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = EC6FEE5AC277A3FEEA95510A;
+			productRefGroup = 593E7C82FAAD94A7E6A04318 /* Products */;
+			projectDirPath = ../../..;
+			projectRoot = "";
+			targets = (
+				ECAFAC2323528A3317A7C9F2 /* Setup */,
+				0CEAA3455274D4DE9B4B82BF /* @examples_cc_external//:lib_impl */,
+				E180851AE3E1EEC8C4944F10 /* //examples/cc/lib:lib_impl */,
+				373A62571D2CA8826AD4F92C /* //examples/cc/lib2:lib_impl */,
+				27EDD304E889980DC176FF62 /* tool */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		48F6FA82818C0DE2760C55C0 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"$PROJECT_FILE_PATH/rules_xcodeproj\"\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf gen_dir\n\nln -sf \"$BUILD_DIR/bazel-out\" gen_dir\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-rules_xcodeproj/external\" external\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$PROJECT_FILE_PATH/rules_xcodeproj/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		0320E1BD9F7CC13B8A051A33 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D8961DA25CBC1AF0367FBA37 /* lib.c in Sources */,
+				9F8860D106D9ABB10483EA7A /* private.h in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		31E865B4B67E6E7FC42468E1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FC39DB0614B0AB5B5A2DF90E /* lib.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5F6E740F936730CFEDAF6F7E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CD2AA10AC79D5924E155E574 /* lib.c in Sources */,
+				D770DE28E597BAF74254AFCB /* private.h in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		72C6D01265A3ACBB4140607C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CFDEFD32F9576B104A39894D /* main.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		09E3E376134BB6CCC0CBAD31 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "@examples_cc_external//:lib_impl";
+			target = 0CEAA3455274D4DE9B4B82BF /* @examples_cc_external//:lib_impl */;
+			targetProxy = 2D50AC8D57F94038C0E530C9 /* PBXContainerItemProxy */;
+		};
+		5072A54D92BD54F162C06B45 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "//examples/cc/lib2:lib_impl";
+			target = 373A62571D2CA8826AD4F92C /* //examples/cc/lib2:lib_impl */;
+			targetProxy = 20B4384B1C553426B14F3544 /* PBXContainerItemProxy */;
+		};
+		540B454076EFF73BC2DE85EA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = C1B43F49D4D864FB0617CC74 /* PBXContainerItemProxy */;
+		};
+		5B98370B1DD907C97C40A27B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 45C913AA706FEBB282C879FE /* PBXContainerItemProxy */;
+		};
+		7B9C45B4ECC722806B78A989 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "//examples/cc/lib:lib_impl";
+			target = E180851AE3E1EEC8C4944F10 /* //examples/cc/lib:lib_impl */;
+			targetProxy = 1AB65E1F649B115C62DA830F /* PBXContainerItemProxy */;
+		};
+		856400D21DBDB4EC4EC06977 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = E00C142BC7B2630EB00776C1 /* PBXContainerItemProxy */;
+		};
+		96604C2752858851BD010B11 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 424240DD0AE59FE97B422D1D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		0030CB4F8C4C1F3537D793A2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/examples_cc_external";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+					"EXTERNAL_SECRET_3=\\\"Goodbye\\\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/examples_cc_external/private",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/examples_cc_external/private",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = lib_impl;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = lib_impl;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/examples_cc_external",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/examples_cc_external",
+				);
+			};
+			name = Debug;
+		};
+		06F3B47FD3F55150815C937C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+					"SECRET_3=\\\"Hello\\\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/examples/cc/lib/private",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib/private",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = lib_impl;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = lib_impl;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin",
+				);
+			};
+			name = Debug;
+		};
+		4A234614294618D445060F03 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = Setup;
+			};
+			name = Debug;
+		};
+		6D957D3747854B613BE7F96E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/tool";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+					"SECRET_2=\\\"World!\\\"",
+					"EXTERNAL_SECRET_2=\\\"World?\\\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = (
+					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(TARGET_DEVICE_PLATFORM_NAME)",
+					"-L/usr/lib/swift",
+					"-filelist",
+					"$(PROJECT_FILE_PATH)/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-1c975e2849a6/examples/cc/tool/tool.LinkFileList,$(BUILD_DIR)",
+					"-ObjC",
+				);
+				PRODUCT_MODULE_NAME = _tool_Stub;
+				PRODUCT_NAME = tool;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = tool;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin",
+					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/examples_cc_external",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/examples_cc_external",
+					"$(PROJECT_DIR)/bazel-rules_xcodeproj/external/bazel_tools",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/bazel_tools",
+				);
+			};
+			name = Debug;
+		};
+		AAB27910AD69F396275140DA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib2";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = lib_impl;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = lib_impl;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin",
+				);
+			};
+			name = Debug;
+		};
+		B0892EE2AB907B40AA4EB960 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BAZEL_PATH = bazel;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
+				COPY_PHASE_STRIP = NO;
+				ONLY_ACTIVE_ARCH = YES;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		52314820FE23152C79C94D1E /* Build configuration list for PBXNativeTarget "//examples/cc/lib:lib_impl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				06F3B47FD3F55150815C937C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B0892EE2AB907B40AA4EB960 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		6B35C64B72AF438AAA80E099 /* Build configuration list for PBXNativeTarget "@examples_cc_external//:lib_impl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0030CB4F8C4C1F3537D793A2 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A234614294618D445060F03 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		CC32E30C4447E4F98912299A /* Build configuration list for PBXNativeTarget "//examples/cc/lib2:lib_impl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AAB27910AD69F396275140DA /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		D146AD00BEF0EE94F6F1E2AD /* Build configuration list for PBXNativeTarget "tool" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6D957D3747854B613BE7F96E /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0805833D09730531AD081697 /* Project object */;
+}

--- a/test/fixtures/cc/bwb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/test/fixtures/cc/bwb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/test/fixtures/cc/bwb.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/test/fixtures/cc/bwb.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/test/fixtures/cc/bwb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/test/fixtures/cc/bwb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-1c975e2849a6/examples/cc/tool/tool.LinkFileList
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-1c975e2849a6/examples/cc/tool/tool.LinkFileList
@@ -1,0 +1,3 @@
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib/liblib_impl.a
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib2/liblib_impl.a
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/examples_cc_external/liblib_impl.a

--- a/test/fixtures/cc/bwb_spec.json
+++ b/test/fixtures/cc/bwb_spec.json
@@ -1,0 +1,447 @@
+{
+    "build_settings": {
+        "ALWAYS_SEARCH_USER_PATHS": false,
+        "BAZEL_PATH": "bazel",
+        "CLANG_ENABLE_OBJC_ARC": true,
+        "CLANG_MODULES_AUTOLINK": false,
+        "COPY_PHASE_STRIP": false,
+        "ONLY_ACTIVE_ARCH": true,
+        "USE_HEADERMAP": false,
+        "VALIDATE_WORKSPACE": false
+    },
+    "extra_files": [
+        "examples/cc/lib/BUILD",
+        "examples/cc/lib/lib.h",
+        "examples/cc/lib2/BUILD",
+        {
+            "_": "examples_cc_external/lib.h",
+            "t": "e"
+        },
+        "examples/cc/tool/BUILD"
+    ],
+    "invalid_target_merges": [],
+    "label": "//test/fixtures/cc:xcodeproj_bwb",
+    "name": "bwb",
+    "target_merges": [],
+    "targets": [
+        "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_NAME": "lib_impl",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "hdrs": [
+                    "examples/cc/lib2/lib.h"
+                ],
+                "srcs": [
+                    "examples/cc/lib2/lib.c"
+                ]
+            },
+            "is_swift": false,
+            "label": "//examples/cc/lib2:lib_impl",
+            "links": [],
+            "modulemaps": [],
+            "name": "lib_impl",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib2",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "lib_impl",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib2/liblib_impl.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//examples/cc/lib:lib_impl darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\"",
+                    "SECRET_3=\\\"Hello\\\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_NAME": "lib_impl",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "examples/cc/lib/lib.c",
+                    "examples/cc/lib/private/private.h"
+                ]
+            },
+            "is_swift": false,
+            "label": "//examples/cc/lib:lib_impl",
+            "links": [],
+            "modulemaps": [],
+            "name": "lib_impl",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "lib_impl",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib/liblib_impl.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "includes": [
+                    "examples/cc/lib/private",
+                    {
+                        "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib/private",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//examples/cc/tool:tool darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\"",
+                    "SECRET_2=\\\"World!\\\"",
+                    "EXTERNAL_SECRET_2=\\\"World?\\\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_MODULE_NAME": "_tool_Stub",
+                "PRODUCT_NAME": "tool",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [
+                "//examples/cc/lib:lib_impl darwin_x86_64-dbg-ST-1c975e2849a6",
+                "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-1c975e2849a6",
+                "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-1c975e2849a6"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "examples/cc/tool/main.c"
+                ]
+            },
+            "is_swift": false,
+            "label": "//examples/cc/tool:tool",
+            "links": [
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib/liblib_impl.a",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/lib2/liblib_impl.a",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/examples_cc_external/liblib_impl.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "tool",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/tool",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "tool",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/examples/cc/tool/tool",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.tool"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "examples_cc_external",
+                        "t": "e"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/examples_cc_external",
+                        "t": "g"
+                    },
+                    {
+                        "_": "bazel_tools",
+                        "t": "e"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/bazel_tools",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\"",
+                    "EXTERNAL_SECRET_3=\\\"Goodbye\\\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_NAME": "lib_impl",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    {
+                        "_": "examples_cc_external/lib.c",
+                        "t": "e"
+                    },
+                    {
+                        "_": "examples_cc_external/private/private.h",
+                        "t": "e"
+                    }
+                ]
+            },
+            "is_swift": false,
+            "label": "@examples_cc_external//:lib_impl",
+            "links": [],
+            "modulemaps": [],
+            "name": "lib_impl",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/examples_cc_external",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "lib_impl",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/examples_cc_external/liblib_impl.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "includes": [
+                    {
+                        "_": "examples_cc_external/private",
+                        "t": "e"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/examples_cc_external/private",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "examples_cc_external",
+                        "t": "e"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/examples_cc_external",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        }
+    ]
+}

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -1,0 +1,1035 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		1264E098850804E77CE82093 /* Bazel Generated Files */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */;
+			buildPhases = (
+				CA47126A96DBA220099058F9 /* Generate Files */,
+				3BBBE88C0B5DFE50E861D039 /* Copy Files */,
+				C39544D2D57030E1F850014D /* Fix Modulemaps */,
+				C1BCE66C756D6574AE7961FF /* Fix Info.plists */,
+			);
+			dependencies = (
+				A375E057D32BEDDB980E23C5 /* PBXTargetDependency */,
+			);
+			name = "Bazel Generated Files";
+			productName = "Bazel Generated Files";
+		};
+		ECAFAC2323528A3317A7C9F2 /* Setup */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildPhases = (
+				48F6FA82818C0DE2760C55C0 /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = Setup;
+			productName = Setup;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		2565B0E6AC6DB939D6A8209E /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C06A565663AED0899589F574 /* main.m */; };
+		2848C0B211EE176A3865CF72 /* SwiftGreetingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE87466AFFDC6606F8518F8 /* SwiftGreetingsTests.swift */; };
+		5FF3391F448E2AD999E2D37A /* private.h in Sources */ = {isa = PBXBuildFile; fileRef = 061F2388C98C7C8A40A50744 /* private.h */; };
+		D339677D7D46139DE6887FAB /* lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59B10F9022E9CC335541BDA /* lib.swift */; };
+		E88BD8A7C61237C9DA4A3253 /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = 2A44BF8F252A4102EA584307 /* lib.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0D08B1B3E78FD0DCDACFB09C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BC691472A2BC47F8E1D5D637;
+			remoteInfo = lib_impl;
+		};
+		13927D4D0197A5640D5F2E1E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1264E098850804E77CE82093;
+			remoteInfo = "Bazel Generated Files";
+		};
+		4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		7B22195AE863596CBAA46EDC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1264E098850804E77CE82093;
+			remoteInfo = "Bazel Generated Files";
+		};
+		941CFFB87F4F5822EFA8B01D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8E3B6C47A6106921076BC573;
+			remoteInfo = lib_swift;
+		};
+		C0AE6AA9FC08390DB1932DDD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8E3B6C47A6106921076BC573;
+			remoteInfo = lib_swift;
+		};
+		C3700581E446951E2320FDD6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		E00C142BC7B2630EB00776C1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		061F2388C98C7C8A40A50744 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
+		12C3BFE593A8E590FD298519 /* LibSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LibSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CE87466AFFDC6606F8518F8 /* SwiftGreetingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftGreetingsTests.swift; sourceTree = "<group>"; };
+		2A44BF8F252A4102EA584307 /* lib.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = lib.m; sourceTree = "<group>"; };
+		2D85BE28EA2A37C7DEC17BFB /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
+		3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		537B806ECAA55F19DAFDF318 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		6C91833F3EB0B218B5BB82FA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		8EEF31F83F9AF990435CC135 /* tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tool; sourceTree = BUILT_PRODUCTS_DIR; };
+		97949DA20D6FB752D6AD72F7 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		A59B10F9022E9CC335541BDA /* lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = lib.swift; sourceTree = "<group>"; };
+		A8BBECFF22A4D078C50CABF3 /* lib_swift.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = lib_swift.swift.modulemap; sourceTree = "<group>"; };
+		AA8B40F3394AF193E0043C9C /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
+		BD61574B80FFFB3513CACD09 /* lib_impl.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = lib_impl.swift.modulemap; sourceTree = "<group>"; };
+		C06A565663AED0899589F574 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		CBE528880485D0994B3CC1FC /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		E3938AB43AEB959A432DB9EF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		F93835BAA75A671D6D3361A9 /* liblib_swift.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_swift.a; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		01E4B400B2286D1CFB58D921 /* command_line */ = {
+			isa = PBXGroup;
+			children = (
+				20C15B1D28D189B67E823851 /* lib */,
+			);
+			path = command_line;
+			sourceTree = "<group>";
+		};
+		063AAADAA89AC96445191502 /* lib */ = {
+			isa = PBXGroup;
+			children = (
+				E29B178A097D05842E01BE95 /* dir with space */,
+				97949DA20D6FB752D6AD72F7 /* BUILD */,
+				2A44BF8F252A4102EA584307 /* lib.m */,
+				A59B10F9022E9CC335541BDA /* lib.swift */,
+				061F2388C98C7C8A40A50744 /* private.h */,
+			);
+			path = lib;
+			sourceTree = "<group>";
+		};
+		06B2A3709BA70AB3B7FBAAAB /* command_line */ = {
+			isa = PBXGroup;
+			children = (
+				063AAADAA89AC96445191502 /* lib */,
+				DFF009E928DD3A84D027B6F2 /* Tests */,
+				A1A003CE7A8C4BBD4565BF3B /* tool */,
+			);
+			path = command_line;
+			sourceTree = "<group>";
+		};
+		1F75B84D472E4F903E58A310 /* apple */ = {
+			isa = PBXGroup;
+			children = (
+				B90C93321F57509ADC051F9E /* testing */,
+			);
+			path = apple;
+			sourceTree = "<group>";
+		};
+		20C15B1D28D189B67E823851 /* lib */ = {
+			isa = PBXGroup;
+			children = (
+				BD61574B80FFFB3513CACD09 /* lib_impl.swift.modulemap */,
+				A8BBECFF22A4D078C50CABF3 /* lib_swift.swift.modulemap */,
+			);
+			path = lib;
+			sourceTree = "<group>";
+		};
+		474F850FCA6E6AEA181D6768 /* command_line */ = {
+			isa = PBXGroup;
+			children = (
+				622EF57851A060CA6130EFE7 /* Tests */,
+			);
+			path = command_line;
+			sourceTree = "<group>";
+		};
+		576EA43EF3C670E75BB29965 /* applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067 */ = {
+			isa = PBXGroup;
+			children = (
+				BCF4203C339FC3412B8AD82B /* bin */,
+			);
+			path = "applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067";
+			sourceTree = "<group>";
+		};
+		593E7C82FAAD94A7E6A04318 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */,
+				F93835BAA75A671D6D3361A9 /* liblib_swift.a */,
+				12C3BFE593A8E590FD298519 /* LibSwiftTests.xctest */,
+				8EEF31F83F9AF990435CC135 /* tool */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		5C439606DF83073F0F7BACA7 /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				EFA29BE57FF39C5CF7781823 /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
+		622EF57851A060CA6130EFE7 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				64C13008E976FEE22339EC68 /* LibSwiftTests.__internal__.__test_bundle-intermediates */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		64C13008E976FEE22339EC68 /* LibSwiftTests.__internal__.__test_bundle-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				6C91833F3EB0B218B5BB82FA /* Info.plist */,
+			);
+			path = "LibSwiftTests.__internal__.__test_bundle-intermediates";
+			sourceTree = "<group>";
+		};
+		97C31BB33E7A6DA71313A1BF /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				474F850FCA6E6AEA181D6768 /* command_line */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		9811D2ED915829A1A7881AFD /* Bazel External Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				DEDBB9862662A833DD5D663E /* build_bazel_rules_apple */,
+			);
+			name = "Bazel External Repositories";
+			path = "bazel-rules_xcodeproj/external";
+			sourceTree = "<group>";
+		};
+		A1A003CE7A8C4BBD4565BF3B /* tool */ = {
+			isa = PBXGroup;
+			children = (
+				537B806ECAA55F19DAFDF318 /* BUILD */,
+				E3938AB43AEB959A432DB9EF /* Info.plist */,
+				C06A565663AED0899589F574 /* main.m */,
+			);
+			path = tool;
+			sourceTree = "<group>";
+		};
+		B2C758656609622F8B6898F4 /* macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067 */ = {
+			isa = PBXGroup;
+			children = (
+				5C439606DF83073F0F7BACA7 /* bin */,
+			);
+			path = "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067";
+			sourceTree = "<group>";
+		};
+		B90C93321F57509ADC051F9E /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				AA8B40F3394AF193E0043C9C /* DefaultTestBundle.plist */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
+		BB34C210E2A56E7B96B81F9A /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				06B2A3709BA70AB3B7FBAAAB /* command_line */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		BCF4203C339FC3412B8AD82B /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				97C31BB33E7A6DA71313A1BF /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
+		C047AF1D451C7E165914273D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C407A8E68D8C611448A3E699 /* Bazel Generated Files */ = {
+			isa = PBXGroup;
+			children = (
+				576EA43EF3C670E75BB29965 /* applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067 */,
+				B2C758656609622F8B6898F4 /* macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067 */,
+			);
+			name = "Bazel Generated Files";
+			path = test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/gen_dir;
+			sourceTree = "<group>";
+		};
+		DEDBB9862662A833DD5D663E /* build_bazel_rules_apple */ = {
+			isa = PBXGroup;
+			children = (
+				1F75B84D472E4F903E58A310 /* apple */,
+			);
+			path = build_bazel_rules_apple;
+			sourceTree = "<group>";
+		};
+		DFF009E928DD3A84D027B6F2 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				CBE528880485D0994B3CC1FC /* BUILD */,
+				1CE87466AFFDC6606F8518F8 /* SwiftGreetingsTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		E29B178A097D05842E01BE95 /* dir with space */ = {
+			isa = PBXGroup;
+			children = (
+				2D85BE28EA2A37C7DEC17BFB /* lib.h */,
+			);
+			path = "dir with space";
+			sourceTree = "<group>";
+		};
+		EC6FEE5AC277A3FEEA95510A = {
+			isa = PBXGroup;
+			children = (
+				BB34C210E2A56E7B96B81F9A /* examples */,
+				9811D2ED915829A1A7881AFD /* Bazel External Repositories */,
+				C407A8E68D8C611448A3E699 /* Bazel Generated Files */,
+				593E7C82FAAD94A7E6A04318 /* Products */,
+				C047AF1D451C7E165914273D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		EFA29BE57FF39C5CF7781823 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				01E4B400B2286D1CFB58D921 /* command_line */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		27EDD304E889980DC176FF62 /* tool */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D146AD00BEF0EE94F6F1E2AD /* Build configuration list for PBXNativeTarget "tool" */;
+			buildPhases = (
+				72C6D01265A3ACBB4140607C /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				856400D21DBDB4EC4EC06977 /* PBXTargetDependency */,
+				0264408EBC1B158ADC203602 /* PBXTargetDependency */,
+			);
+			name = tool;
+			productName = tool;
+			productReference = 8EEF31F83F9AF990435CC135 /* tool */;
+			productType = "com.apple.product-type.tool";
+		};
+		8E3B6C47A6106921076BC573 /* lib_swift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 426DF0C057EB275136F4B9DC /* Build configuration list for PBXNativeTarget "lib_swift" */;
+			buildPhases = (
+				18F25BCCAD587CF0E7BE2E95 /* Sources */,
+				7D1C1AFB1B1C40174C24CF23 /* Copy Swift Generated Header */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				74FDFEB4A044D099CDCEA8F6 /* PBXTargetDependency */,
+				2BC4078E4942848FB045F836 /* PBXTargetDependency */,
+			);
+			name = lib_swift;
+			productName = lib_swift;
+			productReference = F93835BAA75A671D6D3361A9 /* liblib_swift.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		BC691472A2BC47F8E1D5D637 /* lib_impl */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 05724F70616E95211CBAC61C /* Build configuration list for PBXNativeTarget "lib_impl" */;
+			buildPhases = (
+				EB382A674406F86F441C20BE /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				82290885D55F963B9C48F0A2 /* PBXTargetDependency */,
+			);
+			name = lib_impl;
+			productName = lib_impl;
+			productReference = 3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		E56E8F91E4327755D5B09E30 /* LibSwiftTests.__internal__.__test_bundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 74DA3612C32497D21458CAA4 /* Build configuration list for PBXNativeTarget "LibSwiftTests.__internal__.__test_bundle" */;
+			buildPhases = (
+				DCB7EC09ACE7D73B9BDD7F0D /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0EA1F34EB7D23C6AB27F5C21 /* PBXTargetDependency */,
+				2CF2586B0B0366E350C5E6BF /* PBXTargetDependency */,
+			);
+			name = LibSwiftTests.__internal__.__test_bundle;
+			productName = LibSwiftTests;
+			productReference = 12C3BFE593A8E590FD298519 /* LibSwiftTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0805833D09730531AD081697 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					1264E098850804E77CE82093 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					27EDD304E889980DC176FF62 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					8E3B6C47A6106921076BC573 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					BC691472A2BC47F8E1D5D637 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					E56E8F91E4327755D5B09E30 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					ECAFAC2323528A3317A7C9F2 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+				};
+			};
+			buildConfigurationList = 669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = EC6FEE5AC277A3FEEA95510A;
+			productRefGroup = 593E7C82FAAD94A7E6A04318 /* Products */;
+			projectDirPath = ../../..;
+			projectRoot = "";
+			targets = (
+				ECAFAC2323528A3317A7C9F2 /* Setup */,
+				1264E098850804E77CE82093 /* Bazel Generated Files */,
+				BC691472A2BC47F8E1D5D637 /* lib_impl */,
+				8E3B6C47A6106921076BC573 /* lib_swift */,
+				E56E8F91E4327755D5B09E30 /* LibSwiftTests.__internal__.__test_bundle */,
+				27EDD304E889980DC176FF62 /* tool */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3BBBE88C0B5DFE50E861D039 /* Copy Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/generated.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Copy Files";
+			outputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/generated.copied.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"bazel-out\"\n\nrsync \\\n  --files-from \"$PROJECT_FILE_PATH/rules_xcodeproj/generated.rsynclist\" \\\n  --chmod=u+w \\\n  -L \\\n  . \\\n  \"$BUILD_DIR/bazel-out\"\n";
+			showEnvVarsInLog = 0;
+		};
+		48F6FA82818C0DE2760C55C0 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"$PROJECT_FILE_PATH/rules_xcodeproj\"\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf gen_dir\n\nln -sf \"$BUILD_DIR/bazel-out\" gen_dir\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-rules_xcodeproj/external\" external\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$PROJECT_FILE_PATH/rules_xcodeproj/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
+			showEnvVarsInLog = 0;
+		};
+		7D1C1AFB1B1C40174C24CF23 /* Copy Swift Generated Header */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(DERIVED_FILE_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			name = "Copy Swift Generated Header";
+			outputPaths = (
+				"$(CONFIGURATION_BUILD_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C1BCE66C756D6574AE7961FF /* Fix Info.plists */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/infoplists.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Fix Info.plists";
+			outputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/infoplists.fixed.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C39544D2D57030E1F850014D /* Fix Modulemaps */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/modulemaps.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Fix Modulemaps";
+			outputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/modulemaps.fixed.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(\\s*(\\w+ )?header )(?!(\"\\.\\.(\\/\\.\\.)*\\/|\")(bazel-out|external)\\/)(\"(\\.\\.\\/)*)(.*\")%\\1\\6SRCROOT/\\8%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CA47126A96DBA220099058F9 /* Generate Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate Files";
+			outputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/generated.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf \"$PROJECT_DIR/bazel-out\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  ${BAZEL_PATH} \\\n  build \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/command_line:xcodeproj_bwb\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		18F25BCCAD587CF0E7BE2E95 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D339677D7D46139DE6887FAB /* lib.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		72C6D01265A3ACBB4140607C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2565B0E6AC6DB939D6A8209E /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DCB7EC09ACE7D73B9BDD7F0D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2848C0B211EE176A3865CF72 /* SwiftGreetingsTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EB382A674406F86F441C20BE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E88BD8A7C61237C9DA4A3253 /* lib.m in Sources */,
+				5FF3391F448E2AD999E2D37A /* private.h in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0264408EBC1B158ADC203602 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = lib_swift;
+			target = 8E3B6C47A6106921076BC573 /* lib_swift */;
+			targetProxy = 941CFFB87F4F5822EFA8B01D /* PBXContainerItemProxy */;
+		};
+		0EA1F34EB7D23C6AB27F5C21 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
+			targetProxy = 7B22195AE863596CBAA46EDC /* PBXContainerItemProxy */;
+		};
+		2BC4078E4942848FB045F836 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = lib_impl;
+			target = BC691472A2BC47F8E1D5D637 /* lib_impl */;
+			targetProxy = 0D08B1B3E78FD0DCDACFB09C /* PBXContainerItemProxy */;
+		};
+		2CF2586B0B0366E350C5E6BF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = lib_swift;
+			target = 8E3B6C47A6106921076BC573 /* lib_swift */;
+			targetProxy = C0AE6AA9FC08390DB1932DDD /* PBXContainerItemProxy */;
+		};
+		74FDFEB4A044D099CDCEA8F6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
+			targetProxy = 13927D4D0197A5640D5F2E1E /* PBXContainerItemProxy */;
+		};
+		82290885D55F963B9C48F0A2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = C3700581E446951E2320FDD6 /* PBXContainerItemProxy */;
+		};
+		856400D21DBDB4EC4EC06977 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = E00C142BC7B2630EB00776C1 /* PBXContainerItemProxy */;
+		};
+		A375E057D32BEDDB980E23C5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		4A234614294618D445060F03 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = Setup;
+			};
+			name = Debug;
+		};
+		5956C53EC4D795D939CF8F6C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+					"SECRET_3=\\\"Hello\\\"",
+					"SECRET_2=\\\"World!\\\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap -g";
+				PRODUCT_MODULE_NAME = LibSwift;
+				PRODUCT_NAME = lib_swift;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "private/LibSwift-Swift.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = lib_swift;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin",
+				);
+			};
+			name = Debug;
+		};
+		5D95C37273FAF8FEAFAE2065 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+					"SECRET_3=\\\"Hello\\\"",
+					"SECRET_2=\\\"World!\\\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = lib_impl;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = lib_impl;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin",
+				);
+			};
+			name = Debug;
+		};
+		6D957D3747854B613BE7F96E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/tool";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_ENABLE_MODULES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+					"SECRET_3=\\\"Hello\\\"",
+					"SECRET_2=\\\"World!\\\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"\"$(PROJECT_DIR)/examples/command_line/lib/dir with space\"",
+					"\"$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/dir with space\"",
+					"$(PROJECT_DIR)/examples/command_line/lib/private",
+					"$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/private",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = (
+					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(TARGET_DEVICE_PLATFORM_NAME)",
+					"-L/usr/lib/swift",
+					"-filelist",
+					"$(PROJECT_FILE_PATH)/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/examples/command_line/tool/tool.LinkFileList,$(BUILD_DIR)",
+					"-ObjC",
+				);
+				PRODUCT_NAME = tool;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = tool;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin",
+				);
+			};
+			name = Debug;
+		};
+		903631A5EF23335FBA66FC3F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+					"SECRET_3=\\\"Hello\\\"",
+					"SECRET_2=\\\"World!\\\"",
+				);
+				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = (
+					"-filelist",
+					"$(PROJECT_FILE_PATH)/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.LinkFileList,$(BUILD_DIR)",
+					"-ObjC",
+				);
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_swift.swift.xcode.modulemap -g";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
+				PRODUCT_MODULE_NAME = LibSwiftTestsLib;
+				PRODUCT_NAME = LibSwiftTests;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = LibSwiftTests.__internal__.__test_bundle;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin",
+				);
+			};
+			name = Debug;
+		};
+		958FA2D1FA128C21904CB40E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = GenerateBazelFiles;
+			};
+			name = Debug;
+		};
+		B0892EE2AB907B40AA4EB960 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BAZEL_PATH = bazel;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
+				COPY_PHASE_STRIP = NO;
+				ONLY_ACTIVE_ARCH = YES;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		05724F70616E95211CBAC61C /* Build configuration list for PBXNativeTarget "lib_impl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5D95C37273FAF8FEAFAE2065 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				958FA2D1FA128C21904CB40E /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		426DF0C057EB275136F4B9DC /* Build configuration list for PBXNativeTarget "lib_swift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5956C53EC4D795D939CF8F6C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B0892EE2AB907B40AA4EB960 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		74DA3612C32497D21458CAA4 /* Build configuration list for PBXNativeTarget "LibSwiftTests.__internal__.__test_bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				903631A5EF23335FBA66FC3F /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A234614294618D445060F03 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		D146AD00BEF0EE94F6F1E2AD /* Build configuration list for PBXNativeTarget "tool" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6D957D3747854B613BE7F96E /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0805833D09730531AD081697 /* Project object */;
+}

--- a/test/fixtures/command_line/bwb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/test/fixtures/command_line/bwb.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/test/fixtures/command_line/bwb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -1,0 +1,3 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_impl.swift.modulemap
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_swift.swift.modulemap

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -1,0 +1,3 @@
+applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist
+macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_impl.swift.modulemap
+macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_swift.swift.modulemap

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,0 +1,3 @@
+$(PROJECT_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_impl.swift.modulemap
+$(PROJECT_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_swift.swift.modulemap

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
@@ -1,0 +1,1 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
@@ -1,0 +1,1 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/modulemaps.fixed.xcfilelist
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/modulemaps.fixed.xcfilelist
@@ -1,0 +1,2 @@
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_swift.swift.xcode.modulemap

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/modulemaps.xcfilelist
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/modulemaps.xcfilelist
@@ -1,0 +1,2 @@
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_impl.swift.modulemap
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_swift.swift.modulemap

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.LinkFileList
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.LinkFileList
@@ -1,0 +1,2 @@
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/liblib_impl.a
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/liblib_swift.a

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/examples/command_line/tool/tool.LinkFileList
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/examples/command_line/tool/tool.LinkFileList
@@ -1,0 +1,2 @@
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/liblib_impl.a
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/liblib_swift.a

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -1,0 +1,663 @@
+{
+    "build_settings": {
+        "ALWAYS_SEARCH_USER_PATHS": false,
+        "BAZEL_PATH": "bazel",
+        "CLANG_ENABLE_OBJC_ARC": true,
+        "CLANG_MODULES_AUTOLINK": false,
+        "COPY_PHASE_STRIP": false,
+        "ONLY_ACTIVE_ARCH": true,
+        "USE_HEADERMAP": false,
+        "VALIDATE_WORKSPACE": false
+    },
+    "extra_files": [
+        "examples/command_line/lib/BUILD",
+        {
+            "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_impl.swift.modulemap",
+            "t": "g"
+        },
+        "examples/command_line/lib/dir with space/lib.h",
+        "examples/command_line/tool/BUILD",
+        "examples/command_line/tool/Info.plist",
+        "examples/command_line/Tests/BUILD",
+        {
+            "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_swift.swift.modulemap",
+            "t": "g"
+        },
+        {
+            "_": "build_bazel_rules_apple/apple/testing/DefaultTestBundle.plist",
+            "t": "e"
+        },
+        {
+            "_": "applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist",
+            "t": "g"
+        }
+    ],
+    "invalid_target_merges": [],
+    "label": "//test/fixtures/command_line:xcodeproj_bwb",
+    "name": "bwb",
+    "target_merges": [
+        "//examples/command_line/Tests:LibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+        [
+            "//examples/command_line/Tests:LibSwiftTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
+        ],
+        "//examples/command_line/tool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+        [
+            "//examples/command_line/tool:tool applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
+        ]
+    ],
+    "targets": [
+        "//examples/command_line/Tests:LibSwiftTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_BUNDLE_IDENTIFIER": "com.bazelbuild.rulesapple.Tests",
+                "PRODUCT_MODULE_NAME": "_LibSwiftTests_Stub",
+                "PRODUCT_NAME": "LibSwiftTests",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+            "dependencies": [
+                "//examples/command_line/Tests:LibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
+            ],
+            "frameworks": [],
+            "info_plist": {
+                "_": "applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist",
+                "t": "g"
+            },
+            "inputs": {
+                "contains_generated_files": true
+            },
+            "is_swift": false,
+            "label": "//examples/command_line/Tests:LibSwiftTests.__internal__.__test_bundle",
+            "links": [
+                {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/liblib_impl.a",
+                    "t": "g"
+                },
+                {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/liblib_swift.a",
+                    "t": "g"
+                },
+                {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/libLibSwiftTestsLib.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "LibSwiftTests.__internal__.__test_bundle",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "LibSwiftTests",
+                "path": {
+                    "_": "applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle_archive-root/LibSwiftTests.xctest",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.bundle.unit-test"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//examples/command_line/Tests:LibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\"",
+                    "SECRET_3=\\\"Hello\\\"",
+                    "SECRET_2=\\\"World!\\\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "LibSwiftTestsLib",
+                "PRODUCT_NAME": "LibSwiftTestsLib",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+            "dependencies": [
+                "//examples/command_line/lib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "contains_generated_files": true,
+                "srcs": [
+                    "examples/command_line/Tests/SwiftGreetingsTests.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//examples/command_line/Tests:LibSwiftTestsLib",
+            "links": [],
+            "modulemaps": [
+                {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_impl.swift.modulemap",
+                    "t": "g"
+                },
+                {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_swift.swift.modulemap",
+                    "t": "g"
+                }
+            ],
+            "name": "LibSwiftTestsLib",
+            "outputs": {
+                "swift_module": {
+                    "name": "LibSwiftTestsLib.swiftmodule",
+                    "swiftdoc": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTestsLib.swiftdoc",
+                    "swiftmodule": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTestsLib.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTestsLib.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "LibSwiftTestsLib",
+                "path": {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/libLibSwiftTestsLib.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [
+                {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/LibSwift.swiftmodule",
+                    "t": "g"
+                }
+            ],
+            "test_host": null
+        },
+        "//examples/command_line/lib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\"",
+                    "SECRET_3=\\\"Hello\\\"",
+                    "SECRET_2=\\\"World!\\\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_NAME": "lib_impl",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "examples/command_line/lib/lib.m",
+                    "examples/command_line/lib/private.h"
+                ]
+            },
+            "is_swift": false,
+            "label": "//examples/command_line/lib:lib_impl",
+            "links": [],
+            "modulemaps": [],
+            "name": "lib_impl",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "lib_impl",
+                "path": {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/liblib_impl.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//examples/command_line/lib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\"",
+                    "SECRET_3=\\\"Hello\\\"",
+                    "SECRET_2=\\\"World!\\\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "LibSwift",
+                "PRODUCT_NAME": "lib_swift",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "private/LibSwift-Swift.h",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+            "dependencies": [
+                "//examples/command_line/lib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "contains_generated_files": true,
+                "srcs": [
+                    "examples/command_line/lib/lib.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//examples/command_line/lib:lib_swift",
+            "links": [],
+            "modulemaps": [
+                {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/lib_impl.swift.modulemap",
+                    "t": "g"
+                }
+            ],
+            "name": "lib_swift",
+            "outputs": {
+                "swift_module": {
+                    "name": "LibSwift.swiftmodule",
+                    "swiftdoc": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/LibSwift.swiftdoc",
+                    "swiftmodule": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/LibSwift.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/LibSwift.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "lib_swift",
+                "path": {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/liblib_swift.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//examples/command_line/tool:tool applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_MODULE_NAME": "_tool_Stub",
+                "PRODUCT_NAME": "tool",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+            "dependencies": [
+                "//examples/command_line/tool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {},
+            "is_swift": false,
+            "label": "//examples/command_line/tool:tool",
+            "links": [
+                {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/tool/libtool.library.a",
+                    "t": "g"
+                },
+                {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/liblib_swift.a",
+                    "t": "g"
+                },
+                {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/liblib_impl.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "tool",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/tool",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "tool",
+                "path": {
+                    "_": "applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/tool/tool",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.tool"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//examples/command_line/tool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "CLANG_ENABLE_MODULES": true,
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\"",
+                    "SECRET_3=\\\"Hello\\\"",
+                    "SECRET_2=\\\"World!\\\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_NAME": "tool.library",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
+            "dependencies": [
+                "//examples/command_line/lib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "examples/command_line/tool/main.m"
+                ]
+            },
+            "is_swift": false,
+            "label": "//examples/command_line/tool:tool.library",
+            "links": [],
+            "modulemaps": [],
+            "name": "tool.library",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/tool",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "tool.library",
+                "path": {
+                    "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/tool/libtool.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {
+                "includes": [
+                    "examples/command_line/lib/dir with space",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/dir with space",
+                        "t": "g"
+                    },
+                    "examples/command_line/lib/private",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/lib/private",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin",
+                        "t": "g"
+                    }
+                ]
+            },
+            "swiftmodules": [],
+            "test_host": null
+        }
+    ]
+}

--- a/test/fixtures/fixtures.bzl
+++ b/test/fixtures/fixtures.bzl
@@ -7,7 +7,7 @@ _FIXTURE_BASENAMES = [
     "tvos_app",
 ]
 
-_FIXTURE_SUFFIXES = ["bwx"]
+_FIXTURE_SUFFIXES = ["bwx", "bwb"]
 
 _FIXTURE_PACKAGES = ["//test/fixtures/{}".format(b) for b in _FIXTURE_BASENAMES]
 

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -1,0 +1,2120 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		ECAFAC2323528A3317A7C9F2 /* Setup */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildPhases = (
+				48F6FA82818C0DE2760C55C0 /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = Setup;
+			productName = Setup;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		007447878A5814379E7B765E /* Dictionary+Enumerate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1311F2E17F171A48A8E3B180 /* Dictionary+Enumerate.swift */; };
+		03DA8359CF68B4CE3C279FC0 /* PopulateMainGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCEBA76F789E9D71187DFF61 /* PopulateMainGroupTests.swift */; };
+		04886D2571E1ACF144595866 /* SearchPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6236535683C7CE49C73F48A2 /* SearchPaths.swift */; };
+		05D4C943C91F281CF27F2F83 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68733F62C401C1AA84617E96 /* KeyPath.swift */; };
+		0680A4C2872B98AC70E3ADD4 /* DisambiguateTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE03F64CA13C3461D45773E /* DisambiguateTargetsTests.swift */; };
+		086989EA86F5E2D35BC9FA5B /* CustomDumpStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF072F61E054955564EECDA2 /* CustomDumpStringConvertible.swift */; };
+		08BDB7C9B414A51A9260F683 /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F972F9B12146B979CA3E0318 /* PBXProject.swift */; };
+		08FD41A51102F53B418BD3CE /* JSONDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F851023E4F4913D1E369CE /* JSONDecoding.swift */; };
+		096B05250E4C2E55D79A268D /* XCScheme+BuildableReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02819512A69FF33D58EBA61C /* XCScheme+BuildableReference.swift */; };
+		0A904F2FB1E7254686796387 /* PBXReferenceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0152B8A419980E27BD7EE5FB /* PBXReferenceProxy.swift */; };
+		0B5033389291A3C98DAB6E41 /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7F0486AC72B3E68F194D01 /* PathKit.swift */; };
+		0BFA0A77F5504DCED931F795 /* FilePathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E1E2200AB2DCA91F4999CE /* FilePathResolver.swift */; };
+		0D0AC258CDE90DE121688624 /* UserNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356817EF2BC65A89F7FB439C /* UserNotifications.swift */; };
+		0D6ED2396B7AA4FCCB10F093 /* XCBreakpointList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C28A43616AE9FC78C05EE0 /* XCBreakpointList.swift */; };
+		0D85907F40BB6B647D855A72 /* SetTargetDependenciesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C7832C26060C56DE2EAB1A1 /* SetTargetDependenciesTests.swift */; };
+		0F1A9B6BE970BA80097FCE6F /* PBXCopyFilesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958D118534D347C200B0701A /* PBXCopyFilesBuildPhase.swift */; };
+		0F988C99D14D5314D5DE55AE /* CoreMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41944A58347442213CC45E6 /* CoreMotion.swift */; };
+		1238A9F19DF8C3E8C044C69C /* Generator+AddTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 865D483D2084AABC408B35CD /* Generator+AddTargets.swift */; };
+		13C6DF44016DCB53AD3798F0 /* WorkspaceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4ABCD1903D2A2F3FAE064BC /* WorkspaceSettings.swift */; };
+		15120DC7E10B41C7A500DC4C /* Array+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC38B9E7BDCEE1A00F253C2 /* Array+Extras.swift */; };
+		17645385BCB1B73E46212F31 /* XCScheme+BuildableProductRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC04FD3CCB6BC640D46E158 /* XCScheme+BuildableProductRunnable.swift */; };
+		193F6A78FD304D33032124C1 /* XCVersionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C59EAFFB7EF2605BF76058 /* XCVersionGroup.swift */; };
+		1CC4BC9635C0213148A58C93 /* PBXTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90DF1CB872B6732ED05BCF9A /* PBXTarget.swift */; };
+		1D234043EBCEEF3EFC870923 /* Inputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E2669DF0B74F219B31D9AB /* Inputs.swift */; };
+		1D2A68B41A4FA9E2401D41EF /* XCWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0138A3545FE63C005CFAB42F /* XCWorkspace.swift */; };
+		1E3DC0A6287F260FE33F89CE /* Path+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2597D69F32EE134D35CA5EED /* Path+Extras.swift */; };
+		209E823873EA39D5C6A8EF66 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3D4E7C841C2C89DF095466 /* Logger.swift */; };
+		2143F6802705E6E45746C463 /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFA193BCD097396D150AF96 /* Document.swift */; };
+		219C3E15651600D4892C4387 /* CollectionDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B9525BCADA7A75978D1FCC /* CollectionDifference.swift */; };
+		21EFB487A4B2DCA0539113C6 /* BuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE677C0FD789C4A0ADDC1901 /* BuildPhase.swift */; };
+		23041301A5060235785895F8 /* CoreImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55071574526ADBF7683AB165 /* CoreImage.swift */; };
+		25608AD5228D99F311C26845 /* PBXBuildRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B537637F91E4A43CAE2CF2 /* PBXBuildRule.swift */; };
+		265A3566719072FF07A20004 /* CustomDumpRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A40DA2B2633E2E5090B39B /* CustomDumpRepresentable.swift */; };
+		2662F5160B7446672BF10AC3 /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A134E3CBDC57315EE1B0221 /* Element.swift */; };
+		277424E39B6FA6040609F4C2 /* XCScheme+CommandLineArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B23BC150E3266757707492 /* XCScheme+CommandLineArguments.swift */; };
+		2AF393E662D68CBEAC339715 /* Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = F238F3E44302DBE53FF70525 /* Fixtures.swift */; };
+		2C0AEFD36720278D54AF5847 /* String+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0484B5B7FF46952C7EBA2E20 /* String+Utils.swift */; };
+		2C776A46D9F83B6F0BCD48A6 /* CommentedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = D432B71433F4134FFBFA281B /* CommentedString.swift */; };
+		2C8449871037AD0BBB828275 /* PBXBuildFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E299B0F3C05FB32D2951414 /* PBXBuildFile.swift */; };
+		2D41550C6C017839EF6AA36E /* Speech.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1ED821757FFFB97CF9BCA3 /* Speech.swift */; };
+		30641992040B785DB00E790C /* XCScheme+LocationScenarioReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073FBA88B39294943DB5E5A4 /* XCScheme+LocationScenarioReference.swift */; };
+		30D51D7450B1E5BC999396AC /* AnyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C680A79739F778E13D555285 /* AnyType.swift */; };
+		30F0C043E51363669C0D7E43 /* XCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC44F6F9D5F1EBF4D7110DD /* XCConfig.swift */; };
+		36161192BE3C16570649BB90 /* Photos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C89E41DF806BDFD0AF9A374 /* Photos.swift */; };
+		390F0EA150BF1F34944B6ADA /* Sourcery.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0C30E65D6E9C205B83B73E /* Sourcery.swift */; };
+		3A4A00E9748F9B2BE18264A6 /* XCScheme+AditionalOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A1E648AD1793142280604D /* XCScheme+AditionalOption.swift */; };
+		3A7349AFC0C6CBFFC6DEE039 /* SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D323B626241F566F3B8A2CB7 /* SwiftUI.swift */; };
+		3D313135393850D8995F026E /* XCScheme+TestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF69A69C5C9048DCF61E301 /* XCScheme+TestAction.swift */; };
+		4174F4CF85B88F38A10506D6 /* PBXProductType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80ED158A6F786B03F1C41998 /* PBXProductType+Extensions.swift */; };
+		42083CE40AC71C796D40C7A7 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268CB0584C901D862BCEF28A /* Options.swift */; };
+		4974B9AC4C2E129CC6088A1A /* Generator+CreateXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703888D148E8FEB96A8F9716 /* Generator+CreateXcodeProj.swift */; };
+		4978BBDA23E2108C6410D537 /* XCScheme+Runnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A84F2CC6A006E28720D2B /* XCScheme+Runnable.swift */; };
+		4D10A242113D5E0A454F043B /* Dump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173203DBAEA88407DBBF109D /* Dump.swift */; };
+		4E3D153CEB522DFB416A3DBE /* XCScheme+SerialAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F2246D7AB62C07E1D092E7 /* XCScheme+SerialAction.swift */; };
+		51F268CB997C75D3FFBE5DA7 /* Generator+CreateProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9522A589868D9D2C515C4822 /* Generator+CreateProject.swift */; };
+		52A211CD11583B26C7ACFE94 /* XCWorkspaceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D085A4397A412E35122016 /* XCWorkspaceData.swift */; };
+		52A6BC70459DEE9D341E6151 /* Mirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0413D918157ADBE8DAEA92D /* Mirror.swift */; };
+		55DEC752A311C6D8A9A8253C /* Generator+PopulateMainGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD75BB5F3720A6C4B51A43DF /* Generator+PopulateMainGroup.swift */; };
+		561E9544A30BE76E86EF2ED0 /* PBXSourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAADA80AB2FBFD1EB2A75A3D /* PBXSourcesBuildPhase.swift */; };
+		56D1E3A779E64B952444C092 /* Writable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD756B2EEB174424376D063 /* Writable.swift */; };
+		59195F78C9366C3C166CB371 /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AF6892EDF00CA059623628 /* PBXNativeTarget.swift */; };
+		5D436B3E872B368A77248360 /* PBXBatchUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F395A784F145A641B09FC95 /* PBXBatchUpdater.swift */; };
+		606070207B2A1238EAD8C008 /* UserNotificationsUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 789CE33EA9AD15B97F5AA88F /* UserNotificationsUI.swift */; };
+		61403F6850E38C4F143F564B /* PBXProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD85080B3E34F2529D7CB8 /* PBXProj.swift */; };
+		61EFA27F5D961ECA88FE86DB /* TargetID.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40DA547773CCE961E1E2CCD /* TargetID.swift */; };
+		62F2A43822894D2210058772 /* XcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A47D52C1A48A1ED498719F /* XcodeProj.swift */; };
+		6695A3C7FADF608E359B1153 /* XCWorkspaceDataGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748E5C2D56A2ED06BF8F5D39 /* XCWorkspaceDataGroup.swift */; };
+		68E567532FB9A491B36F4344 /* PBXContainerItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B0689562B36DE6F3668B6E /* PBXContainerItemProxy.swift */; };
+		6A8B43D7AB579FFA4EA560A8 /* CustomDumpReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFFE6348E347FF9ED001081 /* CustomDumpReflectable.swift */; };
+		6B28EE0853F7B0F596C5351C /* Generator+SetTargetConfigurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A035CBED0F4DCF5A388F10 /* Generator+SetTargetConfigurations.swift */; };
+		6BA353E9953AC16BBDB0F76B /* FilePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D918C1EA31CECDFC8FF2F6 /* FilePath.swift */; };
+		6BD6785813F2AC9561F5C197 /* PBXProj+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0B7B94D16AAD3979ACCEFA /* PBXProj+Testing.swift */; };
+		6BEA8E1A797CD3E05D0BAE40 /* Generator+CreateFilesAndGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBD705CC770A884D5A78D17D /* Generator+CreateFilesAndGroups.swift */; };
+		6BEEFB6F9ABBD9DE61F18D20 /* CreateFilesAndGroupsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42EAB1A5AEF651AF8F6F865 /* CreateFilesAndGroupsTests.swift */; };
+		72A3C7DA6BF74DE5F2EFC28C /* CreateProductsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40EB7581064768B08E6C529 /* CreateProductsTest.swift */; };
+		72C95B9913557F8ABDA0C644 /* XCScheme+AnalyzeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430A0E83DF369E5ED390CA3A /* XCScheme+AnalyzeAction.swift */; };
+		75B34A42A3528868C8D25993 /* AddTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACBE49740AB347EFAE8EC00 /* AddTargetsTests.swift */; };
+		78D160559CB33620BE055D67 /* PBXTargetDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E0D9481DEB5CB89790C09F /* PBXTargetDependency.swift */; };
+		7B3AD502D81DAD7185608351 /* Generator+WriteXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B56CD9E6641A10324B096B /* Generator+WriteXcodeProj.swift */; };
+		7D2E840E973AA9E5F5898CF0 /* DTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0725D1FE9D931F37B2F6AA3 /* DTO.swift */; };
+		7F476F3EA1860204A2BC970E /* ReferenceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0D02295BBDD7113D940406 /* ReferenceGenerator.swift */; };
+		7F58A80D6FBF4CAAB6A6B59C /* PBXProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A42BDD634CA3FA35830AE1 /* PBXProductType.swift */; };
+		804848AF97DCD0402E5B8587 /* BuildSettingsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD828AC8336C5A1F0C951071 /* BuildSettingsProvider.swift */; };
+		80DB1DEE41E0521C535EF842 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF420FAF127AC6B393E4678 /* PBXResourcesBuildPhase.swift */; };
+		81538A9DF3EE3B84C20E7C11 /* PBXObjectReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA5F81BF5F85E9032BC2014 /* PBXObjectReference.swift */; };
+		83B8755AB81932C2FE256B16 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7DE6268B49662138FC0C90 /* Errors.swift */; };
+		86824C0BC97C6DA06A465D0C /* XCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AD1D57FD4037EC5BB72645 /* XCSharedData.swift */; };
+		86F24F14D749292FBC62BD2C /* Generator+SetTargetDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF368C9DB075CBC4E63E0BCA /* Generator+SetTargetDependencies.swift */; };
+		86FE11FE2B8F03BEE4C909B9 /* PathExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493423CD8285C46D06C4169D /* PathExtensionsTests.swift */; };
+		892C9CFBEE5474105B683C75 /* XCScheme+EnvironmentVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F07848723835EC26C2340C /* XCScheme+EnvironmentVariable.swift */; };
+		8BF8CFA67C6213113810FCAD /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE25BEDFD3646AD0AB54C40 /* PBXContainerItem.swift */; };
+		8D60F9D1D81FEDCE8DDF6B73 /* CreateProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9607F1AB28FE727DED4651 /* CreateProjectTests.swift */; };
+		8FCC248B12F5127B90BCA1A2 /* PlistValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABD1C801DC25791CF7A9BC2 /* PlistValue.swift */; };
+		901D961591589C1891CFAFB6 /* PBXLegacyTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = F37821F06B32120001F7E12D /* PBXLegacyTarget.swift */; };
+		9077EA3A89259730E19B4A78 /* XCSchemeManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007E626D3C6303C4B848B3F6 /* XCSchemeManagement.swift */; };
+		918DEB6EB624CC659A442D18 /* XCConfigurationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6633E691F2753B78D68DD3C9 /* XCConfigurationList.swift */; };
+		966E746DD2F4033E07848B84 /* PBXAggregateTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 350D61290C1B602B60DA483A /* PBXAggregateTarget.swift */; };
+		98DC63B7C9C1743065744E2C /* PBXObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8657DAF8012A508E7FEE54 /* PBXObjects.swift */; };
+		9AECAA3D2388D9FF824EDB5F /* PBXFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C6BD71C5B59C200AE8F91C /* PBXFileReference.swift */; };
+		9C521A1BDD725800EBB7A77A /* PBXObjectParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB3EDAEB4E2CAE755B7284B /* PBXObjectParser.swift */; };
+		9D56629578825A73E01C892C /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E781CE891F4AB4B0E4C30 /* Dictionary+Extras.swift */; };
+		A005E475FCF2134825BDB60D /* Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A247C10F4C33288C1500D2D /* Swift.swift */; };
+		A222D10EC921D5DAB1ADFDD8 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737B837AF4D301FD49E5E8DC /* Errors.swift */; };
+		A4A23349B22F60B10EDF6D9A /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74842CED67D00EEEC35928F3 /* Diff.swift */; };
+		A66786EB13D7E2639036F3BF /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57369B9A38B6DCB2216526AE /* Generator.swift */; };
+		A675EA535B032CEB7C29D343 /* PBXFileElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D486D370E6E28447869688 /* PBXFileElement.swift */; };
+		A68D64FB246101C57F8011AA /* CreateXcodeProjTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7025166F1EB392F463C551D2 /* CreateXcodeProjTests.swift */; };
+		A7D5AE1CFB80FCD54BCA939B /* Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DBD527BA62C0B5EDF789F71 /* Sorting.swift */; };
+		A9517AAC3411C003E2CB531B /* StoreKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00CD1A85389190652E1BEFC9 /* StoreKit.swift */; };
+		A99C8BF4EB3403A8A0EF7359 /* PBXSourceTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71DFD69623D237CF63C0F232 /* PBXSourceTree.swift */; };
+		AB40FAE217E2BAB64BA214AE /* XCWorkspaceDataElementLocationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48CF60E64EACBE1F8C63D3D /* XCWorkspaceDataElementLocationType.swift */; };
+		AB6AAB9A7208DB88DC554AB4 /* XCScheme+ExecutionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457C541A86E3F05E0865CB70 /* XCScheme+ExecutionAction.swift */; };
+		ADCE544F51464E00D1D9524D /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D81D32EB64919C01CE7321 /* KeyedDecodingContainer+Additions.swift */; };
+		AE8961FFE22CBE3B3FD65418 /* XCScheme+ArchiveAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D689E51BC21F8670813CA7 /* XCScheme+ArchiveAction.swift */; };
+		AEB71B0424C2FF94ED50AC21 /* CompileStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A4D6EC3E7B8473C776A368 /* CompileStub.swift */; };
+		AF8E3F0B5232920781A99260 /* Target+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C9C8DAFC01EECD746E229 /* Target+Testing.swift */; };
+		B0A2A06473CECEC37ABAA58C /* PBXBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43EBF1E6F26B25BB157D396 /* PBXBuildPhase.swift */; };
+		B556B319407CEE94214F965A /* CoreLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8220ADCB2EE90910140F8F /* CoreLocation.swift */; };
+		B57969E61CB1565E21DD7F4F /* Equality.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DE54A5806DB0C02CD8FB55D /* Equality.generated.swift */; };
+		B8BF97A20C49B967A6631960 /* BuildSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 425B4EC528B607EEF98825F6 /* BuildSettings.swift */; };
+		BB1FEC913287E5B00F096E68 /* XCTFail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6715701A6A75A2BFF85172AD /* XCTFail.swift */; };
+		BB9A479C58B5371EB58BD6E1 /* XCSwiftPackageProductDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4427E84F30EE600A2E568520 /* XCSwiftPackageProductDependency.swift */; };
+		BC91F35AD1E15D616E4CC164 /* BuildSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49925538DB74BB9BE745F17F /* BuildSetting.swift */; };
+		BEAD5FDAF78EA4826B89E2BD /* NSRecursiveLock+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF5D934175EDDA9EF296101 /* NSRecursiveLock+Sync.swift */; };
+		BF37FF4AE38FE009AF6A77A5 /* Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB357A8A7280647E5513166A /* Foundation.swift */; };
+		C0486D5F399197D1D3FF09B0 /* XcodeProj+CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230BF7ABCF5D7C48951A8641 /* XcodeProj+CustomDump.swift */; };
+		C0C01A34E3B73713C8A5AD93 /* UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D663E878398F3764B9C1A8 /* UIKit.swift */; };
+		C28A10245E6237BB03708CF9 /* XCScheme+RemoteRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053AD1C0C7003B91D7B9EB16 /* XCScheme+RemoteRunnable.swift */; };
+		C3C078F384218F905E374FEF /* XCScheme+PathRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9993D3F386DFC594BC0967A /* XCScheme+PathRunnable.swift */; };
+		C4A4BDEEBC4DEA94A9C38B98 /* XCScheme+ProfileAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01004934C429F4A4F09C0C85 /* XCScheme+ProfileAction.swift */; };
+		CD168B5A573CE3A79098C630 /* PBXProjEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC11446A42A073B91FFC6262 /* PBXProjEncoder.swift */; };
+		CD4B8D1015F9E80BE99DD4CB /* GeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25072DE452FF8EC4AC148C4A /* GeneratorTests.swift */; };
+		CD5048942C21378CDB87CF88 /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4507DAF85285409A7CA226E /* PBXObject.swift */; };
+		CE6CCF1AF17AA0100D2D2A8E /* Decoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721F82FE7F5FD35511FFFB2B /* Decoders.swift */; };
+		CF836785A4BDAA1811B567F7 /* PBXRezBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D06530EE100F0FBF5366BC5 /* PBXRezBuildPhase.swift */; };
+		CFB4FD519F8E383FD4BCB1E3 /* String+md5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AE2420614CF62AD4A8AAB1 /* String+md5.swift */; };
+		D0407AAE9CF50A10917EAE7B /* PBXVariantGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4C427036C3EA7632B3C787 /* PBXVariantGroup.swift */; };
+		D16602634755ABF029048517 /* PBXFrameworksBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E1EBEDD54BAF02A22166DB /* PBXFrameworksBuildPhase.swift */; };
+		D19739179B7FE91C8CF9BEEC /* AEXML+XcodeFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B379DE01A53B895F83E8846C /* AEXML+XcodeFormat.swift */; };
+		D2BCCC871F46C8F9DAD03627 /* PBXGroup+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BCF03A21336243CA3242059 /* PBXGroup+Extensions.swift */; };
+		D36AF35A702DB7F0987E1628 /* XCScheme+BuildAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117052ABC66769C11B7F397A /* XCScheme+BuildAction.swift */; };
+		D548357DA88FF63CF53CB1C5 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8986F9BDAD8DB56D61CBB787 /* String.swift */; };
+		D8706141935099FEB119B28D /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB466879747C3652D74FE85 /* Error.swift */; };
+		D8D3778305DAFBA5A3150598 /* XCWorkspaceDataFileRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C1C5D545E3B4CA06474BDC /* XCWorkspaceDataFileRef.swift */; };
+		D8E574436F559C26407E7247 /* SetTargetConfigurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73417EAFFC70439C38BFDB6 /* SetTargetConfigurations.swift */; };
+		DAEB13CD6BB6B939AE66B3FE /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E27E547A12A951FF64D0C4 /* Box.swift */; };
+		DB319A23886D4E34C33673FC /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6130F9568982104094E3C618 /* Bool+Extras.swift */; };
+		DB8227FED04A839CF551406B /* XCScheme+TestableReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E517675E70186E73924EB60 /* XCScheme+TestableReference.swift */; };
+		DC5F430B976BE451BEF87B75 /* Path+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5B0A0B7C1D6A4838956E41C /* Path+Extensions.swift */; };
+		DD5A44735D378BDE1F46118A /* XCRemoteSwiftPackageReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B175666DC0102DE35EBD173 /* XCRemoteSwiftPackageReference.swift */; };
+		DDBE87915A648B7B27AA8A73 /* XCTAssertNoDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B2C353EE2A9D305660B47 /* XCTAssertNoDifference.swift */; };
+		DFDACE372D86DAF5308E0DE2 /* XCScheme+TestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0654DDFDA028387BCAF843F8 /* XCScheme+TestItem.swift */; };
+		DFEB422950EB6556FF81427F /* Generator+DisambiguateTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9495B72CA99FFB15C026408A /* Generator+DisambiguateTargets.swift */; };
+		E1C8DD75EBE5491687687657 /* XCScheme+StoreKitConfigurationFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC122F4DE7028197FE1C177 /* XCScheme+StoreKitConfigurationFileReference.swift */; };
+		E2339489F3322934D224B39B /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3504926798E0F993FC929F /* Parser.swift */; };
+		E34D297ACAC512E3C961FB43 /* XCScheme+TestPlanReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB97F8B9DCAC47C22823253 /* XCScheme+TestPlanReference.swift */; };
+		E573DCC118186C0FAB27ECD3 /* Generator+CreateProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9558541CFD5066169CA9773 /* Generator+CreateProducts.swift */; };
+		E69C15430624375DCD37079E /* Generator+Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE9C68C0607CFD069F19187 /* Generator+Main.swift */; };
+		E712DCD367C4CD3BA502AD45 /* XCScheme+LaunchAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA8095620DFED5335900D24 /* XCScheme+LaunchAction.swift */; };
+		E87E52EF25B8303265432A7B /* XCWorkspaceDataElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65EB8E516EB0D2F51A692233 /* XCWorkspaceDataElement.swift */; };
+		E9F48F2CD252695AAFAB1EB0 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30D832D39987A4A2D6FC32FC /* Environment.swift */; };
+		EB4A452EE958D49C8D481FC8 /* XCScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B1A9C414C17FC0CB546CCF5 /* XCScheme.swift */; };
+		EF6F4E716AA5BE2772001255 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7BF60244CDDEB8780E0A1B /* PBXHeadersBuildPhase.swift */; };
+		F195F74C145AA147C028F541 /* PBXOutputSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBD0DBAFB6DB4E966DC49EB /* PBXOutputSettings.swift */; };
+		F408E995D0F6C9C1655544A2 /* ProcessTargetMergesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746AD1E908901BF77306B564 /* ProcessTargetMergesTests.swift */; };
+		F45E3A1DA6E6C87FDF69EF5D /* PBXGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CEA06E5C81DCD25281036C7 /* PBXGroup.swift */; };
+		F489A2B6BC16017B0A96F7C5 /* Xcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726579883BDE5C574DD25742 /* Xcode.swift */; };
+		F4D13ACCE9A32E9C849214DA /* GameKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485411F2F79794474B9E8AAB /* GameKit.swift */; };
+		F87890E59D29431994A8AD60 /* XCBuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9354E6340A0B10BEB1FDEE /* XCBuildConfiguration.swift */; };
+		FAED0146F1038080B71472A6 /* Generator+ProcessTargetMerges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E80C203DC9A482C0F657AE7 /* Generator+ProcessTargetMerges.swift */; };
+		FD83242BF95B2ED90590668A /* PBXShellScriptBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133D091B34B3EB60A9400C02 /* PBXShellScriptBuildPhase.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0C1DB5AAE5C62E5351BBB35F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		1AADF09199F79612883EE5EF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		201DCF3149264E9D8AB4CA97 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4A2EC1B2D6969F717CB890DE;
+			remoteInfo = PathKit;
+		};
+		20EC77CE7C6AAE2A1679866F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F12050E30563A81EEBB2EA9B;
+			remoteInfo = generator.library;
+		};
+		2C860512D9D794C14E15BE5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A09CE18EBBDAC65CD0C6B7D1;
+			remoteInfo = XcodeProj;
+		};
+		34739E478519DAF595040254 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9DF90F35406923EA23C68CFC;
+			remoteInfo = XCTestDynamicOverlay;
+		};
+		3E98853617DD142D01E4ECD4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		44D67FDCCFE036B1BE7F2490 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 302F4C6E9EE3F09D4809EF0A;
+			remoteInfo = CustomDump;
+		};
+		47A49BF151336CCF2D4909B1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		5860D57390AE14C57D4A302E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 886150B3C63D0DBEF9BB4E6B;
+			remoteInfo = AEXML;
+		};
+		85F8D55A5DDD5984E2D5D3A9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		C6503A028754D96CDB93B208 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		CD181E6AF3DFD2EF12094EE5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4A2EC1B2D6969F717CB890DE;
+			remoteInfo = PathKit;
+		};
+		CE545ADAA24F8CEBE7071545 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F12050E30563A81EEBB2EA9B;
+			remoteInfo = generator.library;
+		};
+		D9E85C3E10A5FA1310BBEA9A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		F2EEA6546190185B5EED5115 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		007E626D3C6303C4B848B3F6 /* XCSchemeManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCSchemeManagement.swift; sourceTree = "<group>"; };
+		00CD1A85389190652E1BEFC9 /* StoreKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKit.swift; sourceTree = "<group>"; };
+		01004934C429F4A4F09C0C85 /* XCScheme+ProfileAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+ProfileAction.swift"; sourceTree = "<group>"; };
+		0138A3545FE63C005CFAB42F /* XCWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspace.swift; sourceTree = "<group>"; };
+		0152B8A419980E27BD7EE5FB /* PBXReferenceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXReferenceProxy.swift; sourceTree = "<group>"; };
+		02819512A69FF33D58EBA61C /* XCScheme+BuildableReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+BuildableReference.swift"; sourceTree = "<group>"; };
+		028AFCA25E6642D1781D7370 /* tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		03D689E51BC21F8670813CA7 /* XCScheme+ArchiveAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+ArchiveAction.swift"; sourceTree = "<group>"; };
+		0484B5B7FF46952C7EBA2E20 /* String+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Utils.swift"; sourceTree = "<group>"; };
+		053AD1C0C7003B91D7B9EB16 /* XCScheme+RemoteRunnable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+RemoteRunnable.swift"; sourceTree = "<group>"; };
+		05B56CD9E6641A10324B096B /* Generator+WriteXcodeProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+WriteXcodeProj.swift"; sourceTree = "<group>"; };
+		0654DDFDA028387BCAF843F8 /* XCScheme+TestItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+TestItem.swift"; sourceTree = "<group>"; };
+		073FBA88B39294943DB5E5A4 /* XCScheme+LocationScenarioReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+LocationScenarioReference.swift"; sourceTree = "<group>"; };
+		0B1A9C414C17FC0CB546CCF5 /* XCScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCScheme.swift; sourceTree = "<group>"; };
+		0D06530EE100F0FBF5366BC5 /* PBXRezBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXRezBuildPhase.swift; sourceTree = "<group>"; };
+		117052ABC66769C11B7F397A /* XCScheme+BuildAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+BuildAction.swift"; sourceTree = "<group>"; };
+		1311F2E17F171A48A8E3B180 /* Dictionary+Enumerate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Enumerate.swift"; sourceTree = "<group>"; };
+		133D091B34B3EB60A9400C02 /* PBXShellScriptBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXShellScriptBuildPhase.swift; sourceTree = "<group>"; };
+		173203DBAEA88407DBBF109D /* Dump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dump.swift; sourceTree = "<group>"; };
+		1A247C10F4C33288C1500D2D /* Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Swift.swift; sourceTree = "<group>"; };
+		1C7DE6268B49662138FC0C90 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		1D3C9C8DAFC01EECD746E229 /* Target+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Target+Testing.swift"; sourceTree = "<group>"; };
+		1DA5F81BF5F85E9032BC2014 /* PBXObjectReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXObjectReference.swift; sourceTree = "<group>"; };
+		1E299B0F3C05FB32D2951414 /* PBXBuildFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildFile.swift; sourceTree = "<group>"; };
+		1E3D4E7C841C2C89DF095466 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		1E4C427036C3EA7632B3C787 /* PBXVariantGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXVariantGroup.swift; sourceTree = "<group>"; };
+		1EFFE6348E347FF9ED001081 /* CustomDumpReflectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDumpReflectable.swift; sourceTree = "<group>"; };
+		1FC04FD3CCB6BC640D46E158 /* XCScheme+BuildableProductRunnable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+BuildableProductRunnable.swift"; sourceTree = "<group>"; };
+		20A47D52C1A48A1ED498719F /* XcodeProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeProj.swift; sourceTree = "<group>"; };
+		230BF7ABCF5D7C48951A8641 /* XcodeProj+CustomDump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XcodeProj+CustomDump.swift"; sourceTree = "<group>"; };
+		25072DE452FF8EC4AC148C4A /* GeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratorTests.swift; sourceTree = "<group>"; };
+		2597D69F32EE134D35CA5EED /* Path+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+Extras.swift"; sourceTree = "<group>"; };
+		268CB0584C901D862BCEF28A /* Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
+		27A40DA2B2633E2E5090B39B /* CustomDumpRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDumpRepresentable.swift; sourceTree = "<group>"; };
+		29A1E648AD1793142280604D /* XCScheme+AditionalOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+AditionalOption.swift"; sourceTree = "<group>"; };
+		2ABD1C801DC25791CF7A9BC2 /* PlistValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistValue.swift; sourceTree = "<group>"; };
+		2BBD0DBAFB6DB4E966DC49EB /* PBXOutputSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXOutputSettings.swift; sourceTree = "<group>"; };
+		2BCF03A21336243CA3242059 /* PBXGroup+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXGroup+Extensions.swift"; sourceTree = "<group>"; };
+		2C7832C26060C56DE2EAB1A1 /* SetTargetDependenciesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTargetDependenciesTests.swift; sourceTree = "<group>"; };
+		30D832D39987A4A2D6FC32FC /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		350D61290C1B602B60DA483A /* PBXAggregateTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXAggregateTarget.swift; sourceTree = "<group>"; };
+		35445591FE5C7D2FCEF9533F /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		356817EF2BC65A89F7FB439C /* UserNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotifications.swift; sourceTree = "<group>"; };
+		3BCF6545A3BFB3B32552A669 /* libAEXML.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAEXML.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CEA06E5C81DCD25281036C7 /* PBXGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXGroup.swift; sourceTree = "<group>"; };
+		3DBD527BA62C0B5EDF789F71 /* Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sorting.swift; sourceTree = "<group>"; };
+		3E3504926798E0F993FC929F /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
+		425B4EC528B607EEF98825F6 /* BuildSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettings.swift; sourceTree = "<group>"; };
+		430A0E83DF369E5ED390CA3A /* XCScheme+AnalyzeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+AnalyzeAction.swift"; sourceTree = "<group>"; };
+		4427E84F30EE600A2E568520 /* XCSwiftPackageProductDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCSwiftPackageProductDependency.swift; sourceTree = "<group>"; };
+		457C541A86E3F05E0865CB70 /* XCScheme+ExecutionAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+ExecutionAction.swift"; sourceTree = "<group>"; };
+		485411F2F79794474B9E8AAB /* GameKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameKit.swift; sourceTree = "<group>"; };
+		48AE2420614CF62AD4A8AAB1 /* String+md5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+md5.swift"; sourceTree = "<group>"; };
+		48F07848723835EC26C2340C /* XCScheme+EnvironmentVariable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+EnvironmentVariable.swift"; sourceTree = "<group>"; };
+		493423CD8285C46D06C4169D /* PathExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathExtensionsTests.swift; sourceTree = "<group>"; };
+		49925538DB74BB9BE745F17F /* BuildSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSetting.swift; sourceTree = "<group>"; };
+		4A6A84F2CC6A006E28720D2B /* XCScheme+Runnable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+Runnable.swift"; sourceTree = "<group>"; };
+		52B537637F91E4A43CAE2CF2 /* PBXBuildRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildRule.swift; sourceTree = "<group>"; };
+		55071574526ADBF7683AB165 /* CoreImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreImage.swift; sourceTree = "<group>"; };
+		57369B9A38B6DCB2216526AE /* Generator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generator.swift; sourceTree = "<group>"; };
+		57A4D6EC3E7B8473C776A368 /* CompileStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompileStub.swift; sourceTree = "<group>"; };
+		57B23BC150E3266757707492 /* XCScheme+CommandLineArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+CommandLineArguments.swift"; sourceTree = "<group>"; };
+		57CD85080B3E34F2529D7CB8 /* PBXProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProj.swift; sourceTree = "<group>"; };
+		58F2246D7AB62C07E1D092E7 /* XCScheme+SerialAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+SerialAction.swift"; sourceTree = "<group>"; };
+		5A0D02295BBDD7113D940406 /* ReferenceGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferenceGenerator.swift; sourceTree = "<group>"; };
+		5E517675E70186E73924EB60 /* XCScheme+TestableReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+TestableReference.swift"; sourceTree = "<group>"; };
+		5E7B2DB807B1509ABDD69E31 /* libXCTestDynamicOverlay.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libXCTestDynamicOverlay.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		5FBDAA5A97ECD9AA378B9305 /* libCustomDump.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCustomDump.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		6130F9568982104094E3C618 /* Bool+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bool+Extras.swift"; sourceTree = "<group>"; };
+		6236535683C7CE49C73F48A2 /* SearchPaths.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchPaths.swift; sourceTree = "<group>"; };
+		63E2669DF0B74F219B31D9AB /* Inputs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inputs.swift; sourceTree = "<group>"; };
+		65EB8E516EB0D2F51A692233 /* XCWorkspaceDataElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataElement.swift; sourceTree = "<group>"; };
+		6633E691F2753B78D68DD3C9 /* XCConfigurationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCConfigurationList.swift; sourceTree = "<group>"; };
+		6715701A6A75A2BFF85172AD /* XCTFail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTFail.swift; sourceTree = "<group>"; };
+		67D085A4397A412E35122016 /* XCWorkspaceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceData.swift; sourceTree = "<group>"; };
+		68733F62C401C1AA84617E96 /* KeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPath.swift; sourceTree = "<group>"; };
+		6A9607F1AB28FE727DED4651 /* CreateProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProjectTests.swift; sourceTree = "<group>"; };
+		6B175666DC0102DE35EBD173 /* XCRemoteSwiftPackageReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCRemoteSwiftPackageReference.swift; sourceTree = "<group>"; };
+		6BD756B2EEB174424376D063 /* Writable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Writable.swift; sourceTree = "<group>"; };
+		6C89E41DF806BDFD0AF9A374 /* Photos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Photos.swift; sourceTree = "<group>"; };
+		7025166F1EB392F463C551D2 /* CreateXcodeProjTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateXcodeProjTests.swift; sourceTree = "<group>"; };
+		703888D148E8FEB96A8F9716 /* Generator+CreateXcodeProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateXcodeProj.swift"; sourceTree = "<group>"; };
+		71DFD69623D237CF63C0F232 /* PBXSourceTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXSourceTree.swift; sourceTree = "<group>"; };
+		721F82FE7F5FD35511FFFB2B /* Decoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoders.swift; sourceTree = "<group>"; };
+		726579883BDE5C574DD25742 /* Xcode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Xcode.swift; sourceTree = "<group>"; };
+		737B837AF4D301FD49E5E8DC /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		73AF6892EDF00CA059623628 /* PBXNativeTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXNativeTarget.swift; sourceTree = "<group>"; };
+		746AD1E908901BF77306B564 /* ProcessTargetMergesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessTargetMergesTests.swift; sourceTree = "<group>"; };
+		74842CED67D00EEEC35928F3 /* Diff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diff.swift; sourceTree = "<group>"; };
+		748E5C2D56A2ED06BF8F5D39 /* XCWorkspaceDataGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataGroup.swift; sourceTree = "<group>"; };
+		75A07F338721C699EE9FDCA9 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		77B0689562B36DE6F3668B6E /* PBXContainerItemProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXContainerItemProxy.swift; sourceTree = "<group>"; };
+		789CE33EA9AD15B97F5AA88F /* UserNotificationsUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationsUI.swift; sourceTree = "<group>"; };
+		7A134E3CBDC57315EE1B0221 /* Element.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Element.swift; sourceTree = "<group>"; };
+		7AC44F6F9D5F1EBF4D7110DD /* XCConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCConfig.swift; sourceTree = "<group>"; };
+		7D7BF60244CDDEB8780E0A1B /* PBXHeadersBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXHeadersBuildPhase.swift; sourceTree = "<group>"; };
+		7EFA193BCD097396D150AF96 /* Document.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
+		80ED158A6F786B03F1C41998 /* PBXProductType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXProductType+Extensions.swift"; sourceTree = "<group>"; };
+		865D483D2084AABC408B35CD /* Generator+AddTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+AddTargets.swift"; sourceTree = "<group>"; };
+		86D81D32EB64919C01CE7321 /* KeyedDecodingContainer+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Additions.swift"; sourceTree = "<group>"; };
+		87D5D2AB0B152D5CA6FB9ADF /* libgenerator.library.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libgenerator.library.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8986F9BDAD8DB56D61CBB787 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		8BE9C68C0607CFD069F19187 /* Generator+Main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+Main.swift"; sourceTree = "<group>"; };
+		8D6BEA2725F47B747D67B18F /* generator */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = generator; sourceTree = BUILT_PRODUCTS_DIR; };
+		8EA8095620DFED5335900D24 /* XCScheme+LaunchAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+LaunchAction.swift"; sourceTree = "<group>"; };
+		8F0B7B94D16AAD3979ACCEFA /* PBXProj+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXProj+Testing.swift"; sourceTree = "<group>"; };
+		8FB97F8B9DCAC47C22823253 /* XCScheme+TestPlanReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+TestPlanReference.swift"; sourceTree = "<group>"; };
+		90DF1CB872B6732ED05BCF9A /* PBXTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXTarget.swift; sourceTree = "<group>"; };
+		9495B72CA99FFB15C026408A /* Generator+DisambiguateTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+DisambiguateTargets.swift"; sourceTree = "<group>"; };
+		94D486D370E6E28447869688 /* PBXFileElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXFileElement.swift; sourceTree = "<group>"; };
+		9522A589868D9D2C515C4822 /* Generator+CreateProject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateProject.swift"; sourceTree = "<group>"; };
+		958D118534D347C200B0701A /* PBXCopyFilesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXCopyFilesBuildPhase.swift; sourceTree = "<group>"; };
+		97C1C5D545E3B4CA06474BDC /* XCWorkspaceDataFileRef.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataFileRef.swift; sourceTree = "<group>"; };
+		99D663E878398F3764B9C1A8 /* UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKit.swift; sourceTree = "<group>"; };
+		9AC122F4DE7028197FE1C177 /* XCScheme+StoreKitConfigurationFileReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+StoreKitConfigurationFileReference.swift"; sourceTree = "<group>"; };
+		9AC38B9E7BDCEE1A00F253C2 /* Array+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Extras.swift"; sourceTree = "<group>"; };
+		9DE54A5806DB0C02CD8FB55D /* Equality.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Equality.generated.swift; sourceTree = "<group>"; };
+		9E80C203DC9A482C0F657AE7 /* Generator+ProcessTargetMerges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+ProcessTargetMerges.swift"; sourceTree = "<group>"; };
+		9F395A784F145A641B09FC95 /* PBXBatchUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBatchUpdater.swift; sourceTree = "<group>"; };
+		A0C6BD71C5B59C200AE8F91C /* PBXFileReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXFileReference.swift; sourceTree = "<group>"; };
+		A0ED50B45C327F01289522B0 /* libPathKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPathKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1B9525BCADA7A75978D1FCC /* CollectionDifference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionDifference.swift; sourceTree = "<group>"; };
+		A20E781CE891F4AB4B0E4C30 /* Dictionary+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extras.swift"; sourceTree = "<group>"; };
+		A40EB7581064768B08E6C529 /* CreateProductsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProductsTest.swift; sourceTree = "<group>"; };
+		A42EAB1A5AEF651AF8F6F865 /* CreateFilesAndGroupsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateFilesAndGroupsTests.swift; sourceTree = "<group>"; };
+		A4E0D9481DEB5CB89790C09F /* PBXTargetDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXTargetDependency.swift; sourceTree = "<group>"; };
+		A73417EAFFC70439C38BFDB6 /* SetTargetConfigurations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTargetConfigurations.swift; sourceTree = "<group>"; };
+		A9A42BDD634CA3FA35830AE1 /* PBXProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProductType.swift; sourceTree = "<group>"; };
+		AA3B2C353EE2A9D305660B47 /* XCTAssertNoDifference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTAssertNoDifference.swift; sourceTree = "<group>"; };
+		AA8657DAF8012A508E7FEE54 /* PBXObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXObjects.swift; sourceTree = "<group>"; };
+		ABB466879747C3652D74FE85 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
+		AC11446A42A073B91FFC6262 /* PBXProjEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProjEncoder.swift; sourceTree = "<group>"; };
+		AC7F0486AC72B3E68F194D01 /* PathKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathKit.swift; sourceTree = "<group>"; };
+		AF072F61E054955564EECDA2 /* CustomDumpStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDumpStringConvertible.swift; sourceTree = "<group>"; };
+		B2F851023E4F4913D1E369CE /* JSONDecoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoding.swift; sourceTree = "<group>"; };
+		B379DE01A53B895F83E8846C /* AEXML+XcodeFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AEXML+XcodeFormat.swift"; sourceTree = "<group>"; };
+		B40DA547773CCE961E1E2CCD /* TargetID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetID.swift; sourceTree = "<group>"; };
+		B41944A58347442213CC45E6 /* CoreMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreMotion.swift; sourceTree = "<group>"; };
+		BC8220ADCB2EE90910140F8F /* CoreLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreLocation.swift; sourceTree = "<group>"; };
+		BCB3EDAEB4E2CAE755B7284B /* PBXObjectParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXObjectParser.swift; sourceTree = "<group>"; };
+		BD9354E6340A0B10BEB1FDEE /* XCBuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCBuildConfiguration.swift; sourceTree = "<group>"; };
+		BFE25BEDFD3646AD0AB54C40 /* PBXContainerItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXContainerItem.swift; sourceTree = "<group>"; };
+		BFF420FAF127AC6B393E4678 /* PBXResourcesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXResourcesBuildPhase.swift; sourceTree = "<group>"; };
+		C48CF60E64EACBE1F8C63D3D /* XCWorkspaceDataElementLocationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataElementLocationType.swift; sourceTree = "<group>"; };
+		C5B0A0B7C1D6A4838956E41C /* Path+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+Extensions.swift"; sourceTree = "<group>"; };
+		C680A79739F778E13D555285 /* AnyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyType.swift; sourceTree = "<group>"; };
+		C6E1E2200AB2DCA91F4999CE /* FilePathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePathResolver.swift; sourceTree = "<group>"; };
+		C7281BBDA526D590DB2E6B19 /* libXcodeProj.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libXcodeProj.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C9558541CFD5066169CA9773 /* Generator+CreateProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateProducts.swift"; sourceTree = "<group>"; };
+		CB357A8A7280647E5513166A /* Foundation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Foundation.swift; sourceTree = "<group>"; };
+		D323B626241F566F3B8A2CB7 /* SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI.swift; sourceTree = "<group>"; };
+		D432B71433F4134FFBFA281B /* CommentedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentedString.swift; sourceTree = "<group>"; };
+		D4E1EBEDD54BAF02A22166DB /* PBXFrameworksBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXFrameworksBuildPhase.swift; sourceTree = "<group>"; };
+		D9993D3F386DFC594BC0967A /* XCScheme+PathRunnable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+PathRunnable.swift"; sourceTree = "<group>"; };
+		DACBE49740AB347EFAE8EC00 /* AddTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTargetsTests.swift; sourceTree = "<group>"; };
+		DD828AC8336C5A1F0C951071 /* BuildSettingsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettingsProvider.swift; sourceTree = "<group>"; };
+		DDF5D934175EDDA9EF296101 /* NSRecursiveLock+Sync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRecursiveLock+Sync.swift"; sourceTree = "<group>"; };
+		DF0C30E65D6E9C205B83B73E /* Sourcery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sourcery.swift; sourceTree = "<group>"; };
+		E0413D918157ADBE8DAEA92D /* Mirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mirror.swift; sourceTree = "<group>"; };
+		E1A035CBED0F4DCF5A388F10 /* Generator+SetTargetConfigurations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+SetTargetConfigurations.swift"; sourceTree = "<group>"; };
+		E43EBF1E6F26B25BB157D396 /* PBXBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildPhase.swift; sourceTree = "<group>"; };
+		E4507DAF85285409A7CA226E /* PBXObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXObject.swift; sourceTree = "<group>"; };
+		E6E27E547A12A951FF64D0C4 /* Box.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
+		E7C28A43616AE9FC78C05EE0 /* XCBreakpointList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCBreakpointList.swift; sourceTree = "<group>"; };
+		EAADA80AB2FBFD1EB2A75A3D /* PBXSourcesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXSourcesBuildPhase.swift; sourceTree = "<group>"; };
+		EBD705CC770A884D5A78D17D /* Generator+CreateFilesAndGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateFilesAndGroups.swift"; sourceTree = "<group>"; };
+		EDE03F64CA13C3461D45773E /* DisambiguateTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisambiguateTargetsTests.swift; sourceTree = "<group>"; };
+		EE677C0FD789C4A0ADDC1901 /* BuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPhase.swift; sourceTree = "<group>"; };
+		F0725D1FE9D931F37B2F6AA3 /* DTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTO.swift; sourceTree = "<group>"; };
+		F0AD1D57FD4037EC5BB72645 /* XCSharedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCSharedData.swift; sourceTree = "<group>"; };
+		F238F3E44302DBE53FF70525 /* Fixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixtures.swift; sourceTree = "<group>"; };
+		F37821F06B32120001F7E12D /* PBXLegacyTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXLegacyTarget.swift; sourceTree = "<group>"; };
+		F4ABCD1903D2A2F3FAE064BC /* WorkspaceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSettings.swift; sourceTree = "<group>"; };
+		F4D918C1EA31CECDFC8FF2F6 /* FilePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePath.swift; sourceTree = "<group>"; };
+		F8C59EAFFB7EF2605BF76058 /* XCVersionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCVersionGroup.swift; sourceTree = "<group>"; };
+		F972F9B12146B979CA3E0318 /* PBXProject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProject.swift; sourceTree = "<group>"; };
+		FCEBA76F789E9D71187DFF61 /* PopulateMainGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopulateMainGroupTests.swift; sourceTree = "<group>"; };
+		FD75BB5F3720A6C4B51A43DF /* Generator+PopulateMainGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+PopulateMainGroup.swift"; sourceTree = "<group>"; };
+		FDF69A69C5C9048DCF61E301 /* XCScheme+TestAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+TestAction.swift"; sourceTree = "<group>"; };
+		FE1ED821757FFFB97CF9BCA3 /* Speech.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Speech.swift; sourceTree = "<group>"; };
+		FF368C9DB075CBC4E63E0BCA /* Generator+SetTargetDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+SetTargetDependencies.swift"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		07671B3685AFF2D6FBC54376 /* SwiftPackage */ = {
+			isa = PBXGroup;
+			children = (
+				6B175666DC0102DE35EBD173 /* XCRemoteSwiftPackageReference.swift */,
+				4427E84F30EE600A2E568520 /* XCSwiftPackageProductDependency.swift */,
+			);
+			path = SwiftPackage;
+			sourceTree = "<group>";
+		};
+		0928471E270C9807EBDA43B3 /* Scheme */ = {
+			isa = PBXGroup;
+			children = (
+				0B1A9C414C17FC0CB546CCF5 /* XCScheme.swift */,
+				29A1E648AD1793142280604D /* XCScheme+AditionalOption.swift */,
+				430A0E83DF369E5ED390CA3A /* XCScheme+AnalyzeAction.swift */,
+				03D689E51BC21F8670813CA7 /* XCScheme+ArchiveAction.swift */,
+				1FC04FD3CCB6BC640D46E158 /* XCScheme+BuildableProductRunnable.swift */,
+				02819512A69FF33D58EBA61C /* XCScheme+BuildableReference.swift */,
+				117052ABC66769C11B7F397A /* XCScheme+BuildAction.swift */,
+				57B23BC150E3266757707492 /* XCScheme+CommandLineArguments.swift */,
+				48F07848723835EC26C2340C /* XCScheme+EnvironmentVariable.swift */,
+				457C541A86E3F05E0865CB70 /* XCScheme+ExecutionAction.swift */,
+				8EA8095620DFED5335900D24 /* XCScheme+LaunchAction.swift */,
+				073FBA88B39294943DB5E5A4 /* XCScheme+LocationScenarioReference.swift */,
+				D9993D3F386DFC594BC0967A /* XCScheme+PathRunnable.swift */,
+				01004934C429F4A4F09C0C85 /* XCScheme+ProfileAction.swift */,
+				053AD1C0C7003B91D7B9EB16 /* XCScheme+RemoteRunnable.swift */,
+				4A6A84F2CC6A006E28720D2B /* XCScheme+Runnable.swift */,
+				58F2246D7AB62C07E1D092E7 /* XCScheme+SerialAction.swift */,
+				9AC122F4DE7028197FE1C177 /* XCScheme+StoreKitConfigurationFileReference.swift */,
+				5E517675E70186E73924EB60 /* XCScheme+TestableReference.swift */,
+				FDF69A69C5C9048DCF61E301 /* XCScheme+TestAction.swift */,
+				0654DDFDA028387BCAF843F8 /* XCScheme+TestItem.swift */,
+				8FB97F8B9DCAC47C22823253 /* XCScheme+TestPlanReference.swift */,
+				007E626D3C6303C4B848B3F6 /* XCSchemeManagement.swift */,
+			);
+			path = Scheme;
+			sourceTree = "<group>";
+		};
+		1670DF55054806935D88B182 /* Errors */ = {
+			isa = PBXGroup;
+			children = (
+				737B837AF4D301FD49E5E8DC /* Errors.swift */,
+			);
+			path = Errors;
+			sourceTree = "<group>";
+		};
+		2328A8EAE944F9AE4107A7D9 /* com_github_pointfreeco_xctest_dynamic_overlay */ = {
+			isa = PBXGroup;
+			children = (
+				4FBEE702AF377A840BE7137B /* Sources */,
+			);
+			path = com_github_pointfreeco_xctest_dynamic_overlay;
+			sourceTree = "<group>";
+		};
+		2F2933DE92373728EBF7D101 /* Conformances */ = {
+			isa = PBXGroup;
+			children = (
+				55071574526ADBF7683AB165 /* CoreImage.swift */,
+				BC8220ADCB2EE90910140F8F /* CoreLocation.swift */,
+				B41944A58347442213CC45E6 /* CoreMotion.swift */,
+				CB357A8A7280647E5513166A /* Foundation.swift */,
+				485411F2F79794474B9E8AAB /* GameKit.swift */,
+				68733F62C401C1AA84617E96 /* KeyPath.swift */,
+				6C89E41DF806BDFD0AF9A374 /* Photos.swift */,
+				FE1ED821757FFFB97CF9BCA3 /* Speech.swift */,
+				00CD1A85389190652E1BEFC9 /* StoreKit.swift */,
+				1A247C10F4C33288C1500D2D /* Swift.swift */,
+				D323B626241F566F3B8A2CB7 /* SwiftUI.swift */,
+				99D663E878398F3764B9C1A8 /* UIKit.swift */,
+				356817EF2BC65A89F7FB439C /* UserNotifications.swift */,
+				789CE33EA9AD15B97F5AA88F /* UserNotificationsUI.swift */,
+			);
+			path = Conformances;
+			sourceTree = "<group>";
+		};
+		2F82B6A6CF4F055994D6E6DB /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				6BD756B2EEB174424376D063 /* Writable.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
+		3892FC006C39FA3AEF7C87B8 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				5472C482D2DA7A009D92EF3B /* AEXML */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		3CD4C9DD5760967263828581 /* CustomDump */ = {
+			isa = PBXGroup;
+			children = (
+				2F2933DE92373728EBF7D101 /* Conformances */,
+				B26BE9E6A43556966A02F6E0 /* Internal */,
+				1EFFE6348E347FF9ED001081 /* CustomDumpReflectable.swift */,
+				27A40DA2B2633E2E5090B39B /* CustomDumpRepresentable.swift */,
+				AF072F61E054955564EECDA2 /* CustomDumpStringConvertible.swift */,
+				74842CED67D00EEEC35928F3 /* Diff.swift */,
+				173203DBAEA88407DBBF109D /* Dump.swift */,
+				AA3B2C353EE2A9D305660B47 /* XCTAssertNoDifference.swift */,
+			);
+			path = CustomDump;
+			sourceTree = "<group>";
+		};
+		40A6EF3C78498425D13BFEB2 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				49925538DB74BB9BE745F17F /* BuildSetting.swift */,
+				F0725D1FE9D931F37B2F6AA3 /* DTO.swift */,
+				30D832D39987A4A2D6FC32FC /* Environment.swift */,
+				1C7DE6268B49662138FC0C90 /* Errors.swift */,
+				F4D918C1EA31CECDFC8FF2F6 /* FilePath.swift */,
+				C6E1E2200AB2DCA91F4999CE /* FilePathResolver.swift */,
+				57369B9A38B6DCB2216526AE /* Generator.swift */,
+				865D483D2084AABC408B35CD /* Generator+AddTargets.swift */,
+				EBD705CC770A884D5A78D17D /* Generator+CreateFilesAndGroups.swift */,
+				C9558541CFD5066169CA9773 /* Generator+CreateProducts.swift */,
+				9522A589868D9D2C515C4822 /* Generator+CreateProject.swift */,
+				703888D148E8FEB96A8F9716 /* Generator+CreateXcodeProj.swift */,
+				9495B72CA99FFB15C026408A /* Generator+DisambiguateTargets.swift */,
+				8BE9C68C0607CFD069F19187 /* Generator+Main.swift */,
+				FD75BB5F3720A6C4B51A43DF /* Generator+PopulateMainGroup.swift */,
+				9E80C203DC9A482C0F657AE7 /* Generator+ProcessTargetMerges.swift */,
+				E1A035CBED0F4DCF5A388F10 /* Generator+SetTargetConfigurations.swift */,
+				FF368C9DB075CBC4E63E0BCA /* Generator+SetTargetDependencies.swift */,
+				05B56CD9E6641A10324B096B /* Generator+WriteXcodeProj.swift */,
+				63E2669DF0B74F219B31D9AB /* Inputs.swift */,
+				1E3D4E7C841C2C89DF095466 /* Logger.swift */,
+				C5B0A0B7C1D6A4838956E41C /* Path+Extensions.swift */,
+				2BCF03A21336243CA3242059 /* PBXGroup+Extensions.swift */,
+				80ED158A6F786B03F1C41998 /* PBXProductType+Extensions.swift */,
+				6236535683C7CE49C73F48A2 /* SearchPaths.swift */,
+				3DBD527BA62C0B5EDF789F71 /* Sorting.swift */,
+				B40DA547773CCE961E1E2CCD /* TargetID.swift */,
+			);
+			path = src;
+			sourceTree = "<group>";
+		};
+		492A9D78BA7221EE483135CD /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				704BCAB390969CFA18009EE7 /* XcodeProj */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		4CD9FD851AAB9D67FD19FF81 /* com_github_kylef_pathkit */ = {
+			isa = PBXGroup;
+			children = (
+				97594A84BD435DE7803174AC /* Sources */,
+			);
+			path = com_github_kylef_pathkit;
+			sourceTree = "<group>";
+		};
+		4FBEE702AF377A840BE7137B /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				D10A9AF7B845AE03CD6F433F /* XCTestDynamicOverlay */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		5472C482D2DA7A009D92EF3B /* AEXML */ = {
+			isa = PBXGroup;
+			children = (
+				7EFA193BCD097396D150AF96 /* Document.swift */,
+				7A134E3CBDC57315EE1B0221 /* Element.swift */,
+				ABB466879747C3652D74FE85 /* Error.swift */,
+				268CB0584C901D862BCEF28A /* Options.swift */,
+				3E3504926798E0F993FC929F /* Parser.swift */,
+			);
+			path = AEXML;
+			sourceTree = "<group>";
+		};
+		593E7C82FAAD94A7E6A04318 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				8D6BEA2725F47B747D67B18F /* generator */,
+				3BCF6545A3BFB3B32552A669 /* libAEXML.a */,
+				5FBDAA5A97ECD9AA378B9305 /* libCustomDump.a */,
+				87D5D2AB0B152D5CA6FB9ADF /* libgenerator.library.a */,
+				A0ED50B45C327F01289522B0 /* libPathKit.a */,
+				C7281BBDA526D590DB2E6B19 /* libXcodeProj.a */,
+				5E7B2DB807B1509ABDD69E31 /* libXCTestDynamicOverlay.a */,
+				028AFCA25E6642D1781D7370 /* tests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		61AD97755080C09562F102AE /* Workspace */ = {
+			isa = PBXGroup;
+			children = (
+				0138A3545FE63C005CFAB42F /* XCWorkspace.swift */,
+				67D085A4397A412E35122016 /* XCWorkspaceData.swift */,
+				65EB8E516EB0D2F51A692233 /* XCWorkspaceDataElement.swift */,
+				C48CF60E64EACBE1F8C63D3D /* XCWorkspaceDataElementLocationType.swift */,
+				97C1C5D545E3B4CA06474BDC /* XCWorkspaceDataFileRef.swift */,
+				748E5C2D56A2ED06BF8F5D39 /* XCWorkspaceDataGroup.swift */,
+			);
+			path = Workspace;
+			sourceTree = "<group>";
+		};
+		6EF3A79C8E962E540EC231B4 /* Targets */ = {
+			isa = PBXGroup;
+			children = (
+				350D61290C1B602B60DA483A /* PBXAggregateTarget.swift */,
+				F37821F06B32120001F7E12D /* PBXLegacyTarget.swift */,
+				73AF6892EDF00CA059623628 /* PBXNativeTarget.swift */,
+				A9A42BDD634CA3FA35830AE1 /* PBXProductType.swift */,
+				0152B8A419980E27BD7EE5FB /* PBXReferenceProxy.swift */,
+				90DF1CB872B6732ED05BCF9A /* PBXTarget.swift */,
+				A4E0D9481DEB5CB89790C09F /* PBXTargetDependency.swift */,
+			);
+			path = Targets;
+			sourceTree = "<group>";
+		};
+		704BCAB390969CFA18009EE7 /* XcodeProj */ = {
+			isa = PBXGroup;
+			children = (
+				1670DF55054806935D88B182 /* Errors */,
+				AFFE4010B3DE95C4FC9920A3 /* Extensions */,
+				ED9B8640D3E2EFC89A122EA2 /* Objects */,
+				E8CBCA40694FC788C0E8E07D /* Project */,
+				2F82B6A6CF4F055994D6E6DB /* Protocols */,
+				0928471E270C9807EBDA43B3 /* Scheme */,
+				CCF397C5064E8B5EF7CB019D /* Utils */,
+				61AD97755080C09562F102AE /* Workspace */,
+			);
+			path = XcodeProj;
+			sourceTree = "<group>";
+		};
+		73CEA667F51A4B28BFA414FB /* tools */ = {
+			isa = PBXGroup;
+			children = (
+				926156400E723502E6048C74 /* generator */,
+			);
+			path = tools;
+			sourceTree = "<group>";
+		};
+		7D18D899CB85410F3722734E /* com_github_tadija_aexml */ = {
+			isa = PBXGroup;
+			children = (
+				3892FC006C39FA3AEF7C87B8 /* Sources */,
+			);
+			path = com_github_tadija_aexml;
+			sourceTree = "<group>";
+		};
+		926156400E723502E6048C74 /* generator */ = {
+			isa = PBXGroup;
+			children = (
+				40A6EF3C78498425D13BFEB2 /* src */,
+				AB5B741CDFA2CF76B2800D91 /* test */,
+				75A07F338721C699EE9FDCA9 /* BUILD */,
+			);
+			path = generator;
+			sourceTree = "<group>";
+		};
+		95AA1DB04311484BD8DF9D8A /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				425B4EC528B607EEF98825F6 /* BuildSettings.swift */,
+				BD9354E6340A0B10BEB1FDEE /* XCBuildConfiguration.swift */,
+				6633E691F2753B78D68DD3C9 /* XCConfigurationList.swift */,
+			);
+			path = Configuration;
+			sourceTree = "<group>";
+		};
+		97594A84BD435DE7803174AC /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				AC7F0486AC72B3E68F194D01 /* PathKit.swift */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		9811D2ED915829A1A7881AFD /* Bazel External Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				4CD9FD851AAB9D67FD19FF81 /* com_github_kylef_pathkit */,
+				D7FFCD6C56706B85E75B3AF7 /* com_github_pointfreeco_swift_custom_dump */,
+				2328A8EAE944F9AE4107A7D9 /* com_github_pointfreeco_xctest_dynamic_overlay */,
+				7D18D899CB85410F3722734E /* com_github_tadija_aexml */,
+				CCD52FD22F080CD6DA9BD957 /* com_github_tuist_xcodeproj */,
+			);
+			name = "Bazel External Repositories";
+			path = "bazel-rules_xcodeproj/external";
+			sourceTree = "<group>";
+		};
+		9CFB3134561D99EEDB0FD551 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				3CD4C9DD5760967263828581 /* CustomDump */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		A403C77530EAF2A33B494AAD /* BuildPhase */ = {
+			isa = PBXGroup;
+			children = (
+				EE677C0FD789C4A0ADDC1901 /* BuildPhase.swift */,
+				1E299B0F3C05FB32D2951414 /* PBXBuildFile.swift */,
+				E43EBF1E6F26B25BB157D396 /* PBXBuildPhase.swift */,
+				52B537637F91E4A43CAE2CF2 /* PBXBuildRule.swift */,
+				958D118534D347C200B0701A /* PBXCopyFilesBuildPhase.swift */,
+				D4E1EBEDD54BAF02A22166DB /* PBXFrameworksBuildPhase.swift */,
+				7D7BF60244CDDEB8780E0A1B /* PBXHeadersBuildPhase.swift */,
+				BFF420FAF127AC6B393E4678 /* PBXResourcesBuildPhase.swift */,
+				0D06530EE100F0FBF5366BC5 /* PBXRezBuildPhase.swift */,
+				133D091B34B3EB60A9400C02 /* PBXShellScriptBuildPhase.swift */,
+				EAADA80AB2FBFD1EB2A75A3D /* PBXSourcesBuildPhase.swift */,
+			);
+			path = BuildPhase;
+			sourceTree = "<group>";
+		};
+		A4C8A4E2E85C952486F42381 /* Files */ = {
+			isa = PBXGroup;
+			children = (
+				BFE25BEDFD3646AD0AB54C40 /* PBXContainerItem.swift */,
+				77B0689562B36DE6F3668B6E /* PBXContainerItemProxy.swift */,
+				94D486D370E6E28447869688 /* PBXFileElement.swift */,
+				A0C6BD71C5B59C200AE8F91C /* PBXFileReference.swift */,
+				3CEA06E5C81DCD25281036C7 /* PBXGroup.swift */,
+				71DFD69623D237CF63C0F232 /* PBXSourceTree.swift */,
+				1E4C427036C3EA7632B3C787 /* PBXVariantGroup.swift */,
+				F8C59EAFFB7EF2605BF76058 /* XCVersionGroup.swift */,
+			);
+			path = Files;
+			sourceTree = "<group>";
+		};
+		AB5B741CDFA2CF76B2800D91 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				DACBE49740AB347EFAE8EC00 /* AddTargetsTests.swift */,
+				35445591FE5C7D2FCEF9533F /* BUILD */,
+				A42EAB1A5AEF651AF8F6F865 /* CreateFilesAndGroupsTests.swift */,
+				A40EB7581064768B08E6C529 /* CreateProductsTest.swift */,
+				6A9607F1AB28FE727DED4651 /* CreateProjectTests.swift */,
+				7025166F1EB392F463C551D2 /* CreateXcodeProjTests.swift */,
+				EDE03F64CA13C3461D45773E /* DisambiguateTargetsTests.swift */,
+				F238F3E44302DBE53FF70525 /* Fixtures.swift */,
+				25072DE452FF8EC4AC148C4A /* GeneratorTests.swift */,
+				493423CD8285C46D06C4169D /* PathExtensionsTests.swift */,
+				8F0B7B94D16AAD3979ACCEFA /* PBXProj+Testing.swift */,
+				FCEBA76F789E9D71187DFF61 /* PopulateMainGroupTests.swift */,
+				746AD1E908901BF77306B564 /* ProcessTargetMergesTests.swift */,
+				A73417EAFFC70439C38BFDB6 /* SetTargetConfigurations.swift */,
+				2C7832C26060C56DE2EAB1A1 /* SetTargetDependenciesTests.swift */,
+				1D3C9C8DAFC01EECD746E229 /* Target+Testing.swift */,
+				230BF7ABCF5D7C48951A8641 /* XcodeProj+CustomDump.swift */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		AFFE4010B3DE95C4FC9920A3 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				B379DE01A53B895F83E8846C /* AEXML+XcodeFormat.swift */,
+				9AC38B9E7BDCEE1A00F253C2 /* Array+Extras.swift */,
+				6130F9568982104094E3C618 /* Bool+Extras.swift */,
+				1311F2E17F171A48A8E3B180 /* Dictionary+Enumerate.swift */,
+				A20E781CE891F4AB4B0E4C30 /* Dictionary+Extras.swift */,
+				86D81D32EB64919C01CE7321 /* KeyedDecodingContainer+Additions.swift */,
+				DDF5D934175EDDA9EF296101 /* NSRecursiveLock+Sync.swift */,
+				2597D69F32EE134D35CA5EED /* Path+Extras.swift */,
+				48AE2420614CF62AD4A8AAB1 /* String+md5.swift */,
+				0484B5B7FF46952C7EBA2E20 /* String+Utils.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
+		B26BE9E6A43556966A02F6E0 /* Internal */ = {
+			isa = PBXGroup;
+			children = (
+				C680A79739F778E13D555285 /* AnyType.swift */,
+				E6E27E547A12A951FF64D0C4 /* Box.swift */,
+				A1B9525BCADA7A75978D1FCC /* CollectionDifference.swift */,
+				E0413D918157ADBE8DAEA92D /* Mirror.swift */,
+				8986F9BDAD8DB56D61CBB787 /* String.swift */,
+			);
+			path = Internal;
+			sourceTree = "<group>";
+		};
+		C047AF1D451C7E165914273D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		CA7DD8A114179E4211EC51BF /* Project */ = {
+			isa = PBXGroup;
+			children = (
+				E4507DAF85285409A7CA226E /* PBXObject.swift */,
+				BCB3EDAEB4E2CAE755B7284B /* PBXObjectParser.swift */,
+				1DA5F81BF5F85E9032BC2014 /* PBXObjectReference.swift */,
+				AA8657DAF8012A508E7FEE54 /* PBXObjects.swift */,
+				2BBD0DBAFB6DB4E966DC49EB /* PBXOutputSettings.swift */,
+				57CD85080B3E34F2529D7CB8 /* PBXProj.swift */,
+				F972F9B12146B979CA3E0318 /* PBXProject.swift */,
+				AC11446A42A073B91FFC6262 /* PBXProjEncoder.swift */,
+			);
+			path = Project;
+			sourceTree = "<group>";
+		};
+		CCD52FD22F080CD6DA9BD957 /* com_github_tuist_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				492A9D78BA7221EE483135CD /* Sources */,
+			);
+			path = com_github_tuist_xcodeproj;
+			sourceTree = "<group>";
+		};
+		CCF397C5064E8B5EF7CB019D /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				DD828AC8336C5A1F0C951071 /* BuildSettingsProvider.swift */,
+				D432B71433F4134FFBFA281B /* CommentedString.swift */,
+				721F82FE7F5FD35511FFFB2B /* Decoders.swift */,
+				B2F851023E4F4913D1E369CE /* JSONDecoding.swift */,
+				9F395A784F145A641B09FC95 /* PBXBatchUpdater.swift */,
+				2ABD1C801DC25791CF7A9BC2 /* PlistValue.swift */,
+				5A0D02295BBDD7113D940406 /* ReferenceGenerator.swift */,
+				7AC44F6F9D5F1EBF4D7110DD /* XCConfig.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		D10A9AF7B845AE03CD6F433F /* XCTestDynamicOverlay */ = {
+			isa = PBXGroup;
+			children = (
+				6715701A6A75A2BFF85172AD /* XCTFail.swift */,
+			);
+			path = XCTestDynamicOverlay;
+			sourceTree = "<group>";
+		};
+		D13CAAFEC277BE94B22CE6A6 /* Sourcery */ = {
+			isa = PBXGroup;
+			children = (
+				9DE54A5806DB0C02CD8FB55D /* Equality.generated.swift */,
+				DF0C30E65D6E9C205B83B73E /* Sourcery.swift */,
+			);
+			path = Sourcery;
+			sourceTree = "<group>";
+		};
+		D182AF8E059C5832405A845F /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				57A4D6EC3E7B8473C776A368 /* CompileStub.swift */,
+			);
+			name = rules_xcodeproj;
+			path = test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj;
+			sourceTree = "<group>";
+		};
+		D7FFCD6C56706B85E75B3AF7 /* com_github_pointfreeco_swift_custom_dump */ = {
+			isa = PBXGroup;
+			children = (
+				9CFB3134561D99EEDB0FD551 /* Sources */,
+			);
+			path = com_github_pointfreeco_swift_custom_dump;
+			sourceTree = "<group>";
+		};
+		E8CBCA40694FC788C0E8E07D /* Project */ = {
+			isa = PBXGroup;
+			children = (
+				F4ABCD1903D2A2F3FAE064BC /* WorkspaceSettings.swift */,
+				E7C28A43616AE9FC78C05EE0 /* XCBreakpointList.swift */,
+				726579883BDE5C574DD25742 /* Xcode.swift */,
+				20A47D52C1A48A1ED498719F /* XcodeProj.swift */,
+				F0AD1D57FD4037EC5BB72645 /* XCSharedData.swift */,
+			);
+			path = Project;
+			sourceTree = "<group>";
+		};
+		EC6FEE5AC277A3FEEA95510A = {
+			isa = PBXGroup;
+			children = (
+				73CEA667F51A4B28BFA414FB /* tools */,
+				9811D2ED915829A1A7881AFD /* Bazel External Repositories */,
+				D182AF8E059C5832405A845F /* rules_xcodeproj */,
+				593E7C82FAAD94A7E6A04318 /* Products */,
+				C047AF1D451C7E165914273D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		ED9B8640D3E2EFC89A122EA2 /* Objects */ = {
+			isa = PBXGroup;
+			children = (
+				A403C77530EAF2A33B494AAD /* BuildPhase */,
+				95AA1DB04311484BD8DF9D8A /* Configuration */,
+				A4C8A4E2E85C952486F42381 /* Files */,
+				CA7DD8A114179E4211EC51BF /* Project */,
+				D13CAAFEC277BE94B22CE6A6 /* Sourcery */,
+				07671B3685AFF2D6FBC54376 /* SwiftPackage */,
+				6EF3A79C8E962E540EC231B4 /* Targets */,
+			);
+			path = Objects;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		302F4C6E9EE3F09D4809EF0A /* CustomDump */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3D2103FB87F295A76D072C9F /* Build configuration list for PBXNativeTarget "CustomDump" */;
+			buildPhases = (
+				ECA0F39C31AA33C5A27E2A13 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B06DB2B1738DF952C859FCC0 /* PBXTargetDependency */,
+				94E1DFA69955CA57806ABE25 /* PBXTargetDependency */,
+			);
+			name = CustomDump;
+			productName = CustomDump;
+			productReference = 5FBDAA5A97ECD9AA378B9305 /* libCustomDump.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		4A2EC1B2D6969F717CB890DE /* PathKit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CACF77A1FAAA2F54E5824DC5 /* Build configuration list for PBXNativeTarget "PathKit" */;
+			buildPhases = (
+				CEFFF3DAD94295451F05F496 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CE39FCA5D027B650D9A85BE5 /* PBXTargetDependency */,
+			);
+			name = PathKit;
+			productName = PathKit;
+			productReference = A0ED50B45C327F01289522B0 /* libPathKit.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		85C876DB90D51CD225023BB2 /* generator */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9C3B0DA5FF54217998FA354A /* Build configuration list for PBXNativeTarget "generator" */;
+			buildPhases = (
+				42A070DBC30FFCFC46CB6D1F /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9ABF3DD32B1D73FEFA114778 /* PBXTargetDependency */,
+				C0C4842B0D633EDDA463F849 /* PBXTargetDependency */,
+			);
+			name = generator;
+			productName = generator;
+			productReference = 8D6BEA2725F47B747D67B18F /* generator */;
+			productType = "com.apple.product-type.tool";
+		};
+		886150B3C63D0DBEF9BB4E6B /* AEXML */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 87A63B9392379C37ECE35BB3 /* Build configuration list for PBXNativeTarget "AEXML" */;
+			buildPhases = (
+				CC35872CAB45EE11F90DA749 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2F0F2305A1894AA95623CDC3 /* PBXTargetDependency */,
+			);
+			name = AEXML;
+			productName = AEXML;
+			productReference = 3BCF6545A3BFB3B32552A669 /* libAEXML.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		979D12680661F4B864602CE6 /* tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2AE3F241DE7B5C62A4FBFD3F /* Build configuration list for PBXNativeTarget "tests" */;
+			buildPhases = (
+				90B131D058F213F9EE1D4E2A /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3121B63F982B90DC1BC80DC6 /* PBXTargetDependency */,
+				272FB95BF351D18E24AF12EE /* PBXTargetDependency */,
+				3880438A5A38C4F764B735E5 /* PBXTargetDependency */,
+			);
+			name = tests;
+			productName = tests;
+			productReference = 028AFCA25E6642D1781D7370 /* tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		9DF90F35406923EA23C68CFC /* XCTestDynamicOverlay */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6151A35A4285123290BF712B /* Build configuration list for PBXNativeTarget "XCTestDynamicOverlay" */;
+			buildPhases = (
+				3902E6234DBCF661FBA29FE8 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D9328141BD90BECA04EFA044 /* PBXTargetDependency */,
+			);
+			name = XCTestDynamicOverlay;
+			productName = XCTestDynamicOverlay;
+			productReference = 5E7B2DB807B1509ABDD69E31 /* libXCTestDynamicOverlay.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		A09CE18EBBDAC65CD0C6B7D1 /* XcodeProj */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 961CB57C52E0929989B5B13A /* Build configuration list for PBXNativeTarget "XcodeProj" */;
+			buildPhases = (
+				831BF4DD9F4124A081FB32B3 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9D86DF7F047B9F71860DFD0C /* PBXTargetDependency */,
+				15C9D6D9FFC25DEDBF1B4FB1 /* PBXTargetDependency */,
+				2A18DCEDD62C0092B4434B53 /* PBXTargetDependency */,
+			);
+			name = XcodeProj;
+			productName = XcodeProj;
+			productReference = C7281BBDA526D590DB2E6B19 /* libXcodeProj.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		F12050E30563A81EEBB2EA9B /* generator.library */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 537F24897CAC8E48070BBA94 /* Build configuration list for PBXNativeTarget "generator.library" */;
+			buildPhases = (
+				CD48CA78C6E062C9AC7C30B5 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3D917D223B855889FCC41320 /* PBXTargetDependency */,
+				3C87B52A50F5CA5CA4F4127C /* PBXTargetDependency */,
+				89785168DF6A2CA38BEB0A0C /* PBXTargetDependency */,
+			);
+			name = generator.library;
+			productName = generator.library;
+			productReference = 87D5D2AB0B152D5CA6FB9ADF /* libgenerator.library.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0805833D09730531AD081697 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					302F4C6E9EE3F09D4809EF0A = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					4A2EC1B2D6969F717CB890DE = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					85C876DB90D51CD225023BB2 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					886150B3C63D0DBEF9BB4E6B = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					979D12680661F4B864602CE6 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					9DF90F35406923EA23C68CFC = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					A09CE18EBBDAC65CD0C6B7D1 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					ECAFAC2323528A3317A7C9F2 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					F12050E30563A81EEBB2EA9B = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+				};
+			};
+			buildConfigurationList = 669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = EC6FEE5AC277A3FEEA95510A;
+			productRefGroup = 593E7C82FAAD94A7E6A04318 /* Products */;
+			projectDirPath = ../../..;
+			projectRoot = "";
+			targets = (
+				ECAFAC2323528A3317A7C9F2 /* Setup */,
+				886150B3C63D0DBEF9BB4E6B /* AEXML */,
+				302F4C6E9EE3F09D4809EF0A /* CustomDump */,
+				85C876DB90D51CD225023BB2 /* generator */,
+				F12050E30563A81EEBB2EA9B /* generator.library */,
+				4A2EC1B2D6969F717CB890DE /* PathKit */,
+				979D12680661F4B864602CE6 /* tests */,
+				A09CE18EBBDAC65CD0C6B7D1 /* XcodeProj */,
+				9DF90F35406923EA23C68CFC /* XCTestDynamicOverlay */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		48F6FA82818C0DE2760C55C0 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"$PROJECT_FILE_PATH/rules_xcodeproj\"\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf gen_dir\n\nln -sf \"$BUILD_DIR/bazel-out\" gen_dir\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-rules_xcodeproj/external\" external\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$PROJECT_FILE_PATH/rules_xcodeproj/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3902E6234DBCF661FBA29FE8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB1FEC913287E5B00F096E68 /* XCTFail.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		42A070DBC30FFCFC46CB6D1F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AEB71B0424C2FF94ED50AC21 /* CompileStub.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		831BF4DD9F4124A081FB32B3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A222D10EC921D5DAB1ADFDD8 /* Errors.swift in Sources */,
+				D19739179B7FE91C8CF9BEEC /* AEXML+XcodeFormat.swift in Sources */,
+				15120DC7E10B41C7A500DC4C /* Array+Extras.swift in Sources */,
+				DB319A23886D4E34C33673FC /* Bool+Extras.swift in Sources */,
+				007447878A5814379E7B765E /* Dictionary+Enumerate.swift in Sources */,
+				9D56629578825A73E01C892C /* Dictionary+Extras.swift in Sources */,
+				ADCE544F51464E00D1D9524D /* KeyedDecodingContainer+Additions.swift in Sources */,
+				BEAD5FDAF78EA4826B89E2BD /* NSRecursiveLock+Sync.swift in Sources */,
+				1E3DC0A6287F260FE33F89CE /* Path+Extras.swift in Sources */,
+				2C0AEFD36720278D54AF5847 /* String+Utils.swift in Sources */,
+				CFB4FD519F8E383FD4BCB1E3 /* String+md5.swift in Sources */,
+				21EFB487A4B2DCA0539113C6 /* BuildPhase.swift in Sources */,
+				2C8449871037AD0BBB828275 /* PBXBuildFile.swift in Sources */,
+				B0A2A06473CECEC37ABAA58C /* PBXBuildPhase.swift in Sources */,
+				25608AD5228D99F311C26845 /* PBXBuildRule.swift in Sources */,
+				0F1A9B6BE970BA80097FCE6F /* PBXCopyFilesBuildPhase.swift in Sources */,
+				D16602634755ABF029048517 /* PBXFrameworksBuildPhase.swift in Sources */,
+				EF6F4E716AA5BE2772001255 /* PBXHeadersBuildPhase.swift in Sources */,
+				80DB1DEE41E0521C535EF842 /* PBXResourcesBuildPhase.swift in Sources */,
+				CF836785A4BDAA1811B567F7 /* PBXRezBuildPhase.swift in Sources */,
+				FD83242BF95B2ED90590668A /* PBXShellScriptBuildPhase.swift in Sources */,
+				561E9544A30BE76E86EF2ED0 /* PBXSourcesBuildPhase.swift in Sources */,
+				B8BF97A20C49B967A6631960 /* BuildSettings.swift in Sources */,
+				F87890E59D29431994A8AD60 /* XCBuildConfiguration.swift in Sources */,
+				918DEB6EB624CC659A442D18 /* XCConfigurationList.swift in Sources */,
+				8BF8CFA67C6213113810FCAD /* PBXContainerItem.swift in Sources */,
+				68E567532FB9A491B36F4344 /* PBXContainerItemProxy.swift in Sources */,
+				A675EA535B032CEB7C29D343 /* PBXFileElement.swift in Sources */,
+				9AECAA3D2388D9FF824EDB5F /* PBXFileReference.swift in Sources */,
+				F45E3A1DA6E6C87FDF69EF5D /* PBXGroup.swift in Sources */,
+				A99C8BF4EB3403A8A0EF7359 /* PBXSourceTree.swift in Sources */,
+				D0407AAE9CF50A10917EAE7B /* PBXVariantGroup.swift in Sources */,
+				193F6A78FD304D33032124C1 /* XCVersionGroup.swift in Sources */,
+				CD5048942C21378CDB87CF88 /* PBXObject.swift in Sources */,
+				9C521A1BDD725800EBB7A77A /* PBXObjectParser.swift in Sources */,
+				81538A9DF3EE3B84C20E7C11 /* PBXObjectReference.swift in Sources */,
+				98DC63B7C9C1743065744E2C /* PBXObjects.swift in Sources */,
+				F195F74C145AA147C028F541 /* PBXOutputSettings.swift in Sources */,
+				61403F6850E38C4F143F564B /* PBXProj.swift in Sources */,
+				CD168B5A573CE3A79098C630 /* PBXProjEncoder.swift in Sources */,
+				08BDB7C9B414A51A9260F683 /* PBXProject.swift in Sources */,
+				B57969E61CB1565E21DD7F4F /* Equality.generated.swift in Sources */,
+				390F0EA150BF1F34944B6ADA /* Sourcery.swift in Sources */,
+				DD5A44735D378BDE1F46118A /* XCRemoteSwiftPackageReference.swift in Sources */,
+				BB9A479C58B5371EB58BD6E1 /* XCSwiftPackageProductDependency.swift in Sources */,
+				966E746DD2F4033E07848B84 /* PBXAggregateTarget.swift in Sources */,
+				901D961591589C1891CFAFB6 /* PBXLegacyTarget.swift in Sources */,
+				59195F78C9366C3C166CB371 /* PBXNativeTarget.swift in Sources */,
+				7F58A80D6FBF4CAAB6A6B59C /* PBXProductType.swift in Sources */,
+				0A904F2FB1E7254686796387 /* PBXReferenceProxy.swift in Sources */,
+				1CC4BC9635C0213148A58C93 /* PBXTarget.swift in Sources */,
+				78D160559CB33620BE055D67 /* PBXTargetDependency.swift in Sources */,
+				13C6DF44016DCB53AD3798F0 /* WorkspaceSettings.swift in Sources */,
+				0D6ED2396B7AA4FCCB10F093 /* XCBreakpointList.swift in Sources */,
+				86824C0BC97C6DA06A465D0C /* XCSharedData.swift in Sources */,
+				F489A2B6BC16017B0A96F7C5 /* Xcode.swift in Sources */,
+				62F2A43822894D2210058772 /* XcodeProj.swift in Sources */,
+				56D1E3A779E64B952444C092 /* Writable.swift in Sources */,
+				3A4A00E9748F9B2BE18264A6 /* XCScheme+AditionalOption.swift in Sources */,
+				72C95B9913557F8ABDA0C644 /* XCScheme+AnalyzeAction.swift in Sources */,
+				AE8961FFE22CBE3B3FD65418 /* XCScheme+ArchiveAction.swift in Sources */,
+				D36AF35A702DB7F0987E1628 /* XCScheme+BuildAction.swift in Sources */,
+				17645385BCB1B73E46212F31 /* XCScheme+BuildableProductRunnable.swift in Sources */,
+				096B05250E4C2E55D79A268D /* XCScheme+BuildableReference.swift in Sources */,
+				277424E39B6FA6040609F4C2 /* XCScheme+CommandLineArguments.swift in Sources */,
+				892C9CFBEE5474105B683C75 /* XCScheme+EnvironmentVariable.swift in Sources */,
+				AB6AAB9A7208DB88DC554AB4 /* XCScheme+ExecutionAction.swift in Sources */,
+				E712DCD367C4CD3BA502AD45 /* XCScheme+LaunchAction.swift in Sources */,
+				30641992040B785DB00E790C /* XCScheme+LocationScenarioReference.swift in Sources */,
+				C3C078F384218F905E374FEF /* XCScheme+PathRunnable.swift in Sources */,
+				C4A4BDEEBC4DEA94A9C38B98 /* XCScheme+ProfileAction.swift in Sources */,
+				C28A10245E6237BB03708CF9 /* XCScheme+RemoteRunnable.swift in Sources */,
+				4978BBDA23E2108C6410D537 /* XCScheme+Runnable.swift in Sources */,
+				4E3D153CEB522DFB416A3DBE /* XCScheme+SerialAction.swift in Sources */,
+				E1C8DD75EBE5491687687657 /* XCScheme+StoreKitConfigurationFileReference.swift in Sources */,
+				3D313135393850D8995F026E /* XCScheme+TestAction.swift in Sources */,
+				DFDACE372D86DAF5308E0DE2 /* XCScheme+TestItem.swift in Sources */,
+				E34D297ACAC512E3C961FB43 /* XCScheme+TestPlanReference.swift in Sources */,
+				DB8227FED04A839CF551406B /* XCScheme+TestableReference.swift in Sources */,
+				EB4A452EE958D49C8D481FC8 /* XCScheme.swift in Sources */,
+				9077EA3A89259730E19B4A78 /* XCSchemeManagement.swift in Sources */,
+				804848AF97DCD0402E5B8587 /* BuildSettingsProvider.swift in Sources */,
+				2C776A46D9F83B6F0BCD48A6 /* CommentedString.swift in Sources */,
+				CE6CCF1AF17AA0100D2D2A8E /* Decoders.swift in Sources */,
+				08FD41A51102F53B418BD3CE /* JSONDecoding.swift in Sources */,
+				5D436B3E872B368A77248360 /* PBXBatchUpdater.swift in Sources */,
+				8FCC248B12F5127B90BCA1A2 /* PlistValue.swift in Sources */,
+				7F476F3EA1860204A2BC970E /* ReferenceGenerator.swift in Sources */,
+				30F0C043E51363669C0D7E43 /* XCConfig.swift in Sources */,
+				1D2A68B41A4FA9E2401D41EF /* XCWorkspace.swift in Sources */,
+				52A211CD11583B26C7ACFE94 /* XCWorkspaceData.swift in Sources */,
+				E87E52EF25B8303265432A7B /* XCWorkspaceDataElement.swift in Sources */,
+				AB40FAE217E2BAB64BA214AE /* XCWorkspaceDataElementLocationType.swift in Sources */,
+				D8D3778305DAFBA5A3150598 /* XCWorkspaceDataFileRef.swift in Sources */,
+				6695A3C7FADF608E359B1153 /* XCWorkspaceDataGroup.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		90B131D058F213F9EE1D4E2A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				75B34A42A3528868C8D25993 /* AddTargetsTests.swift in Sources */,
+				6BEEFB6F9ABBD9DE61F18D20 /* CreateFilesAndGroupsTests.swift in Sources */,
+				72A3C7DA6BF74DE5F2EFC28C /* CreateProductsTest.swift in Sources */,
+				8D60F9D1D81FEDCE8DDF6B73 /* CreateProjectTests.swift in Sources */,
+				A68D64FB246101C57F8011AA /* CreateXcodeProjTests.swift in Sources */,
+				0680A4C2872B98AC70E3ADD4 /* DisambiguateTargetsTests.swift in Sources */,
+				2AF393E662D68CBEAC339715 /* Fixtures.swift in Sources */,
+				CD4B8D1015F9E80BE99DD4CB /* GeneratorTests.swift in Sources */,
+				6BD6785813F2AC9561F5C197 /* PBXProj+Testing.swift in Sources */,
+				86FE11FE2B8F03BEE4C909B9 /* PathExtensionsTests.swift in Sources */,
+				03DA8359CF68B4CE3C279FC0 /* PopulateMainGroupTests.swift in Sources */,
+				F408E995D0F6C9C1655544A2 /* ProcessTargetMergesTests.swift in Sources */,
+				D8E574436F559C26407E7247 /* SetTargetConfigurations.swift in Sources */,
+				0D85907F40BB6B647D855A72 /* SetTargetDependenciesTests.swift in Sources */,
+				AF8E3F0B5232920781A99260 /* Target+Testing.swift in Sources */,
+				C0486D5F399197D1D3FF09B0 /* XcodeProj+CustomDump.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CC35872CAB45EE11F90DA749 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2143F6802705E6E45746C463 /* Document.swift in Sources */,
+				2662F5160B7446672BF10AC3 /* Element.swift in Sources */,
+				D8706141935099FEB119B28D /* Error.swift in Sources */,
+				42083CE40AC71C796D40C7A7 /* Options.swift in Sources */,
+				E2339489F3322934D224B39B /* Parser.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CD48CA78C6E062C9AC7C30B5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BC91F35AD1E15D616E4CC164 /* BuildSetting.swift in Sources */,
+				7D2E840E973AA9E5F5898CF0 /* DTO.swift in Sources */,
+				E9F48F2CD252695AAFAB1EB0 /* Environment.swift in Sources */,
+				83B8755AB81932C2FE256B16 /* Errors.swift in Sources */,
+				6BA353E9953AC16BBDB0F76B /* FilePath.swift in Sources */,
+				0BFA0A77F5504DCED931F795 /* FilePathResolver.swift in Sources */,
+				1238A9F19DF8C3E8C044C69C /* Generator+AddTargets.swift in Sources */,
+				6BEA8E1A797CD3E05D0BAE40 /* Generator+CreateFilesAndGroups.swift in Sources */,
+				E573DCC118186C0FAB27ECD3 /* Generator+CreateProducts.swift in Sources */,
+				51F268CB997C75D3FFBE5DA7 /* Generator+CreateProject.swift in Sources */,
+				4974B9AC4C2E129CC6088A1A /* Generator+CreateXcodeProj.swift in Sources */,
+				DFEB422950EB6556FF81427F /* Generator+DisambiguateTargets.swift in Sources */,
+				E69C15430624375DCD37079E /* Generator+Main.swift in Sources */,
+				55DEC752A311C6D8A9A8253C /* Generator+PopulateMainGroup.swift in Sources */,
+				FAED0146F1038080B71472A6 /* Generator+ProcessTargetMerges.swift in Sources */,
+				6B28EE0853F7B0F596C5351C /* Generator+SetTargetConfigurations.swift in Sources */,
+				86F24F14D749292FBC62BD2C /* Generator+SetTargetDependencies.swift in Sources */,
+				7B3AD502D81DAD7185608351 /* Generator+WriteXcodeProj.swift in Sources */,
+				A66786EB13D7E2639036F3BF /* Generator.swift in Sources */,
+				1D234043EBCEEF3EFC870923 /* Inputs.swift in Sources */,
+				209E823873EA39D5C6A8EF66 /* Logger.swift in Sources */,
+				D2BCCC871F46C8F9DAD03627 /* PBXGroup+Extensions.swift in Sources */,
+				4174F4CF85B88F38A10506D6 /* PBXProductType+Extensions.swift in Sources */,
+				DC5F430B976BE451BEF87B75 /* Path+Extensions.swift in Sources */,
+				04886D2571E1ACF144595866 /* SearchPaths.swift in Sources */,
+				A7D5AE1CFB80FCD54BCA939B /* Sorting.swift in Sources */,
+				61EFA27F5D961ECA88FE86DB /* TargetID.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CEFFF3DAD94295451F05F496 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0B5033389291A3C98DAB6E41 /* PathKit.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ECA0F39C31AA33C5A27E2A13 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				23041301A5060235785895F8 /* CoreImage.swift in Sources */,
+				B556B319407CEE94214F965A /* CoreLocation.swift in Sources */,
+				0F988C99D14D5314D5DE55AE /* CoreMotion.swift in Sources */,
+				BF37FF4AE38FE009AF6A77A5 /* Foundation.swift in Sources */,
+				F4D13ACCE9A32E9C849214DA /* GameKit.swift in Sources */,
+				05D4C943C91F281CF27F2F83 /* KeyPath.swift in Sources */,
+				36161192BE3C16570649BB90 /* Photos.swift in Sources */,
+				2D41550C6C017839EF6AA36E /* Speech.swift in Sources */,
+				A9517AAC3411C003E2CB531B /* StoreKit.swift in Sources */,
+				A005E475FCF2134825BDB60D /* Swift.swift in Sources */,
+				3A7349AFC0C6CBFFC6DEE039 /* SwiftUI.swift in Sources */,
+				C0C01A34E3B73713C8A5AD93 /* UIKit.swift in Sources */,
+				0D0AC258CDE90DE121688624 /* UserNotifications.swift in Sources */,
+				606070207B2A1238EAD8C008 /* UserNotificationsUI.swift in Sources */,
+				6A8B43D7AB579FFA4EA560A8 /* CustomDumpReflectable.swift in Sources */,
+				265A3566719072FF07A20004 /* CustomDumpRepresentable.swift in Sources */,
+				086989EA86F5E2D35BC9FA5B /* CustomDumpStringConvertible.swift in Sources */,
+				A4A23349B22F60B10EDF6D9A /* Diff.swift in Sources */,
+				4D10A242113D5E0A454F043B /* Dump.swift in Sources */,
+				30D51D7450B1E5BC999396AC /* AnyType.swift in Sources */,
+				DAEB13CD6BB6B939AE66B3FE /* Box.swift in Sources */,
+				219C3E15651600D4892C4387 /* CollectionDifference.swift in Sources */,
+				52A6BC70459DEE9D341E6151 /* Mirror.swift in Sources */,
+				D548357DA88FF63CF53CB1C5 /* String.swift in Sources */,
+				DDBE87915A648B7B27AA8A73 /* XCTAssertNoDifference.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		15C9D6D9FFC25DEDBF1B4FB1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = AEXML;
+			target = 886150B3C63D0DBEF9BB4E6B /* AEXML */;
+			targetProxy = 5860D57390AE14C57D4A302E /* PBXContainerItemProxy */;
+		};
+		272FB95BF351D18E24AF12EE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CustomDump;
+			target = 302F4C6E9EE3F09D4809EF0A /* CustomDump */;
+			targetProxy = 44D67FDCCFE036B1BE7F2490 /* PBXContainerItemProxy */;
+		};
+		2A18DCEDD62C0092B4434B53 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PathKit;
+			target = 4A2EC1B2D6969F717CB890DE /* PathKit */;
+			targetProxy = CD181E6AF3DFD2EF12094EE5 /* PBXContainerItemProxy */;
+		};
+		2F0F2305A1894AA95623CDC3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 3E98853617DD142D01E4ECD4 /* PBXContainerItemProxy */;
+		};
+		3121B63F982B90DC1BC80DC6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = D9E85C3E10A5FA1310BBEA9A /* PBXContainerItemProxy */;
+		};
+		3880438A5A38C4F764B735E5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = generator.library;
+			target = F12050E30563A81EEBB2EA9B /* generator.library */;
+			targetProxy = 20EC77CE7C6AAE2A1679866F /* PBXContainerItemProxy */;
+		};
+		3C87B52A50F5CA5CA4F4127C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PathKit;
+			target = 4A2EC1B2D6969F717CB890DE /* PathKit */;
+			targetProxy = 201DCF3149264E9D8AB4CA97 /* PBXContainerItemProxy */;
+		};
+		3D917D223B855889FCC41320 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = F2EEA6546190185B5EED5115 /* PBXContainerItemProxy */;
+		};
+		89785168DF6A2CA38BEB0A0C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = XcodeProj;
+			target = A09CE18EBBDAC65CD0C6B7D1 /* XcodeProj */;
+			targetProxy = 2C860512D9D794C14E15BE5B /* PBXContainerItemProxy */;
+		};
+		94E1DFA69955CA57806ABE25 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = XCTestDynamicOverlay;
+			target = 9DF90F35406923EA23C68CFC /* XCTestDynamicOverlay */;
+			targetProxy = 34739E478519DAF595040254 /* PBXContainerItemProxy */;
+		};
+		9ABF3DD32B1D73FEFA114778 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 1AADF09199F79612883EE5EF /* PBXContainerItemProxy */;
+		};
+		9D86DF7F047B9F71860DFD0C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 85F8D55A5DDD5984E2D5D3A9 /* PBXContainerItemProxy */;
+		};
+		B06DB2B1738DF952C859FCC0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 47A49BF151336CCF2D4909B1 /* PBXContainerItemProxy */;
+		};
+		C0C4842B0D633EDDA463F849 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = generator.library;
+			target = F12050E30563A81EEBB2EA9B /* generator.library */;
+			targetProxy = CE545ADAA24F8CEBE7071545 /* PBXContainerItemProxy */;
+		};
+		CE39FCA5D027B650D9A85BE5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 0C1DB5AAE5C62E5351BBB35F /* PBXContainerItemProxy */;
+		};
+		D9328141BD90BECA04EFA044 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = C6503A028754D96CDB93B208 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		235F4F04C2DF95E7079ED732 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_MODULE_NAME = PathKit;
+				PRODUCT_NAME = PathKit;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = PathKit;
+			};
+			name = Debug;
+		};
+		4A234614294618D445060F03 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = Setup;
+			};
+			name = Debug;
+		};
+		690A039D63AF0A09BE54B464 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_MODULE_NAME = XcodeProj;
+				PRODUCT_NAME = XcodeProj;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = XcodeProj;
+			};
+			name = Debug;
+		};
+		89C4F2F8967BBC9C91979C2F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_MODULE_NAME = AEXML;
+				PRODUCT_NAME = AEXML;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = AEXML;
+			};
+			name = Debug;
+		};
+		B0892EE2AB907B40AA4EB960 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BAZEL_PATH = bazel;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
+				COPY_PHASE_STRIP = NO;
+				ONLY_ACTIVE_ARCH = YES;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+		B52234979D85E6DED42999FE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_MODULE_NAME = XCTestDynamicOverlay;
+				PRODUCT_NAME = XCTestDynamicOverlay;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = XCTestDynamicOverlay;
+			};
+			name = Debug;
+		};
+		C54F06B60C905CFF51CDA2DE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_swift_custom_dump";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_MODULE_NAME = CustomDump;
+				PRODUCT_NAME = CustomDump;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = CustomDump;
+			};
+			name = Debug;
+		};
+		CE8A864F719785A99D16C3BC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/test";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = (
+					"-filelist",
+					"$(PROJECT_FILE_PATH)/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-1c975e2849a6/tools/generator/test/tests.LinkFileList,$(BUILD_DIR)",
+					"-ObjC",
+				);
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_MODULE_NAME = tests;
+				PRODUCT_NAME = tests;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_swift_custom_dump";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = tests;
+			};
+			name = Debug;
+		};
+		DC1884C822C7D3AD5CAA6B9E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = (
+					"-filelist",
+					"$(PROJECT_FILE_PATH)/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-1c975e2849a6/tools/generator/generator.LinkFileList,$(BUILD_DIR)",
+					"-ObjC",
+				);
+				PRODUCT_MODULE_NAME = _generator_Stub;
+				PRODUCT_NAME = generator;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = generator;
+			};
+			name = Debug;
+		};
+		FDE20AE9FE7D017A88D1BF1B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_MODULE_NAME = generator;
+				PRODUCT_NAME = generator.library;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = generator.library;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		2AE3F241DE7B5C62A4FBFD3F /* Build configuration list for PBXNativeTarget "tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CE8A864F719785A99D16C3BC /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		3D2103FB87F295A76D072C9F /* Build configuration list for PBXNativeTarget "CustomDump" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C54F06B60C905CFF51CDA2DE /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		537F24897CAC8E48070BBA94 /* Build configuration list for PBXNativeTarget "generator.library" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FDE20AE9FE7D017A88D1BF1B /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		6151A35A4285123290BF712B /* Build configuration list for PBXNativeTarget "XCTestDynamicOverlay" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B52234979D85E6DED42999FE /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B0892EE2AB907B40AA4EB960 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A234614294618D445060F03 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		87A63B9392379C37ECE35BB3 /* Build configuration list for PBXNativeTarget "AEXML" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				89C4F2F8967BBC9C91979C2F /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		961CB57C52E0929989B5B13A /* Build configuration list for PBXNativeTarget "XcodeProj" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				690A039D63AF0A09BE54B464 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		9C3B0DA5FF54217998FA354A /* Build configuration list for PBXNativeTarget "generator" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DC1884C822C7D3AD5CAA6B9E /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		CACF77A1FAAA2F54E5824DC5 /* Build configuration list for PBXNativeTarget "PathKit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				235F4F04C2DF95E7079ED732 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0805833D09730531AD081697 /* Project object */;
+}

--- a/test/fixtures/generator/bwb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/test/fixtures/generator/bwb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/test/fixtures/generator/bwb.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/test/fixtures/generator/bwb.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/test/fixtures/generator/bwb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/test/fixtures/generator/bwb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-1c975e2849a6/tools/generator/generator.LinkFileList
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-1c975e2849a6/tools/generator/generator.LinkFileList
@@ -1,0 +1,4 @@
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit/libPathKit.a
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml/libAEXML.a
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/libgenerator.library.a

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-1c975e2849a6/tools/generator/test/tests.LinkFileList
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-1c975e2849a6/tools/generator/test/tests.LinkFileList
@@ -1,0 +1,6 @@
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit/libPathKit.a
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml/libAEXML.a
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/libgenerator.library.a

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -1,0 +1,1474 @@
+{
+    "build_settings": {
+        "ALWAYS_SEARCH_USER_PATHS": false,
+        "BAZEL_PATH": "bazel",
+        "CLANG_ENABLE_OBJC_ARC": true,
+        "CLANG_MODULES_AUTOLINK": false,
+        "COPY_PHASE_STRIP": false,
+        "ONLY_ACTIVE_ARCH": true,
+        "USE_HEADERMAP": false,
+        "VALIDATE_WORKSPACE": false
+    },
+    "extra_files": [
+        "tools/generator/BUILD",
+        "tools/generator/test/BUILD"
+    ],
+    "invalid_target_merges": [
+        "//tools/generator:generator.library darwin_x86_64-dbg-ST-1c975e2849a6",
+        [
+            "//tools/generator:generator darwin_x86_64-dbg-ST-1c975e2849a6"
+        ]
+    ],
+    "label": "//test/fixtures/generator:xcodeproj_bwb",
+    "name": "bwb",
+    "target_merges": [
+        "//tools/generator/test:tests.library darwin_x86_64-dbg-ST-1c975e2849a6",
+        [
+            "//tools/generator/test:tests darwin_x86_64-dbg-ST-1c975e2849a6"
+        ]
+    ],
+    "targets": [
+        "//tools/generator/test:tests darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_MODULE_NAME": "_tests_Stub",
+                "PRODUCT_NAME": "tests",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [
+                "//tools/generator/test:tests.library darwin_x86_64-dbg-ST-1c975e2849a6"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {},
+            "is_swift": false,
+            "label": "//tools/generator/test:tests",
+            "links": [
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit/libPathKit.a",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml/libAEXML.a",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/libgenerator.library.a",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/test/libtests.library.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "tests",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/test",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "tests",
+                "path": "tools/generator/test/tests.xctest",
+                "type": "com.apple.product-type.bundle.unit-test"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//tools/generator/test:tests.library darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "ENABLE_TESTING_SEARCH_PATHS": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "tests",
+                "PRODUCT_NAME": "tests.library",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [
+                "//tools/generator:generator.library darwin_x86_64-dbg-ST-1c975e2849a6",
+                "@com_github_pointfreeco_swift_custom_dump//:CustomDump darwin_x86_64-dbg-ST-1c975e2849a6"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "tools/generator/test/AddTargetsTests.swift",
+                    "tools/generator/test/CreateFilesAndGroupsTests.swift",
+                    "tools/generator/test/CreateProductsTest.swift",
+                    "tools/generator/test/CreateProjectTests.swift",
+                    "tools/generator/test/CreateXcodeProjTests.swift",
+                    "tools/generator/test/DisambiguateTargetsTests.swift",
+                    "tools/generator/test/Fixtures.swift",
+                    "tools/generator/test/GeneratorTests.swift",
+                    "tools/generator/test/PBXProj+Testing.swift",
+                    "tools/generator/test/PathExtensionsTests.swift",
+                    "tools/generator/test/PopulateMainGroupTests.swift",
+                    "tools/generator/test/ProcessTargetMergesTests.swift",
+                    "tools/generator/test/SetTargetConfigurations.swift",
+                    "tools/generator/test/SetTargetDependenciesTests.swift",
+                    "tools/generator/test/Target+Testing.swift",
+                    "tools/generator/test/XcodeProj+CustomDump.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//tools/generator/test:tests.library",
+            "links": [],
+            "modulemaps": [],
+            "name": "tests.library",
+            "outputs": {
+                "swift_module": {
+                    "name": "tests.swiftmodule",
+                    "swiftdoc": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/test/tests.swiftdoc",
+                    "swiftmodule": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/test/tests.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/test/tests.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/test",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "tests.library",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/test/libtests.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/generator.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule",
+                    "t": "g"
+                }
+            ],
+            "test_host": null
+        },
+        "//tools/generator:generator darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_MODULE_NAME": "_generator_Stub",
+                "PRODUCT_NAME": "generator",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [
+                "//tools/generator:generator.library darwin_x86_64-dbg-ST-1c975e2849a6"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {},
+            "is_swift": false,
+            "label": "//tools/generator:generator",
+            "links": [
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit/libPathKit.a",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml/libAEXML.a",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/libgenerator.library.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "generator",
+            "outputs": {},
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "generator",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/generator",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.tool"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//tools/generator:generator.library darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "generator",
+                "PRODUCT_NAME": "generator.library",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [
+                "@com_github_kylef_pathkit//:PathKit darwin_x86_64-dbg-ST-1c975e2849a6",
+                "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-dbg-ST-1c975e2849a6"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "tools/generator/src/BuildSetting.swift",
+                    "tools/generator/src/DTO.swift",
+                    "tools/generator/src/Environment.swift",
+                    "tools/generator/src/Errors.swift",
+                    "tools/generator/src/FilePath.swift",
+                    "tools/generator/src/FilePathResolver.swift",
+                    "tools/generator/src/Generator+AddTargets.swift",
+                    "tools/generator/src/Generator+CreateFilesAndGroups.swift",
+                    "tools/generator/src/Generator+CreateProducts.swift",
+                    "tools/generator/src/Generator+CreateProject.swift",
+                    "tools/generator/src/Generator+CreateXcodeProj.swift",
+                    "tools/generator/src/Generator+DisambiguateTargets.swift",
+                    "tools/generator/src/Generator+Main.swift",
+                    "tools/generator/src/Generator+PopulateMainGroup.swift",
+                    "tools/generator/src/Generator+ProcessTargetMerges.swift",
+                    "tools/generator/src/Generator+SetTargetConfigurations.swift",
+                    "tools/generator/src/Generator+SetTargetDependencies.swift",
+                    "tools/generator/src/Generator+WriteXcodeProj.swift",
+                    "tools/generator/src/Generator.swift",
+                    "tools/generator/src/Inputs.swift",
+                    "tools/generator/src/Logger.swift",
+                    "tools/generator/src/PBXGroup+Extensions.swift",
+                    "tools/generator/src/PBXProductType+Extensions.swift",
+                    "tools/generator/src/Path+Extensions.swift",
+                    "tools/generator/src/SearchPaths.swift",
+                    "tools/generator/src/Sorting.swift",
+                    "tools/generator/src/TargetID.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//tools/generator:generator.library",
+            "links": [],
+            "modulemaps": [],
+            "name": "generator.library",
+            "outputs": {
+                "swift_module": {
+                    "name": "generator.swiftmodule",
+                    "swiftdoc": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/generator.swiftdoc",
+                    "swiftmodule": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/generator.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/generator.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "generator.library",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/tools/generator/libgenerator.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
+                    "t": "g"
+                }
+            ],
+            "test_host": null
+        },
+        "@com_github_kylef_pathkit//:PathKit darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "PathKit",
+                "PRODUCT_NAME": "PathKit",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    {
+                        "_": "com_github_kylef_pathkit/Sources/PathKit.swift",
+                        "t": "e"
+                    }
+                ]
+            },
+            "is_swift": true,
+            "label": "@com_github_kylef_pathkit//:PathKit",
+            "links": [],
+            "modulemaps": [],
+            "name": "PathKit",
+            "outputs": {
+                "swift_module": {
+                    "name": "PathKit.swiftmodule",
+                    "swiftdoc": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit/PathKit.swiftdoc",
+                    "swiftmodule": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit/PathKit.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "PathKit",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit/libPathKit.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "@com_github_pointfreeco_swift_custom_dump//:CustomDump darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "CustomDump",
+                "PRODUCT_NAME": "CustomDump",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [
+                "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay darwin_x86_64-dbg-ST-1c975e2849a6"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreImage.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreLocation.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreMotion.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Foundation.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/GameKit.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/KeyPath.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Photos.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Speech.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/StoreKit.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/Swift.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/SwiftUI.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/UIKit.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/UserNotifications.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/UserNotificationsUI.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/CustomDumpReflectable.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/CustomDumpRepresentable.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/CustomDumpStringConvertible.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Diff.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Dump.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/AnyType.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/Box.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/CollectionDifference.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/Mirror.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/String.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/XCTAssertNoDifference.swift",
+                        "t": "e"
+                    }
+                ]
+            },
+            "is_swift": true,
+            "label": "@com_github_pointfreeco_swift_custom_dump//:CustomDump",
+            "links": [],
+            "modulemaps": [],
+            "name": "CustomDump",
+            "outputs": {
+                "swift_module": {
+                    "name": "CustomDump.swiftmodule",
+                    "swiftdoc": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftdoc",
+                    "swiftmodule": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_swift_custom_dump",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "CustomDump",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
+                    "t": "g"
+                }
+            ],
+            "test_host": null
+        },
+        "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "XCTestDynamicOverlay",
+                "PRODUCT_NAME": "XCTestDynamicOverlay",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    {
+                        "_": "com_github_pointfreeco_xctest_dynamic_overlay/Sources/XCTestDynamicOverlay/XCTFail.swift",
+                        "t": "e"
+                    }
+                ]
+            },
+            "is_swift": true,
+            "label": "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay",
+            "links": [],
+            "modulemaps": [],
+            "name": "XCTestDynamicOverlay",
+            "outputs": {
+                "swift_module": {
+                    "name": "XCTestDynamicOverlay.swiftmodule",
+                    "swiftdoc": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftdoc",
+                    "swiftmodule": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "XCTestDynamicOverlay",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "@com_github_tadija_aexml//:AEXML darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "AEXML",
+                "PRODUCT_NAME": "AEXML",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    {
+                        "_": "com_github_tadija_aexml/Sources/AEXML/Document.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tadija_aexml/Sources/AEXML/Element.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tadija_aexml/Sources/AEXML/Error.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tadija_aexml/Sources/AEXML/Options.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tadija_aexml/Sources/AEXML/Parser.swift",
+                        "t": "e"
+                    }
+                ]
+            },
+            "is_swift": true,
+            "label": "@com_github_tadija_aexml//:AEXML",
+            "links": [],
+            "modulemaps": [],
+            "name": "AEXML",
+            "outputs": {
+                "swift_module": {
+                    "name": "AEXML.swiftmodule",
+                    "swiftdoc": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml/AEXML.swiftdoc",
+                    "swiftmodule": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml/AEXML.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "AEXML",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml/libAEXML.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-dbg-ST-1c975e2849a6",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "XcodeProj",
+                "PRODUCT_NAME": "XcodeProj",
+                "SUPPORTED_PLATFORMS": "macosx",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5"
+            },
+            "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
+            "dependencies": [
+                "@com_github_tadija_aexml//:AEXML darwin_x86_64-dbg-ST-1c975e2849a6",
+                "@com_github_kylef_pathkit//:PathKit darwin_x86_64-dbg-ST-1c975e2849a6"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Errors/Errors.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Array+Extras.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Bool+Extras.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Dictionary+Enumerate.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Dictionary+Extras.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/KeyedDecodingContainer+Additions.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/NSRecursiveLock+Sync.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Path+Extras.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/String+Utils.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/String+md5.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/BuildPhase.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXBuildFile.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXBuildPhase.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXBuildRule.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXCopyFilesBuildPhase.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXFrameworksBuildPhase.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXHeadersBuildPhase.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXResourcesBuildPhase.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXRezBuildPhase.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXShellScriptBuildPhase.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/BuildPhase/PBXSourcesBuildPhase.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Configuration/BuildSettings.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Configuration/XCBuildConfiguration.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Configuration/XCConfigurationList.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXContainerItem.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXContainerItemProxy.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXFileElement.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXFileReference.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXGroup.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXSourceTree.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/PBXVariantGroup.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Files/XCVersionGroup.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObject.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObjectParser.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObjectReference.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXObjects.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXOutputSettings.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXProj.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXProjEncoder.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Project/PBXProject.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Sourcery/Equality.generated.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Sourcery/Sourcery.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/SwiftPackage/XCSwiftPackageProductDependency.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXAggregateTarget.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXLegacyTarget.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXNativeTarget.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXProductType.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXReferenceProxy.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXTarget.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Objects/Targets/PBXTargetDependency.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Project/WorkspaceSettings.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Project/XCBreakpointList.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Project/XCSharedData.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Project/Xcode.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Project/XcodeProj.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Protocols/Writable.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+AditionalOption.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+AnalyzeAction.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+ArchiveAction.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+BuildAction.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+BuildableProductRunnable.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+BuildableReference.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+CommandLineArguments.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+EnvironmentVariable.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+ExecutionAction.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+LaunchAction.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+LocationScenarioReference.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+PathRunnable.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+ProfileAction.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+RemoteRunnable.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+Runnable.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+SerialAction.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+StoreKitConfigurationFileReference.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestAction.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestItem.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestPlanReference.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme+TestableReference.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCScheme.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Scheme/XCSchemeManagement.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/BuildSettingsProvider.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/CommentedString.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/Decoders.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/JSONDecoding.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/PBXBatchUpdater.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/PlistValue.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/ReferenceGenerator.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Utils/XCConfig.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspace.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceData.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataElement.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataElementLocationType.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataFileRef.swift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Workspace/XCWorkspaceDataGroup.swift",
+                        "t": "e"
+                    }
+                ]
+            },
+            "is_swift": true,
+            "label": "@com_github_tuist_xcodeproj//:XcodeProj",
+            "links": [],
+            "modulemaps": [],
+            "name": "XcodeProj",
+            "outputs": {
+                "swift_module": {
+                    "name": "XcodeProj.swiftmodule",
+                    "swiftdoc": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftdoc",
+                    "swiftmodule": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "11.0",
+                "os": "macos"
+            },
+            "product": {
+                "name": "XcodeProj",
+                "path": {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                    "t": "g"
+                },
+                {
+                    "_": "darwin_x86_64-dbg-ST-1c975e2849a6/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                    "t": "g"
+                }
+            ],
+            "test_host": null
+        }
+    ]
+}

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -1,0 +1,838 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		1264E098850804E77CE82093 /* Bazel Generated Files */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */;
+			buildPhases = (
+				CA47126A96DBA220099058F9 /* Generate Files */,
+				3BBBE88C0B5DFE50E861D039 /* Copy Files */,
+				C1BCE66C756D6574AE7961FF /* Fix Info.plists */,
+			);
+			dependencies = (
+				A375E057D32BEDDB980E23C5 /* PBXTargetDependency */,
+			);
+			name = "Bazel Generated Files";
+			productName = "Bazel Generated Files";
+		};
+		ECAFAC2323528A3317A7C9F2 /* Setup */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildPhases = (
+				48F6FA82818C0DE2760C55C0 /* ShellScript */,
+			);
+			dependencies = (
+			);
+			name = Setup;
+			productName = Setup;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		39BF0A575DB868D507469F87 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D13467AC1061414CAD92AA /* ContentView.swift */; };
+		89A8B99F685895EF23E51FD7 /* ExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6FBABBE0C0A9D915CBF85B /* ExampleUITestsLaunchTests.swift */; };
+		9CD5A0199DE49FB72FBBEE5B /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75AFCD0AE3F74ABC41475218 /* ExampleTests.swift */; };
+		AB903A67D5E295F09FE79F90 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0E59FF263E41FFE42D58A1 /* ExampleApp.swift */; };
+		AF930B17065972D8E2AF26D7 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E8EC5800B28DC7A5B63624 /* ExampleUITests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0F71FB02423BEEE76DFEE7A7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1264E098850804E77CE82093;
+			remoteInfo = "Bazel Generated Files";
+		};
+		4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
+			remoteInfo = Setup;
+		};
+		7EDBC9AA0948CBD61D742C1D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DEF15AA97EC0FE28A9A97CAA;
+			remoteInfo = Example;
+		};
+		B29F6183C154822D72EC2305 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1264E098850804E77CE82093;
+			remoteInfo = "Bazel Generated Files";
+		};
+		EBD0C87C46CE3A0065D73AA0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DEF15AA97EC0FE28A9A97CAA;
+			remoteInfo = Example;
+		};
+		FA89BC6DF686E165E775357E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1264E098850804E77CE82093;
+			remoteInfo = "Bazel Generated Files";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		046B8A4A93C2A9CFCABF22C0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		1AD4E21BF05EA13F3C0E032B /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		2B44F67549E67DB7CD04B8A1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		39004B79217BED4A67CB9A93 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		44C19A56FE797949930D145D /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		50D13467AC1061414CAD92AA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		75AFCD0AE3F74ABC41475218 /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
+		8A36CA287ABB5359FEC0F830 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		AA8B40F3394AF193E0043C9C /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
+		AD6FBABBE0C0A9D915CBF85B /* ExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		B08A809AF7FC433536160D00 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		D227CE711F51FF221F83B7EA /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6E8EC5800B28DC7A5B63624 /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
+		DB017F09DAA174C86C32DE47 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		E470DDDC0990D96A685DB11C /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA0E59FF263E41FFE42D58A1 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		083AF4B2C93542D2E28E5918 /* tvos_app */ = {
+			isa = PBXGroup;
+			children = (
+				2ACEC1C546E9B7840BB7F382 /* Example */,
+				A5E6FCA929EA2C81FBA4D1C5 /* ExampleTests */,
+				2ED1BB9D913567D9730ABA10 /* ExampleUITests */,
+			);
+			path = tvos_app;
+			sourceTree = "<group>";
+		};
+		1F75B84D472E4F903E58A310 /* apple */ = {
+			isa = PBXGroup;
+			children = (
+				B90C93321F57509ADC051F9E /* testing */,
+			);
+			path = apple;
+			sourceTree = "<group>";
+		};
+		2ACEC1C546E9B7840BB7F382 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				D9E0B7B0F1BFB47311DAB30F /* Example-intermediates */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		2ED1BB9D913567D9730ABA10 /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				C608D70C5577748422711EDF /* ExampleUITests.__internal__.__test_bundle-intermediates */,
+			);
+			path = ExampleUITests;
+			sourceTree = "<group>";
+		};
+		593E7C82FAAD94A7E6A04318 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D227CE711F51FF221F83B7EA /* Example.app */,
+				E470DDDC0990D96A685DB11C /* ExampleTests.xctest */,
+				44C19A56FE797949930D145D /* ExampleUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		753268662FBC8ED78F92E88E /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				083AF4B2C93542D2E28E5918 /* tvos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		871C58B635798AE8B859A78F /* ExampleTests.__internal__.__test_bundle-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				2B44F67549E67DB7CD04B8A1 /* Info.plist */,
+			);
+			path = "ExampleTests.__internal__.__test_bundle-intermediates";
+			sourceTree = "<group>";
+		};
+		8A4520AA26B6158FA29DFA58 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				39004B79217BED4A67CB9A93 /* BUILD */,
+				50D13467AC1061414CAD92AA /* ContentView.swift */,
+				FA0E59FF263E41FFE42D58A1 /* ExampleApp.swift */,
+				DB017F09DAA174C86C32DE47 /* Info.plist */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		962A94CEC4834EE66167AEEF /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				8A36CA287ABB5359FEC0F830 /* BUILD */,
+				75AFCD0AE3F74ABC41475218 /* ExampleTests.swift */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
+		9811D2ED915829A1A7881AFD /* Bazel External Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				DEDBB9862662A833DD5D663E /* build_bazel_rules_apple */,
+			);
+			name = "Bazel External Repositories";
+			path = "bazel-rules_xcodeproj/external";
+			sourceTree = "<group>";
+		};
+		A5E6FCA929EA2C81FBA4D1C5 /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				871C58B635798AE8B859A78F /* ExampleTests.__internal__.__test_bundle-intermediates */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
+		B90C93321F57509ADC051F9E /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				AA8B40F3394AF193E0043C9C /* DefaultTestBundle.plist */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
+		BB34C210E2A56E7B96B81F9A /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				FE08DC4FE2EB3C1D3FAC175F /* tvos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		C047AF1D451C7E165914273D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C407A8E68D8C611448A3E699 /* Bazel Generated Files */ = {
+			isa = PBXGroup;
+			children = (
+				F43528CBB1F71BB1AC5CD5FE /* applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3 */,
+			);
+			name = "Bazel Generated Files";
+			path = test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/gen_dir;
+			sourceTree = "<group>";
+		};
+		C608D70C5577748422711EDF /* ExampleUITests.__internal__.__test_bundle-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				B08A809AF7FC433536160D00 /* Info.plist */,
+			);
+			path = "ExampleUITests.__internal__.__test_bundle-intermediates";
+			sourceTree = "<group>";
+		};
+		D9E0B7B0F1BFB47311DAB30F /* Example-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				046B8A4A93C2A9CFCABF22C0 /* Info.plist */,
+			);
+			path = "Example-intermediates";
+			sourceTree = "<group>";
+		};
+		DEDBB9862662A833DD5D663E /* build_bazel_rules_apple */ = {
+			isa = PBXGroup;
+			children = (
+				1F75B84D472E4F903E58A310 /* apple */,
+			);
+			path = build_bazel_rules_apple;
+			sourceTree = "<group>";
+		};
+		E0989A83615208C9B5CAF41C /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				753268662FBC8ED78F92E88E /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
+		E3A32E13D18203BECE3A34CF /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				1AD4E21BF05EA13F3C0E032B /* BUILD */,
+				D6E8EC5800B28DC7A5B63624 /* ExampleUITests.swift */,
+				AD6FBABBE0C0A9D915CBF85B /* ExampleUITestsLaunchTests.swift */,
+			);
+			path = ExampleUITests;
+			sourceTree = "<group>";
+		};
+		EC6FEE5AC277A3FEEA95510A = {
+			isa = PBXGroup;
+			children = (
+				BB34C210E2A56E7B96B81F9A /* examples */,
+				9811D2ED915829A1A7881AFD /* Bazel External Repositories */,
+				C407A8E68D8C611448A3E699 /* Bazel Generated Files */,
+				593E7C82FAAD94A7E6A04318 /* Products */,
+				C047AF1D451C7E165914273D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		F43528CBB1F71BB1AC5CD5FE /* applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3 */ = {
+			isa = PBXGroup;
+			children = (
+				E0989A83615208C9B5CAF41C /* bin */,
+			);
+			path = "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3";
+			sourceTree = "<group>";
+		};
+		FE08DC4FE2EB3C1D3FAC175F /* tvos_app */ = {
+			isa = PBXGroup;
+			children = (
+				8A4520AA26B6158FA29DFA58 /* Example */,
+				962A94CEC4834EE66167AEEF /* ExampleTests */,
+				E3A32E13D18203BECE3A34CF /* ExampleUITests */,
+			);
+			path = tvos_app;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		BBF4D59A51801FF17E35E34E /* ExampleUITests.__internal__.__test_bundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4146445A590327AFBC6ECD1E /* Build configuration list for PBXNativeTarget "ExampleUITests.__internal__.__test_bundle" */;
+			buildPhases = (
+				75999A4F6D73EAE88A550D8B /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2E6EA1FEE98746DEE423C1E9 /* PBXTargetDependency */,
+				4D0DFDD11CB698CEA15C699E /* PBXTargetDependency */,
+			);
+			name = ExampleUITests.__internal__.__test_bundle;
+			productName = ExampleUITests;
+			productReference = 44C19A56FE797949930D145D /* ExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		D133FDFF63F008FDDB07BE99 /* ExampleTests.__internal__.__test_bundle */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8D7CAA9B63F689C04C435E90 /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */;
+			buildPhases = (
+				8E9A15D36D0A0B335579D589 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C2D1B7F2CA0445827922D05C /* PBXTargetDependency */,
+				F670F941F6741D0D3E7AC4A3 /* PBXTargetDependency */,
+			);
+			name = ExampleTests.__internal__.__test_bundle;
+			productName = ExampleTests;
+			productReference = E470DDDC0990D96A685DB11C /* ExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		DEF15AA97EC0FE28A9A97CAA /* Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4E80458017EA17FB5B672FEB /* Build configuration list for PBXNativeTarget "Example" */;
+			buildPhases = (
+				F94B766A6F00B6427D27F290 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2AE8FD8829F7134BE519ADAC /* PBXTargetDependency */,
+			);
+			name = Example;
+			productName = Example;
+			productReference = D227CE711F51FF221F83B7EA /* Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0805833D09730531AD081697 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					1264E098850804E77CE82093 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					BBF4D59A51801FF17E35E34E = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
+					};
+					D133FDFF63F008FDDB07BE99 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
+					};
+					DEF15AA97EC0FE28A9A97CAA = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 1320;
+					};
+					ECAFAC2323528A3317A7C9F2 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+				};
+			};
+			buildConfigurationList = 669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = EC6FEE5AC277A3FEEA95510A;
+			productRefGroup = 593E7C82FAAD94A7E6A04318 /* Products */;
+			projectDirPath = ../../..;
+			projectRoot = "";
+			targets = (
+				ECAFAC2323528A3317A7C9F2 /* Setup */,
+				1264E098850804E77CE82093 /* Bazel Generated Files */,
+				DEF15AA97EC0FE28A9A97CAA /* Example */,
+				D133FDFF63F008FDDB07BE99 /* ExampleTests.__internal__.__test_bundle */,
+				BBF4D59A51801FF17E35E34E /* ExampleUITests.__internal__.__test_bundle */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3BBBE88C0B5DFE50E861D039 /* Copy Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/generated.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Copy Files";
+			outputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/generated.copied.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"bazel-out\"\n\nrsync \\\n  --files-from \"$PROJECT_FILE_PATH/rules_xcodeproj/generated.rsynclist\" \\\n  --chmod=u+w \\\n  -L \\\n  . \\\n  \"$BUILD_DIR/bazel-out\"\n";
+			showEnvVarsInLog = 0;
+		};
+		48F6FA82818C0DE2760C55C0 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\ncd \"$PROJECT_FILE_PATH/rules_xcodeproj\"\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf gen_dir\n\nln -sf \"$BUILD_DIR/bazel-out\" gen_dir\n\ncd \"$BUILD_DIR\"\nln -sfn \"$PROJECT_DIR\" SRCROOT\nln -sfn \"$PROJECT_DIR/bazel-rules_xcodeproj/external\" external\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$PROJECT_FILE_PATH/rules_xcodeproj/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
+			showEnvVarsInLog = 0;
+		};
+		C1BCE66C756D6574AE7961FF /* Fix Info.plists */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/infoplists.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Fix Info.plists";
+			outputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/infoplists.fixed.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CA47126A96DBA220099058F9 /* Generate Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate Files";
+			outputFileListPaths = (
+				"$(PROJECT_FILE_PATH)/rules_xcodeproj/generated.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\n# Need to remove the directory that Xcode creates as part of output prep\nrm -rf \"$PROJECT_DIR/bazel-out\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  ${BAZEL_PATH} \\\n  build \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/tvos_app:xcodeproj_bwb\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		75999A4F6D73EAE88A550D8B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AF930B17065972D8E2AF26D7 /* ExampleUITests.swift in Sources */,
+				89A8B99F685895EF23E51FD7 /* ExampleUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8E9A15D36D0A0B335579D589 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9CD5A0199DE49FB72FBBEE5B /* ExampleTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F94B766A6F00B6427D27F290 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				39BF0A575DB868D507469F87 /* ContentView.swift in Sources */,
+				AB903A67D5E295F09FE79F90 /* ExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		2AE8FD8829F7134BE519ADAC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
+			targetProxy = FA89BC6DF686E165E775357E /* PBXContainerItemProxy */;
+		};
+		2E6EA1FEE98746DEE423C1E9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
+			targetProxy = B29F6183C154822D72EC2305 /* PBXContainerItemProxy */;
+		};
+		4D0DFDD11CB698CEA15C699E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Example;
+			target = DEF15AA97EC0FE28A9A97CAA /* Example */;
+			targetProxy = EBD0C87C46CE3A0065D73AA0 /* PBXContainerItemProxy */;
+		};
+		A375E057D32BEDDB980E23C5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Setup;
+			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
+			targetProxy = 4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */;
+		};
+		C2D1B7F2CA0445827922D05C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Generated Files";
+			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
+			targetProxy = 0F71FB02423BEEE76DFEE7A7 /* PBXContainerItemProxy */;
+		};
+		F670F941F6741D0D3E7AC4A3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Example;
+			target = DEF15AA97EC0FE28A9A97CAA /* Example */;
+			targetProxy = 7EDBC9AA0948CBD61D742C1D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		394CCE329FB879734646BC3A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.uitests;
+				PRODUCT_MODULE_NAME = ExampleUITests;
+				PRODUCT_NAME = ExampleUITests;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = appletvsimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = ExampleUITests.__internal__.__test_bundle;
+				TEST_TARGET_NAME = Example;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+			};
+			name = Debug;
+		};
+		4A234614294618D445060F03 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = Setup;
+			};
+			name = Debug;
+		};
+		958FA2D1FA128C21904CB40E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = GenerateBazelFiles;
+			};
+			name = Debug;
+		};
+		B0892EE2AB907B40AA4EB960 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BAZEL_PATH = bazel;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
+				COPY_PHASE_STRIP = NO;
+				ONLY_ACTIVE_ARCH = YES;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+		ED022D7827FA072088152A34 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
+				PRODUCT_MODULE_NAME = Example;
+				PRODUCT_NAME = Example;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = appletvsimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = Example;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+			};
+			name = Debug;
+		};
+		F4B8552398B786F68242064D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				INFOPLIST_FILE = "$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				OTHER_CFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-g",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -g -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.tests;
+				PRODUCT_MODULE_NAME = ExampleTests;
+				PRODUCT_NAME = ExampleTests;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = appletvsimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example$(TARGET_BUILD_SUBPATH)";
+				TARGET_NAME = ExampleTests.__internal__.__test_bundle;
+				TEST_HOST = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example.app/Example";
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				958FA2D1FA128C21904CB40E /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		4146445A590327AFBC6ECD1E /* Build configuration list for PBXNativeTarget "ExampleUITests.__internal__.__test_bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				394CCE329FB879734646BC3A /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		4E80458017EA17FB5B672FEB /* Build configuration list for PBXNativeTarget "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ED022D7827FA072088152A34 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B0892EE2AB907B40AA4EB960 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A234614294618D445060F03 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		8D7CAA9B63F689C04C435E90 /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F4B8552398B786F68242064D /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0805833D09730531AD081697 /* Project object */;
+}

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -1,0 +1,3 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -1,0 +1,3 @@
+applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
+applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,0 +1,3 @@
+$(PROJECT_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
+$(PROJECT_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
@@ -1,0 +1,3 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
@@ -1,0 +1,3 @@
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(PROJECT_FILE_PATH)/rules_xcodeproj/gen_dir/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -1,0 +1,615 @@
+{
+    "build_settings": {
+        "ALWAYS_SEARCH_USER_PATHS": false,
+        "BAZEL_PATH": "bazel",
+        "CLANG_ENABLE_OBJC_ARC": true,
+        "CLANG_MODULES_AUTOLINK": false,
+        "COPY_PHASE_STRIP": false,
+        "ONLY_ACTIVE_ARCH": true,
+        "USE_HEADERMAP": false,
+        "VALIDATE_WORKSPACE": false
+    },
+    "extra_files": [
+        "examples/tvos_app/Example/BUILD",
+        "examples/tvos_app/Example/Info.plist",
+        {
+            "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.plist",
+            "t": "g"
+        },
+        "examples/tvos_app/ExampleTests/BUILD",
+        {
+            "_": "build_bazel_rules_apple/apple/testing/DefaultTestBundle.plist",
+            "t": "e"
+        },
+        {
+            "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
+            "t": "g"
+        },
+        "examples/tvos_app/ExampleUITests/BUILD",
+        {
+            "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist",
+            "t": "g"
+        }
+    ],
+    "invalid_target_merges": [],
+    "label": "//test/fixtures/tvos_app:xcodeproj_bwb",
+    "name": "bwb",
+    "target_merges": [
+        "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+        [
+            "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
+        ],
+        "//examples/tvos_app/ExampleTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+        [
+            "//examples/tvos_app/ExampleTests:ExampleTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
+        ],
+        "//examples/tvos_app/ExampleUITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+        [
+            "//examples/tvos_app/ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
+        ]
+    ],
+    "targets": [
+        "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
+                "PRODUCT_MODULE_NAME": "_Example_Stub",
+                "PRODUCT_NAME": "Example",
+                "SUPPORTED_PLATFORMS": "appletvsimulator",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+            "dependencies": [
+                "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
+            ],
+            "frameworks": [],
+            "info_plist": {
+                "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.plist",
+                "t": "g"
+            },
+            "inputs": {
+                "contains_generated_files": true
+            },
+            "is_swift": false,
+            "label": "//examples/tvos_app/Example:Example",
+            "links": [
+                {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/libExample.library.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "Example",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "Example",
+                "path": {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example_archive-root/Payload/Example.app",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.application"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "Example",
+                "PRODUCT_NAME": "Example.library",
+                "SUPPORTED_PLATFORMS": "appletvsimulator",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "examples/tvos_app/Example/ContentView.swift",
+                    "examples/tvos_app/Example/ExampleApp.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//examples/tvos_app/Example:Example.library",
+            "links": [],
+            "modulemaps": [],
+            "name": "Example.library",
+            "outputs": {
+                "swift_module": {
+                    "name": "Example.swiftmodule",
+                    "swiftdoc": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example.swiftdoc",
+                    "swiftmodule": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "Example.library",
+                "path": {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/libExample.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        },
+        "//examples/tvos_app/ExampleTests:ExampleTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.tests",
+                "PRODUCT_MODULE_NAME": "_ExampleTests_Stub",
+                "PRODUCT_NAME": "ExampleTests",
+                "SUPPORTED_PLATFORMS": "appletvsimulator",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+            "dependencies": [
+                "//examples/tvos_app/ExampleTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+                "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
+            ],
+            "frameworks": [],
+            "info_plist": {
+                "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
+                "t": "g"
+            },
+            "inputs": {
+                "contains_generated_files": true
+            },
+            "is_swift": false,
+            "label": "//examples/tvos_app/ExampleTests:ExampleTests.__internal__.__test_bundle",
+            "links": [
+                {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/libExampleTests.library.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "ExampleTests.__internal__.__test_bundle",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "ExampleTests",
+                "path": {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle_archive-root/ExampleTests.xctest",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.bundle.unit-test"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
+        },
+        "//examples/tvos_app/ExampleTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "ENABLE_TESTING_SEARCH_PATHS": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "ExampleTests",
+                "PRODUCT_NAME": "ExampleTests.library",
+                "SUPPORTED_PLATFORMS": "appletvsimulator",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+            "dependencies": [
+                "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
+            ],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "examples/tvos_app/ExampleTests/ExampleTests.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//examples/tvos_app/ExampleTests:ExampleTests.library",
+            "links": [],
+            "modulemaps": [],
+            "name": "ExampleTests.library",
+            "outputs": {
+                "swift_module": {
+                    "name": "ExampleTests.swiftmodule",
+                    "swiftdoc": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftdoc",
+                    "swiftmodule": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "ExampleTests.library",
+                "path": {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/libExampleTests.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [
+                {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example.swiftmodule",
+                    "t": "g"
+                }
+            ],
+            "test_host": null
+        },
+        "//examples/tvos_app/ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.uitests",
+                "PRODUCT_MODULE_NAME": "_ExampleUITests_Stub",
+                "PRODUCT_NAME": "ExampleUITests",
+                "SUPPORTED_PLATFORMS": "appletvsimulator",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+            "dependencies": [
+                "//examples/tvos_app/ExampleUITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+                "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
+            ],
+            "frameworks": [],
+            "info_plist": {
+                "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist",
+                "t": "g"
+            },
+            "inputs": {
+                "contains_generated_files": true
+            },
+            "is_swift": false,
+            "label": "//examples/tvos_app/ExampleUITests:ExampleUITests.__internal__.__test_bundle",
+            "links": [
+                {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/libExampleUITests.library.a",
+                    "t": "g"
+                }
+            ],
+            "modulemaps": [],
+            "name": "ExampleUITests.__internal__.__test_bundle",
+            "outputs": {
+                "dsyms": []
+            },
+            "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "ExampleUITests",
+                "path": {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle_archive-root/ExampleUITests.xctest",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.bundle.ui-testing"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
+        },
+        "//examples/tvos_app/ExampleUITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+        {
+            "build_settings": {
+                "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "ENABLE_TESTING_SEARCH_PATHS": true,
+                "GCC_PREPROCESSOR_DEFINITIONS": [
+                    "_FORTIFY_SOURCE=1",
+                    "__DATE__=\"redacted\"",
+                    "__TIMESTAMP__=\"redacted\"",
+                    "__TIME__=\"redacted\""
+                ],
+                "OTHER_CFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_CPLUSPLUSFLAGS": [
+                    "-fstack-protector",
+                    "-Wall",
+                    "-Wthread-safety",
+                    "-Wself-assign",
+                    "-fno-omit-frame-pointer",
+                    "-g",
+                    "-no-canonical-prefixes",
+                    "-pthread",
+                    "-no-canonical-prefixes",
+                    "-Wno-builtin-macro-redefined"
+                ],
+                "OTHER_LDFLAGS": [
+                    "-ObjC"
+                ],
+                "OTHER_SWIFT_FLAGS": "-g",
+                "PRODUCT_MODULE_NAME": "ExampleUITests",
+                "PRODUCT_NAME": "ExampleUITests.library",
+                "SUPPORTED_PLATFORMS": "appletvsimulator",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5",
+                "TVOS_DEPLOYMENT_TARGET": "15.0"
+            },
+            "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
+            "dependencies": [],
+            "frameworks": [],
+            "info_plist": null,
+            "inputs": {
+                "srcs": [
+                    "examples/tvos_app/ExampleUITests/ExampleUITests.swift",
+                    "examples/tvos_app/ExampleUITests/ExampleUITestsLaunchTests.swift"
+                ]
+            },
+            "is_swift": true,
+            "label": "//examples/tvos_app/ExampleUITests:ExampleUITests.library",
+            "links": [],
+            "modulemaps": [],
+            "name": "ExampleUITests.library",
+            "outputs": {
+                "swift_module": {
+                    "name": "ExampleUITests.swiftmodule",
+                    "swiftdoc": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftdoc",
+                    "swiftmodule": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftmodule",
+                    "swiftsourceinfo": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftsourceinfo"
+                }
+            },
+            "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests",
+            "platform": {
+                "arch": "x86_64",
+                "environment": "Simulator",
+                "minimum_os_version": "15.0",
+                "os": "tvos"
+            },
+            "product": {
+                "name": "ExampleUITests.library",
+                "path": {
+                    "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/libExampleUITests.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "resource_bundles": [],
+            "search_paths": {},
+            "swiftmodules": [],
+            "test_host": null
+        }
+    ]
+}

--- a/xcodeproj/internal/fixtures.bzl
+++ b/xcodeproj/internal/fixtures.bzl
@@ -110,7 +110,7 @@ def xcodeproj_fixture(
         *,
         name = "xcodeproj",
         workspace_name = "rules_xcodeproj",
-        modes_and_suffixes = [("xcode", "bwx")],
+        modes_and_suffixes = [("xcode", "bwx"), ("bazel", "bwb")],
         targets):
     """Creates the fixture for an existing `xcodeproj` target.
 


### PR DESCRIPTION
Right now the only difference is that in `bazel` mode the `compilation_mode` is currently forced to be `dbg`. This "restriction" will be lifted when we implement proper configuration support. For now though, we need this compilation mode to enable debugging in Build with Bazel.

We now also generate another set of fixtures for Build with Bazel, a.k.a "bwb".