### PR TITLE
Add support for code signing entitlements in Xcode build

### DIFF
--- a/examples/ios_app/Example/BUILD
+++ b/examples/ios_app/Example/BUILD
@@ -14,6 +14,7 @@ ios_application(
     app_icons = glob(["Assets.xcassets/AppIcon.appiconset/**"]),
     bundle_id = "io.buildbuddy.example",
     bundle_name = "Example",
+    entitlements = "app.entitlements",
     families = ["iphone"],
     infoplists = [":Info.plist"],
     minimum_os_version = "15.0",

--- a/examples/ios_app/Example/app.entitlements
+++ b/examples/ios_app/Example/app.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -251,9 +251,11 @@
 		86B6FAB2FF4A94053E4D470E /* ExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		8ADB9E176B3AB4F6354A1167 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		8F8B001AB6315D99F13FAC92 /* libCoreUtilsObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCoreUtilsObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		936C89D0AECF460936BF9489 /* app.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = app.entitlements; sourceTree = "<group>"; };
 		9BF5CE4ADD5163F5308F8626 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9D61CBAFE2C78BDC7960D5A4 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		A619B11AC2106BAC08FA7DB0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		A9F2D0BF181945BB567E521F /* Example_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example_entitlements.entitlements; sourceTree = "<group>"; };
 		AA8B40F3394AF193E0043C9C /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
 		ADE221FC6902DE7F5C1351D9 /* TestingUtils.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = TestingUtils.swift.modulemap; sourceTree = "<group>"; };
 		B236D472E2B01203C379DE61 /* Foo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Foo.h; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 			isa = PBXGroup;
 			children = (
 				585AD694A7FC50DCE514B6E2 /* Example-intermediates */,
+				A9F2D0BF181945BB567E521F /* Example_entitlements.entitlements */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -438,6 +441,7 @@
 			children = (
 				B97C2835F125F69B2FDF8477 /* nested */,
 				1B8846860A494D5FC82D2072 /* PreviewContent */,
+				936C89D0AECF460936BF9489 /* app.entitlements */,
 				1F2546A475C2CA76D8E89436 /* Assets.xcassets */,
 				3044751746014D22D03BB28E /* BUILD */,
 				8ADB9E176B3AB4F6354A1167 /* ContentView.swift */,
@@ -1693,6 +1697,8 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example_entitlements.entitlements";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -1,3 +1,4 @@
+$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example_entitlements.entitlements
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.plist
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -1,3 +1,4 @@
+applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example_entitlements.entitlements
 applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.plist
 applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
 applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,3 +1,4 @@
+$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example_entitlements.entitlements
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -45,9 +45,14 @@
         "Example/Assets.xcassets/AppIcon.appiconset/ipad_1x_icon.png",
         "Example/Assets.xcassets/AppIcon.appiconset/ipad_2x_icon.png",
         "Example/Assets.xcassets/AppIcon.appiconset/ipadpro_2x_icon.png",
+        "Example/app.entitlements",
         "Example/Info.plist",
         {
             "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.plist",
+            "t": "g"
+        },
+        {
+            "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example_entitlements.entitlements",
             "t": "g"
         },
         "TestingUtils/BUILD",
@@ -164,6 +169,7 @@
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "hdrs": [
@@ -272,6 +278,10 @@
             "dependencies": [
                 "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
             ],
+            "entitlements": {
+                "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example_entitlements.entitlements",
+                "t": "g"
+            },
             "info_plist": {
                 "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.plist",
                 "t": "g"
@@ -413,6 +423,7 @@
                 "//ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
                 "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "contains_generated_files": true,
@@ -546,6 +557,7 @@
                 "//ExampleObjcTests:ExampleObjcTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
                 "//Example:Example applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -656,6 +668,7 @@
                 "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
                 "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -728,6 +741,7 @@
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "resources": [
@@ -817,6 +831,7 @@
                 "//ExampleTests:ExampleTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
                 "//Example:Example applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -928,6 +943,7 @@
                 "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
                 "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "contains_generated_files": true,
@@ -1073,6 +1089,7 @@
                 "//ExampleUITests:ExampleUITests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
                 "//Example:Example applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -1172,6 +1189,7 @@
             "dependencies": [
                 "@examples_ios_app_external//:ExternalResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -1258,6 +1276,7 @@
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "contains_generated_files": true,
@@ -1356,6 +1375,7 @@
             "dependencies": [
                 "//CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "hdrs": [
@@ -1424,6 +1444,7 @@
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "resources": [

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -222,11 +222,13 @@
 		082E81D1A4883526CA3B52D8 /* ExampleFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExampleFramework.framework; sourceTree = "<group>"; };
 		087B3E45AA9A7430D1BEC9B8 /* ExampleResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		104ECD97B1C1B9C4DF3F9949 /* ExampleObjcTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleObjcTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1114222EF47A93F0F39BC416 /* app.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = app.entitlements; sourceTree = "<group>"; };
 		1379EEF52DFB4BAB82770648 /* CoreUtilsObjC.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = CoreUtilsObjC.swift.modulemap; sourceTree = "<group>"; };
 		147E33BBAF4F6DCF2F01C37A /* Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
 		1783C9E8ED9EAFC163C0D653 /* Answers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Answers.m; sourceTree = "<group>"; };
 		181A626E7874B82CF2F6E536 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1D174B1D4C25E9FD21719679 /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1D403927ED5F261E104DFD99 /* Example_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example_entitlements.entitlements; sourceTree = "<group>"; };
 		1FD92C95D6623911CFD690F3 /* Greeting.swift.stencil */ = {isa = PBXFileReference; path = Greeting.swift.stencil; sourceTree = "<group>"; };
 		20F5652D5E2B14049EC02195 /* CoreUtils.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreUtils.pch; sourceTree = "<group>"; };
 		213259970531EA32B992572A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -556,6 +558,7 @@
 			isa = PBXGroup;
 			children = (
 				156FF8AA2594C9C9ED5012DB /* Example-intermediates */,
+				1D403927ED5F261E104DFD99 /* Example_entitlements.entitlements */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -595,6 +598,7 @@
 			children = (
 				D71EB598E6B4BE7F35063F30 /* nested */,
 				E3C90F22A5DD89C34CFED453 /* PreviewContent */,
+				1114222EF47A93F0F39BC416 /* app.entitlements */,
 				213259970531EA32B992572A /* Assets.xcassets */,
 				66FD903A85D9EC8C1EBDC3C2 /* BUILD */,
 				A6F89F28CB6CFCADEC31B05F /* ContentView.swift */,
@@ -1680,6 +1684,8 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example_entitlements.entitlements";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -1,3 +1,4 @@
+$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example_entitlements.entitlements
 $(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.plist
 $(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
 $(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -1,3 +1,4 @@
+applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example_entitlements.entitlements
 applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.plist
 applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
 applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,3 +1,4 @@
+$(BAZEL_OUT)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example_entitlements.entitlements
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -45,9 +45,14 @@
         "Example/Assets.xcassets/AppIcon.appiconset/ipad_1x_icon.png",
         "Example/Assets.xcassets/AppIcon.appiconset/ipad_2x_icon.png",
         "Example/Assets.xcassets/AppIcon.appiconset/ipadpro_2x_icon.png",
+        "Example/app.entitlements",
         "Example/Info.plist",
         {
             "_": "applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.plist",
+            "t": "g"
+        },
+        {
+            "_": "applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example_entitlements.entitlements",
             "t": "g"
         },
         "TestingUtils/BUILD",
@@ -163,6 +168,7 @@
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "hdrs": [
@@ -270,6 +276,10 @@
             "dependencies": [
                 "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
             ],
+            "entitlements": {
+                "_": "applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example_entitlements.entitlements",
+                "t": "g"
+            },
             "info_plist": {
                 "_": "applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.plist",
                 "t": "g"
@@ -410,6 +420,7 @@
                 "//ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
                 "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "contains_generated_files": true,
@@ -542,6 +553,7 @@
                 "//ExampleObjcTests:ExampleObjcTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
                 "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -651,6 +663,7 @@
                 "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
                 "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -723,6 +736,7 @@
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "resources": [
@@ -811,6 +825,7 @@
                 "//ExampleTests:ExampleTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
                 "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -921,6 +936,7 @@
                 "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
                 "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "contains_generated_files": true,
@@ -1065,6 +1081,7 @@
                 "//ExampleUITests:ExampleUITests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
                 "//Example:Example applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -1162,6 +1179,7 @@
             "dependencies": [
                 "@examples_ios_app_external//:ExternalResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -1246,6 +1264,7 @@
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "contains_generated_files": true,
@@ -1343,6 +1362,7 @@
             "dependencies": [
                 "//CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "hdrs": [
@@ -1411,6 +1431,7 @@
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "resources": [

--- a/test/fixtures/cc/bwb_spec.json
+++ b/test/fixtures/cc/bwb_spec.json
@@ -72,6 +72,7 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "hdrs": [
@@ -169,6 +170,7 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -268,6 +270,7 @@
                 "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-1c975e2849a6",
                 "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-1c975e2849a6"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -393,6 +396,7 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [

--- a/test/fixtures/cc/bwx_spec.json
+++ b/test/fixtures/cc/bwx_spec.json
@@ -71,6 +71,7 @@
             },
             "configuration": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "hdrs": [
@@ -167,6 +168,7 @@
             },
             "configuration": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -265,6 +267,7 @@
                 "@examples_cc_external//:lib_impl darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
                 "//examples/cc/lib2:lib_impl darwin_x86_64-fastbuild-ST-d53d69b6b8c1"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -389,6 +392,7 @@
             },
             "configuration": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -100,6 +100,7 @@
             "dependencies": [
                 "//examples/command_line/Tests:LibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -206,6 +207,7 @@
             "dependencies": [
                 "//examples/command_line/lib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "contains_generated_files": true,
@@ -309,6 +311,7 @@
             },
             "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -405,6 +408,7 @@
                 "//examples/command_line/lib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
                 "//examples/command_line/lib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "contains_generated_files": true,
@@ -501,6 +505,7 @@
             },
             "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "hdrs": [
@@ -591,6 +596,7 @@
             "dependencies": [
                 "//examples/command_line/tool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {},
             "is_swift": false,
@@ -689,6 +695,7 @@
             "dependencies": [
                 "//examples/command_line/lib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -99,6 +99,7 @@
             "dependencies": [
                 "//examples/command_line/Tests:LibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -203,6 +204,7 @@
             "dependencies": [
                 "//examples/command_line/lib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "contains_generated_files": true,
@@ -305,6 +307,7 @@
             },
             "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -399,6 +402,7 @@
                 "//examples/command_line/lib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059",
                 "//examples/command_line/lib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "contains_generated_files": true,
@@ -494,6 +498,7 @@
             },
             "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "hdrs": [
@@ -583,6 +588,7 @@
             "dependencies": [
                 "//examples/command_line/tool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {},
             "is_swift": false,
@@ -680,6 +686,7 @@
             "dependencies": [
                 "//examples/command_line/lib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -77,6 +77,7 @@
             "dependencies": [
                 "//tools/generator/test:tests.library darwin_x86_64-dbg-ST-1c975e2849a6"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {},
             "is_swift": false,
@@ -191,6 +192,7 @@
                 "//tools/generator:generator.library darwin_x86_64-dbg-ST-1c975e2849a6",
                 "@com_github_pointfreeco_swift_custom_dump//:CustomDump darwin_x86_64-dbg-ST-1c975e2849a6"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -315,6 +317,7 @@
             "dependencies": [
                 "//tools/generator:generator.library darwin_x86_64-dbg-ST-1c975e2849a6"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {},
             "is_swift": false,
@@ -420,6 +423,7 @@
                 "@com_github_kylef_pathkit//:PathKit darwin_x86_64-dbg-ST-1c975e2849a6",
                 "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-dbg-ST-1c975e2849a6"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -550,6 +554,7 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -831,6 +836,7 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -918,6 +924,7 @@
             "dependencies": [
                 "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay darwin_x86_64-dbg-ST-1c975e2849a6"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -1104,6 +1111,7 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -1189,6 +1197,7 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-1c975e2849a6",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -1293,6 +1302,7 @@
                 "@com_github_tadija_aexml//:AEXML darwin_x86_64-dbg-ST-1c975e2849a6",
                 "@com_github_kylef_pathkit//:PathKit darwin_x86_64-dbg-ST-1c975e2849a6"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -76,6 +76,7 @@
             "dependencies": [
                 "//tools/generator/test:tests.library darwin_x86_64-fastbuild-ST-d53d69b6b8c1"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {},
             "is_swift": false,
@@ -188,6 +189,7 @@
                 "//tools/generator:generator.library darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
                 "@com_github_pointfreeco_swift_custom_dump//:CustomDump darwin_x86_64-fastbuild-ST-d53d69b6b8c1"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -311,6 +313,7 @@
             "dependencies": [
                 "//tools/generator:generator.library darwin_x86_64-fastbuild-ST-d53d69b6b8c1"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {},
             "is_swift": false,
@@ -414,6 +417,7 @@
                 "@com_github_kylef_pathkit//:PathKit darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
                 "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-fastbuild-ST-d53d69b6b8c1"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -542,6 +546,7 @@
             },
             "configuration": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -821,6 +826,7 @@
             },
             "configuration": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -906,6 +912,7 @@
             "dependencies": [
                 "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay darwin_x86_64-fastbuild-ST-d53d69b6b8c1"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -1090,6 +1097,7 @@
             },
             "configuration": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -1173,6 +1181,7 @@
             },
             "configuration": "darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -1275,6 +1284,7 @@
                 "@com_github_tadija_aexml//:AEXML darwin_x86_64-fastbuild-ST-d53d69b6b8c1",
                 "@com_github_kylef_pathkit//:PathKit darwin_x86_64-fastbuild-ST-d53d69b6b8c1"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		D227CE711F51FF221F83B7EA /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6E8EC5800B28DC7A5B63624 /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
 		DB017F09DAA174C86C32DE47 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		DEF1BD617010A2A06F82EDD2 /* Example_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example_entitlements.entitlements; sourceTree = "<group>"; };
 		E470DDDC0990D96A685DB11C /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA0E59FF263E41FFE42D58A1 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -110,6 +111,7 @@
 			isa = PBXGroup;
 			children = (
 				D9E0B7B0F1BFB47311DAB30F /* Example-intermediates */,
+				DEF1BD617010A2A06F82EDD2 /* Example_entitlements.entitlements */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -618,6 +620,8 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example_entitlements.entitlements";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -1,3 +1,4 @@
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example_entitlements.entitlements
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -1,3 +1,4 @@
+applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example_entitlements.entitlements
 applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
 applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
 applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,3 +1,4 @@
+$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example_entitlements.entitlements
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -16,6 +16,10 @@
             "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.plist",
             "t": "g"
         },
+        {
+            "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example_entitlements.entitlements",
+            "t": "g"
+        },
         "examples/tvos_app/ExampleTests/BUILD",
         {
             "_": "build_bazel_rules_apple/apple/testing/DefaultTestBundle.plist",
@@ -99,6 +103,10 @@
             "dependencies": [
                 "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
             ],
+            "entitlements": {
+                "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example_entitlements.entitlements",
+                "t": "g"
+            },
             "info_plist": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.plist",
                 "t": "g"
@@ -190,6 +198,7 @@
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -273,6 +282,7 @@
                 "//examples/tvos_app/ExampleTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
                 "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -367,6 +377,7 @@
             "dependencies": [
                 "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -454,6 +465,7 @@
                 "//examples/tvos_app/ExampleUITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
                 "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -546,6 +558,7 @@
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [

--- a/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		7D93AE929FC4703B992B9F20 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		7E6A6CF9C9CD7BEED9F65CA3 /* ExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		7F19CF48F63AFA6D8D07E876 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		8DFEB3C239C99D7EA013ABC6 /* Example_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example_entitlements.entitlements; sourceTree = "<group>"; };
 		99B15598E2A225AF0402DDCF /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
 		AE960EFF7013DD45F88383CC /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B69AF786B804E6CD15F61528 /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -165,6 +166,7 @@
 			isa = PBXGroup;
 			children = (
 				CF50F1124F87E06FEE0DD95F /* Example-intermediates */,
+				8DFEB3C239C99D7EA013ABC6 /* Example_entitlements.entitlements */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -654,6 +656,8 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example_entitlements.entitlements";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;

--- a/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -1,3 +1,4 @@
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example_entitlements.entitlements
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -1,3 +1,4 @@
+applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example_entitlements.entitlements
 applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
 applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
 applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,3 +1,4 @@
+$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example_entitlements.entitlements
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -16,6 +16,10 @@
             "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist",
             "t": "g"
         },
+        {
+            "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example_entitlements.entitlements",
+            "t": "g"
+        },
         "examples/tvos_app/ExampleTests/BUILD",
         {
             "_": "build_bazel_rules_apple/apple/testing/DefaultTestBundle.plist",
@@ -98,6 +102,10 @@
             "dependencies": [
                 "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
             ],
+            "entitlements": {
+                "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example_entitlements.entitlements",
+                "t": "g"
+            },
             "info_plist": {
                 "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist",
                 "t": "g"
@@ -187,6 +195,7 @@
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -269,6 +278,7 @@
                 "//examples/tvos_app/ExampleTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
                 "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -361,6 +371,7 @@
             "dependencies": [
                 "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
             ],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [
@@ -447,6 +458,7 @@
                 "//examples/tvos_app/ExampleUITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
                 "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6"
             ],
+            "entitlements": null,
             "info_plist": {
                 "_": "applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist",
                 "t": "g"
@@ -537,6 +549,7 @@
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6",
             "dependencies": [],
+            "entitlements": null,
             "info_plist": null,
             "inputs": {
                 "srcs": [

--- a/tools/generator/src/DTO.swift
+++ b/tools/generator/src/DTO.swift
@@ -28,6 +28,7 @@ struct Target: Equatable, Decodable {
     var inputs: Inputs
     var linkerInputs: LinkerInputs
     var infoPlist: FilePath?
+    var entitlements: FilePath?
     var dependencies: Set<TargetID>
 }
 

--- a/tools/generator/src/Generator+SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator+SetTargetConfigurations.swift
@@ -157,6 +157,14 @@ Target "\(id)" not found in `pbxTargets`
               buildSettings["GENERATE_INFOPLIST_FILE"] = true
             }
 
+            if let entitlements = target.entitlements {
+                let entitlementsPath = try filePathResolver.resolve(entitlements)
+                buildSettings["CODE_SIGN_ENTITLEMENTS"] = entitlementsPath.string.quoted
+                // This is required because otherwise Xcode fails the build due 
+                // the entitlements file being modified by the Bazel build script.
+                buildSettings["CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION"] = true
+            }
+
             if let pch = target.inputs.pch {
                 let pchPath = try filePathResolver.resolve(pch)
 

--- a/xcodeproj/internal/entitlements.bzl
+++ b/xcodeproj/internal/entitlements.bzl
@@ -1,0 +1,12 @@
+"""API to retrieve an entitlements file from a `Target`."""
+
+load("@build_bazel_rules_apple//apple:providers.bzl", "AppleBundleInfo")
+
+def _get_file(target):
+    if AppleBundleInfo in target:
+        return target[AppleBundleInfo].entitlements
+    return None
+
+entitlements = struct(
+    get_file = _get_file,
+)

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -83,6 +83,7 @@ def xcode_target(
         inputs,
         linker_inputs,
         info_plist,
+        entitlements,
         dependencies):
     """Generates the partial json string representation of an Xcode target.
 
@@ -114,6 +115,7 @@ def xcode_target(
         inputs: The value returned from `input_files.collect`.
         linker_inputs: A value returned from `linker_input_files.collect`.
         info_plist: A value as returned by `files.file_path` or `None`.
+        entitlements: A value as returned by `files.file_path()` or `None`.
         dependencies: A `depset` of `id`s of targets that this target depends
             on.
 
@@ -146,6 +148,7 @@ def xcode_target(
         ),
         linker_inputs = linker_input_files.to_dto(linker_inputs),
         info_plist = file_path_to_dto(info_plist),
+        entitlements = file_path_to_dto(entitlements),
         dependencies = dependencies.to_list(),
     ))
 

--- a/xcodeproj/internal/target.bzl
+++ b/xcodeproj/internal/target.bzl
@@ -23,6 +23,7 @@ load(
     "parsed_file_path",
 )
 load(":info_plists.bzl", "info_plists")
+load(":entitlements.bzl", "entitlements")
 load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "create_opts_search_paths", "process_opts")
@@ -155,6 +156,12 @@ def _process_top_level_target(*, ctx, target, bundle_info, transitive_infos):
     if info_plist_file:
         info_plist = file_path(info_plist_file)
         additional_files.append(info_plist_file)
+
+    entitlements_file_path = None
+    entitlements_file = entitlements.get_file(target)
+    if entitlements_file:
+        entitlements_file_path = file_path(entitlements_file)
+        additional_files.append(entitlements_file)
 
     resource_owner = str(target.label)
     inputs = input_files.collect(
@@ -327,6 +334,7 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
             inputs = inputs,
             linker_inputs = linker_inputs,
             info_plist = info_plist,
+            entitlements = entitlements_file_path,
             dependencies = dependencies,
         ),
     )
@@ -499,6 +507,7 @@ def _process_library_target(*, ctx, target, transitive_infos):
             inputs = inputs,
             linker_inputs = linker_inputs,
             info_plist = None,
+            entitlements = None,
             dependencies = dependencies,
         ),
     )
@@ -639,6 +648,7 @@ def _process_resource_target(*, ctx, target, transitive_infos):
             inputs = inputs,
             linker_inputs = linker_inputs,
             info_plist = None,
+            entitlements = None,
             dependencies = dependencies,
         ),
     )


### PR DESCRIPTION
Part of #72 and #96.

This PR adds support for fetching the produced `entitlements` file and setting the right build settings in Xcode. This allows to build the app with the correct entitlements inside of Xcode.