### PR TITLE
Handle projects with no external dependencies

### DIFF
--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -48,7 +48,7 @@ struct Environment {
         _ files: [FilePath: File],
         _ filePathResolver: FilePathResolver,
         _ xcodeprojBazelLabel: String
-    ) throws -> PBXAggregateTarget
+    ) throws -> PBXAggregateTarget?
     
     let addTargets: (
         _ pbxProj: PBXProj,
@@ -56,7 +56,7 @@ struct Environment {
         _ products: Products,
         _ files: [FilePath: File],
         _ filePathResolver: FilePathResolver,
-        _ bazelDependenciesTarget: PBXAggregateTarget
+        _ bazelDependenciesTarget: PBXAggregateTarget?
     ) throws -> [TargetID: PBXNativeTarget]
 
     let setTargetConfigurations: (

--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -8,7 +8,7 @@ extension Generator {
         products: Products,
         files: [FilePath: File],
         filePathResolver: FilePathResolver,
-        bazelDependenciesTarget: PBXAggregateTarget
+        bazelDependenciesTarget: PBXAggregateTarget?
     ) throws -> [TargetID: PBXNativeTarget] {
         let pbxProject = pbxProj.rootObject!
 
@@ -81,7 +81,9 @@ Product for target "\(id)" not found in `products`
             pbxProject.targets.append(pbxTarget)
             pbxTargets[id] = pbxTarget
 
-            _ = try pbxTarget.addDependency(target: bazelDependenciesTarget)
+            if let bazelDependenciesTarget = bazelDependenciesTarget {
+                _ = try pbxTarget.addDependency(target: bazelDependenciesTarget)
+            }
         }
 
         return pbxTargets

--- a/tools/generator/src/Generator+CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator+CreateFilesAndGroups.swift
@@ -472,9 +472,11 @@ private extension Path {
 }
 
 extension Sequence where Element == FilePath {
+    var containsExternalFiles: Bool { contains { $0.type == .external } }
     var containsGeneratedFiles: Bool { contains { $0.type == .generated } }
 }
 
 extension Dictionary where Key == FilePath {
+    var containsExternalFiles: Bool { keys.containsExternalFiles }
     var containsGeneratedFiles: Bool { keys.containsGeneratedFiles }
 }

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -254,7 +254,7 @@ final class GeneratorTests: XCTestCase {
             files: [FilePath: File],
             filePathResolver: FilePathResolver,
             xcodeprojBazelLabel: String
-        ) throws -> PBXAggregateTarget {
+        ) throws -> PBXAggregateTarget? {
             addBazelDependenciesTargetCalled.append(.init(
                 pbxProj: pbxProj,
                 files: files,
@@ -281,7 +281,7 @@ final class GeneratorTests: XCTestCase {
             let products: Products
             let files: [FilePath: File]
             let filePathResolver: FilePathResolver
-            let bazelDependenciesTarget: PBXAggregateTarget
+            let bazelDependenciesTarget: PBXAggregateTarget?
         }
 
         var addTargetsCalled: [AddTargetsCalled] = []
@@ -291,7 +291,7 @@ final class GeneratorTests: XCTestCase {
             products: Products,
             files: [FilePath: File],
             filePathResolver: FilePathResolver,
-            bazelDependenciesTarget: PBXAggregateTarget
+            bazelDependenciesTarget: PBXAggregateTarget?
         ) throws -> [TargetID: PBXNativeTarget] {
             addTargetsCalled.append(.init(
                 pbxProj: pbxProj,

--- a/xcodeproj/internal/installer.template.sh
+++ b/xcodeproj/internal/installer.template.sh
@@ -63,7 +63,11 @@ plutil -remove BuildSystemType "$workspace_settings" > /dev/null || true
 
 echo 'Updated project at "%output_path%"'
 
-if [ ! -d "$dest/rules_xcodeproj/links/gen_dir" ]; then
+if [[ \
+  -f "$dest/rules_xcodeproj/external.xcfilelist" || \
+  -f "$dest/rules_xcodeproj/generated.xcfilelist" && \
+  ! -d "$dest/rules_xcodeproj/links/gen_dir" \
+]]; then
   # If "gen_dir" doesn't exist, this is most likely a fresh project. In that
   # case, we should create generated files to have the initial experience be
   # better.


### PR DESCRIPTION
We now only set `externalFileListPath` as an `outputFileListPaths` if there are external files. If a project doesn't have external or generated files we no longer create the `Bazel Dependencies` target. Finally, if there is no `Bazel Dependencies` target, we don't try to run its scheme during install.