### PR TITLE
Move `-filelist` to be before other linker settings

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1329,11 +1329,11 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = (
+					"-filelist",
+					"$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList",
 					"-Wl,-rpath,/usr/lib/swift",
 					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
 					"-L/usr/lib/swift",
-					"-filelist",
-					"$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList",
 					"-framework",
 					Foundation,
 					"-weak_framework",

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -1642,11 +1642,11 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = (
+					"-filelist",
+					"$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList",
 					"-Wl,-rpath,/usr/lib/swift",
 					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
 					"-L/usr/lib/swift",
-					"-filelist",
-					"$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList",
 					"-framework",
 					Foundation,
 					"-weak_framework",

--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -609,11 +609,11 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = (
+					"-filelist",
+					"$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-1c975e2849a6/examples/cc/tool/tool.LinkFileList",
 					"-Wl,-rpath,/usr/lib/swift",
 					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
 					"-L/usr/lib/swift",
-					"-filelist",
-					"$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-1c975e2849a6/examples/cc/tool/tool.LinkFileList",
 					"-ObjC",
 				);
 				PRODUCT_MODULE_NAME = _tool_Stub;

--- a/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
@@ -638,11 +638,11 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = (
+					"-filelist",
+					"$(INTERNAL_DIR)/targets/darwin_x86_64-fastbuild-ST-d53d69b6b8c1/examples/cc/tool/tool.LinkFileList",
 					"-Wl,-rpath,/usr/lib/swift",
 					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
 					"-L/usr/lib/swift",
-					"-filelist",
-					"$(INTERNAL_DIR)/targets/darwin_x86_64-fastbuild-ST-d53d69b6b8c1/examples/cc/tool/tool.LinkFileList",
 					"-ObjC",
 				);
 				PRODUCT_MODULE_NAME = _tool_Stub;

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -865,11 +865,11 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = (
+					"-filelist",
+					"$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/examples/command_line/tool/tool.LinkFileList",
 					"-Wl,-rpath,/usr/lib/swift",
 					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
 					"-L/usr/lib/swift",
-					"-filelist",
-					"$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/examples/command_line/tool/tool.LinkFileList",
 					"-ObjC",
 				);
 				PRODUCT_NAME = tool;

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -959,11 +959,11 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = (
+					"-filelist",
+					"$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059/examples/command_line/tool/tool.LinkFileList",
 					"-Wl,-rpath,/usr/lib/swift",
 					"-L$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)",
 					"-L/usr/lib/swift",
-					"-filelist",
-					"$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059/examples/command_line/tool/tool.LinkFileList",
 					"-ObjC",
 				);
 				PRODUCT_NAME = tool;

--- a/tools/generator/src/Generator+SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator+SetTargetConfigurations.swift
@@ -110,16 +110,6 @@ Target "\(id)" not found in `pbxTargets`
                 )
             }
 
-            if !target.linkerInputs.staticLibraries.isEmpty {
-                let linkFileList = try filePathResolver
-                    .resolve(try target.linkFileListFilePath())
-                    .string
-                try targetBuildSettings.prepend(
-                    onKey: "OTHER_LDFLAGS",
-                    ["-filelist", linkFileList.quoted]
-                )
-            }
-
             if !target.isSwift
                 && target.product.type.isExecutable
                 && target.inputs.containsSourceFiles
@@ -133,6 +123,16 @@ Target "\(id)" not found in `pbxTargets`
 """,
                         "-L/usr/lib/swift",
                     ]
+                )
+            }
+
+            if !target.linkerInputs.staticLibraries.isEmpty {
+                let linkFileList = try filePathResolver
+                    .resolve(try target.linkFileListFilePath())
+                    .string
+                try targetBuildSettings.prepend(
+                    onKey: "OTHER_LDFLAGS",
+                    ["-filelist", linkFileList.quoted]
                 )
             }
 

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1487,13 +1487,13 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2$(TARGET_BUILD_SUBPATH)
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/C 2",
                 "GENERATE_INFOPLIST_FILE": true,
                 "OTHER_LDFLAGS": [
+                    "-filelist",
+                    #""$(INTERNAL_DIR)/targets/a1b2c/C 2/d.LinkFileList""#,
                     "-Wl,-rpath,/usr/lib/swift",
                     """
 -L$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)
 """,
                     "-L/usr/lib/swift",
-                    "-filelist",
-                    #""$(INTERNAL_DIR)/targets/a1b2c/C 2/d.LinkFileList""#,
                 ],
                 "SDKROOT": "macosx",
                 "TARGET_NAME": targets["C 2"]!.name,


### PR DESCRIPTION
This is just to better match Xcode's behavior.