### PR TITLE
Fetch Bazel External Repositories as part of build

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -7,31 +7,19 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		1264E098850804E77CE82093 /* Bazel Generated Files */ = {
+		9281ECD979418C4678530C3F /* Bazel Dependencies */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */;
+			buildConfigurationList = CBAD4D93C81A6196323B1482 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */;
 			buildPhases = (
-				CA47126A96DBA220099058F9 /* Generate Files */,
-				3BBBE88C0B5DFE50E861D039 /* Copy Files */,
-				C39544D2D57030E1F850014D /* Fix Modulemaps */,
-				C1BCE66C756D6574AE7961FF /* Fix Info.plists */,
-			);
-			dependencies = (
-				A375E057D32BEDDB980E23C5 /* PBXTargetDependency */,
-			);
-			name = "Bazel Generated Files";
-			productName = "Bazel Generated Files";
-		};
-		ECAFAC2323528A3317A7C9F2 /* Setup */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */;
-			buildPhases = (
-				48F6FA82818C0DE2760C55C0 /* ShellScript */,
+				FD442F9D0D3F77311B69FA42 /* Generate Files */,
+				391E7CA7B16FAFAE0457D1C2 /* Copy Files */,
+				77D46E44C108C6CEE2F89E0D /* Fix Modulemaps */,
+				4CBF24D403529E7553176153 /* Fix Info.plists */,
 			);
 			dependencies = (
 			);
-			name = Setup;
-			productName = Setup;
+			name = "Bazel Dependencies";
+			productName = "Bazel Dependencies";
 		};
 /* End PBXAggregateTarget section */
 
@@ -64,19 +52,26 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0F71FB02423BEEE76DFEE7A7 /* PBXContainerItemProxy */ = {
+		110986C710000A69ABE319EB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1264E098850804E77CE82093;
-			remoteInfo = "Bazel Generated Files";
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
-		12BBDEF891F9CEDDBCF66227 /* PBXContainerItemProxy */ = {
+		11A1653A0467DE3D23FB985F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
+		};
+		1CF9C88B9ECC02A32824AAE3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 		253F301DFAC4DBD74F463E32 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -85,6 +80,13 @@
 			remoteGlobalIDString = F175A7E1019A952CA7F66BBC;
 			remoteInfo = TestingUtils;
 		};
+		3BA2A8D5AC47F95AE6B6270F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
+		};
 		40C4645E155842FBD47B3D44 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -92,19 +94,19 @@
 			remoteGlobalIDString = 95C60B89B988FCC45A4A0562;
 			remoteInfo = ExampleResources;
 		};
-		4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */ = {
+		591ABC5BE762ED1E70EA3F66 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
-		73935C723008807A2920DC10 /* PBXContainerItemProxy */ = {
+		791B7678D5C0BBAAA4BECD8F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1264E098850804E77CE82093;
-			remoteInfo = "Bazel Generated Files";
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 		7DC9F0A22A7B1E5E310197D9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -120,13 +122,6 @@
 			remoteGlobalIDString = DEF15AA97EC0FE28A9A97CAA;
 			remoteInfo = Example;
 		};
-		80B7F7FC096EA6B5D2CEF6A4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
-		};
 		8AFCF859AE8A8F088DB4EF97 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -140,13 +135,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 64AE6000A6317B9C077F3B1E;
 			remoteInfo = CoreUtilsObjC;
-		};
-		9AF12B3279FCACB57125FEC0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
 		};
 		9B5B4C5E0C8D4797ADCE6AB2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -176,19 +164,19 @@
 			remoteGlobalIDString = 34820134F30D904FFA06D27A;
 			remoteInfo = Utils;
 		};
-		B29F6183C154822D72EC2305 /* PBXContainerItemProxy */ = {
+		B71878DACFF4D4B444BFDCD1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1264E098850804E77CE82093;
-			remoteInfo = "Bazel Generated Files";
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
-		CC375C8586CC07711829D641 /* PBXContainerItemProxy */ = {
+		C0D80619D2C42BB73BC97511 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 		DE2ABDC3A4020CEAD5FB18F6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -204,19 +192,12 @@
 			remoteGlobalIDString = DEF15AA97EC0FE28A9A97CAA;
 			remoteInfo = Example;
 		};
-		FA89BC6DF686E165E775357E /* PBXContainerItemProxy */ = {
+		F1A79CE8A62EBCC634CC11D9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1264E098850804E77CE82093;
-			remoteInfo = "Bazel Generated Files";
-		};
-		FB75881099C5283F0B88B414 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1264E098850804E77CE82093;
-			remoteInfo = "Bazel Generated Files";
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -665,7 +646,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				A15F1A249509401D0B74005A /* PBXTargetDependency */,
+				5A94226F24858CC8DD8ADB1C /* PBXTargetDependency */,
 			);
 			name = ExternalResources;
 			productName = ExternalResources;
@@ -681,7 +662,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				0FD2BFD3DDD85BFE6D5269C5 /* PBXTargetDependency */,
+				D154D1693D52F814DF193634 /* PBXTargetDependency */,
 				525486294F10747C8F6172F4 /* PBXTargetDependency */,
 			);
 			name = Utils;
@@ -698,7 +679,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				EB99382E68EB53291BF54D3F /* PBXTargetDependency */,
+				0E5E247666C0F0835980B66F /* PBXTargetDependency */,
 			);
 			name = CoreUtilsObjC;
 			productName = CoreUtilsObjC;
@@ -715,7 +696,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				191F9026661B68825A423330 /* PBXTargetDependency */,
+				8752815C18F0ED1D8E490F5A /* PBXTargetDependency */,
 				C7F459DED8FA911CD017E629 /* PBXTargetDependency */,
 				4340DE112FCC7EC33567A231 /* PBXTargetDependency */,
 				6CF6D5E9860D81504C950316 /* PBXTargetDependency */,
@@ -734,7 +715,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				BC25428763663CB2C98EAB87 /* PBXTargetDependency */,
+				887D596648519CB223622FF9 /* PBXTargetDependency */,
 			);
 			name = ExampleResources;
 			productName = ExampleResources;
@@ -751,7 +732,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				2E6EA1FEE98746DEE423C1E9 /* PBXTargetDependency */,
+				5DFE3D6D6371279C87EFC9F6 /* PBXTargetDependency */,
 				4D0DFDD11CB698CEA15C699E /* PBXTargetDependency */,
 				4759CE70D5CD08547DBA3195 /* PBXTargetDependency */,
 			);
@@ -770,7 +751,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				C2D1B7F2CA0445827922D05C /* PBXTargetDependency */,
+				1D5CD5B9BA8C334C7A88A805 /* PBXTargetDependency */,
 				F670F941F6741D0D3E7AC4A3 /* PBXTargetDependency */,
 				DC91293E0A2166D8365173A5 /* PBXTargetDependency */,
 				C2C1C85130B75A2A4AA73509 /* PBXTargetDependency */,
@@ -793,7 +774,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				2AE8FD8829F7134BE519ADAC /* PBXTargetDependency */,
+				2047D4B3EA4C6F4853601156 /* PBXTargetDependency */,
 				E4CC90D212BA2CFA0249920B /* PBXTargetDependency */,
 				4D0F270A9C4875B0F9EFA648 /* PBXTargetDependency */,
 			);
@@ -812,7 +793,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				A369504133B5C51B55717635 /* PBXTargetDependency */,
+				7609B5394B41B8F5C0A07CBD /* PBXTargetDependency */,
 			);
 			name = TestingUtils;
 			productName = TestingUtils;
@@ -833,9 +814,6 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
-					1264E098850804E77CE82093 = {
-						CreatedOnToolsVersion = 13.2.1;
-					};
 					34820134F30D904FFA06D27A = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -848,6 +826,9 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
+					};
+					9281ECD979418C4678530C3F = {
+						CreatedOnToolsVersion = 13.2.1;
 					};
 					95C60B89B988FCC45A4A0562 = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -866,9 +847,6 @@
 					DEF15AA97EC0FE28A9A97CAA = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
-					};
-					ECAFAC2323528A3317A7C9F2 = {
-						CreatedOnToolsVersion = 13.2.1;
 					};
 					F175A7E1019A952CA7F66BBC = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -890,8 +868,7 @@
 			projectDirPath = ../..;
 			projectRoot = "";
 			targets = (
-				ECAFAC2323528A3317A7C9F2 /* Setup */,
-				1264E098850804E77CE82093 /* Bazel Generated Files */,
+				9281ECD979418C4678530C3F /* Bazel Dependencies */,
 				64AE6000A6317B9C077F3B1E /* CoreUtilsObjC */,
 				DEF15AA97EC0FE28A9A97CAA /* Example */,
 				7E5DFA29686635FDE423D8F4 /* ExampleObjcTests.__internal__.__test_bundle */,
@@ -964,7 +941,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3BBBE88C0B5DFE50E861D039 /* Copy Files */ = {
+		391E7CA7B16FAFAE0457D1C2 /* Copy Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1002,22 +979,7 @@
 			shellScript = "cp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		48F6FA82818C0DE2760C55C0 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\ntouch BUILD\ntouch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf gen_dir\n  rm -rf external\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
-			showEnvVarsInLog = 0;
-		};
-		C1BCE66C756D6574AE7961FF /* Fix Info.plists */ = {
+		4CBF24D403529E7553176153 /* Fix Info.plists */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1038,7 +1000,7 @@
 			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C39544D2D57030E1F850014D /* Fix Modulemaps */ = {
+		77D46E44C108C6CEE2F89E0D /* Fix Modulemaps */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1059,7 +1021,7 @@
 			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(\\s*(\\w+ )?header )(?!(\"\\.\\.(\\/\\.\\.)*\\/|\")(bazel-out|external)\\/)(\"(\\.\\.\\/)*)(.*\")%\\1\\6SRCROOT/\\8%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CA47126A96DBA220099058F9 /* Generate Files */ = {
+		FD442F9D0D3F77311B69FA42 /* Generate Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -1076,7 +1038,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures:fixture_bwb\n";
+			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\n  touch BUILD\n  touch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf external\n  rm -rf gen_dir\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n\ncd \"$SRCROOT\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures:fixture_bwb\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1143,29 +1105,23 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		0FD2BFD3DDD85BFE6D5269C5 /* PBXTargetDependency */ = {
+		0E5E247666C0F0835980B66F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 12BBDEF891F9CEDDBCF66227 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = C0D80619D2C42BB73BC97511 /* PBXContainerItemProxy */;
 		};
-		191F9026661B68825A423330 /* PBXTargetDependency */ = {
+		1D5CD5B9BA8C334C7A88A805 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
-			targetProxy = FB75881099C5283F0B88B414 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 110986C710000A69ABE319EB /* PBXContainerItemProxy */;
 		};
-		2AE8FD8829F7134BE519ADAC /* PBXTargetDependency */ = {
+		2047D4B3EA4C6F4853601156 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
-			targetProxy = FA89BC6DF686E165E775357E /* PBXContainerItemProxy */;
-		};
-		2E6EA1FEE98746DEE423C1E9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
-			targetProxy = B29F6183C154822D72EC2305 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 1CF9C88B9ECC02A32824AAE3 /* PBXContainerItemProxy */;
 		};
 		4340DE112FCC7EC33567A231 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1197,35 +1153,41 @@
 			target = 64AE6000A6317B9C077F3B1E /* CoreUtilsObjC */;
 			targetProxy = 97350A84E43A3D97DB7FF16B /* PBXContainerItemProxy */;
 		};
+		5A94226F24858CC8DD8ADB1C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = F1A79CE8A62EBCC634CC11D9 /* PBXContainerItemProxy */;
+		};
+		5DFE3D6D6371279C87EFC9F6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = B71878DACFF4D4B444BFDCD1 /* PBXContainerItemProxy */;
+		};
 		6CF6D5E9860D81504C950316 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Utils;
 			target = 34820134F30D904FFA06D27A /* Utils */;
 			targetProxy = 7DC9F0A22A7B1E5E310197D9 /* PBXContainerItemProxy */;
 		};
-		A15F1A249509401D0B74005A /* PBXTargetDependency */ = {
+		7609B5394B41B8F5C0A07CBD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = CC375C8586CC07711829D641 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 791B7678D5C0BBAAA4BECD8F /* PBXContainerItemProxy */;
 		};
-		A369504133B5C51B55717635 /* PBXTargetDependency */ = {
+		8752815C18F0ED1D8E490F5A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
-			targetProxy = 73935C723008807A2920DC10 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 11A1653A0467DE3D23FB985F /* PBXContainerItemProxy */;
 		};
-		A375E057D32BEDDB980E23C5 /* PBXTargetDependency */ = {
+		887D596648519CB223622FF9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */;
-		};
-		BC25428763663CB2C98EAB87 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 80B7F7FC096EA6B5D2CEF6A4 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 591ABC5BE762ED1E70EA3F66 /* PBXContainerItemProxy */;
 		};
 		C2C1C85130B75A2A4AA73509 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1233,17 +1195,17 @@
 			target = F175A7E1019A952CA7F66BBC /* TestingUtils */;
 			targetProxy = 253F301DFAC4DBD74F463E32 /* PBXContainerItemProxy */;
 		};
-		C2D1B7F2CA0445827922D05C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
-			targetProxy = 0F71FB02423BEEE76DFEE7A7 /* PBXContainerItemProxy */;
-		};
 		C7F459DED8FA911CD017E629 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Example;
 			target = DEF15AA97EC0FE28A9A97CAA /* Example */;
 			targetProxy = A0F480345DF9DC369DA636A3 /* PBXContainerItemProxy */;
+		};
+		D154D1693D52F814DF193634 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 3BA2A8D5AC47F95AE6B6270F /* PBXContainerItemProxy */;
 		};
 		D32ED35208CAB32B6C2A56B3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1262,12 +1224,6 @@
 			name = ExampleResources;
 			target = 95C60B89B988FCC45A4A0562 /* ExampleResources */;
 			targetProxy = DE2ABDC3A4020CEAD5FB18F6 /* PBXContainerItemProxy */;
-		};
-		EB99382E68EB53291BF54D3F /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 9AF12B3279FCACB57125FEC0 /* PBXContainerItemProxy */;
 		};
 		F670F941F6741D0D3E7AC4A3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1492,18 +1448,6 @@
 			};
 			name = Debug;
 		};
-		4A234614294618D445060F03 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = Setup;
-			};
-			name = Debug;
-		};
 		71CDD5A48E2EA7B78D29CDD7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1516,18 +1460,6 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphonesimulator;
 				TARGET_NAME = ExternalResources;
-			};
-			name = Debug;
-		};
-		958FA2D1FA128C21904CB40E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = GenerateBazelFiles;
 			};
 			name = Debug;
 		};
@@ -1690,6 +1622,18 @@
 				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+		D6C64C86AFDFF55D55C69DFF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;
 		};
@@ -1875,14 +1819,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				958FA2D1FA128C21904CB40E /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		2DA2E74A7235D7B2754DAB9F /* Build configuration list for PBXNativeTarget "ExampleResources" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1931,14 +1867,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4A234614294618D445060F03 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		8D7CAA9B63F689C04C435E90 /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1951,6 +1879,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A56BEE637DA1B6A442624451 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		CBAD4D93C81A6196323B1482 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6C64C86AFDFF55D55C69DFF /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -7,31 +7,19 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		259BD17350ABF44CECE076AA /* Bazel Generated Files */ = {
+		657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 2EE6FA675E0D16D8070B0477 /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */;
+			buildConfigurationList = 1CF9208AFC262BED8CB8A0A9 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */;
 			buildPhases = (
-				107DDC90FF1C27D140777338 /* Generate Files */,
-				588A3D0F8C7F3BC89386E0B0 /* Copy Files */,
-				B3A06EEB8CFD571AB8F5BFAB /* Fix Modulemaps */,
-				83B35A792C311A4BA4FDD64C /* Fix Info.plists */,
-			);
-			dependencies = (
-				F8C60BA7FF48BAF712148980 /* PBXTargetDependency */,
-			);
-			name = "Bazel Generated Files";
-			productName = "Bazel Generated Files";
-		};
-		D5818B90A725A9C678DAB333 /* Setup */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 7786D074CB72C5247C39ED2F /* Build configuration list for PBXAggregateTarget "Setup" */;
-			buildPhases = (
-				ACC8D5FD5A8A2BBA4C7F6853 /* ShellScript */,
+				EFD5DC5BF35D589213C98597 /* Generate Files */,
+				14DE13B950F0A4E49F5CF508 /* Copy Files */,
+				D59B838F58CCDC97935C509C /* Fix Modulemaps */,
+				FF8B0244BAA1F32D8929C997 /* Fix Info.plists */,
 			);
 			dependencies = (
 			);
-			name = Setup;
-			productName = Setup;
+			name = "Bazel Dependencies";
+			productName = "Bazel Dependencies";
 		};
 /* End PBXAggregateTarget section */
 
@@ -78,47 +66,33 @@
 			remoteGlobalIDString = 42A7256A505DA3DFEA69C941;
 			remoteInfo = TestingUtils;
 		};
-		1FEF594BB1009034792049E9 /* PBXContainerItemProxy */ = {
+		4586EA019F9A0AEB5C3C760A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
-		288D31D755F0153696C9DB29 /* PBXContainerItemProxy */ = {
+		5372562177EBC1BD93515F6C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
-		2B6ACF8C2FE3C370D699C149 /* PBXContainerItemProxy */ = {
+		55D8683784886A4A2DE0797F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
-		3A4D7E67AD5036ADB20D69E4 /* PBXContainerItemProxy */ = {
+		6696E8D173BF56A40F4EBFC3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 259BD17350ABF44CECE076AA;
-			remoteInfo = "Bazel Generated Files";
-		};
-		513084DA66939A090497A2BC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 259BD17350ABF44CECE076AA;
-			remoteInfo = "Bazel Generated Files";
-		};
-		61A3CFD71A717D7DC4F3C542 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
 		6ED91B607D49D808DA25E0DE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -126,13 +100,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 225701F2BB3EA192424F07FE;
 			remoteInfo = ExampleResources;
-		};
-		6F8F383F7312A0FC17937C32 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
 		};
 		74D605DCFD345388C0AEF131 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -148,6 +115,13 @@
 			remoteGlobalIDString = 9E46111B59CD5CC4865299C2;
 			remoteInfo = Example;
 		};
+		8BA5150BAD500ED81E254043 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
+		};
 		93BD7009B9CA0DBECFEDB13C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -162,6 +136,13 @@
 			remoteGlobalIDString = 225701F2BB3EA192424F07FE;
 			remoteInfo = ExampleResources;
 		};
+		9BC443317E7CE097B2BC3F22 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
+		};
 		A2202E540FBEDC3B11423E69 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -169,26 +150,26 @@
 			remoteGlobalIDString = 9EEE562EF383D06390A55602;
 			remoteInfo = ExternalResources;
 		};
+		B3BF93B9052C6E5D977B763D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
+		};
+		B7A58450E8974BF0DDB3874D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
+		};
 		BAAECFBDB24D9E22FDDAE7AB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 42E984F26D5B4ECBE0F0F076;
 			remoteInfo = Utils;
-		};
-		C454C7006724CF7E98AA8AD1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 259BD17350ABF44CECE076AA;
-			remoteInfo = "Bazel Generated Files";
-		};
-		D90D54A5E4C7708475358BFD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 259BD17350ABF44CECE076AA;
-			remoteInfo = "Bazel Generated Files";
 		};
 		EB2CE0E79F60A8591B178E70 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -204,12 +185,12 @@
 			remoteGlobalIDString = 9E46111B59CD5CC4865299C2;
 			remoteInfo = Example;
 		};
-		FB06C3A30C909F16C06AD2A3 /* PBXContainerItemProxy */ = {
+		FAFC63CF1192A75AB24F3CC0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 259BD17350ABF44CECE076AA;
-			remoteInfo = "Bazel Generated Files";
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
 		FE8CA39EE27D6C96DC480525 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -665,7 +646,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				45A5750360AC912E8CC7736B /* PBXTargetDependency */,
+				479C523BF517576655D49649 /* PBXTargetDependency */,
 			);
 			name = ExampleResources;
 			productName = ExampleResources;
@@ -682,7 +663,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				5FAD2A571B2362FB2AC58F38 /* PBXTargetDependency */,
+				D2C66BCC6F0028CB67737692 /* PBXTargetDependency */,
 			);
 			name = TestingUtils;
 			productName = TestingUtils;
@@ -698,7 +679,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				85FBAD4F588E244786ABF5CC /* PBXTargetDependency */,
+				91101406CEC9E21A6B6DA77A /* PBXTargetDependency */,
 				21FDB4F141406B606E0B74C7 /* PBXTargetDependency */,
 			);
 			name = Utils;
@@ -716,7 +697,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				DEE0E258B29100BBE8FAB1D0 /* PBXTargetDependency */,
+				D5BD59BE8BB2DCCFD7B0AFFD /* PBXTargetDependency */,
 				97533C63F9ED14EA06D9942B /* PBXTargetDependency */,
 				558E53F433AD3073C54A1F99 /* PBXTargetDependency */,
 				619B92520AE04DF475C71CE3 /* PBXTargetDependency */,
@@ -736,7 +717,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				07B95CCC17640C4AAA7EAB52 /* PBXTargetDependency */,
+				D88707E90E059FB39F3F6680 /* PBXTargetDependency */,
 				EA5A8DB030DD28F2F1A365FE /* PBXTargetDependency */,
 				B8D1904683275B0D2D926E5F /* PBXTargetDependency */,
 				9F31E9A775F9E479436059E7 /* PBXTargetDependency */,
@@ -759,7 +740,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				2716FF92D4EEBF8A703870A9 /* PBXTargetDependency */,
+				D85FAC7924D560883A5EC96A /* PBXTargetDependency */,
 				330934BB9FAB5FCD57B18598 /* PBXTargetDependency */,
 				BF0C8F6D0A6CA8F2C761C954 /* PBXTargetDependency */,
 			);
@@ -777,7 +758,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				F59520A0B2D66A17B19D6F0E /* PBXTargetDependency */,
+				A63D16002E1FCE62ACF9E99D /* PBXTargetDependency */,
 			);
 			name = ExternalResources;
 			productName = ExternalResources;
@@ -793,7 +774,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				D4938ABE19F7755E3D8B6A4B /* PBXTargetDependency */,
+				D033A41CE5DF3139188DCCCE /* PBXTargetDependency */,
 			);
 			name = CoreUtilsObjC;
 			productName = CoreUtilsObjC;
@@ -810,7 +791,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				D101CD69962413EF33FD887F /* PBXTargetDependency */,
+				5DDC602419E90C9570AA2AD7 /* PBXTargetDependency */,
 				2D8ED23480A44C6BB910460C /* PBXTargetDependency */,
 				D8395909BBABBF02986121AE /* PBXTargetDependency */,
 			);
@@ -833,9 +814,6 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
-					259BD17350ABF44CECE076AA = {
-						CreatedOnToolsVersion = 13.2.1;
-					};
 					42A7256A505DA3DFEA69C941 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -854,6 +832,9 @@
 						LastSwiftMigration = 1320;
 						TestTargetID = 9E46111B59CD5CC4865299C2;
 					};
+					657E5F38D9811E4DFA49DA75 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
 					9E46111B59CD5CC4865299C2 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -871,9 +852,6 @@
 						LastSwiftMigration = 1320;
 						TestTargetID = 9E46111B59CD5CC4865299C2;
 					};
-					D5818B90A725A9C678DAB333 = {
-						CreatedOnToolsVersion = 13.2.1;
-					};
 				};
 			};
 			buildConfigurationList = 8C14447CB8BDD86ECF450932 /* Build configuration list for PBXProject "bwx" */;
@@ -890,8 +868,7 @@
 			projectDirPath = ../..;
 			projectRoot = "";
 			targets = (
-				D5818B90A725A9C678DAB333 /* Setup */,
-				259BD17350ABF44CECE076AA /* Bazel Generated Files */,
+				657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */,
 				A0257519AD63A69C6DF51958 /* CoreUtilsObjC */,
 				9E46111B59CD5CC4865299C2 /* Example */,
 				4BF4D16D8EFD29114BC29B92 /* ExampleObjcTests.__internal__.__test_bundle */,
@@ -981,27 +958,7 @@
 			shellScript = "cp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		107DDC90FF1C27D140777338 /* Generate Files */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Generate Files";
-			outputFileListPaths = (
-				"$(INTERNAL_DIR)/external.xcfilelist",
-				"$(INTERNAL_DIR)/generated.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures:fixture_bwx\n";
-			showEnvVarsInLog = 0;
-		};
-		588A3D0F8C7F3BC89386E0B0 /* Copy Files */ = {
+		14DE13B950F0A4E49F5CF508 /* Copy Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1022,43 +979,7 @@
 			shellScript = "set -eu\n\ncd \"$BAZEL_OUT\"\n\n# Sync to \"$BUILD_DIR/bazel-out\". This is the same as \"$GEN_DIR\" for normal\n# builds, but is different for Index Builds. `PBXBuildFile`s will use the\n# \"$GEN_DIR\" version, so indexing might get messed up until they are normally\n# generated. It's the best we can do though as we need to use the `gen_dir`\n# symlink.\nrsync \\\n  --files-from \"$INTERNAL_DIR/generated.rsynclist\" \\\n  --chmod=u+w \\\n  -L \\\n  . \\\n  \"$BUILD_DIR/bazel-out\"\n";
 			showEnvVarsInLog = 0;
 		};
-		83B35A792C311A4BA4FDD64C /* Fix Info.plists */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"$(INTERNAL_DIR)/infoplists.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = "Fix Info.plists";
-			outputFileListPaths = (
-				"$(INTERNAL_DIR)/infoplists.fixed.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		ACC8D5FD5A8A2BBA4C7F6853 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\ntouch BUILD\ntouch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf gen_dir\n  rm -rf external\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
-			showEnvVarsInLog = 0;
-		};
-		B3A06EEB8CFD571AB8F5BFAB /* Fix Modulemaps */ = {
+		D59B838F58CCDC97935C509C /* Fix Modulemaps */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1077,6 +998,47 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(\\s*(\\w+ )?header )(?!(\"\\.\\.(\\/\\.\\.)*\\/|\")(bazel-out|external)\\/)(\"(\\.\\.\\/)*)(.*\")%\\1\\6SRCROOT/\\8%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EFD5DC5BF35D589213C98597 /* Generate Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate Files";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/external.xcfilelist",
+				"$(INTERNAL_DIR)/generated.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\n  touch BUILD\n  touch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf external\n  rm -rf gen_dir\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n\ncd \"$SRCROOT\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures:fixture_bwx\n";
+			showEnvVarsInLog = 0;
+		};
+		FF8B0244BAA1F32D8929C997 /* Fix Info.plists */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(INTERNAL_DIR)/infoplists.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Fix Info.plists";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/infoplists.fixed.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1143,23 +1105,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		07B95CCC17640C4AAA7EAB52 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 259BD17350ABF44CECE076AA /* Bazel Generated Files */;
-			targetProxy = 3A4D7E67AD5036ADB20D69E4 /* PBXContainerItemProxy */;
-		};
 		21FDB4F141406B606E0B74C7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CoreUtilsObjC;
 			target = A0257519AD63A69C6DF51958 /* CoreUtilsObjC */;
 			targetProxy = 93BD7009B9CA0DBECFEDB13C /* PBXContainerItemProxy */;
-		};
-		2716FF92D4EEBF8A703870A9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 259BD17350ABF44CECE076AA /* Bazel Generated Files */;
-			targetProxy = 513084DA66939A090497A2BC /* PBXContainerItemProxy */;
 		};
 		2D8ED23480A44C6BB910460C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1179,11 +1129,11 @@
 			target = 42E984F26D5B4ECBE0F0F076 /* Utils */;
 			targetProxy = BAAECFBDB24D9E22FDDAE7AB /* PBXContainerItemProxy */;
 		};
-		45A5750360AC912E8CC7736B /* PBXTargetDependency */ = {
+		479C523BF517576655D49649 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 2B6ACF8C2FE3C370D699C149 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = FAFC63CF1192A75AB24F3CC0 /* PBXContainerItemProxy */;
 		};
 		558E53F433AD3073C54A1F99 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1191,11 +1141,11 @@
 			target = 42A7256A505DA3DFEA69C941 /* TestingUtils */;
 			targetProxy = EB2CE0E79F60A8591B178E70 /* PBXContainerItemProxy */;
 		};
-		5FAD2A571B2362FB2AC58F38 /* PBXTargetDependency */ = {
+		5DDC602419E90C9570AA2AD7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 259BD17350ABF44CECE076AA /* Bazel Generated Files */;
-			targetProxy = FB06C3A30C909F16C06AD2A3 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = B7A58450E8974BF0DDB3874D /* PBXContainerItemProxy */;
 		};
 		619B92520AE04DF475C71CE3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1203,11 +1153,11 @@
 			target = 42E984F26D5B4ECBE0F0F076 /* Utils */;
 			targetProxy = FE8CA39EE27D6C96DC480525 /* PBXContainerItemProxy */;
 		};
-		85FBAD4F588E244786ABF5CC /* PBXTargetDependency */ = {
+		91101406CEC9E21A6B6DA77A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 288D31D755F0153696C9DB29 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 8BA5150BAD500ED81E254043 /* PBXContainerItemProxy */;
 		};
 		97533C63F9ED14EA06D9942B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1221,6 +1171,12 @@
 			target = 42A7256A505DA3DFEA69C941 /* TestingUtils */;
 			targetProxy = 174C08D2039C2604CB3A0F76 /* PBXContainerItemProxy */;
 		};
+		A63D16002E1FCE62ACF9E99D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = B3BF93B9052C6E5D977B763D /* PBXContainerItemProxy */;
+		};
 		B8D1904683275B0D2D926E5F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ExampleResources;
@@ -1233,17 +1189,23 @@
 			target = 42E984F26D5B4ECBE0F0F076 /* Utils */;
 			targetProxy = 74D605DCFD345388C0AEF131 /* PBXContainerItemProxy */;
 		};
-		D101CD69962413EF33FD887F /* PBXTargetDependency */ = {
+		D033A41CE5DF3139188DCCCE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 259BD17350ABF44CECE076AA /* Bazel Generated Files */;
-			targetProxy = D90D54A5E4C7708475358BFD /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 4586EA019F9A0AEB5C3C760A /* PBXContainerItemProxy */;
 		};
-		D4938ABE19F7755E3D8B6A4B /* PBXTargetDependency */ = {
+		D2C66BCC6F0028CB67737692 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 1FEF594BB1009034792049E9 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 6696E8D173BF56A40F4EBFC3 /* PBXContainerItemProxy */;
+		};
+		D5BD59BE8BB2DCCFD7B0AFFD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 5372562177EBC1BD93515F6C /* PBXContainerItemProxy */;
 		};
 		D8395909BBABBF02986121AE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1251,29 +1213,23 @@
 			target = 9EEE562EF383D06390A55602 /* ExternalResources */;
 			targetProxy = A2202E540FBEDC3B11423E69 /* PBXContainerItemProxy */;
 		};
-		DEE0E258B29100BBE8FAB1D0 /* PBXTargetDependency */ = {
+		D85FAC7924D560883A5EC96A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 259BD17350ABF44CECE076AA /* Bazel Generated Files */;
-			targetProxy = C454C7006724CF7E98AA8AD1 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 55D8683784886A4A2DE0797F /* PBXContainerItemProxy */;
+		};
+		D88707E90E059FB39F3F6680 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 9BC443317E7CE097B2BC3F22 /* PBXContainerItemProxy */;
 		};
 		EA5A8DB030DD28F2F1A365FE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Example;
 			target = 9E46111B59CD5CC4865299C2 /* Example */;
 			targetProxy = 8499CD2F34D395AA377AFF38 /* PBXContainerItemProxy */;
-		};
-		F59520A0B2D66A17B19D6F0E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 6F8F383F7312A0FC17937C32 /* PBXContainerItemProxy */;
-		};
-		F8C60BA7FF48BAF712148980 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 61A3CFD71A717D7DC4F3C542 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1423,7 +1379,7 @@
 			};
 			name = Debug;
 		};
-		3622C4F3E1128EBBC1184E8E /* Debug */ = {
+		3120F32C41840B1165104AAF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
@@ -1431,7 +1387,7 @@
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = Setup;
+				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;
 		};
@@ -1447,18 +1403,6 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphonesimulator;
 				TARGET_NAME = ExampleResources;
-			};
-			name = Debug;
-		};
-		69CBD9D87F696E661A4DF9B7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = GenerateBazelFiles;
 			};
 			name = Debug;
 		};
@@ -1876,18 +1820,18 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		2E81F0BC3C859DAC10F012BE /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */ = {
+		1CF9208AFC262BED8CB8A0A9 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A0DA4321BC5CEDE7AEC20E53 /* Debug */,
+				3120F32C41840B1165104AAF /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		2EE6FA675E0D16D8070B0477 /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */ = {
+		2E81F0BC3C859DAC10F012BE /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				69CBD9D87F696E661A4DF9B7 /* Debug */,
+				A0DA4321BC5CEDE7AEC20E53 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -1904,14 +1848,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				25D4C219ADDE4A582281497B /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		7786D074CB72C5247C39ED2F /* Build configuration list for PBXAggregateTarget "Setup" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				3622C4F3E1128EBBC1184E8E /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -7,16 +7,16 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		ECAFAC2323528A3317A7C9F2 /* Setup */ = {
+		9281ECD979418C4678530C3F /* Bazel Dependencies */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildConfigurationList = CBAD4D93C81A6196323B1482 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */;
 			buildPhases = (
-				48F6FA82818C0DE2760C55C0 /* ShellScript */,
+				6398E3770F65EE12E743E761 /* Fetch External Repositories */,
 			);
 			dependencies = (
 			);
-			name = Setup;
-			productName = Setup;
+			name = "Bazel Dependencies";
+			productName = "Bazel Dependencies";
 		};
 /* End PBXAggregateTarget section */
 
@@ -44,6 +44,13 @@
 			remoteGlobalIDString = 373A62571D2CA8826AD4F92C;
 			remoteInfo = "//examples/cc/lib2:lib_impl";
 		};
+		282F5C276D4DAB386C2899A5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
+		};
 		2D50AC8D57F94038C0E530C9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -51,33 +58,26 @@
 			remoteGlobalIDString = 0CEAA3455274D4DE9B4B82BF;
 			remoteInfo = "@examples_cc_external//:lib_impl";
 		};
-		424240DD0AE59FE97B422D1D /* PBXContainerItemProxy */ = {
+		616F0B3ABCE95C25B92F1794 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
-		45C913AA706FEBB282C879FE /* PBXContainerItemProxy */ = {
+		E349CADD4533360A9E1E5124 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
-		C1B43F49D4D864FB0617CC74 /* PBXContainerItemProxy */ = {
+		EF6C4CA3EF04D54D85A202DF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
-		};
-		E00C142BC7B2630EB00776C1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -232,7 +232,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				5B98370B1DD907C97C40A27B /* PBXTargetDependency */,
+				7CA79F5C774E519C39689DE2 /* PBXTargetDependency */,
 			);
 			name = "@examples_cc_external//:lib_impl";
 			productName = lib_impl;
@@ -248,7 +248,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				856400D21DBDB4EC4EC06977 /* PBXTargetDependency */,
+				BF95D87B4DA9A4D893322682 /* PBXTargetDependency */,
 				09E3E376134BB6CCC0CBAD31 /* PBXTargetDependency */,
 				7B9C45B4ECC722806B78A989 /* PBXTargetDependency */,
 				5072A54D92BD54F162C06B45 /* PBXTargetDependency */,
@@ -267,7 +267,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				540B454076EFF73BC2DE85EA /* PBXTargetDependency */,
+				2F339B29F8220414A251F19A /* PBXTargetDependency */,
 			);
 			name = "//examples/cc/lib2:lib_impl";
 			productName = lib_impl;
@@ -283,7 +283,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				96604C2752858851BD010B11 /* PBXTargetDependency */,
+				AED5111F50E78199A14249EB /* PBXTargetDependency */,
 			);
 			name = "//examples/cc/lib:lib_impl";
 			productName = lib_impl;
@@ -312,12 +312,12 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
+					9281ECD979418C4678530C3F = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
 					E180851AE3E1EEC8C4944F10 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
-					};
-					ECAFAC2323528A3317A7C9F2 = {
-						CreatedOnToolsVersion = 13.2.1;
 					};
 				};
 			};
@@ -334,7 +334,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
-				ECAFAC2323528A3317A7C9F2 /* Setup */,
+				9281ECD979418C4678530C3F /* Bazel Dependencies */,
 				0CEAA3455274D4DE9B4B82BF /* @examples_cc_external//:lib_impl */,
 				E180851AE3E1EEC8C4944F10 /* //examples/cc/lib:lib_impl */,
 				373A62571D2CA8826AD4F92C /* //examples/cc/lib2:lib_impl */,
@@ -344,7 +344,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		48F6FA82818C0DE2760C55C0 /* ShellScript */ = {
+		6398E3770F65EE12E743E761 /* Fetch External Repositories */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -352,11 +352,15 @@
 			);
 			inputPaths = (
 			);
+			name = "Fetch External Repositories";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/external.xcfilelist",
+			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\ntouch BUILD\ntouch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf gen_dir\n  rm -rf external\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
+			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\n  touch BUILD\n  touch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf external\n  rm -rf gen_dir\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\ncd \"$SRCROOT\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --nobuild \\\n  --experimental_convenience_symlinks=ignore \\\n  //test/fixtures/cc:xcodeproj_bwb\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -405,23 +409,17 @@
 			target = 0CEAA3455274D4DE9B4B82BF /* @examples_cc_external//:lib_impl */;
 			targetProxy = 2D50AC8D57F94038C0E530C9 /* PBXContainerItemProxy */;
 		};
+		2F339B29F8220414A251F19A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 282F5C276D4DAB386C2899A5 /* PBXContainerItemProxy */;
+		};
 		5072A54D92BD54F162C06B45 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "//examples/cc/lib2:lib_impl";
 			target = 373A62571D2CA8826AD4F92C /* //examples/cc/lib2:lib_impl */;
 			targetProxy = 20B4384B1C553426B14F3544 /* PBXContainerItemProxy */;
-		};
-		540B454076EFF73BC2DE85EA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = C1B43F49D4D864FB0617CC74 /* PBXContainerItemProxy */;
-		};
-		5B98370B1DD907C97C40A27B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 45C913AA706FEBB282C879FE /* PBXContainerItemProxy */;
 		};
 		7B9C45B4ECC722806B78A989 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -429,17 +427,23 @@
 			target = E180851AE3E1EEC8C4944F10 /* //examples/cc/lib:lib_impl */;
 			targetProxy = 1AB65E1F649B115C62DA830F /* PBXContainerItemProxy */;
 		};
-		856400D21DBDB4EC4EC06977 /* PBXTargetDependency */ = {
+		7CA79F5C774E519C39689DE2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = E00C142BC7B2630EB00776C1 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 616F0B3ABCE95C25B92F1794 /* PBXContainerItemProxy */;
 		};
-		96604C2752858851BD010B11 /* PBXTargetDependency */ = {
+		AED5111F50E78199A14249EB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 424240DD0AE59FE97B422D1D /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = E349CADD4533360A9E1E5124 /* PBXContainerItemProxy */;
+		};
+		BF95D87B4DA9A4D893322682 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = EF6C4CA3EF04D54D85A202DF /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -561,18 +565,6 @@
 					"$(PROJECT_DIR)",
 					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-1c975e2849a6/bin",
 				);
-			};
-			name = Debug;
-		};
-		4A234614294618D445060F03 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = Setup;
 			};
 			name = Debug;
 		};
@@ -726,6 +718,18 @@
 			};
 			name = Debug;
 		};
+		D6C64C86AFDFF55D55C69DFF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = BazelDependencies;
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -753,10 +757,10 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+		CBAD4D93C81A6196323B1482 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4A234614294618D445060F03 /* Debug */,
+				D6C64C86AFDFF55D55C69DFF /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
@@ -7,16 +7,16 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		D5818B90A725A9C678DAB333 /* Setup */ = {
+		657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 7786D074CB72C5247C39ED2F /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildConfigurationList = 1CF9208AFC262BED8CB8A0A9 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */;
 			buildPhases = (
-				ACC8D5FD5A8A2BBA4C7F6853 /* ShellScript */,
+				A82BD2D49506D22549483203 /* Fetch External Repositories */,
 			);
 			dependencies = (
 			);
-			name = Setup;
-			productName = Setup;
+			name = "Bazel Dependencies";
+			productName = "Bazel Dependencies";
 		};
 /* End PBXAggregateTarget section */
 
@@ -30,12 +30,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		3BF89DBD8B60767844F4269F /* PBXContainerItemProxy */ = {
+		06B9BC89668E20616CD7F364 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
 		59511478AA09290DC3C73AC2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -44,13 +44,6 @@
 			remoteGlobalIDString = 9DF8EA4260F38FC7243F6241;
 			remoteInfo = "@examples_cc_external//:lib_impl";
 		};
-		85A47486FDE528D6536C89EA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
-		};
 		8698CD4A6028A873CA99945C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -58,19 +51,26 @@
 			remoteGlobalIDString = BCD9FA95C7CBE2A799AC3DF9;
 			remoteInfo = "//examples/cc/lib:lib_impl";
 		};
-		961CBE9493D0D1521A5F8E10 /* PBXContainerItemProxy */ = {
+		8BBBD18AF62B7FB2BA7B2553 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
-		97CBACB6B0D12D2FDFF478F4 /* PBXContainerItemProxy */ = {
+		8E968503C0D5BE01C052F555 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
+		};
+		CA788DF6BBB87BA0F98CE3DD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
 		E2C8E26DA4198C7C2B9239BD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -232,7 +232,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				AA110E1C3329031D06A8486A /* PBXTargetDependency */,
+				1A82EA359DDDFD28BD576BEE /* PBXTargetDependency */,
 			);
 			name = "@examples_cc_external//:lib_impl";
 			productName = lib_impl;
@@ -248,7 +248,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				42B789B23FA9B3B7EC861B6C /* PBXTargetDependency */,
+				59D0AC2DA4328D2CE5E51ED2 /* PBXTargetDependency */,
 			);
 			name = "//examples/cc/lib2:lib_impl";
 			productName = lib_impl;
@@ -264,7 +264,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				D07460E72D4CC0D6AED81E93 /* PBXTargetDependency */,
+				BB8A109CA4B7B9A88E775432 /* PBXTargetDependency */,
 			);
 			name = "//examples/cc/lib:lib_impl";
 			productName = lib_impl;
@@ -280,7 +280,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				7E8A508DF9AEE5FBD0CE79F6 /* PBXTargetDependency */,
+				10ECF6ABB6A3DA527E8F6091 /* PBXTargetDependency */,
 				59AC8FC7ED45C65DBD76BA41 /* PBXTargetDependency */,
 				1122A5CB331663C0EE9EAB7D /* PBXTargetDependency */,
 				42759F6FCC327FD82603CB04 /* PBXTargetDependency */,
@@ -300,6 +300,9 @@
 				LastSwiftUpdateCheck = 1320;
 				LastUpgradeCheck = 1320;
 				TargetAttributes = {
+					657E5F38D9811E4DFA49DA75 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
 					9DF8EA4260F38FC7243F6241 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -311,9 +314,6 @@
 					BCD9FA95C7CBE2A799AC3DF9 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
-					};
-					D5818B90A725A9C678DAB333 = {
-						CreatedOnToolsVersion = 13.2.1;
 					};
 					EC6A68AC956C60AA25485960 = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -334,7 +334,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
-				D5818B90A725A9C678DAB333 /* Setup */,
+				657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */,
 				9DF8EA4260F38FC7243F6241 /* @examples_cc_external//:lib_impl */,
 				BCD9FA95C7CBE2A799AC3DF9 /* //examples/cc/lib:lib_impl */,
 				B2EDA6BA27C01B7B8423DADB /* //examples/cc/lib2:lib_impl */,
@@ -344,7 +344,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		ACC8D5FD5A8A2BBA4C7F6853 /* ShellScript */ = {
+		A82BD2D49506D22549483203 /* Fetch External Repositories */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -352,11 +352,15 @@
 			);
 			inputPaths = (
 			);
+			name = "Fetch External Repositories";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/external.xcfilelist",
+			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\ntouch BUILD\ntouch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf gen_dir\n  rm -rf external\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
+			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\n  touch BUILD\n  touch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf external\n  rm -rf gen_dir\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\ncd \"$SRCROOT\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --nobuild \\\n  --experimental_convenience_symlinks=ignore \\\n  //test/fixtures/cc:xcodeproj_bwx\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -399,11 +403,23 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		10ECF6ABB6A3DA527E8F6091 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 8BBBD18AF62B7FB2BA7B2553 /* PBXContainerItemProxy */;
+		};
 		1122A5CB331663C0EE9EAB7D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "//examples/cc/lib:lib_impl";
 			target = BCD9FA95C7CBE2A799AC3DF9 /* //examples/cc/lib:lib_impl */;
 			targetProxy = 8698CD4A6028A873CA99945C /* PBXContainerItemProxy */;
+		};
+		1A82EA359DDDFD28BD576BEE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = CA788DF6BBB87BA0F98CE3DD /* PBXContainerItemProxy */;
 		};
 		42759F6FCC327FD82603CB04 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -411,40 +427,28 @@
 			target = B2EDA6BA27C01B7B8423DADB /* //examples/cc/lib2:lib_impl */;
 			targetProxy = E2C8E26DA4198C7C2B9239BD /* PBXContainerItemProxy */;
 		};
-		42B789B23FA9B3B7EC861B6C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 3BF89DBD8B60767844F4269F /* PBXContainerItemProxy */;
-		};
 		59AC8FC7ED45C65DBD76BA41 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "@examples_cc_external//:lib_impl";
 			target = 9DF8EA4260F38FC7243F6241 /* @examples_cc_external//:lib_impl */;
 			targetProxy = 59511478AA09290DC3C73AC2 /* PBXContainerItemProxy */;
 		};
-		7E8A508DF9AEE5FBD0CE79F6 /* PBXTargetDependency */ = {
+		59D0AC2DA4328D2CE5E51ED2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 85A47486FDE528D6536C89EA /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 8E968503C0D5BE01C052F555 /* PBXContainerItemProxy */;
 		};
-		AA110E1C3329031D06A8486A /* PBXTargetDependency */ = {
+		BB8A109CA4B7B9A88E775432 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 97CBACB6B0D12D2FDFF478F4 /* PBXContainerItemProxy */;
-		};
-		D07460E72D4CC0D6AED81E93 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 961CBE9493D0D1521A5F8E10 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 06B9BC89668E20616CD7F364 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		3622C4F3E1128EBBC1184E8E /* Debug */ = {
+		3120F32C41840B1165104AAF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
@@ -452,7 +456,7 @@
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = Setup;
+				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;
 		};
@@ -725,18 +729,18 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		1DD860963E9CFCDCE0CE985C /* Build configuration list for PBXNativeTarget "//examples/cc/lib2:lib_impl" */ = {
+		1CF9208AFC262BED8CB8A0A9 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CF6609A15495C44CBDB37C68 /* Debug */,
+				3120F32C41840B1165104AAF /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		7786D074CB72C5247C39ED2F /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+		1DD860963E9CFCDCE0CE985C /* Build configuration list for PBXNativeTarget "//examples/cc/lib2:lib_impl" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				3622C4F3E1128EBBC1184E8E /* Debug */,
+				CF6609A15495C44CBDB37C68 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -7,31 +7,19 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		1264E098850804E77CE82093 /* Bazel Generated Files */ = {
+		9281ECD979418C4678530C3F /* Bazel Dependencies */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */;
+			buildConfigurationList = CBAD4D93C81A6196323B1482 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */;
 			buildPhases = (
-				CA47126A96DBA220099058F9 /* Generate Files */,
-				3BBBE88C0B5DFE50E861D039 /* Copy Files */,
-				C39544D2D57030E1F850014D /* Fix Modulemaps */,
-				C1BCE66C756D6574AE7961FF /* Fix Info.plists */,
-			);
-			dependencies = (
-				A375E057D32BEDDB980E23C5 /* PBXTargetDependency */,
-			);
-			name = "Bazel Generated Files";
-			productName = "Bazel Generated Files";
-		};
-		ECAFAC2323528A3317A7C9F2 /* Setup */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */;
-			buildPhases = (
-				48F6FA82818C0DE2760C55C0 /* ShellScript */,
+				FD442F9D0D3F77311B69FA42 /* Generate Files */,
+				391E7CA7B16FAFAE0457D1C2 /* Copy Files */,
+				77D46E44C108C6CEE2F89E0D /* Fix Modulemaps */,
+				4CBF24D403529E7553176153 /* Fix Info.plists */,
 			);
 			dependencies = (
 			);
-			name = Setup;
-			productName = Setup;
+			name = "Bazel Dependencies";
+			productName = "Bazel Dependencies";
 		};
 /* End PBXAggregateTarget section */
 
@@ -51,26 +39,12 @@
 			remoteGlobalIDString = BC691472A2BC47F8E1D5D637;
 			remoteInfo = lib_impl;
 		};
-		13927D4D0197A5640D5F2E1E /* PBXContainerItemProxy */ = {
+		49BDB6255162C6878FFC3286 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1264E098850804E77CE82093;
-			remoteInfo = "Bazel Generated Files";
-		};
-		4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
-		};
-		7B22195AE863596CBAA46EDC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1264E098850804E77CE82093;
-			remoteInfo = "Bazel Generated Files";
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 		941CFFB87F4F5822EFA8B01D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -86,19 +60,26 @@
 			remoteGlobalIDString = 8E3B6C47A6106921076BC573;
 			remoteInfo = lib_swift;
 		};
-		C3700581E446951E2320FDD6 /* PBXContainerItemProxy */ = {
+		C8155DB861760DF4B9F086CC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
-		E00C142BC7B2630EB00776C1 /* PBXContainerItemProxy */ = {
+		E84F3D37FC9B7386169F9A20 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
+		};
+		EF6C4CA3EF04D54D85A202DF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -354,7 +335,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				856400D21DBDB4EC4EC06977 /* PBXTargetDependency */,
+				BF95D87B4DA9A4D893322682 /* PBXTargetDependency */,
 				0264408EBC1B158ADC203602 /* PBXTargetDependency */,
 			);
 			name = tool;
@@ -372,7 +353,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				74FDFEB4A044D099CDCEA8F6 /* PBXTargetDependency */,
+				F8E77B03B350308E332E8543 /* PBXTargetDependency */,
 				2BC4078E4942848FB045F836 /* PBXTargetDependency */,
 			);
 			name = lib_swift;
@@ -389,7 +370,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				82290885D55F963B9C48F0A2 /* PBXTargetDependency */,
+				7CC9669C82B829743EB97628 /* PBXTargetDependency */,
 			);
 			name = lib_impl;
 			productName = lib_impl;
@@ -405,7 +386,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				0EA1F34EB7D23C6AB27F5C21 /* PBXTargetDependency */,
+				E291B87B53A3A7A89DB5D119 /* PBXTargetDependency */,
 				2CF2586B0B0366E350C5E6BF /* PBXTargetDependency */,
 			);
 			name = LibSwiftTests.__internal__.__test_bundle;
@@ -423,9 +404,6 @@
 				LastSwiftUpdateCheck = 1320;
 				LastUpgradeCheck = 1320;
 				TargetAttributes = {
-					1264E098850804E77CE82093 = {
-						CreatedOnToolsVersion = 13.2.1;
-					};
 					27EDD304E889980DC176FF62 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -434,6 +412,9 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
+					9281ECD979418C4678530C3F = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
 					BC691472A2BC47F8E1D5D637 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -441,9 +422,6 @@
 					E56E8F91E4327755D5B09E30 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
-					};
-					ECAFAC2323528A3317A7C9F2 = {
-						CreatedOnToolsVersion = 13.2.1;
 					};
 				};
 			};
@@ -460,8 +438,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
-				ECAFAC2323528A3317A7C9F2 /* Setup */,
-				1264E098850804E77CE82093 /* Bazel Generated Files */,
+				9281ECD979418C4678530C3F /* Bazel Dependencies */,
 				BC691472A2BC47F8E1D5D637 /* lib_impl */,
 				8E3B6C47A6106921076BC573 /* lib_swift */,
 				E56E8F91E4327755D5B09E30 /* LibSwiftTests.__internal__.__test_bundle */,
@@ -471,7 +448,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3BBBE88C0B5DFE50E861D039 /* Copy Files */ = {
+		391E7CA7B16FAFAE0457D1C2 /* Copy Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -492,39 +469,7 @@
 			shellScript = "set -eu\n\ncd \"$BAZEL_OUT\"\n\n# Sync to \"$BUILD_DIR/bazel-out\". This is the same as \"$GEN_DIR\" for normal\n# builds, but is different for Index Builds. `PBXBuildFile`s will use the\n# \"$GEN_DIR\" version, so indexing might get messed up until they are normally\n# generated. It's the best we can do though as we need to use the `gen_dir`\n# symlink.\nrsync \\\n  --files-from \"$INTERNAL_DIR/generated.rsynclist\" \\\n  --chmod=u+w \\\n  -L \\\n  . \\\n  \"$BUILD_DIR/bazel-out\"\n";
 			showEnvVarsInLog = 0;
 		};
-		48F6FA82818C0DE2760C55C0 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\ntouch BUILD\ntouch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf gen_dir\n  rm -rf external\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
-			showEnvVarsInLog = 0;
-		};
-		7D1C1AFB1B1C40174C24CF23 /* Copy Swift Generated Header */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(DERIVED_FILE_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
-			);
-			name = "Copy Swift Generated Header";
-			outputPaths = (
-				"$(CONFIGURATION_BUILD_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "cp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C1BCE66C756D6574AE7961FF /* Fix Info.plists */ = {
+		4CBF24D403529E7553176153 /* Fix Info.plists */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -545,7 +490,7 @@
 			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C39544D2D57030E1F850014D /* Fix Modulemaps */ = {
+		77D46E44C108C6CEE2F89E0D /* Fix Modulemaps */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -566,7 +511,24 @@
 			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(\\s*(\\w+ )?header )(?!(\"\\.\\.(\\/\\.\\.)*\\/|\")(bazel-out|external)\\/)(\"(\\.\\.\\/)*)(.*\")%\\1\\6SRCROOT/\\8%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CA47126A96DBA220099058F9 /* Generate Files */ = {
+		7D1C1AFB1B1C40174C24CF23 /* Copy Swift Generated Header */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(DERIVED_FILE_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			name = "Copy Swift Generated Header";
+			outputPaths = (
+				"$(CONFIGURATION_BUILD_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FD442F9D0D3F77311B69FA42 /* Generate Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -583,7 +545,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/command_line:xcodeproj_bwb\n";
+			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\n  touch BUILD\n  touch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf external\n  rm -rf gen_dir\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n\ncd \"$SRCROOT\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/command_line:xcodeproj_bwb\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -631,12 +593,6 @@
 			target = 8E3B6C47A6106921076BC573 /* lib_swift */;
 			targetProxy = 941CFFB87F4F5822EFA8B01D /* PBXContainerItemProxy */;
 		};
-		0EA1F34EB7D23C6AB27F5C21 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
-			targetProxy = 7B22195AE863596CBAA46EDC /* PBXContainerItemProxy */;
-		};
 		2BC4078E4942848FB045F836 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = lib_impl;
@@ -649,45 +605,33 @@
 			target = 8E3B6C47A6106921076BC573 /* lib_swift */;
 			targetProxy = C0AE6AA9FC08390DB1932DDD /* PBXContainerItemProxy */;
 		};
-		74FDFEB4A044D099CDCEA8F6 /* PBXTargetDependency */ = {
+		7CC9669C82B829743EB97628 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
-			targetProxy = 13927D4D0197A5640D5F2E1E /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = E84F3D37FC9B7386169F9A20 /* PBXContainerItemProxy */;
 		};
-		82290885D55F963B9C48F0A2 /* PBXTargetDependency */ = {
+		BF95D87B4DA9A4D893322682 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = C3700581E446951E2320FDD6 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = EF6C4CA3EF04D54D85A202DF /* PBXContainerItemProxy */;
 		};
-		856400D21DBDB4EC4EC06977 /* PBXTargetDependency */ = {
+		E291B87B53A3A7A89DB5D119 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = E00C142BC7B2630EB00776C1 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = C8155DB861760DF4B9F086CC /* PBXContainerItemProxy */;
 		};
-		A375E057D32BEDDB980E23C5 /* PBXTargetDependency */ = {
+		F8E77B03B350308E332E8543 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 49BDB6255162C6878FFC3286 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		4A234614294618D445060F03 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = Setup;
-			};
-			name = Debug;
-		};
 		5956C53EC4D795D939CF8F6C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -943,18 +887,6 @@
 			};
 			name = Debug;
 		};
-		958FA2D1FA128C21904CB40E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = GenerateBazelFiles;
-			};
-			name = Debug;
-		};
 		B0892EE2AB907B40AA4EB960 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -976,6 +908,18 @@
 			};
 			name = Debug;
 		};
+		D6C64C86AFDFF55D55C69DFF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = BazelDependencies;
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -983,14 +927,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				5D95C37273FAF8FEAFAE2065 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				958FA2D1FA128C21904CB40E /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -1019,10 +955,10 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */ = {
+		CBAD4D93C81A6196323B1482 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4A234614294618D445060F03 /* Debug */,
+				D6C64C86AFDFF55D55C69DFF /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -7,31 +7,19 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		259BD17350ABF44CECE076AA /* Bazel Generated Files */ = {
+		657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 2EE6FA675E0D16D8070B0477 /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */;
+			buildConfigurationList = 1CF9208AFC262BED8CB8A0A9 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */;
 			buildPhases = (
-				107DDC90FF1C27D140777338 /* Generate Files */,
-				588A3D0F8C7F3BC89386E0B0 /* Copy Files */,
-				B3A06EEB8CFD571AB8F5BFAB /* Fix Modulemaps */,
-				83B35A792C311A4BA4FDD64C /* Fix Info.plists */,
-			);
-			dependencies = (
-				F8C60BA7FF48BAF712148980 /* PBXTargetDependency */,
-			);
-			name = "Bazel Generated Files";
-			productName = "Bazel Generated Files";
-		};
-		D5818B90A725A9C678DAB333 /* Setup */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 7786D074CB72C5247C39ED2F /* Build configuration list for PBXAggregateTarget "Setup" */;
-			buildPhases = (
-				ACC8D5FD5A8A2BBA4C7F6853 /* ShellScript */,
+				EFD5DC5BF35D589213C98597 /* Generate Files */,
+				14DE13B950F0A4E49F5CF508 /* Copy Files */,
+				D59B838F58CCDC97935C509C /* Fix Modulemaps */,
+				FF8B0244BAA1F32D8929C997 /* Fix Info.plists */,
 			);
 			dependencies = (
 			);
-			name = Setup;
-			productName = Setup;
+			name = "Bazel Dependencies";
+			productName = "Bazel Dependencies";
 		};
 /* End PBXAggregateTarget section */
 
@@ -51,26 +39,26 @@
 			remoteGlobalIDString = 195FCD65F4EB377830E3E996;
 			remoteInfo = lib_swift;
 		};
-		42C9BA6F5963F54AC64770E3 /* PBXContainerItemProxy */ = {
+		8BBBD18AF62B7FB2BA7B2553 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 259BD17350ABF44CECE076AA;
-			remoteInfo = "Bazel Generated Files";
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
-		61A3CFD71A717D7DC4F3C542 /* PBXContainerItemProxy */ = {
+		B0C48A885AAB4B338F5457ED /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
-		85A47486FDE528D6536C89EA /* PBXContainerItemProxy */ = {
+		BD9A874E2F6E38703790C461 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
 		CA9CDA938E8AE3259FBC42DC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -79,13 +67,6 @@
 			remoteGlobalIDString = 8329F08BE01D4CC32B819CE9;
 			remoteInfo = lib_impl;
 		};
-		CCFA5C26E876A28800306318 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 259BD17350ABF44CECE076AA;
-			remoteInfo = "Bazel Generated Files";
-		};
 		CEF33237E121C8902D54BB86 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -93,12 +74,12 @@
 			remoteGlobalIDString = 195FCD65F4EB377830E3E996;
 			remoteInfo = lib_swift;
 		};
-		CF0950AA4708A1DEE0605B93 /* PBXContainerItemProxy */ = {
+		EE89CCA5CCF1C26DAA0505EA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -354,7 +335,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				4B9B0A5BC99CBED7CBB7DB2A /* PBXTargetDependency */,
+				D83476C7D73E68CF9961DDAE /* PBXTargetDependency */,
 				1945C34941723F46B78E9D8D /* PBXTargetDependency */,
 			);
 			name = LibSwiftTests.__internal__.__test_bundle;
@@ -372,7 +353,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				CCFC862EC3FE8F463FAB59AF /* PBXTargetDependency */,
+				085D63D0B3A87638171583ED /* PBXTargetDependency */,
 				5788E50D72472F75EFAA6061 /* PBXTargetDependency */,
 			);
 			name = lib_swift;
@@ -389,7 +370,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				80FD4401A5D29D1B01030F3A /* PBXTargetDependency */,
+				3BEEB43740C27C0D0C69F2D0 /* PBXTargetDependency */,
 			);
 			name = lib_impl;
 			productName = lib_impl;
@@ -405,7 +386,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				7E8A508DF9AEE5FBD0CE79F6 /* PBXTargetDependency */,
+				10ECF6ABB6A3DA527E8F6091 /* PBXTargetDependency */,
 				204A0BCF0B6A0D2D142BCA76 /* PBXTargetDependency */,
 			);
 			name = tool;
@@ -431,15 +412,12 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
-					259BD17350ABF44CECE076AA = {
+					657E5F38D9811E4DFA49DA75 = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
 					8329F08BE01D4CC32B819CE9 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
-					};
-					D5818B90A725A9C678DAB333 = {
-						CreatedOnToolsVersion = 13.2.1;
 					};
 					EC6A68AC956C60AA25485960 = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -460,8 +438,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
-				D5818B90A725A9C678DAB333 /* Setup */,
-				259BD17350ABF44CECE076AA /* Bazel Generated Files */,
+				657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */,
 				8329F08BE01D4CC32B819CE9 /* lib_impl */,
 				195FCD65F4EB377830E3E996 /* lib_swift */,
 				0290E727C546D76C651A3B2D /* LibSwiftTests.__internal__.__test_bundle */,
@@ -471,27 +448,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		107DDC90FF1C27D140777338 /* Generate Files */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Generate Files";
-			outputFileListPaths = (
-				"$(INTERNAL_DIR)/external.xcfilelist",
-				"$(INTERNAL_DIR)/generated.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/command_line:xcodeproj_bwx\n";
-			showEnvVarsInLog = 0;
-		};
-		588A3D0F8C7F3BC89386E0B0 /* Copy Files */ = {
+		14DE13B950F0A4E49F5CF508 /* Copy Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -512,27 +469,6 @@
 			shellScript = "set -eu\n\ncd \"$BAZEL_OUT\"\n\n# Sync to \"$BUILD_DIR/bazel-out\". This is the same as \"$GEN_DIR\" for normal\n# builds, but is different for Index Builds. `PBXBuildFile`s will use the\n# \"$GEN_DIR\" version, so indexing might get messed up until they are normally\n# generated. It's the best we can do though as we need to use the `gen_dir`\n# symlink.\nrsync \\\n  --files-from \"$INTERNAL_DIR/generated.rsynclist\" \\\n  --chmod=u+w \\\n  -L \\\n  . \\\n  \"$BUILD_DIR/bazel-out\"\n";
 			showEnvVarsInLog = 0;
 		};
-		83B35A792C311A4BA4FDD64C /* Fix Info.plists */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"$(INTERNAL_DIR)/infoplists.xcfilelist",
-			);
-			inputPaths = (
-			);
-			name = "Fix Info.plists";
-			outputFileListPaths = (
-				"$(INTERNAL_DIR)/infoplists.fixed.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
-			showEnvVarsInLog = 0;
-		};
 		88F7F6781328CA74DCF58611 /* Copy Swift Generated Header */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -550,22 +486,7 @@
 			shellScript = "cp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		ACC8D5FD5A8A2BBA4C7F6853 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\ntouch BUILD\ntouch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf gen_dir\n  rm -rf external\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
-			showEnvVarsInLog = 0;
-		};
-		B3A06EEB8CFD571AB8F5BFAB /* Fix Modulemaps */ = {
+		D59B838F58CCDC97935C509C /* Fix Modulemaps */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -584,6 +505,47 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.modulemap}.xcode.modulemap\"\n  perl -p -e \\\n    's%^(\\s*(\\w+ )?header )(?!(\"\\.\\.(\\/\\.\\.)*\\/|\")(bazel-out|external)\\/)(\"(\\.\\.\\/)*)(.*\")%\\1\\6SRCROOT/\\8%' \\\n    < \"$input\" \\\n    > \"$output\"\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EFD5DC5BF35D589213C98597 /* Generate Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate Files";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/external.xcfilelist",
+				"$(INTERNAL_DIR)/generated.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\n  touch BUILD\n  touch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf external\n  rm -rf gen_dir\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n\ncd \"$SRCROOT\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/command_line:xcodeproj_bwx\n";
+			showEnvVarsInLog = 0;
+		};
+		FF8B0244BAA1F32D8929C997 /* Fix Info.plists */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(INTERNAL_DIR)/infoplists.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Fix Info.plists";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/infoplists.fixed.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -625,6 +587,18 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		085D63D0B3A87638171583ED /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = BD9A874E2F6E38703790C461 /* PBXContainerItemProxy */;
+		};
+		10ECF6ABB6A3DA527E8F6091 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 8BBBD18AF62B7FB2BA7B2553 /* PBXContainerItemProxy */;
+		};
 		1945C34941723F46B78E9D8D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = lib_swift;
@@ -637,11 +611,11 @@
 			target = 195FCD65F4EB377830E3E996 /* lib_swift */;
 			targetProxy = CEF33237E121C8902D54BB86 /* PBXContainerItemProxy */;
 		};
-		4B9B0A5BC99CBED7CBB7DB2A /* PBXTargetDependency */ = {
+		3BEEB43740C27C0D0C69F2D0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 259BD17350ABF44CECE076AA /* Bazel Generated Files */;
-			targetProxy = CCFA5C26E876A28800306318 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = EE89CCA5CCF1C26DAA0505EA /* PBXContainerItemProxy */;
 		};
 		5788E50D72472F75EFAA6061 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -649,34 +623,16 @@
 			target = 8329F08BE01D4CC32B819CE9 /* lib_impl */;
 			targetProxy = CA9CDA938E8AE3259FBC42DC /* PBXContainerItemProxy */;
 		};
-		7E8A508DF9AEE5FBD0CE79F6 /* PBXTargetDependency */ = {
+		D83476C7D73E68CF9961DDAE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 85A47486FDE528D6536C89EA /* PBXContainerItemProxy */;
-		};
-		80FD4401A5D29D1B01030F3A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = CF0950AA4708A1DEE0605B93 /* PBXContainerItemProxy */;
-		};
-		CCFC862EC3FE8F463FAB59AF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 259BD17350ABF44CECE076AA /* Bazel Generated Files */;
-			targetProxy = 42C9BA6F5963F54AC64770E3 /* PBXContainerItemProxy */;
-		};
-		F8C60BA7FF48BAF712148980 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 61A3CFD71A717D7DC4F3C542 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = B0C48A885AAB4B338F5457ED /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		3622C4F3E1128EBBC1184E8E /* Debug */ = {
+		3120F32C41840B1165104AAF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
@@ -684,19 +640,7 @@
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = Setup;
-			};
-			name = Debug;
-		};
-		69CBD9D87F696E661A4DF9B7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = GenerateBazelFiles;
+				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;
 		};
@@ -975,10 +919,10 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		2EE6FA675E0D16D8070B0477 /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */ = {
+		1CF9208AFC262BED8CB8A0A9 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				69CBD9D87F696E661A4DF9B7 /* Debug */,
+				3120F32C41840B1165104AAF /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -987,14 +931,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				E078891F555499CFC0B704FC /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		7786D074CB72C5247C39ED2F /* Build configuration list for PBXAggregateTarget "Setup" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				3622C4F3E1128EBBC1184E8E /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -7,16 +7,16 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		ECAFAC2323528A3317A7C9F2 /* Setup */ = {
+		9281ECD979418C4678530C3F /* Bazel Dependencies */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildConfigurationList = CBAD4D93C81A6196323B1482 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */;
 			buildPhases = (
-				48F6FA82818C0DE2760C55C0 /* ShellScript */,
+				6398E3770F65EE12E743E761 /* Fetch External Repositories */,
 			);
 			dependencies = (
 			);
-			name = Setup;
-			productName = Setup;
+			name = "Bazel Dependencies";
+			productName = "Bazel Dependencies";
 		};
 /* End PBXAggregateTarget section */
 
@@ -196,19 +196,19 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0C1DB5AAE5C62E5351BBB35F /* PBXContainerItemProxy */ = {
+		0879335532B98E33BF6BF4C4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
-		1AADF09199F79612883EE5EF /* PBXContainerItemProxy */ = {
+		173D3837CC2355C09B4722CF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 		201DCF3149264E9D8AB4CA97 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -224,6 +224,13 @@
 			remoteGlobalIDString = F12050E30563A81EEBB2EA9B;
 			remoteInfo = generator.library;
 		};
+		293F186D89C78567377B1C93 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
+		};
 		2C860512D9D794C14E15BE5B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -238,13 +245,6 @@
 			remoteGlobalIDString = 9DF90F35406923EA23C68CFC;
 			remoteInfo = XCTestDynamicOverlay;
 		};
-		3E98853617DD142D01E4ECD4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
-		};
 		44D67FDCCFE036B1BE7F2490 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -252,12 +252,12 @@
 			remoteGlobalIDString = 302F4C6E9EE3F09D4809EF0A;
 			remoteInfo = CustomDump;
 		};
-		47A49BF151336CCF2D4909B1 /* PBXContainerItemProxy */ = {
+		4AA42476D09CFFBF85E02DCA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 		5860D57390AE14C57D4A302E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -266,19 +266,26 @@
 			remoteGlobalIDString = 886150B3C63D0DBEF9BB4E6B;
 			remoteInfo = AEXML;
 		};
-		85F8D55A5DDD5984E2D5D3A9 /* PBXContainerItemProxy */ = {
+		60AF15424D1FAF71C6054523 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
-		C6503A028754D96CDB93B208 /* PBXContainerItemProxy */ = {
+		BCBF87D30139B74A2F0EAE5F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
+		};
+		C0E3B30F79F9DE5C9B5640E9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 		CD181E6AF3DFD2EF12094EE5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -294,19 +301,12 @@
 			remoteGlobalIDString = F12050E30563A81EEBB2EA9B;
 			remoteInfo = generator.library;
 		};
-		D9E85C3E10A5FA1310BBEA9A /* PBXContainerItemProxy */ = {
+		D157564C43F0EE22553BDD68 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
-		};
-		F2EEA6546190185B5EED5115 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -1010,7 +1010,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				B06DB2B1738DF952C859FCC0 /* PBXTargetDependency */,
+				E70EB53C035C7420B9C7B634 /* PBXTargetDependency */,
 				94E1DFA69955CA57806ABE25 /* PBXTargetDependency */,
 			);
 			name = CustomDump;
@@ -1027,7 +1027,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				CE39FCA5D027B650D9A85BE5 /* PBXTargetDependency */,
+				1A8365E344501BAFDAEF1807 /* PBXTargetDependency */,
 			);
 			name = PathKit;
 			productName = PathKit;
@@ -1043,7 +1043,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				9ABF3DD32B1D73FEFA114778 /* PBXTargetDependency */,
+				B008392B21E0873350179B5E /* PBXTargetDependency */,
 				C0C4842B0D633EDDA463F849 /* PBXTargetDependency */,
 			);
 			name = generator;
@@ -1060,7 +1060,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				2F0F2305A1894AA95623CDC3 /* PBXTargetDependency */,
+				6D01FFE986A0ADC6196F2BBA /* PBXTargetDependency */,
 			);
 			name = AEXML;
 			productName = AEXML;
@@ -1076,7 +1076,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				3121B63F982B90DC1BC80DC6 /* PBXTargetDependency */,
+				8846CB4833983D95814168A2 /* PBXTargetDependency */,
 				272FB95BF351D18E24AF12EE /* PBXTargetDependency */,
 				3880438A5A38C4F764B735E5 /* PBXTargetDependency */,
 			);
@@ -1094,7 +1094,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				D9328141BD90BECA04EFA044 /* PBXTargetDependency */,
+				E05837FCBD9C29411453F840 /* PBXTargetDependency */,
 			);
 			name = XCTestDynamicOverlay;
 			productName = XCTestDynamicOverlay;
@@ -1110,7 +1110,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				9D86DF7F047B9F71860DFD0C /* PBXTargetDependency */,
+				19D99A91C72B04EDE5327CBF /* PBXTargetDependency */,
 				15C9D6D9FFC25DEDBF1B4FB1 /* PBXTargetDependency */,
 				2A18DCEDD62C0092B4434B53 /* PBXTargetDependency */,
 			);
@@ -1128,7 +1128,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				3D917D223B855889FCC41320 /* PBXTargetDependency */,
+				85A82591E91C64E1BE8A1302 /* PBXTargetDependency */,
 				3C87B52A50F5CA5CA4F4127C /* PBXTargetDependency */,
 				89785168DF6A2CA38BEB0A0C /* PBXTargetDependency */,
 			);
@@ -1163,6 +1163,9 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
+					9281ECD979418C4678530C3F = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
 					979D12680661F4B864602CE6 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -1174,9 +1177,6 @@
 					A09CE18EBBDAC65CD0C6B7D1 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
-					};
-					ECAFAC2323528A3317A7C9F2 = {
-						CreatedOnToolsVersion = 13.2.1;
 					};
 					F12050E30563A81EEBB2EA9B = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -1197,7 +1197,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
-				ECAFAC2323528A3317A7C9F2 /* Setup */,
+				9281ECD979418C4678530C3F /* Bazel Dependencies */,
 				886150B3C63D0DBEF9BB4E6B /* AEXML */,
 				302F4C6E9EE3F09D4809EF0A /* CustomDump */,
 				85C876DB90D51CD225023BB2 /* generator */,
@@ -1211,7 +1211,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		48F6FA82818C0DE2760C55C0 /* ShellScript */ = {
+		6398E3770F65EE12E743E761 /* Fetch External Repositories */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -1219,11 +1219,15 @@
 			);
 			inputPaths = (
 			);
+			name = "Fetch External Repositories";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/external.xcfilelist",
+			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\ntouch BUILD\ntouch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf gen_dir\n  rm -rf external\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
+			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\n  touch BUILD\n  touch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf external\n  rm -rf gen_dir\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\ncd \"$SRCROOT\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --nobuild \\\n  --experimental_convenience_symlinks=ignore \\\n  //test/fixtures/generator:xcodeproj_bwb\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1466,6 +1470,18 @@
 			target = 886150B3C63D0DBEF9BB4E6B /* AEXML */;
 			targetProxy = 5860D57390AE14C57D4A302E /* PBXContainerItemProxy */;
 		};
+		19D99A91C72B04EDE5327CBF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = C0E3B30F79F9DE5C9B5640E9 /* PBXContainerItemProxy */;
+		};
+		1A8365E344501BAFDAEF1807 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 0879335532B98E33BF6BF4C4 /* PBXContainerItemProxy */;
+		};
 		272FB95BF351D18E24AF12EE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = CustomDump;
@@ -1477,18 +1493,6 @@
 			name = PathKit;
 			target = 4A2EC1B2D6969F717CB890DE /* PathKit */;
 			targetProxy = CD181E6AF3DFD2EF12094EE5 /* PBXContainerItemProxy */;
-		};
-		2F0F2305A1894AA95623CDC3 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 3E98853617DD142D01E4ECD4 /* PBXContainerItemProxy */;
-		};
-		3121B63F982B90DC1BC80DC6 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = D9E85C3E10A5FA1310BBEA9A /* PBXContainerItemProxy */;
 		};
 		3880438A5A38C4F764B735E5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1502,11 +1506,23 @@
 			target = 4A2EC1B2D6969F717CB890DE /* PathKit */;
 			targetProxy = 201DCF3149264E9D8AB4CA97 /* PBXContainerItemProxy */;
 		};
-		3D917D223B855889FCC41320 /* PBXTargetDependency */ = {
+		6D01FFE986A0ADC6196F2BBA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = F2EEA6546190185B5EED5115 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 293F186D89C78567377B1C93 /* PBXContainerItemProxy */;
+		};
+		85A82591E91C64E1BE8A1302 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = BCBF87D30139B74A2F0EAE5F /* PBXContainerItemProxy */;
+		};
+		8846CB4833983D95814168A2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 60AF15424D1FAF71C6054523 /* PBXContainerItemProxy */;
 		};
 		89785168DF6A2CA38BEB0A0C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1520,23 +1536,11 @@
 			target = 9DF90F35406923EA23C68CFC /* XCTestDynamicOverlay */;
 			targetProxy = 34739E478519DAF595040254 /* PBXContainerItemProxy */;
 		};
-		9ABF3DD32B1D73FEFA114778 /* PBXTargetDependency */ = {
+		B008392B21E0873350179B5E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 1AADF09199F79612883EE5EF /* PBXContainerItemProxy */;
-		};
-		9D86DF7F047B9F71860DFD0C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 85F8D55A5DDD5984E2D5D3A9 /* PBXContainerItemProxy */;
-		};
-		B06DB2B1738DF952C859FCC0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 47A49BF151336CCF2D4909B1 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 173D3837CC2355C09B4722CF /* PBXContainerItemProxy */;
 		};
 		C0C4842B0D633EDDA463F849 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1544,17 +1548,17 @@
 			target = F12050E30563A81EEBB2EA9B /* generator.library */;
 			targetProxy = CE545ADAA24F8CEBE7071545 /* PBXContainerItemProxy */;
 		};
-		CE39FCA5D027B650D9A85BE5 /* PBXTargetDependency */ = {
+		E05837FCBD9C29411453F840 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 0C1DB5AAE5C62E5351BBB35F /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 4AA42476D09CFFBF85E02DCA /* PBXContainerItemProxy */;
 		};
-		D9328141BD90BECA04EFA044 /* PBXTargetDependency */ = {
+		E70EB53C035C7420B9C7B634 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = C6503A028754D96CDB93B208 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = D157564C43F0EE22553BDD68 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1611,18 +1615,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGET_NAME = PathKit;
-			};
-			name = Debug;
-		};
-		4A234614294618D445060F03 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = Setup;
 			};
 			name = Debug;
 		};
@@ -1930,6 +1922,18 @@
 			};
 			name = Debug;
 		};
+		D6C64C86AFDFF55D55C69DFF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = BazelDependencies;
+			};
+			name = Debug;
+		};
 		DC1884C822C7D3AD5CAA6B9E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2083,14 +2087,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4A234614294618D445060F03 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		87A63B9392379C37ECE35BB3 /* Build configuration list for PBXNativeTarget "AEXML" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2119,6 +2115,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				235F4F04C2DF95E7079ED732 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		CBAD4D93C81A6196323B1482 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6C64C86AFDFF55D55C69DFF /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -7,16 +7,16 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		D5818B90A725A9C678DAB333 /* Setup */ = {
+		657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 7786D074CB72C5247C39ED2F /* Build configuration list for PBXAggregateTarget "Setup" */;
+			buildConfigurationList = 1CF9208AFC262BED8CB8A0A9 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */;
 			buildPhases = (
-				ACC8D5FD5A8A2BBA4C7F6853 /* ShellScript */,
+				A82BD2D49506D22549483203 /* Fetch External Repositories */,
 			);
 			dependencies = (
 			);
-			name = Setup;
-			productName = Setup;
+			name = "Bazel Dependencies";
+			productName = "Bazel Dependencies";
 		};
 /* End PBXAggregateTarget section */
 
@@ -203,13 +203,6 @@
 			remoteGlobalIDString = 3A4021D8F5FC68CD4FB8B6F1;
 			remoteInfo = generator.library;
 		};
-		078F734B4CE2439511E2B877 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
-		};
 		199D8335E402470EC00D40BF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -217,26 +210,19 @@
 			remoteGlobalIDString = 19FA71657765A036575B20D8;
 			remoteInfo = XcodeProj;
 		};
+		319C30CA1810E6C4D2D31C7B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
+		};
 		3A1A9FA674016F6D082BD8E2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 299DA591171C10F8AF73F244;
 			remoteInfo = PathKit;
-		};
-		3D96237821DB62CBE201923C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
-		};
-		43A3E53ECEBC755935FD0489 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
 		};
 		4FA052E4857080583368FC00 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -252,26 +238,33 @@
 			remoteGlobalIDString = 299DA591171C10F8AF73F244;
 			remoteInfo = PathKit;
 		};
-		7A453DCAC27F01FEE2748F54 /* PBXContainerItemProxy */ = {
+		662BF6F9914221881A01EED3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
-		82D46AF219CB3F0DA8A8FF1B /* PBXContainerItemProxy */ = {
+		6BFF0ED595BF75D0308AF48D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
-		8ED828B9473B2451AEA6A4F9 /* PBXContainerItemProxy */ = {
+		7951293FDA128320F7AB4636 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
+		};
+		97D76F5F92DB69E680400CD8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
 		9B5B6558D92A38CDB5A55353 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -294,19 +287,26 @@
 			remoteGlobalIDString = CFD3DFAB502EFF52937E5E51;
 			remoteInfo = CustomDump;
 		};
-		D65CF6B07F4F91A81F0E990E /* PBXContainerItemProxy */ = {
+		D524A4D2429633DFDDF92CA6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
-		E3DFB8602FBD794842B5DBA5 /* PBXContainerItemProxy */ = {
+		FB79B5625C17E28955E462B7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
+		};
+		FE76E76431E4FFEDFED51D4B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -1010,7 +1010,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				AB3C6C0A109277EC4E1B066C /* PBXTargetDependency */,
+				4CFCD1BC935D0ECF7B377C05 /* PBXTargetDependency */,
 				D5F65B44A3A5B58EC00BF47B /* PBXTargetDependency */,
 				4460D0461ECFE2C5DB3906C8 /* PBXTargetDependency */,
 			);
@@ -1028,7 +1028,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				C5EFC5DC0E08024738CAD4BB /* PBXTargetDependency */,
+				C7AD4A75DA389E2877527121 /* PBXTargetDependency */,
 			);
 			name = PathKit;
 			productName = PathKit;
@@ -1044,7 +1044,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				91BF89DC528ACC71A7F4E035 /* PBXTargetDependency */,
+				E32B494E5BC7AB22F804B2D4 /* PBXTargetDependency */,
 				5F445F20107721899DF3B81D /* PBXTargetDependency */,
 			);
 			name = generator;
@@ -1061,7 +1061,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				8D553CC7B891915233AFB799 /* PBXTargetDependency */,
+				C6E0CB98C89E381C614B4F5F /* PBXTargetDependency */,
 				708CE6F5066B3FED83964946 /* PBXTargetDependency */,
 				4AA89D33E273962408747D43 /* PBXTargetDependency */,
 			);
@@ -1079,7 +1079,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				EA5F44930A3E7C360A733A88 /* PBXTargetDependency */,
+				42E285C99D0B12A259C1EA41 /* PBXTargetDependency */,
 			);
 			name = AEXML;
 			productName = AEXML;
@@ -1095,7 +1095,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				82289CE2BA47DF981352FD89 /* PBXTargetDependency */,
+				636C3A6A7019D4C48B527D3F /* PBXTargetDependency */,
 			);
 			name = XCTestDynamicOverlay;
 			productName = XCTestDynamicOverlay;
@@ -1111,7 +1111,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				8BAE21C4BC369CBAFD59D47D /* PBXTargetDependency */,
+				7CFFDA7F05CEC82B26D1C1B4 /* PBXTargetDependency */,
 				BDA5A0BF9D7D71AD15621E90 /* PBXTargetDependency */,
 			);
 			name = CustomDump;
@@ -1128,7 +1128,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				876B7DE88A0B6E6EDCAC83D7 /* PBXTargetDependency */,
+				109C26D1DB4D01D48A8E8659 /* PBXTargetDependency */,
 				4C7A6159FE1C37782DBAFBF5 /* PBXTargetDependency */,
 				6B1BD6C53E3B9BE4EF005D0C /* PBXTargetDependency */,
 			);
@@ -1163,6 +1163,9 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
+					657E5F38D9811E4DFA49DA75 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
 					AFE4D24E5783CFEA55476089 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -1174,9 +1177,6 @@
 					CFD3DFAB502EFF52937E5E51 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
-					};
-					D5818B90A725A9C678DAB333 = {
-						CreatedOnToolsVersion = 13.2.1;
 					};
 					F5FCEC7426929BDA7F9F1875 = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -1197,7 +1197,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
-				D5818B90A725A9C678DAB333 /* Setup */,
+				657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */,
 				AFE4D24E5783CFEA55476089 /* AEXML */,
 				CFD3DFAB502EFF52937E5E51 /* CustomDump */,
 				2FED647E7A6091DF616D345B /* generator */,
@@ -1211,7 +1211,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		ACC8D5FD5A8A2BBA4C7F6853 /* ShellScript */ = {
+		A82BD2D49506D22549483203 /* Fetch External Repositories */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -1219,11 +1219,15 @@
 			);
 			inputPaths = (
 			);
+			name = "Fetch External Repositories";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/external.xcfilelist",
+			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\ntouch BUILD\ntouch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf gen_dir\n  rm -rf external\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
+			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\n  touch BUILD\n  touch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf external\n  rm -rf gen_dir\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\ncd \"$SRCROOT\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --nobuild \\\n  --experimental_convenience_symlinks=ignore \\\n  //test/fixtures/generator:xcodeproj_bwx\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -1460,6 +1464,18 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		109C26D1DB4D01D48A8E8659 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 7951293FDA128320F7AB4636 /* PBXContainerItemProxy */;
+		};
+		42E285C99D0B12A259C1EA41 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 319C30CA1810E6C4D2D31C7B /* PBXContainerItemProxy */;
+		};
 		4460D0461ECFE2C5DB3906C8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = PathKit;
@@ -1478,11 +1494,23 @@
 			target = CFD3DFAB502EFF52937E5E51 /* CustomDump */;
 			targetProxy = CFBF834907E2F47679529098 /* PBXContainerItemProxy */;
 		};
+		4CFCD1BC935D0ECF7B377C05 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = D524A4D2429633DFDDF92CA6 /* PBXContainerItemProxy */;
+		};
 		5F445F20107721899DF3B81D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = generator.library;
 			target = 3A4021D8F5FC68CD4FB8B6F1 /* generator.library */;
 			targetProxy = 052BA76161805F1B8304674C /* PBXContainerItemProxy */;
+		};
+		636C3A6A7019D4C48B527D3F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = FE76E76431E4FFEDFED51D4B /* PBXContainerItemProxy */;
 		};
 		6B1BD6C53E3B9BE4EF005D0C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1496,41 +1524,11 @@
 			target = 299DA591171C10F8AF73F244 /* PathKit */;
 			targetProxy = 5F803C1AC4A2B51D785ED2A9 /* PBXContainerItemProxy */;
 		};
-		82289CE2BA47DF981352FD89 /* PBXTargetDependency */ = {
+		7CFFDA7F05CEC82B26D1C1B4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 82D46AF219CB3F0DA8A8FF1B /* PBXContainerItemProxy */;
-		};
-		876B7DE88A0B6E6EDCAC83D7 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 3D96237821DB62CBE201923C /* PBXContainerItemProxy */;
-		};
-		8BAE21C4BC369CBAFD59D47D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 43A3E53ECEBC755935FD0489 /* PBXContainerItemProxy */;
-		};
-		8D553CC7B891915233AFB799 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 7A453DCAC27F01FEE2748F54 /* PBXContainerItemProxy */;
-		};
-		91BF89DC528ACC71A7F4E035 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 078F734B4CE2439511E2B877 /* PBXContainerItemProxy */;
-		};
-		AB3C6C0A109277EC4E1B066C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = D65CF6B07F4F91A81F0E990E /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 662BF6F9914221881A01EED3 /* PBXContainerItemProxy */;
 		};
 		BDA5A0BF9D7D71AD15621E90 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1538,11 +1536,17 @@
 			target = CE60FB500B781C8126957C5A /* XCTestDynamicOverlay */;
 			targetProxy = 9B5B6558D92A38CDB5A55353 /* PBXContainerItemProxy */;
 		};
-		C5EFC5DC0E08024738CAD4BB /* PBXTargetDependency */ = {
+		C6E0CB98C89E381C614B4F5F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = E3DFB8602FBD794842B5DBA5 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 6BFF0ED595BF75D0308AF48D /* PBXContainerItemProxy */;
+		};
+		C7AD4A75DA389E2877527121 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 97D76F5F92DB69E680400CD8 /* PBXContainerItemProxy */;
 		};
 		D5F65B44A3A5B58EC00BF47B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1550,11 +1554,11 @@
 			target = AFE4D24E5783CFEA55476089 /* AEXML */;
 			targetProxy = 4FA052E4857080583368FC00 /* PBXContainerItemProxy */;
 		};
-		EA5F44930A3E7C360A733A88 /* PBXTargetDependency */ = {
+		E32B494E5BC7AB22F804B2D4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 8ED828B9473B2451AEA6A4F9 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = FB79B5625C17E28955E462B7 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1724,7 +1728,7 @@
 			};
 			name = Debug;
 		};
-		3622C4F3E1128EBBC1184E8E /* Debug */ = {
+		3120F32C41840B1165104AAF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
@@ -1732,7 +1736,7 @@
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = Setup;
+				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;
 		};
@@ -2051,6 +2055,14 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		1CF9208AFC262BED8CB8A0A9 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3120F32C41840B1165104AAF /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		40FEEA421A7F15F350EDECCF /* Build configuration list for PBXNativeTarget "CustomDump" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2063,14 +2075,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2CF2D823BAEE3DAB1F52A77C /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		7786D074CB72C5247C39ED2F /* Build configuration list for PBXAggregateTarget "Setup" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				3622C4F3E1128EBBC1184E8E /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -7,30 +7,18 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		1264E098850804E77CE82093 /* Bazel Generated Files */ = {
+		9281ECD979418C4678530C3F /* Bazel Dependencies */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */;
+			buildConfigurationList = CBAD4D93C81A6196323B1482 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */;
 			buildPhases = (
-				CA47126A96DBA220099058F9 /* Generate Files */,
-				3BBBE88C0B5DFE50E861D039 /* Copy Files */,
-				C1BCE66C756D6574AE7961FF /* Fix Info.plists */,
-			);
-			dependencies = (
-				A375E057D32BEDDB980E23C5 /* PBXTargetDependency */,
-			);
-			name = "Bazel Generated Files";
-			productName = "Bazel Generated Files";
-		};
-		ECAFAC2323528A3317A7C9F2 /* Setup */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */;
-			buildPhases = (
-				48F6FA82818C0DE2760C55C0 /* ShellScript */,
+				FD442F9D0D3F77311B69FA42 /* Generate Files */,
+				391E7CA7B16FAFAE0457D1C2 /* Copy Files */,
+				4CBF24D403529E7553176153 /* Fix Info.plists */,
 			);
 			dependencies = (
 			);
-			name = Setup;
-			productName = Setup;
+			name = "Bazel Dependencies";
+			productName = "Bazel Dependencies";
 		};
 /* End PBXAggregateTarget section */
 
@@ -43,19 +31,19 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0F71FB02423BEEE76DFEE7A7 /* PBXContainerItemProxy */ = {
+		110986C710000A69ABE319EB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1264E098850804E77CE82093;
-			remoteInfo = "Bazel Generated Files";
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
-		4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */ = {
+		1CF9C88B9ECC02A32824AAE3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = ECAFAC2323528A3317A7C9F2;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 		7EDBC9AA0948CBD61D742C1D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -64,12 +52,12 @@
 			remoteGlobalIDString = DEF15AA97EC0FE28A9A97CAA;
 			remoteInfo = Example;
 		};
-		B29F6183C154822D72EC2305 /* PBXContainerItemProxy */ = {
+		B71878DACFF4D4B444BFDCD1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 1264E098850804E77CE82093;
-			remoteInfo = "Bazel Generated Files";
+			remoteGlobalIDString = 9281ECD979418C4678530C3F;
+			remoteInfo = "Bazel Dependencies";
 		};
 		EBD0C87C46CE3A0065D73AA0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -77,13 +65,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = DEF15AA97EC0FE28A9A97CAA;
 			remoteInfo = Example;
-		};
-		FA89BC6DF686E165E775357E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 1264E098850804E77CE82093;
-			remoteInfo = "Bazel Generated Files";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -319,7 +300,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				2E6EA1FEE98746DEE423C1E9 /* PBXTargetDependency */,
+				5DFE3D6D6371279C87EFC9F6 /* PBXTargetDependency */,
 				4D0DFDD11CB698CEA15C699E /* PBXTargetDependency */,
 			);
 			name = ExampleUITests.__internal__.__test_bundle;
@@ -336,7 +317,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				C2D1B7F2CA0445827922D05C /* PBXTargetDependency */,
+				1D5CD5B9BA8C334C7A88A805 /* PBXTargetDependency */,
 				F670F941F6741D0D3E7AC4A3 /* PBXTargetDependency */,
 			);
 			name = ExampleTests.__internal__.__test_bundle;
@@ -353,7 +334,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				2AE8FD8829F7134BE519ADAC /* PBXTargetDependency */,
+				2047D4B3EA4C6F4853601156 /* PBXTargetDependency */,
 			);
 			name = Example;
 			productName = Example;
@@ -370,7 +351,7 @@
 				LastSwiftUpdateCheck = 1320;
 				LastUpgradeCheck = 1320;
 				TargetAttributes = {
-					1264E098850804E77CE82093 = {
+					9281ECD979418C4678530C3F = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
 					BBF4D59A51801FF17E35E34E = {
@@ -387,9 +368,6 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
-					ECAFAC2323528A3317A7C9F2 = {
-						CreatedOnToolsVersion = 13.2.1;
-					};
 				};
 			};
 			buildConfigurationList = 669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */;
@@ -405,8 +383,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
-				ECAFAC2323528A3317A7C9F2 /* Setup */,
-				1264E098850804E77CE82093 /* Bazel Generated Files */,
+				9281ECD979418C4678530C3F /* Bazel Dependencies */,
 				DEF15AA97EC0FE28A9A97CAA /* Example */,
 				D133FDFF63F008FDDB07BE99 /* ExampleTests.__internal__.__test_bundle */,
 				BBF4D59A51801FF17E35E34E /* ExampleUITests.__internal__.__test_bundle */,
@@ -415,7 +392,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3BBBE88C0B5DFE50E861D039 /* Copy Files */ = {
+		391E7CA7B16FAFAE0457D1C2 /* Copy Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -436,22 +413,7 @@
 			shellScript = "set -eu\n\ncd \"$BAZEL_OUT\"\n\n# Sync to \"$BUILD_DIR/bazel-out\". This is the same as \"$GEN_DIR\" for normal\n# builds, but is different for Index Builds. `PBXBuildFile`s will use the\n# \"$GEN_DIR\" version, so indexing might get messed up until they are normally\n# generated. It's the best we can do though as we need to use the `gen_dir`\n# symlink.\nrsync \\\n  --files-from \"$INTERNAL_DIR/generated.rsynclist\" \\\n  --chmod=u+w \\\n  -L \\\n  . \\\n  \"$BUILD_DIR/bazel-out\"\n";
 			showEnvVarsInLog = 0;
 		};
-		48F6FA82818C0DE2760C55C0 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\ntouch BUILD\ntouch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf gen_dir\n  rm -rf external\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
-			showEnvVarsInLog = 0;
-		};
-		C1BCE66C756D6574AE7961FF /* Fix Info.plists */ = {
+		4CBF24D403529E7553176153 /* Fix Info.plists */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -472,7 +434,7 @@
 			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CA47126A96DBA220099058F9 /* Generate Files */ = {
+		FD442F9D0D3F77311B69FA42 /* Generate Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -489,7 +451,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/tvos_app:xcodeproj_bwb\n";
+			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\n  touch BUILD\n  touch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf external\n  rm -rf gen_dir\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n\ncd \"$SRCROOT\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/tvos_app:xcodeproj_bwb\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -524,17 +486,17 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		2AE8FD8829F7134BE519ADAC /* PBXTargetDependency */ = {
+		1D5CD5B9BA8C334C7A88A805 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
-			targetProxy = FA89BC6DF686E165E775357E /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 110986C710000A69ABE319EB /* PBXContainerItemProxy */;
 		};
-		2E6EA1FEE98746DEE423C1E9 /* PBXTargetDependency */ = {
+		2047D4B3EA4C6F4853601156 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
-			targetProxy = B29F6183C154822D72EC2305 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = 1CF9C88B9ECC02A32824AAE3 /* PBXContainerItemProxy */;
 		};
 		4D0DFDD11CB698CEA15C699E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -542,17 +504,11 @@
 			target = DEF15AA97EC0FE28A9A97CAA /* Example */;
 			targetProxy = EBD0C87C46CE3A0065D73AA0 /* PBXContainerItemProxy */;
 		};
-		A375E057D32BEDDB980E23C5 /* PBXTargetDependency */ = {
+		5DFE3D6D6371279C87EFC9F6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Setup;
-			target = ECAFAC2323528A3317A7C9F2 /* Setup */;
-			targetProxy = 4FF040B8DA21FA1493FC2656 /* PBXContainerItemProxy */;
-		};
-		C2D1B7F2CA0445827922D05C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 1264E098850804E77CE82093 /* Bazel Generated Files */;
-			targetProxy = 0F71FB02423BEEE76DFEE7A7 /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 9281ECD979418C4678530C3F /* Bazel Dependencies */;
+			targetProxy = B71878DACFF4D4B444BFDCD1 /* PBXContainerItemProxy */;
 		};
 		F670F941F6741D0D3E7AC4A3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -621,30 +577,6 @@
 			};
 			name = Debug;
 		};
-		4A234614294618D445060F03 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = Setup;
-			};
-			name = Debug;
-		};
-		958FA2D1FA128C21904CB40E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = GenerateBazelFiles;
-			};
-			name = Debug;
-		};
 		B0892EE2AB907B40AA4EB960 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -663,6 +595,18 @@
 				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+		D6C64C86AFDFF55D55C69DFF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;
 		};
@@ -790,14 +734,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		066D8E1C48CF4B93B4CF57FF /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				958FA2D1FA128C21904CB40E /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		4146445A590327AFBC6ECD1E /* Build configuration list for PBXNativeTarget "ExampleUITests.__internal__.__test_bundle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -822,18 +758,18 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		8346E6B74C22AB86411AD67E /* Build configuration list for PBXAggregateTarget "Setup" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4A234614294618D445060F03 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		8D7CAA9B63F689C04C435E90 /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				F4B8552398B786F68242064D /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		CBAD4D93C81A6196323B1482 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D6C64C86AFDFF55D55C69DFF /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
@@ -7,30 +7,18 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		259BD17350ABF44CECE076AA /* Bazel Generated Files */ = {
+		657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 2EE6FA675E0D16D8070B0477 /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */;
+			buildConfigurationList = 1CF9208AFC262BED8CB8A0A9 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */;
 			buildPhases = (
-				107DDC90FF1C27D140777338 /* Generate Files */,
-				588A3D0F8C7F3BC89386E0B0 /* Copy Files */,
-				83B35A792C311A4BA4FDD64C /* Fix Info.plists */,
-			);
-			dependencies = (
-				F8C60BA7FF48BAF712148980 /* PBXTargetDependency */,
-			);
-			name = "Bazel Generated Files";
-			productName = "Bazel Generated Files";
-		};
-		D5818B90A725A9C678DAB333 /* Setup */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 7786D074CB72C5247C39ED2F /* Build configuration list for PBXAggregateTarget "Setup" */;
-			buildPhases = (
-				ACC8D5FD5A8A2BBA4C7F6853 /* ShellScript */,
+				EFD5DC5BF35D589213C98597 /* Generate Files */,
+				14DE13B950F0A4E49F5CF508 /* Copy Files */,
+				FF8B0244BAA1F32D8929C997 /* Fix Info.plists */,
 			);
 			dependencies = (
 			);
-			name = Setup;
-			productName = Setup;
+			name = "Bazel Dependencies";
+			productName = "Bazel Dependencies";
 		};
 /* End PBXAggregateTarget section */
 
@@ -43,26 +31,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		3A4D7E67AD5036ADB20D69E4 /* PBXContainerItemProxy */ = {
+		55D8683784886A4A2DE0797F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 259BD17350ABF44CECE076AA;
-			remoteInfo = "Bazel Generated Files";
-		};
-		513084DA66939A090497A2BC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 259BD17350ABF44CECE076AA;
-			remoteInfo = "Bazel Generated Files";
-		};
-		61A3CFD71A717D7DC4F3C542 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D5818B90A725A9C678DAB333;
-			remoteInfo = Setup;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
 		8499CD2F34D395AA377AFF38 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -71,12 +45,19 @@
 			remoteGlobalIDString = 9E46111B59CD5CC4865299C2;
 			remoteInfo = Example;
 		};
-		D90D54A5E4C7708475358BFD /* PBXContainerItemProxy */ = {
+		9BC443317E7CE097B2BC3F22 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 259BD17350ABF44CECE076AA;
-			remoteInfo = "Bazel Generated Files";
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
+		};
+		B7A58450E8974BF0DDB3874D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 657E5F38D9811E4DFA49DA75;
+			remoteInfo = "Bazel Dependencies";
 		};
 		ED9670CE9ACD8301A0DA97C3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -319,7 +300,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				07B95CCC17640C4AAA7EAB52 /* PBXTargetDependency */,
+				D88707E90E059FB39F3F6680 /* PBXTargetDependency */,
 				EA5A8DB030DD28F2F1A365FE /* PBXTargetDependency */,
 			);
 			name = ExampleTests.__internal__.__test_bundle;
@@ -336,7 +317,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				2716FF92D4EEBF8A703870A9 /* PBXTargetDependency */,
+				D85FAC7924D560883A5EC96A /* PBXTargetDependency */,
 			);
 			name = Example;
 			productName = Example;
@@ -352,7 +333,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				D101CD69962413EF33FD887F /* PBXTargetDependency */,
+				5DDC602419E90C9570AA2AD7 /* PBXTargetDependency */,
 				2D8ED23480A44C6BB910460C /* PBXTargetDependency */,
 			);
 			name = ExampleUITests.__internal__.__test_bundle;
@@ -370,13 +351,13 @@
 				LastSwiftUpdateCheck = 1320;
 				LastUpgradeCheck = 1320;
 				TargetAttributes = {
-					259BD17350ABF44CECE076AA = {
-						CreatedOnToolsVersion = 13.2.1;
-					};
 					5742A33EA302007E9758E24B = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 						TestTargetID = 9E46111B59CD5CC4865299C2;
+					};
+					657E5F38D9811E4DFA49DA75 = {
+						CreatedOnToolsVersion = 13.2.1;
 					};
 					9E46111B59CD5CC4865299C2 = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -386,9 +367,6 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 						TestTargetID = 9E46111B59CD5CC4865299C2;
-					};
-					D5818B90A725A9C678DAB333 = {
-						CreatedOnToolsVersion = 13.2.1;
 					};
 				};
 			};
@@ -405,8 +383,7 @@
 			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
-				D5818B90A725A9C678DAB333 /* Setup */,
-				259BD17350ABF44CECE076AA /* Bazel Generated Files */,
+				657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */,
 				9E46111B59CD5CC4865299C2 /* Example */,
 				5742A33EA302007E9758E24B /* ExampleTests.__internal__.__test_bundle */,
 				BDC5BB543739DEC8809249F9 /* ExampleUITests.__internal__.__test_bundle */,
@@ -415,27 +392,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		107DDC90FF1C27D140777338 /* Generate Files */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Generate Files";
-			outputFileListPaths = (
-				"$(INTERNAL_DIR)/external.xcfilelist",
-				"$(INTERNAL_DIR)/generated.xcfilelist",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/tvos_app:xcodeproj_bwx\n";
-			showEnvVarsInLog = 0;
-		};
-		588A3D0F8C7F3BC89386E0B0 /* Copy Files */ = {
+		14DE13B950F0A4E49F5CF508 /* Copy Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -456,7 +413,27 @@
 			shellScript = "set -eu\n\ncd \"$BAZEL_OUT\"\n\n# Sync to \"$BUILD_DIR/bazel-out\". This is the same as \"$GEN_DIR\" for normal\n# builds, but is different for Index Builds. `PBXBuildFile`s will use the\n# \"$GEN_DIR\" version, so indexing might get messed up until they are normally\n# generated. It's the best we can do though as we need to use the `gen_dir`\n# symlink.\nrsync \\\n  --files-from \"$INTERNAL_DIR/generated.rsynclist\" \\\n  --chmod=u+w \\\n  -L \\\n  . \\\n  \"$BUILD_DIR/bazel-out\"\n";
 			showEnvVarsInLog = 0;
 		};
-		83B35A792C311A4BA4FDD64C /* Fix Info.plists */ = {
+		EFD5DC5BF35D589213C98597 /* Generate Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate Files";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/external.xcfilelist",
+				"$(INTERNAL_DIR)/generated.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\n  touch BUILD\n  touch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf external\n  rm -rf gen_dir\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n\ncd \"$SRCROOT\"\n\nenv -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --experimental_convenience_symlinks=ignore \\\n  --output_groups=generated_inputs \\\n  //test/fixtures/tvos_app:xcodeproj_bwx\n";
+			showEnvVarsInLog = 0;
+		};
+		FF8B0244BAA1F32D8929C997 /* Fix Info.plists */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -475,21 +452,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -eu\n\nwhile IFS= read -r input; do\n  output=\"${input%.plist}.xcode.plist\"\n  cp \"$input\" \"$output\"\n  plutil -remove UIDeviceFamily \"$output\" || true\ndone < \"$SCRIPT_INPUT_FILE_LIST_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		ACC8D5FD5A8A2BBA4C7F6853 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -eu\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"${PATH//\\/usr\\/local\\/bin//opt/homebrew/bin:/usr/local/bin}\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --experimental_convenience_symlinks=ignore \\\n  output_path)\nexternal=\"${output_path%/*/*/*}/external\"\n\n# We only want to modify `$LINKS_DIR` during normal builds since Indexing can\n# run concurrent to normal builds\nif [ \"$ACTION\" != \"indexbuild\" ]; then\n  mkdir -p \"$LINKS_DIR\"\n  cd \"$LINKS_DIR\"\n\n  # Add BUILD and DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n  # files to the internal links directory to prevent Bazel from recursing into\n  # it, and thus following the `external` symlink\ntouch BUILD\ntouch DONT_FOLLOW_SYMLINKS_WHEN_TRAVERSING_THIS_DIRECTORY_VIA_A_RECURSIVE_TARGET_PATTERN\n\n  # Need to remove the directories that Xcode creates as part of output prep\n  rm -rf gen_dir\n  rm -rf external\n\n  ln -sf \"$external\" external\n  ln -sf \"$BUILD_DIR/bazel-out\" gen_dir\nfi\n\ncd \"$BUILD_DIR\"\n\nrm -rf external\nrm -rf real-bazel-out\n\nln -sf \"$external\" external\nln -sf \"$output_path\" real-bazel-out\nln -sfn \"$PROJECT_DIR\" SRCROOT\n\n# Create parent directories of generated files, so the project navigator works\n# better faster\n\nmkdir -p bazel-out\ncd bazel-out\n\nsed 's|\\/[^\\/]*$||' \\\n  \"$INTERNAL_DIR/generated.rsynclist\" \\\n  | uniq \\\n  | while IFS= read -r dir\ndo\n  mkdir -p \"$dir\"\ndone\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -524,41 +486,35 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		07B95CCC17640C4AAA7EAB52 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 259BD17350ABF44CECE076AA /* Bazel Generated Files */;
-			targetProxy = 3A4D7E67AD5036ADB20D69E4 /* PBXContainerItemProxy */;
-		};
-		2716FF92D4EEBF8A703870A9 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 259BD17350ABF44CECE076AA /* Bazel Generated Files */;
-			targetProxy = 513084DA66939A090497A2BC /* PBXContainerItemProxy */;
-		};
 		2D8ED23480A44C6BB910460C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Example;
 			target = 9E46111B59CD5CC4865299C2 /* Example */;
 			targetProxy = ED9670CE9ACD8301A0DA97C3 /* PBXContainerItemProxy */;
 		};
-		D101CD69962413EF33FD887F /* PBXTargetDependency */ = {
+		5DDC602419E90C9570AA2AD7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Bazel Generated Files";
-			target = 259BD17350ABF44CECE076AA /* Bazel Generated Files */;
-			targetProxy = D90D54A5E4C7708475358BFD /* PBXContainerItemProxy */;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = B7A58450E8974BF0DDB3874D /* PBXContainerItemProxy */;
+		};
+		D85FAC7924D560883A5EC96A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 55D8683784886A4A2DE0797F /* PBXContainerItemProxy */;
+		};
+		D88707E90E059FB39F3F6680 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Bazel Dependencies";
+			target = 657E5F38D9811E4DFA49DA75 /* Bazel Dependencies */;
+			targetProxy = 9BC443317E7CE097B2BC3F22 /* PBXContainerItemProxy */;
 		};
 		EA5A8DB030DD28F2F1A365FE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Example;
 			target = 9E46111B59CD5CC4865299C2 /* Example */;
 			targetProxy = 8499CD2F34D395AA377AFF38 /* PBXContainerItemProxy */;
-		};
-		F8C60BA7FF48BAF712148980 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Setup;
-			target = D5818B90A725A9C678DAB333 /* Setup */;
-			targetProxy = 61A3CFD71A717D7DC4F3C542 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -620,7 +576,7 @@
 			};
 			name = Debug;
 		};
-		3622C4F3E1128EBBC1184E8E /* Debug */ = {
+		3120F32C41840B1165104AAF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
@@ -628,19 +584,7 @@
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = Setup;
-			};
-			name = Debug;
-		};
-		69CBD9D87F696E661A4DF9B7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALLOW_TARGET_PLATFORM_SPECIALIZATION = YES;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = GenerateBazelFiles;
+				TARGET_NAME = BazelDependencies;
 			};
 			name = Debug;
 		};
@@ -795,26 +739,18 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		1CF9208AFC262BED8CB8A0A9 /* Build configuration list for PBXAggregateTarget "Bazel Dependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3120F32C41840B1165104AAF /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		2E81F0BC3C859DAC10F012BE /* Build configuration list for PBXNativeTarget "ExampleTests.__internal__.__test_bundle" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A0DA4321BC5CEDE7AEC20E53 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		2EE6FA675E0D16D8070B0477 /* Build configuration list for PBXAggregateTarget "Bazel Generated Files" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				69CBD9D87F696E661A4DF9B7 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		7786D074CB72C5247C39ED2F /* Build configuration list for PBXAggregateTarget "Setup" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				3622C4F3E1128EBBC1184E8E /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/tools/generator/test/AddTargetsTests.swift
+++ b/tools/generator/test/AddTargetsTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @testable import generator
 
 final class AddTargetsTests: XCTestCase {
-    func test_basic() throws {
+    func test_integration() throws {
         // Arrange
 
         let pbxProj = Fixtures.pbxProj()

--- a/xcodeproj/internal/installer.template.sh
+++ b/xcodeproj/internal/installer.template.sh
@@ -69,23 +69,14 @@ if [ ! -d "$dest/rules_xcodeproj/links/gen_dir" ]; then
   # better.
   echo "Running one time setup..."
 
-  if %pre_generate_files%; then
-    echo "Creating generated files..."
-    scheme="Bazel Generated Files"
-    msg="generate files"
-  else
-    scheme="Setup"
-    msg="setup"
-  fi
-
   cd "$BUILD_WORKSPACE_DIRECTORY"
   error_log=$(mktemp)
   exit_status=0
-  xcodebuild -project "$dest" -scheme "$scheme" \
+  xcodebuild -project "$dest" -scheme "Bazel Dependencies" \
     > "$error_log" 2>&1 \
     || exit_status=$?
   if [ $exit_status -ne 0 ]; then
-    echo "WARNING: Failed to $msg:"
+    echo "WARNING: Failed to build \"Bazel Dependencies\" scheme:"
     cat "$error_log" >&2
   fi
 fi

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -123,8 +123,7 @@ def _write_installer(
         ctx,
         name = None,
         install_path,
-        xcodeproj,
-        pre_generate_files):
+        xcodeproj):
     installer = ctx.actions.declare_file(
         "{}-installer.sh".format(name or ctx.attr.name),
     )
@@ -135,7 +134,6 @@ def _write_installer(
         is_executable = True,
         substitutions = {
             "%output_path%": install_path,
-            "%pre_generate_files%": "true" if pre_generate_files else "false",
             "%source_path%": xcodeproj.short_path,
         },
     )
@@ -178,8 +176,6 @@ def _xcodeproj_impl(ctx):
         attrs_info = None,
         transitive_infos = [(None, info) for info in infos],
     )
-    pre_generate_files = (ctx.attr.pre_generate_files and
-                          inputs.generated.to_list())
 
     spec_file = _write_json_spec(
         ctx = ctx,
@@ -197,7 +193,6 @@ def _xcodeproj_impl(ctx):
         ctx = ctx,
         install_path = install_path,
         xcodeproj = xcodeproj,
-        pre_generate_files = pre_generate_files,
     )
 
     return [
@@ -225,9 +220,6 @@ def make_xcodeproj_rule(*, transition = None):
         "build_mode": attr.string(
             default = "xcode",
             values = ["xcode", "bazel"],
-        ),
-        "pre_generate_files": attr.bool(
-            default = True,
         ),
         "project_name": attr.string(),
         "targets": attr.label_list(


### PR DESCRIPTION
Fixes #323.

This merges the "Setup" and "Bazel Generated Files" targets into a "Bazel Dependencies" target. This target is a dependency of every other target. And most importantly, it now has a different run script to fetch external repositories if there are no generated files.