### PR TITLE
Fix xcodeproj_tests  test names

### DIFF
--- a/test/internal/xcodeproj_tests/xcodeproj_tests_tests.bzl
+++ b/test/internal/xcodeproj_tests/xcodeproj_tests_tests.bzl
@@ -9,7 +9,7 @@ def _from_fixture_test(ctx):
     # Specify target
     actual = xcodeproj_tests.from_fixture("//path/to/pkg:custom_xcodeproj")
     expected = struct(
-        basename = "pkg",
+        basename = "pkg_custom_xcodeproj",
         target_under_test = "//path/to/pkg:custom_xcodeproj",
         expected_spec = "@//path/to/pkg:custom_xcodeproj_spec",
         expected_xcodeproj = "@//path/to/pkg:custom_xcodeproj_output",

--- a/xcodeproj/internal/xcodeproj_tests.bzl
+++ b/xcodeproj/internal/xcodeproj_tests.bzl
@@ -40,7 +40,10 @@ def _from_fixture(
     )
 
     if basename == None:
-        basename = paths.basename(pkg)
+        basename = "{basename}_{name}".format(
+            basename = paths.basename(pkg),
+            name = target_under_test_label.name,
+        )
     if expected_spec == None:
         expected_spec = "{pkg}:{name}".format(
             pkg = pkg,


### PR DESCRIPTION
With multiple fixtures per package there were name collisions.