### PR TITLE
Add output file collection

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -132,7 +132,7 @@ def _collect(
         additional_files: A `list` of `File`s to add to the inputs. This can
             be used to add files to the `generated` and `extra_files` fields
             (e.g. modulemaps or BUILD files).
-        transitive_infos: A list of `XcodeProjInfo`s for the transitive
+        transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
             dependencies of `target`.
 
     Returns:
@@ -318,7 +318,7 @@ def _merge(*, attrs_info, transitive_infos):
 
     Args:
         attrs_info: The `InputFileAttributesInfo` for the target.
-        transitive_infos: A list of `XcodeProjInfo`s for the transitive
+        transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
             dependencies of the current target.
 
     Returns:

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -1,0 +1,192 @@
+"""Module containing functions dealing with target output files."""
+
+load(":output_group_map.bzl", "output_group_map")
+
+# Utility
+
+def _create(*, direct_outputs = None, attrs_info = None, transitive_infos):
+    """Creates the internal data structure of the `output_files` module.
+
+    Args:
+        direct_outputs: A value returned from `_get_outputs`, or `None` if
+            the outputs are being merged.
+        attrs_info: The `InputFileAttributesInfo` for the target.
+        transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
+            dependencies of the current target.
+
+    Returns:
+        A `struct` representing the internal data structure of the
+        `output_files` module.
+    """
+    build = depset(
+        direct_outputs.build if direct_outputs else None,
+        transitive = [
+            info.outputs._build
+            for attr, info in transitive_infos
+            if (not attrs_info or
+                info.target_type in attrs_info.xcode_targets.get(attr, [None]))
+        ],
+    )
+    index = depset(
+        direct_outputs.index if direct_outputs else None,
+        transitive = [
+            info.outputs._index
+            for attr, info in transitive_infos
+            if (not attrs_info or
+                info.target_type in attrs_info.xcode_targets.get(attr, [None]))
+        ],
+    )
+
+    if direct_outputs:
+        direct_group_list = [
+            ("b {}".format(direct_outputs.id), build),
+            ("i {}".format(direct_outputs.id), index),
+        ]
+    else:
+        direct_group_list = None
+
+    output_group_list = depset(
+        direct_group_list,
+        transitive = [
+            info.outputs._output_group_list
+            for attr, info in transitive_infos
+            if (not attrs_info or
+                info.target_type in attrs_info.xcode_targets.get(attr, [None]))
+        ],
+    )
+
+    return struct(
+        _build = build,
+        _index = index,
+        _output_group_list = output_group_list,
+    )
+
+def _get_outputs(*, bundle_info, id, swift_info):
+    """Collects the output files for a given target.
+
+    The outputs are bucketed into two categories: build and index. The build
+    category contains the files that are needed by Xcode to build, run, or test
+    a target. The index category contains files that are needed by Xcode's
+    indexing process.
+
+    Args:
+        bundle_info: The `AppleBundleInfo` provider for the target, or `None`.
+        id: The unique identifier of the target.
+        swift_info: The `SwiftInfo` provider for the target, or `None`.
+
+    Returns:
+        A `struct` containing the following fields:
+
+        *   `build`: A `list` of `File`s that are needed by Xcode to build, run,
+            or test the target.
+        *   `id`: The unique identifier of the target.
+        *   `index`: A `list` of `File`s that are needed by Xcode's indexing
+            process.
+    """
+    build = []
+    index = []
+
+    if bundle_info:
+        build.append(bundle_info.archive)
+
+    # TODO: Collect headers for CC targets
+
+    # TODO: Determine which of these are actually needed for build vs index
+    if swift_info:
+        for module in swift_info.direct_modules:
+            if module.compilation_context:
+                index.extend(module.compilation_context.module_maps)
+
+            swift = module.swift
+            if not swift:
+                continue
+            build.append(swift.swiftdoc)
+            index.append(swift.swiftdoc)
+            build.append(swift.swiftmodule)
+            index.append(swift.swiftmodule)
+            if swift.swiftinterface:
+                build.append(swift.swiftinterface)
+                index.append(swift.swiftinterface)
+
+    return struct(build = build, id = id, index = index)
+
+# API
+
+def _collect(
+        *,
+        bundle_info,
+        swift_info,
+        id,
+        transitive_infos):
+    """Collects the outputs of a target.
+
+    Args:
+        bundle_info: The `AppleBundleInfo` provider for  the target, or `None`.
+        swift_info: The `SwiftInfo` provider for the target, or `None`.
+        id: A unique identifier for the target.
+        transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
+            dependencies of the target.
+
+    Returns:
+        An opaque `struct` that should be used with
+        `output_files.to_output_groups_fields`.
+    """
+
+    # TODO: When building a static library, we probably only need direct
+    #       outputs, not transitive ones. We should account for that.
+    outputs = _get_outputs(
+        bundle_info = bundle_info,
+        id = id,
+        swift_info = swift_info,
+    )
+
+    return _create(
+        direct_outputs = outputs,
+        transitive_infos = transitive_infos,
+    )
+
+def _merge(*, attrs_info, transitive_infos):
+    """Creates merged outputs.
+
+    Args:
+        attrs_info: The `InputFileAttributesInfo` for the target.
+        transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
+            dependencies of the current target.
+
+    Returns:
+        A value similar to the one returned from `output_files.collect`. The
+        values include the outputs of the transitive dependencies, via
+        `transitive_infos` (e.g. `generated` and `extra_files`).
+    """
+    return _create(transitive_infos = transitive_infos, attrs_info = attrs_info)
+
+def _to_output_groups_fields(*, ctx, outputs, toplevel_cache_buster):
+    """Generates a dictionary to be splatted into `OutputGroupInfo`.
+
+    Args:
+        ctx: The rule context.
+        outputs: A value returned from `output_files.collect()`.
+        toplevel_cache_buster: A `list` of `File`s that change with each build,
+            and are used as inputs to the output map generation, to ensure that
+            the files references by the output map are always downloaded from
+            the remote cache, even when using `--remote_download_toplevel`.
+
+    Returns:
+        A `dict` where the keys are output group names and the values are
+        `depset` of `File`s.
+    """
+    return {
+        name: depset([output_group_map.write_map(
+            ctx = ctx,
+            name = name.replace("/", "_").replace(" ", "_"),
+            files = files,
+            toplevel_cache_buster = toplevel_cache_buster,
+        )])
+        for name, files in outputs._output_group_list.to_list()
+    }
+
+output_files = struct(
+    collect = _collect,
+    merge = _merge,
+    to_output_groups_fields = _to_output_groups_fields,
+)

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -78,6 +78,10 @@ A value returned from `linker_input_files.collect`.
 A `depset` of structs with 'src' and 'dest' fields. The 'src' field is the id of
 the target that can be merged into the target with the id of the 'dest' field.
 """,
+        "outputs": """\
+A value returned from `output_files.collect`, that contains information about
+the output files for this target and its transitive dependencies.
+""",
         "required_links": """\
 A `depset` of all static library files that are linked into top-level targets
 besides their primary top-level targets.

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -26,6 +26,7 @@ load(":info_plists.bzl", "info_plists")
 load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "create_opts_search_paths", "process_opts")
+load(":output_files.bzl", "output_files")
 load(":platform.bzl", "process_platform")
 load(
     ":providers.bzl",
@@ -50,6 +51,7 @@ def _processed_target(
         dependencies,
         inputs,
         linker_inputs,
+        outputs,
         potential_target_merges,
         required_links,
         resource_bundles,
@@ -67,6 +69,8 @@ def _processed_target(
         linker_inputs: A value returned from `linker_input_files.collect`
             that will provide values for the `XcodeProjInfo.linker_inputs`
             field.
+        outputs: A value as returned from `output_files.collect` that will
+            provide values for the `XcodeProjInfo.outputs` field.
         potential_target_merges: An optional `list` of `struct`s that will be in
             the `XcodeProjInfo.potential_target_merges` `depset`.
         required_links: An optional `list` of strings that will be in the
@@ -86,6 +90,7 @@ def _processed_target(
         dependencies = dependencies,
         inputs = inputs,
         linker_inputs = linker_inputs,
+        outputs = outputs,
         potential_target_merges = potential_target_merges,
         required_links = required_links,
         resource_bundles = resource_bundles,
@@ -305,6 +310,12 @@ def _process_top_level_target(*, ctx, target, bundle_info, transitive_infos):
         additional_files = additional_files,
         transitive_infos = transitive_infos,
     )
+    outputs = output_files.collect(
+        bundle_info = bundle_info,
+        swift_info = swift_info,
+        id = id,
+        transitive_infos = transitive_infos,
+    )
 
     build_settings = {}
 
@@ -425,6 +436,7 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
         dependencies = dependencies,
         inputs = inputs,
         linker_inputs = linker_inputs,
+        outputs = outputs,
         potential_target_merges = potential_target_merges,
         required_links = required_links,
         resource_bundles = resource_bundles,
@@ -568,6 +580,12 @@ def _process_library_target(*, ctx, target, transitive_infos):
         additional_files = modulemaps.files,
         transitive_infos = transitive_infos,
     )
+    outputs = output_files.collect(
+        bundle_info = None,
+        swift_info = swift_info,
+        id = id,
+        transitive_infos = transitive_infos,
+    )
 
     resource_bundles = resource_bundle_products.collect(
         owner = resource_owner,
@@ -596,6 +614,7 @@ def _process_library_target(*, ctx, target, transitive_infos):
         dependencies = dependencies,
         inputs = inputs,
         linker_inputs = linker_inputs,
+        outputs = outputs,
         potential_target_merges = None,
         required_links = None,
         resource_bundles = resource_bundles,
@@ -705,6 +724,12 @@ def _process_resource_target(*, ctx, target, transitive_infos):
         owner = resource_owner,
         transitive_infos = transitive_infos,
     )
+    outputs = output_files.collect(
+        bundle_info = None,
+        swift_info = None,
+        id = id,
+        transitive_infos = transitive_infos,
+    )
 
     resource_bundles = resource_bundle_products.collect(
         bundle_path = bundle_path,
@@ -729,6 +754,7 @@ def _process_resource_target(*, ctx, target, transitive_infos):
         dependencies = dependencies,
         inputs = inputs,
         linker_inputs = linker_inputs,
+        outputs = outputs,
         potential_target_merges = None,
         required_links = None,
         resource_bundles = resource_bundles,
@@ -800,6 +826,10 @@ def _process_non_xcode_target(*, ctx, target, transitive_infos):
             objc = objc,
             is_xcode_target = False,
         ),
+        outputs = output_files.merge(
+            attrs_info = attrs_info,
+            transitive_infos = transitive_infos,
+        ),
         potential_target_merges = None,
         required_links = None,
         resource_bundles = resource_bundle_products.collect(
@@ -848,6 +878,7 @@ def _target_info_fields(
         dependencies,
         inputs,
         linker_inputs,
+        outputs,
         potential_target_merges,
         required_links,
         resource_bundles,
@@ -863,6 +894,7 @@ def _target_info_fields(
         dependencies: Maps to the `XcodeProjInfo.dependencies` field.
         inputs: Maps to the `XcodeProjInfo.inputs` field.
         linker_inputs: Maps to the `XcodeProjInfo.linker_inputs` field.
+        outputs: Maps to the `XcodeProjInfo.outputs` field.
         potential_target_merges: Maps to the
             `XcodeProjInfo.potential_target_merges` field.
         required_links: Maps to the `XcodeProjInfo.required_links` field.
@@ -879,6 +911,7 @@ def _target_info_fields(
         *   `generated_inputs`
         *   `inputs`
         *   `linker_inputs`
+        *   `outputs`
         *   `potential_target_merges`
         *   `required_links`
         *   `resource_bundles`
@@ -891,6 +924,7 @@ def _target_info_fields(
         "dependencies": dependencies,
         "inputs": inputs,
         "linker_inputs": linker_inputs,
+        "outputs": outputs,
         "potential_target_merges": potential_target_merges,
         "required_links": required_links,
         "resource_bundles": resource_bundles,
@@ -921,6 +955,10 @@ def _skip_target(*, deps, transitive_infos):
             transitive_infos = transitive_infos,
         ),
         inputs = input_files.merge(
+            attrs_info = None,
+            transitive_infos = transitive_infos,
+        ),
+        outputs = output_files.merge(
             attrs_info = None,
             transitive_infos = transitive_infos,
         ),
@@ -1173,6 +1211,7 @@ def _process_target(*, ctx, target, transitive_infos):
         dependencies = processed_target.dependencies,
         inputs = processed_target.inputs,
         linker_inputs = processed_target.linker_inputs,
+        outputs = processed_target.outputs,
         potential_target_merges = depset(
             processed_target.potential_target_merges,
             transitive = [

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -1,11 +1,13 @@
 """Implementation of the `xcodeproj` rule."""
 
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":files.bzl", "file_path", "file_path_to_dto")
 load(":flattened_key_values.bzl", "flattened_key_values")
 load(":input_files.bzl", "input_files")
+load(":output_files.bzl", "output_files")
 load(":providers.bzl", "XcodeProjInfo", "XcodeProjOutputInfo")
 load(":xcodeproj_aspect.bzl", "xcodeproj_aspect")
 
@@ -176,6 +178,10 @@ def _xcodeproj_impl(ctx):
         attrs_info = None,
         transitive_infos = [(None, info) for info in infos],
     )
+    outputs = output_files.merge(
+        attrs_info = None,
+        transitive_infos = [(None, info) for info in infos],
+    )
 
     spec_file = _write_json_spec(
         ctx = ctx,
@@ -202,10 +208,17 @@ def _xcodeproj_impl(ctx):
             runfiles = ctx.runfiles(files = [xcodeproj]),
         ),
         OutputGroupInfo(
-            **input_files.to_output_groups_fields(
-                ctx = ctx,
-                inputs = inputs,
-                toplevel_cache_buster = ctx.files.toplevel_cache_buster,
+            **dicts.add(
+                input_files.to_output_groups_fields(
+                    ctx = ctx,
+                    inputs = inputs,
+                    toplevel_cache_buster = ctx.files.toplevel_cache_buster,
+                ),
+                output_files.to_output_groups_fields(
+                    ctx = ctx,
+                    outputs = outputs,
+                    toplevel_cache_buster = ctx.files.toplevel_cache_buster,
+                ),
             )
         ),
         XcodeProjOutputInfo(


### PR DESCRIPTION
Similar to our generated inputs collection, we can now specify output groups to cause the building of desired outputs. This is needed for Build with Bazel.

We currently support two modes: build (`b`) and indexing (`i`). The build mode will collect outputs needed by Xcode for a build, run, or test to work. The indexing mode will collect outputs needed by Xcode's indexing processes.

For example, this will build the files needed for indexing of `PathKit`:
```
bazel build --output_groups='i @com_github_kylef_pathkit//:PathKit darwin_arm64-fastbuild'
```