### PR TITLE
Add basic plumbing for implementing the generation of Xcode schemes

### DIFF
--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		4744038ECA6A1F58F45AB520 /* OrderedSet+Partial SetAlgebra+Basics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B803E192ED98560009C6D /* OrderedSet+Partial SetAlgebra+Basics.swift */; };
 		4974B9AC4C2E129CC6088A1A /* Generator+CreateXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 703888D148E8FEB96A8F9716 /* Generator+CreateXcodeProj.swift */; };
 		4978BBDA23E2108C6410D537 /* XCScheme+Runnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A84F2CC6A006E28720D2B /* XCScheme+Runnable.swift */; };
+		4A2573A7CE96E1ECA318EBA8 /* Generator+CreateXCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDFD9E80A2C5CD8C7FD9857D /* Generator+CreateXCSharedData.swift */; };
 		4D10A242113D5E0A454F043B /* Dump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173203DBAEA88407DBBF109D /* Dump.swift */; };
 		4D2097EFFBD4914896E87BA8 /* _HashTable+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C0073B2B714F5319BE5A11 /* _HashTable+Testing.swift */; };
 		4E28CB9358C8A9F9182DA0E8 /* _Hashtable+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20573500FA17CDB30A03469A /* _Hashtable+Header.swift */; };
@@ -610,6 +611,7 @@
 		FD5E768F0086402FCD23DDD0 /* _HashTable+Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+Constants.swift"; sourceTree = "<group>"; };
 		FD75BB5F3720A6C4B51A43DF /* Generator+PopulateMainGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+PopulateMainGroup.swift"; sourceTree = "<group>"; };
 		FDF69A69C5C9048DCF61E301 /* XCScheme+TestAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+TestAction.swift"; sourceTree = "<group>"; };
+		FDFD9E80A2C5CD8C7FD9857D /* Generator+CreateXCSharedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateXCSharedData.swift"; sourceTree = "<group>"; };
 		FE1ED821757FFFB97CF9BCA3 /* Speech.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Speech.swift; sourceTree = "<group>"; };
 		FF368C9DB075CBC4E63E0BCA /* Generator+SetTargetDependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+SetTargetDependencies.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -782,6 +784,7 @@
 				C9558541CFD5066169CA9773 /* Generator+CreateProducts.swift */,
 				9522A589868D9D2C515C4822 /* Generator+CreateProject.swift */,
 				703888D148E8FEB96A8F9716 /* Generator+CreateXcodeProj.swift */,
+				FDFD9E80A2C5CD8C7FD9857D /* Generator+CreateXCSharedData.swift */,
 				9495B72CA99FFB15C026408A /* Generator+DisambiguateTargets.swift */,
 				8BE9C68C0607CFD069F19187 /* Generator+Main.swift */,
 				FD75BB5F3720A6C4B51A43DF /* Generator+PopulateMainGroup.swift */,
@@ -1652,6 +1655,7 @@
 				6BEA8E1A797CD3E05D0BAE40 /* Generator+CreateFilesAndGroups.swift in Sources */,
 				E573DCC118186C0FAB27ECD3 /* Generator+CreateProducts.swift in Sources */,
 				51F268CB997C75D3FFBE5DA7 /* Generator+CreateProject.swift in Sources */,
+				4A2573A7CE96E1ECA318EBA8 /* Generator+CreateXCSharedData.swift in Sources */,
 				4974B9AC4C2E129CC6088A1A /* Generator+CreateXcodeProj.swift in Sources */,
 				DFEB422950EB6556FF81427F /* Generator+DisambiguateTargets.swift in Sources */,
 				E69C15430624375DCD37079E /* Generator+Main.swift in Sources */,

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		7F2927EE0191B937929E8EA9 /* Generator+CreateXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04307C3D13AF08A10830B41 /* Generator+CreateXCSchemes.swift */; };
 		7F476F3EA1860204A2BC970E /* ReferenceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0D02295BBDD7113D940406 /* ReferenceGenerator.swift */; };
 		7F58A80D6FBF4CAAB6A6B59C /* PBXProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A42BDD634CA3FA35830AE1 /* PBXProductType.swift */; };
+		80361D1C6E985B1C92E65811 /* CreateXCSharedDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE5F2E4FC573D27FCB8DF34 /* CreateXCSharedDataTests.swift */; };
 		804848AF97DCD0402E5B8587 /* BuildSettingsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD828AC8336C5A1F0C951071 /* BuildSettingsProvider.swift */; };
 		80DB1DEE41E0521C535EF842 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF420FAF127AC6B393E4678 /* PBXResourcesBuildPhase.swift */; };
 		81538A9DF3EE3B84C20E7C11 /* PBXObjectReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA5F81BF5F85E9032BC2014 /* PBXObjectReference.swift */; };
@@ -549,6 +550,7 @@
 		AC7F0486AC72B3E68F194D01 /* PathKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathKit.swift; sourceTree = "<group>"; };
 		ACF678DB87E07DDDF0999336 /* OrderedSet+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Testing.swift"; sourceTree = "<group>"; };
 		AF072F61E054955564EECDA2 /* CustomDumpStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDumpStringConvertible.swift; sourceTree = "<group>"; };
+		AFE5F2E4FC573D27FCB8DF34 /* CreateXCSharedDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateXCSharedDataTests.swift; sourceTree = "<group>"; };
 		B2F851023E4F4913D1E369CE /* JSONDecoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoding.swift; sourceTree = "<group>"; };
 		B379DE01A53B895F83E8846C /* AEXML+XcodeFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AEXML+XcodeFormat.swift"; sourceTree = "<group>"; };
 		B40DA547773CCE961E1E2CCD /* TargetID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TargetID.swift; sourceTree = "<group>"; };
@@ -1019,6 +1021,7 @@
 				A40EB7581064768B08E6C529 /* CreateProductsTest.swift */,
 				6A9607F1AB28FE727DED4651 /* CreateProjectTests.swift */,
 				7025166F1EB392F463C551D2 /* CreateXcodeProjTests.swift */,
+				AFE5F2E4FC573D27FCB8DF34 /* CreateXCSharedDataTests.swift */,
 				EDE03F64CA13C3461D45773E /* DisambiguateTargetsTests.swift */,
 				F238F3E44302DBE53FF70525 /* Fixtures.swift */,
 				25072DE452FF8EC4AC148C4A /* GeneratorTests.swift */,
@@ -1615,6 +1618,7 @@
 				6BEEFB6F9ABBD9DE61F18D20 /* CreateFilesAndGroupsTests.swift in Sources */,
 				72A3C7DA6BF74DE5F2EFC28C /* CreateProductsTest.swift in Sources */,
 				8D60F9D1D81FEDCE8DDF6B73 /* CreateProjectTests.swift in Sources */,
+				80361D1C6E985B1C92E65811 /* CreateXCSharedDataTests.swift in Sources */,
 				A68D64FB246101C57F8011AA /* CreateXcodeProjTests.swift in Sources */,
 				0680A4C2872B98AC70E3ADD4 /* DisambiguateTargetsTests.swift in Sources */,
 				2AF393E662D68CBEAC339715 /* Fixtures.swift in Sources */,

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		78D160559CB33620BE055D67 /* PBXTargetDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E0D9481DEB5CB89790C09F /* PBXTargetDependency.swift */; };
 		7B3AD502D81DAD7185608351 /* Generator+WriteXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B56CD9E6641A10324B096B /* Generator+WriteXcodeProj.swift */; };
 		7D2E840E973AA9E5F5898CF0 /* DTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0725D1FE9D931F37B2F6AA3 /* DTO.swift */; };
+		7F2927EE0191B937929E8EA9 /* Generator+CreateXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04307C3D13AF08A10830B41 /* Generator+CreateXCSchemes.swift */; };
 		7F476F3EA1860204A2BC970E /* ReferenceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0D02295BBDD7113D940406 /* ReferenceGenerator.swift */; };
 		7F58A80D6FBF4CAAB6A6B59C /* PBXProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A42BDD634CA3FA35830AE1 /* PBXProductType.swift */; };
 		804848AF97DCD0402E5B8587 /* BuildSettingsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD828AC8336C5A1F0C951071 /* BuildSettingsProvider.swift */; };
@@ -597,6 +598,7 @@
 		ED0F122B168D474ADA615A76 /* OrderedDictionary+CustomDebugStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+CustomDebugStringConvertible.swift"; sourceTree = "<group>"; };
 		EDE03F64CA13C3461D45773E /* DisambiguateTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisambiguateTargetsTests.swift; sourceTree = "<group>"; };
 		EE677C0FD789C4A0ADDC1901 /* BuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPhase.swift; sourceTree = "<group>"; };
+		F04307C3D13AF08A10830B41 /* Generator+CreateXCSchemes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateXCSchemes.swift"; sourceTree = "<group>"; };
 		F0725D1FE9D931F37B2F6AA3 /* DTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTO.swift; sourceTree = "<group>"; };
 		F0AD1D57FD4037EC5BB72645 /* XCSharedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCSharedData.swift; sourceTree = "<group>"; };
 		F238F3E44302DBE53FF70525 /* Fixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixtures.swift; sourceTree = "<group>"; };
@@ -784,6 +786,7 @@
 				C9558541CFD5066169CA9773 /* Generator+CreateProducts.swift */,
 				9522A589868D9D2C515C4822 /* Generator+CreateProject.swift */,
 				703888D148E8FEB96A8F9716 /* Generator+CreateXcodeProj.swift */,
+				F04307C3D13AF08A10830B41 /* Generator+CreateXCSchemes.swift */,
 				FDFD9E80A2C5CD8C7FD9857D /* Generator+CreateXCSharedData.swift */,
 				9495B72CA99FFB15C026408A /* Generator+DisambiguateTargets.swift */,
 				8BE9C68C0607CFD069F19187 /* Generator+Main.swift */,
@@ -1655,6 +1658,7 @@
 				6BEA8E1A797CD3E05D0BAE40 /* Generator+CreateFilesAndGroups.swift in Sources */,
 				E573DCC118186C0FAB27ECD3 /* Generator+CreateProducts.swift in Sources */,
 				51F268CB997C75D3FFBE5DA7 /* Generator+CreateProject.swift in Sources */,
+				7F2927EE0191B937929E8EA9 /* Generator+CreateXCSchemes.swift in Sources */,
 				4A2573A7CE96E1ECA318EBA8 /* Generator+CreateXCSharedData.swift in Sources */,
 				4974B9AC4C2E129CC6088A1A /* Generator+CreateXcodeProj.swift in Sources */,
 				DFEB422950EB6556FF81427F /* Generator+DisambiguateTargets.swift in Sources */,

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -434,6 +434,7 @@
                     "tools/generator/src/Generator+CreateFilesAndGroups.swift",
                     "tools/generator/src/Generator+CreateProducts.swift",
                     "tools/generator/src/Generator+CreateProject.swift",
+                    "tools/generator/src/Generator+CreateXCSchemes.swift",
                     "tools/generator/src/Generator+CreateXCSharedData.swift",
                     "tools/generator/src/Generator+CreateXcodeProj.swift",
                     "tools/generator/src/Generator+DisambiguateTargets.swift",

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -434,6 +434,7 @@
                     "tools/generator/src/Generator+CreateFilesAndGroups.swift",
                     "tools/generator/src/Generator+CreateProducts.swift",
                     "tools/generator/src/Generator+CreateProject.swift",
+                    "tools/generator/src/Generator+CreateXCSharedData.swift",
                     "tools/generator/src/Generator+CreateXcodeProj.swift",
                     "tools/generator/src/Generator+DisambiguateTargets.swift",
                     "tools/generator/src/Generator+Main.swift",

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -198,6 +198,7 @@
                     "tools/generator/test/CreateFilesAndGroupsTests.swift",
                     "tools/generator/test/CreateProductsTest.swift",
                     "tools/generator/test/CreateProjectTests.swift",
+                    "tools/generator/test/CreateXCSharedDataTests.swift",
                     "tools/generator/test/CreateXcodeProjTests.swift",
                     "tools/generator/test/DisambiguateTargetsTests.swift",
                     "tools/generator/test/Fixtures.swift",

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		2B291E95CCB447383EB7AE87 /* XCScheme+EnvironmentVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22FB6646E89CD0F8B7C2C39 /* XCScheme+EnvironmentVariable.swift */; };
 		2B5CE87F591A88AE69E2EA93 /* CustomDumpRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88789669F25DD7E154C15036 /* CustomDumpRepresentable.swift */; };
 		2F23E98B7032105D6B0D28C8 /* OrderedSet+UnstableInternals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8415E01540549AB7D9DC7775 /* OrderedSet+UnstableInternals.swift */; };
+		30D5B9A89D41795BE4359B14 /* Generator+CreateXCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A3046CDCECF5B1135A1D0E /* Generator+CreateXCSharedData.swift */; };
 		33B7CF1072ED2BECDE1093EE /* PBXProductType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0926F34E2099B433D5550DCD /* PBXProductType+Extensions.swift */; };
 		3468B9267DEA583FB703DC62 /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB78F15F8AFA4FD268CBC7BD /* KeyedDecodingContainer+Additions.swift */; };
 		34AA2315505226D74BC238A6 /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1140300C723A6A3D0EC452A4 /* Element.swift */; };
@@ -407,6 +408,7 @@
 		1267D8B9A2E0172402C0AD0C /* XCScheme+Runnable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+Runnable.swift"; sourceTree = "<group>"; };
 		159077487BA2582632AE5FCB /* CustomDumpReflectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDumpReflectable.swift; sourceTree = "<group>"; };
 		15B947E1837B5A93F9780BD6 /* OrderedDictionary+Values.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Values.swift"; sourceTree = "<group>"; };
+		18A3046CDCECF5B1135A1D0E /* Generator+CreateXCSharedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateXCSharedData.swift"; sourceTree = "<group>"; };
 		198C3110BC4D1378F886FABB /* XCWorkspaceDataElementLocationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataElementLocationType.swift; sourceTree = "<group>"; };
 		1B1F611F9FE1838B9E8CC41C /* OrderedSet+Partial RangeReplaceableCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial RangeReplaceableCollection.swift"; sourceTree = "<group>"; };
 		1CA2DC08D1A87C12C91B467D /* OrderedSet+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Codable.swift"; sourceTree = "<group>"; };
@@ -1122,6 +1124,7 @@
 				CB3A0C56E6309EC169805A89 /* Generator+CreateProducts.swift */,
 				4B0489BBEB7C17EFEB6AE185 /* Generator+CreateProject.swift */,
 				46FAB1B8F9AB1BD009B78FA6 /* Generator+CreateXcodeProj.swift */,
+				18A3046CDCECF5B1135A1D0E /* Generator+CreateXCSharedData.swift */,
 				6BA7E31A29E125E3633EC7C6 /* Generator+DisambiguateTargets.swift */,
 				ADF88F06ADD246BEF6FBE6F3 /* Generator+Main.swift */,
 				C82BFDAFBA290861DF5C9ACD /* Generator+PopulateMainGroup.swift */,
@@ -1607,6 +1610,7 @@
 				BF3A961C3C9160CDB03BBAD5 /* Generator+CreateFilesAndGroups.swift in Sources */,
 				ED5F0F0FA5A045D7F75F3815 /* Generator+CreateProducts.swift in Sources */,
 				7EFB7F70225BBBE18BD502FD /* Generator+CreateProject.swift in Sources */,
+				30D5B9A89D41795BE4359B14 /* Generator+CreateXCSharedData.swift in Sources */,
 				494319462485B704527D1BA7 /* Generator+CreateXcodeProj.swift in Sources */,
 				ED347450B34C5682C31794E4 /* Generator+DisambiguateTargets.swift in Sources */,
 				E00618A325EF5833C59AC724 /* Generator+Main.swift in Sources */,

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		7179F32217C3BEEA636F5051 /* Generator+AddTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79EFC55270A7F9C95452FF71 /* Generator+AddTargets.swift */; };
 		72049B7D69FF7FD021452042 /* Writable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE87E1BA432999CAE565E4 /* Writable.swift */; };
 		735D5210F46BBA12E2A5F882 /* DTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = F52B40BE9E5A13756AD20F88 /* DTO.swift */; };
+		73AC905D0A5BCA30C4E708CE /* CreateXCSharedDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6160799DF1E959D7EF7F1CDB /* CreateXCSharedDataTests.swift */; };
 		7409FB4D1290B6C3D1A84D54 /* XCScheme+Runnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1267D8B9A2E0172402C0AD0C /* XCScheme+Runnable.swift */; };
 		749B0793FC0A4EECC80ADB28 /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850F1749D2A1AD1CFDC0018B /* Dictionary+Extras.swift */; };
 		74BE9529D3022CC8ED1EF4BC /* PBXSourceTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1823B73B5FA76655C55208 /* PBXSourceTree.swift */; };
@@ -471,6 +472,7 @@
 		5E0508567B3931B91F6BFBF4 /* _HashTable+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+CustomStringConvertible.swift"; sourceTree = "<group>"; };
 		5F24115825DF2B1E009D5EEC /* Equality.generated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Equality.generated.swift; sourceTree = "<group>"; };
 		612B7195005F9E0BE7F69147 /* OrderedSet+ReserveCapacity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+ReserveCapacity.swift"; sourceTree = "<group>"; };
+		6160799DF1E959D7EF7F1CDB /* CreateXCSharedDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateXCSharedDataTests.swift; sourceTree = "<group>"; };
 		62C5676FE6D1E8E366E560E4 /* String+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Utils.swift"; sourceTree = "<group>"; };
 		631FF94DFE5F13AC99391DD3 /* Sourcery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sourcery.swift; sourceTree = "<group>"; };
 		63B584159BE8C17D78ED2F8B /* Foundation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Foundation.swift; sourceTree = "<group>"; };
@@ -757,6 +759,7 @@
 				798455D7A824BAB585C1E8EB /* CreateProductsTest.swift */,
 				E200ED9999C2E4E55C7EC34E /* CreateProjectTests.swift */,
 				4BC5B799900C53A6F581CF62 /* CreateXcodeProjTests.swift */,
+				6160799DF1E959D7EF7F1CDB /* CreateXCSharedDataTests.swift */,
 				B85F30A6B61E80F5E31CB607 /* DisambiguateTargetsTests.swift */,
 				B742237DAD78B14D2D76247E /* Fixtures.swift */,
 				39D97BF140AD29497D75D5A2 /* GeneratorTests.swift */,
@@ -1562,6 +1565,7 @@
 				250DE90578C454256F39C418 /* CreateFilesAndGroupsTests.swift in Sources */,
 				D28AD805F11C60A1A2CEBE5A /* CreateProductsTest.swift in Sources */,
 				0B06F16B6814BDD36D863BDF /* CreateProjectTests.swift in Sources */,
+				73AC905D0A5BCA30C4E708CE /* CreateXCSharedDataTests.swift in Sources */,
 				5F50664E006EE645FFC8B076 /* CreateXcodeProjTests.swift in Sources */,
 				3CC3CF23728FFF27C3332D92 /* DisambiguateTargetsTests.swift in Sources */,
 				E652CF138CE3C81AFF67C354 /* Fixtures.swift in Sources */,

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		0C9998F93EE859EDA61355AF /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D740A39A7753D2B8D21F375 /* PBXNativeTarget.swift */; };
 		0D05D88A81FF1ED06AE2BF8B /* SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5320E25757AF149A406D12 /* SwiftUI.swift */; };
 		0E16E95D724F1693E1638E94 /* PBXBatchUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = E842D0488C59F4DFAA82FE0E /* PBXBatchUpdater.swift */; };
+		0ECB525A51FEB74588AAC93B /* Generator+CreateXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E95084ACBED4858D5559E399 /* Generator+CreateXCSchemes.swift */; };
 		114337D1EE92A54BD108429D /* XCScheme+SerialAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3EB849AA377331B54327E0 /* XCScheme+SerialAction.swift */; };
 		1288DA0AB3DA8C0A7757FC13 /* BuildSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D96374AEC70A27090561C1A7 /* BuildSetting.swift */; };
 		1310313F22DBFF5FDC0124B2 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0917D4CE41302D9DE4C953AE /* Box.swift */; };
@@ -600,6 +601,7 @@
 		E842D0488C59F4DFAA82FE0E /* PBXBatchUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBatchUpdater.swift; sourceTree = "<group>"; };
 		E87B383CA6F0E63B5353F77F /* OrderedSet+Partial SetAlgebra+Operations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial SetAlgebra+Operations.swift"; sourceTree = "<group>"; };
 		E8BB71068908E1D8FA3058CB /* OrderedDictionary+ExpressibleByDictionaryLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+ExpressibleByDictionaryLiteral.swift"; sourceTree = "<group>"; };
+		E95084ACBED4858D5559E399 /* Generator+CreateXCSchemes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateXCSchemes.swift"; sourceTree = "<group>"; };
 		E9A234AB51A97D97EE651298 /* OrderedSet+Partial SetAlgebra+Basics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial SetAlgebra+Basics.swift"; sourceTree = "<group>"; };
 		EC5DDE735367F49D1F8347A4 /* Target+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Target+Testing.swift"; sourceTree = "<group>"; };
 		ECF2375E72B499C63E3F5AD9 /* ReferenceGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferenceGenerator.swift; sourceTree = "<group>"; };
@@ -1124,6 +1126,7 @@
 				CB3A0C56E6309EC169805A89 /* Generator+CreateProducts.swift */,
 				4B0489BBEB7C17EFEB6AE185 /* Generator+CreateProject.swift */,
 				46FAB1B8F9AB1BD009B78FA6 /* Generator+CreateXcodeProj.swift */,
+				E95084ACBED4858D5559E399 /* Generator+CreateXCSchemes.swift */,
 				18A3046CDCECF5B1135A1D0E /* Generator+CreateXCSharedData.swift */,
 				6BA7E31A29E125E3633EC7C6 /* Generator+DisambiguateTargets.swift */,
 				ADF88F06ADD246BEF6FBE6F3 /* Generator+Main.swift */,
@@ -1610,6 +1613,7 @@
 				BF3A961C3C9160CDB03BBAD5 /* Generator+CreateFilesAndGroups.swift in Sources */,
 				ED5F0F0FA5A045D7F75F3815 /* Generator+CreateProducts.swift in Sources */,
 				7EFB7F70225BBBE18BD502FD /* Generator+CreateProject.swift in Sources */,
+				0ECB525A51FEB74588AAC93B /* Generator+CreateXCSchemes.swift in Sources */,
 				30D5B9A89D41795BE4359B14 /* Generator+CreateXCSharedData.swift in Sources */,
 				494319462485B704527D1BA7 /* Generator+CreateXcodeProj.swift in Sources */,
 				ED347450B34C5682C31794E4 /* Generator+DisambiguateTargets.swift in Sources */,

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -428,6 +428,7 @@
                     "tools/generator/src/Generator+CreateFilesAndGroups.swift",
                     "tools/generator/src/Generator+CreateProducts.swift",
                     "tools/generator/src/Generator+CreateProject.swift",
+                    "tools/generator/src/Generator+CreateXCSchemes.swift",
                     "tools/generator/src/Generator+CreateXCSharedData.swift",
                     "tools/generator/src/Generator+CreateXcodeProj.swift",
                     "tools/generator/src/Generator+DisambiguateTargets.swift",

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -195,6 +195,7 @@
                     "tools/generator/test/CreateFilesAndGroupsTests.swift",
                     "tools/generator/test/CreateProductsTest.swift",
                     "tools/generator/test/CreateProjectTests.swift",
+                    "tools/generator/test/CreateXCSharedDataTests.swift",
                     "tools/generator/test/CreateXcodeProjTests.swift",
                     "tools/generator/test/DisambiguateTargetsTests.swift",
                     "tools/generator/test/Fixtures.swift",

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -428,6 +428,7 @@
                     "tools/generator/src/Generator+CreateFilesAndGroups.swift",
                     "tools/generator/src/Generator+CreateProducts.swift",
                     "tools/generator/src/Generator+CreateProject.swift",
+                    "tools/generator/src/Generator+CreateXCSharedData.swift",
                     "tools/generator/src/Generator+CreateXcodeProj.swift",
                     "tools/generator/src/Generator+DisambiguateTargets.swift",
                     "tools/generator/src/Generator+Main.swift",

--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -73,6 +73,8 @@ struct Environment {
         _ pbxTargets: [TargetID: PBXNativeTarget]
     ) throws -> Void
 
+    let createXCSharedData: (_ schemes: [XCScheme]) -> XCSharedData
+
     let createXcodeProj: (
         _ pbxProj: PBXProj,
         _ sharedData: XCSharedData?

--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -73,6 +73,10 @@ struct Environment {
         _ pbxTargets: [TargetID: PBXNativeTarget]
     ) throws -> Void
 
+    let createXCSchemes: (
+        _ disambiguatedTargets: [TargetID: DisambiguatedTarget]
+    ) -> [XCScheme]
+
     let createXCSharedData: (_ schemes: [XCScheme]) -> XCSharedData
 
     let createXcodeProj: (

--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -73,7 +73,10 @@ struct Environment {
         _ pbxTargets: [TargetID: PBXNativeTarget]
     ) throws -> Void
 
-    let createXcodeProj: (_ pbxProj: PBXProj) -> XcodeProj
+    let createXcodeProj: (
+        _ pbxProj: PBXProj,
+        _ sharedData: XCSharedData?
+    ) -> XcodeProj
 
     let writeXcodeProj: (
         _ xcodeProj: XcodeProj,

--- a/tools/generator/src/Generator+CreateXCSchemes.swift
+++ b/tools/generator/src/Generator+CreateXCSchemes.swift
@@ -5,7 +5,7 @@ extension Generator {
     static func createXCSchemes(
         disambiguatedTargets _: [TargetID: DisambiguatedTarget]
     ) -> [XCScheme] {
-        // TODO(cgrindel: IMPLEMENT ME!
+        // GH101: Implement logic to create schemes from targets.
         return []
     }
 }

--- a/tools/generator/src/Generator+CreateXCSchemes.swift
+++ b/tools/generator/src/Generator+CreateXCSchemes.swift
@@ -1,0 +1,11 @@
+import XcodeProj
+
+extension Generator {
+    /// Creates an array of `XCScheme` entries for the specified targets.
+    static func createXCSchemes(
+        disambiguatedTargets _: [TargetID: DisambiguatedTarget]
+    ) -> [XCScheme] {
+        // TODO(cgrindel: IMPLEMENT ME!
+        return []
+    }
+}

--- a/tools/generator/src/Generator+CreateXCSharedData.swift
+++ b/tools/generator/src/Generator+CreateXCSharedData.swift
@@ -1,0 +1,8 @@
+import XcodeProj
+
+extension Generator {
+    /// Creates an `XCSharedData`.
+    static func createXCSharedData(schemes: [XCScheme]) -> XCSharedData {
+        return XCSharedData(schemes: schemes)
+    }
+}

--- a/tools/generator/src/Generator+CreateXcodeProj.swift
+++ b/tools/generator/src/Generator+CreateXcodeProj.swift
@@ -3,8 +3,8 @@ import XcodeProj
 extension Generator {
     /// Creates an `XcodeProj` for the given `PBXProj`.
     static func createXcodeProj(
-        for pbxProj: PBXProj, 
-        sharedData: XCSharedData? = nil
+        for pbxProj: PBXProj,
+        sharedData: XCSharedData?
     ) -> XcodeProj {
         return XcodeProj(
             workspace: XCWorkspace(),

--- a/tools/generator/src/Generator+CreateXcodeProj.swift
+++ b/tools/generator/src/Generator+CreateXcodeProj.swift
@@ -2,10 +2,14 @@ import XcodeProj
 
 extension Generator {
     /// Creates an `XcodeProj` for the given `PBXProj`.
-    static func createXcodeProj(for pbxProj: PBXProj) -> XcodeProj {
+    static func createXcodeProj(
+        for pbxProj: PBXProj, 
+        sharedData: XCSharedData? = nil
+    ) -> XcodeProj {
         return XcodeProj(
             workspace: XCWorkspace(),
-            pbxproj: pbxProj
+            pbxproj: pbxProj,
+            sharedData: sharedData
         )
     }
 }

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -135,21 +135,18 @@ Was unable to merge "\(srcTarget.label) \
             pbxTargets
         )
 
-        // DEBUG BEGIN
-        fputs("*** CHUCK pbxTargets:\n", stderr)
-        for (idx, item) in pbxTargets.enumerated() {
-            fputs("*** CHUCK   \(idx) : \(String(reflecting: item))\n", stderr)
-        }
-        fputs("*** CHUCK disambiguatedTargets:\n", stderr)
-        for (idx, item) in disambiguatedTargets.enumerated() {
-            fputs("*** CHUCK   \(idx) : \(String(reflecting: item))\n", stderr)
-        }
-        // DEBUG END
+        // // DEBUG BEGIN
+        // fputs("*** CHUCK pbxTargets:\n", stderr)
+        // for (idx, item) in pbxTargets.enumerated() {
+        //     fputs("*** CHUCK   \(idx) : \(String(reflecting: item))\n", stderr)
+        // }
+        // fputs("*** CHUCK disambiguatedTargets:\n", stderr)
+        // for (idx, item) in disambiguatedTargets.enumerated() {
+        //     fputs("*** CHUCK   \(idx) : \(String(reflecting: item))\n", stderr)
+        // }
+        // // DEBUG END
 
-        // TODO(chuck): FIX ME!
         let schemes = environment.createXCSchemes(disambiguatedTargets)
-        // let schemes = [XCScheme]()
-
         let sharedData = environment.createXCSharedData(schemes)
 
          let xcodeProj = environment.createXcodeProj(pbxProj, sharedData)

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -1,10 +1,6 @@
 import PathKit
 import XcodeProj
 
-// DEBUG BEGIN
-import Darwin
-// DEBUG END
-
 /// A class that generates and writes to disk an Xcode project.
 ///
 /// The `Generator` class is stateless. It can be used to generate multiple
@@ -134,17 +130,6 @@ Was unable to merge "\(srcTarget.label) \
             disambiguatedTargets,
             pbxTargets
         )
-
-        // // DEBUG BEGIN
-        // fputs("*** CHUCK pbxTargets:\n", stderr)
-        // for (idx, item) in pbxTargets.enumerated() {
-        //     fputs("*** CHUCK   \(idx) : \(String(reflecting: item))\n", stderr)
-        // }
-        // fputs("*** CHUCK disambiguatedTargets:\n", stderr)
-        // for (idx, item) in disambiguatedTargets.enumerated() {
-        //     fputs("*** CHUCK   \(idx) : \(String(reflecting: item))\n", stderr)
-        // }
-        // // DEBUG END
 
         let schemes = environment.createXCSchemes(disambiguatedTargets)
         let sharedData = environment.createXCSharedData(schemes)

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -129,7 +129,7 @@ Was unable to merge "\(srcTarget.label) \
             pbxTargets
         )
 
-         let xcodeProj = environment.createXcodeProj(pbxProj)
+         let xcodeProj = environment.createXcodeProj(pbxProj, nil)
          try environment.writeXcodeProj(
             xcodeProj,
             files,

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -18,6 +18,7 @@ class Generator {
         addTargets: Generator.addTargets,
         setTargetConfigurations: Generator.setTargetConfigurations,
         setTargetDependencies: Generator.setTargetDependencies,
+        createXCSharedData: Generator.createXCSharedData,
         createXcodeProj: Generator.createXcodeProj,
         writeXcodeProj: Generator.writeXcodeProj
     )
@@ -129,7 +130,10 @@ Was unable to merge "\(srcTarget.label) \
             pbxTargets
         )
 
-         let xcodeProj = environment.createXcodeProj(pbxProj, nil)
+        // TODO(chuck): Pass in the schemes
+        let sharedData = environment.createXCSharedData([])
+
+         let xcodeProj = environment.createXcodeProj(pbxProj, sharedData)
          try environment.writeXcodeProj(
             xcodeProj,
             files,

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -1,6 +1,10 @@
 import PathKit
 import XcodeProj
 
+// DEBUG BEGIN
+import Darwin
+// DEBUG END
+
 /// A class that generates and writes to disk an Xcode project.
 ///
 /// The `Generator` class is stateless. It can be used to generate multiple
@@ -18,6 +22,7 @@ class Generator {
         addTargets: Generator.addTargets,
         setTargetConfigurations: Generator.setTargetConfigurations,
         setTargetDependencies: Generator.setTargetDependencies,
+        createXCSchemes: Generator.createXCSchemes,
         createXCSharedData: Generator.createXCSharedData,
         createXcodeProj: Generator.createXcodeProj,
         writeXcodeProj: Generator.writeXcodeProj
@@ -130,8 +135,22 @@ Was unable to merge "\(srcTarget.label) \
             pbxTargets
         )
 
-        // TODO(chuck): Pass in the schemes
-        let sharedData = environment.createXCSharedData([])
+        // DEBUG BEGIN
+        fputs("*** CHUCK pbxTargets:\n", stderr)
+        for (idx, item) in pbxTargets.enumerated() {
+            fputs("*** CHUCK   \(idx) : \(String(reflecting: item))\n", stderr)
+        }
+        fputs("*** CHUCK disambiguatedTargets:\n", stderr)
+        for (idx, item) in disambiguatedTargets.enumerated() {
+            fputs("*** CHUCK   \(idx) : \(String(reflecting: item))\n", stderr)
+        }
+        // DEBUG END
+
+        // TODO(chuck): FIX ME!
+        let schemes = environment.createXCSchemes(disambiguatedTargets)
+        // let schemes = [XCScheme]()
+
+        let sharedData = environment.createXCSharedData(schemes)
 
          let xcodeProj = environment.createXcodeProj(pbxProj, sharedData)
          try environment.writeXcodeProj(

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -134,13 +134,13 @@ Was unable to merge "\(srcTarget.label) \
         let schemes = environment.createXCSchemes(disambiguatedTargets)
         let sharedData = environment.createXCSharedData(schemes)
 
-         let xcodeProj = environment.createXcodeProj(pbxProj, sharedData)
-         try environment.writeXcodeProj(
+        let xcodeProj = environment.createXcodeProj(pbxProj, sharedData)
+        try environment.writeXcodeProj(
             xcodeProj,
             files,
             internalDirectoryName,
             outputPath
-         )
+        )
     }
 }
 

--- a/tools/generator/test/CreateXCSharedDataTests.swift
+++ b/tools/generator/test/CreateXCSharedDataTests.swift
@@ -1,0 +1,32 @@
+import CustomDump
+import XcodeProj
+import XCTest
+
+@testable import generator
+
+final class CreateXCSharedDataTests: XCTestCase {
+    func test_basic() throws {
+        // // Arrange
+
+        // let pbxProj = Fixtures.pbxProj()
+        // let expectedPBXProj = Fixtures.pbxProj()
+
+        // // TODO: Schemes
+        // let expectedXcodeProj = XcodeProj(
+        //     workspace: XCWorkspace(),
+        //     pbxproj: expectedPBXProj
+        // )
+
+        // // Act
+
+        // let xcodeProj = Generator.createXcodeProj(for: pbxProj)
+
+        // try pbxProj.fixReferences()
+        // try expectedPBXProj.fixReferences()
+
+        // // Assert
+
+        // XCTAssertNoDifference(xcodeProj, expectedXcodeProj)
+        XCTFail("IMPLEMENT ME!")
+    }
+}

--- a/tools/generator/test/CreateXCSharedDataTests.swift
+++ b/tools/generator/test/CreateXCSharedDataTests.swift
@@ -6,27 +6,18 @@ import XCTest
 
 final class CreateXCSharedDataTests: XCTestCase {
     func test_basic() throws {
-        // // Arrange
+        // Arrange
 
-        // let pbxProj = Fixtures.pbxProj()
-        // let expectedPBXProj = Fixtures.pbxProj()
+        let schemes = Fixtures.xcSchemes()
 
-        // // TODO: Schemes
-        // let expectedXcodeProj = XcodeProj(
-        //     workspace: XCWorkspace(),
-        //     pbxproj: expectedPBXProj
-        // )
+        let expectedSharedData = XCSharedData(schemes: schemes)
 
-        // // Act
+        // Act
 
-        // let xcodeProj = Generator.createXcodeProj(for: pbxProj)
+        let sharedData = Generator.createXCSharedData(schemes: schemes)
 
-        // try pbxProj.fixReferences()
-        // try expectedPBXProj.fixReferences()
+        // Assert
 
-        // // Assert
-
-        // XCTAssertNoDifference(xcodeProj, expectedXcodeProj)
-        XCTFail("IMPLEMENT ME!")
+        XCTAssertNoDifference(sharedData, expectedSharedData)
     }
 }

--- a/tools/generator/test/CreateXcodeProjTests.swift
+++ b/tools/generator/test/CreateXcodeProjTests.swift
@@ -9,17 +9,18 @@ final class CreateXcodeProjTests: XCTestCase {
         // Arrange
 
         let pbxProj = Fixtures.pbxProj()
-        let expectedPBXProj = Fixtures.pbxProj()
+        let sharedData = Fixtures.xcSharedData()
 
-        // TODO: Schemes
+        let expectedPBXProj = Fixtures.pbxProj()
         let expectedXcodeProj = XcodeProj(
             workspace: XCWorkspace(),
-            pbxproj: expectedPBXProj
+            pbxproj: expectedPBXProj,
+            sharedData: sharedData
         )
 
         // Act
 
-        let xcodeProj = Generator.createXcodeProj(for: pbxProj)
+        let xcodeProj = Generator.createXcodeProj(for: pbxProj, sharedData: sharedData)
 
         try pbxProj.fixReferences()
         try expectedPBXProj.fixReferences()

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1555,4 +1555,13 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
 
         return pbxTargets
     }
+
+    static func xcSchemes() -> [XCScheme] {
+        return [XCScheme(name: "Custom Scheme", lastUpgradeVersion: nil, version: nil)]
+    }
+
+    static func xcSharedData() -> XCSharedData {
+        let schemes = xcSchemes()
+        return XCSharedData(schemes: schemes)
+    }
 }

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -382,20 +382,24 @@ final class GeneratorTests: XCTestCase {
 
         struct CreateXcodeProjCalled: Equatable {
             let pbxProj: PBXProj
+            let sharedData: XCSharedData?
         }
 
         var createXcodeProjCalled: [CreateXcodeProjCalled] = []
         func createXcodeProj(
-            for pbxProj: PBXProj
+            for pbxProj: PBXProj,
+            sharedData: XCSharedData?
         ) -> XcodeProj {
             createXcodeProjCalled.append(.init(
-                pbxProj: pbxProj
+                pbxProj: pbxProj,
+                sharedData: sharedData
             ))
             return xcodeProj
         }
 
         let expectedCreateXcodeProjCalled = [CreateXcodeProjCalled(
-            pbxProj: pbxProj
+            pbxProj: pbxProj,
+            sharedData: nil
         )]
 
         // MARK: writeXcodeProj()

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -66,10 +66,14 @@ final class GeneratorTests: XCTestCase {
         let pbxTargets: [TargetID: PBXNativeTarget] = [
             "A": PBXNativeTarget(name: "A (3456a)"),
         ]
+        // TODO(chuck): Update to pass along a scheme.
+        // let schemes = [XCScheme(name: "Custom Scheme", lastUpgradeVersion: nil, version: nil)]
+        let schemes = [XCScheme]()
+        let sharedData = XCSharedData(schemes: schemes)
         let xcodeProj = XcodeProj(
             workspace: XCWorkspace(),
             pbxproj: pbxProj,
-            sharedData: nil
+            sharedData: sharedData
         )
 
         var expectedMessagesLogged: [StubLogger.MessageLogged] = []
@@ -378,6 +382,22 @@ final class GeneratorTests: XCTestCase {
             pbxTargets: pbxTargets
         )]
 
+        // MARK: createXCSharedData()
+
+        struct CreateXCSharedDataCalled: Equatable {
+            let schemes: [XCScheme]
+        }
+
+        var createXCSharedDataCalled: [CreateXCSharedDataCalled] = []
+        func createXCSharedData(schemes: [XCScheme]) -> XCSharedData {
+            createXCSharedDataCalled.append(.init(schemes: schemes))
+            return sharedData
+        }
+
+        let expectedCreateXCSharedDataCalled = [CreateXCSharedDataCalled(
+            schemes: schemes
+        )]
+
         // MARK: createXcodeProj()
 
         struct CreateXcodeProjCalled: Equatable {
@@ -399,7 +419,7 @@ final class GeneratorTests: XCTestCase {
 
         let expectedCreateXcodeProjCalled = [CreateXcodeProjCalled(
             pbxProj: pbxProj,
-            sharedData: nil
+            sharedData: sharedData
         )]
 
         // MARK: writeXcodeProj()
@@ -447,6 +467,7 @@ final class GeneratorTests: XCTestCase {
             addTargets: addTargets,
             setTargetConfigurations: setTargetConfigurations,
             setTargetDependencies: setTargetDependencies,
+            createXCSharedData: createXCSharedData,
             createXcodeProj: createXcodeProj,
             writeXcodeProj: writeXcodeProj
         )
@@ -506,6 +527,10 @@ final class GeneratorTests: XCTestCase {
         XCTAssertNoDifference(
             setTargetDependenciesCalled,
             expectedSetTargetDependenciesCalled
+        )
+        XCTAssertNoDifference(
+            createXCSharedDataCalled,
+            expectedCreateXCSharedDataCalled
         )
         XCTAssertNoDifference(
             createXcodeProjCalled,

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -66,9 +66,7 @@ final class GeneratorTests: XCTestCase {
         let pbxTargets: [TargetID: PBXNativeTarget] = [
             "A": PBXNativeTarget(name: "A (3456a)"),
         ]
-        // TODO(chuck): Update to pass along a scheme.
-        // let schemes = [XCScheme(name: "Custom Scheme", lastUpgradeVersion: nil, version: nil)]
-        let schemes = [XCScheme]()
+        let schemes = [XCScheme(name: "Custom Scheme", lastUpgradeVersion: nil, version: nil)]
         let sharedData = XCSharedData(schemes: schemes)
         let xcodeProj = XcodeProj(
             workspace: XCWorkspace(),
@@ -382,6 +380,22 @@ final class GeneratorTests: XCTestCase {
             pbxTargets: pbxTargets
         )]
 
+        // MARK: createXCSchemes()
+
+        struct CreateXCSchemesCalled: Equatable {
+            let disambiguatedTargets: [TargetID: DisambiguatedTarget]
+        }
+
+        var createXCSchemesCalled: [CreateXCSchemesCalled] = []
+        func createXCSchemes(disambiguatedTargets: [TargetID: DisambiguatedTarget]) -> [XCScheme] {
+            createXCSchemesCalled.append(.init(disambiguatedTargets: disambiguatedTargets))
+            return schemes
+        }
+
+        let expectedCreateXCSchemesCalled = [CreateXCSchemesCalled(
+            disambiguatedTargets: disambiguatedTargets
+        )]
+
         // MARK: createXCSharedData()
 
         struct CreateXCSharedDataCalled: Equatable {
@@ -467,6 +481,7 @@ final class GeneratorTests: XCTestCase {
             addTargets: addTargets,
             setTargetConfigurations: setTargetConfigurations,
             setTargetDependencies: setTargetDependencies,
+            createXCSchemes: createXCSchemes,
             createXCSharedData: createXCSharedData,
             createXcodeProj: createXcodeProj,
             writeXcodeProj: writeXcodeProj
@@ -527,6 +542,10 @@ final class GeneratorTests: XCTestCase {
         XCTAssertNoDifference(
             setTargetDependenciesCalled,
             expectedSetTargetDependenciesCalled
+        )
+        XCTAssertNoDifference(
+            createXCSchemesCalled,
+            expectedCreateXCSchemesCalled
         )
         XCTAssertNoDifference(
             createXCSharedDataCalled,

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -387,7 +387,9 @@ final class GeneratorTests: XCTestCase {
         }
 
         var createXCSchemesCalled: [CreateXCSchemesCalled] = []
-        func createXCSchemes(disambiguatedTargets: [TargetID: DisambiguatedTarget]) -> [XCScheme] {
+        func createXCSchemes(
+            disambiguatedTargets: [TargetID: DisambiguatedTarget]
+        ) -> [XCScheme] {
             createXCSchemesCalled.append(.init(disambiguatedTargets: disambiguatedTargets))
             return schemes
         }


### PR DESCRIPTION
Related to #101.

- Added stub for `createXCSchemes`.
- Added implementation for `createXCSharedData`.
- Updated `createXcodeProj` to accept the shared data.
- Added basic test for `createXCSharedData`.
- Updated test for `createXcodeProj` to include shared data.

The logic for creating the schemes will be in the next PR.