### PR TITLE
Use `$(GEN_DIR)` for more files referenced by build settings

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1306,7 +1306,7 @@
 					"$(PROJECT_DIR)/CoreUtilsObjC",
 					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -1443,7 +1443,7 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -1729,7 +1729,7 @@
 					"$(PROJECT_DIR)/CoreUtilsObjC",
 					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/Example/Example-intermediates/Info.xcode.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1816,7 +1816,7 @@
 					"$(PROJECT_DIR)/CoreUtilsObjC",
 					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/CoreUtilsObjC",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-d8c59b644fe5/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -1377,7 +1377,7 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -1548,7 +1548,7 @@
 					"$(PROJECT_DIR)/CoreUtilsObjC",
 					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -1633,7 +1633,7 @@
 					"$(PROJECT_DIR)/CoreUtilsObjC",
 					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -1717,7 +1717,7 @@
 					"$(PROJECT_DIR)/CoreUtilsObjC",
 					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/CoreUtilsObjC",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.xcode.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -903,7 +903,7 @@
 					"SECRET_3=\\\"Hello\\\"",
 					"SECRET_2=\\\"World!\\\"",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-4fb8349bf067/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -841,7 +841,7 @@
 					"SECRET_3=\\\"Hello\\\"",
 					"SECRET_2=\\\"World!\\\"",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -537,7 +537,7 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				OTHER_CFLAGS = (
 					"-fstack-protector",
 					"-Wall",
@@ -631,7 +631,7 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -693,7 +693,7 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-8c1599e2f1a3/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				OTHER_CFLAGS = (
 					"-fstack-protector",
 					"-Wall",

--- a/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
@@ -538,7 +538,7 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				OTHER_CFLAGS = (
 					"-fstack-protector",
 					"-Wall",
@@ -608,7 +608,7 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				OTHER_CFLAGS = (
 					"-fstack-protector",
 					"-Wall",
@@ -668,7 +668,7 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				INFOPLIST_FILE = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist";
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/tools/generator/src/FilePathResolver.swift
+++ b/tools/generator/src/FilePathResolver.swift
@@ -22,7 +22,7 @@ struct FilePathResolver: Equatable {
 
     func resolve(
         _ filePath: FilePath,
-        useBuildDir: Bool = true,
+        useGenDir: Bool = false,
         useOriginalGeneratedFiles: Bool = false,
         mode: Mode = .buildSetting
     ) throws -> Path {
@@ -63,7 +63,18 @@ struct FilePathResolver: Equatable {
 """)
                 }
                 return bazelOutDir + filePath.path
-            } else if useBuildDir {
+            } else if useGenDir {
+                let copiedBazelOutDir: Path
+                switch mode {
+                case .buildSetting:
+                    copiedBazelOutDir = "$(GEN_DIR)"
+                case .script:
+                    copiedBazelOutDir = "$GEN_DIR"
+                case .srcRoot:
+                    copiedBazelOutDir = linksDirectory + "gen_dir"
+                }
+                return copiedBazelOutDir + filePath.path
+            } else {
                 let buildDir: Path
                 switch mode {
                 case .buildSetting:
@@ -76,17 +87,6 @@ struct FilePathResolver: Equatable {
 """)
                 }
                 return buildDir + "bazel-out" + filePath.path
-            } else {
-                let copiedBazelOutDir: Path
-                switch mode {
-                case .buildSetting:
-                    copiedBazelOutDir = "$(GEN_DIR)"
-                case .script:
-                    copiedBazelOutDir = "$GEN_DIR"
-                case .srcRoot:
-                    copiedBazelOutDir = linksDirectory + "gen_dir"
-                }
-                return copiedBazelOutDir + filePath.path
             }
         case .internal:
             let internalDir: Path

--- a/tools/generator/src/Generator+CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator+CreateFilesAndGroups.swift
@@ -387,7 +387,7 @@ extension Generator {
             // We need to use `$(GEN_DIR)` instead of `$(BUILD_DIR)` here to
             // match the project navigator. This is only needed for files
             // referenced by `PBXBuildFile`.
-            return try filePathResolver.resolve(filePath, useBuildDir: false)
+            return try filePathResolver.resolve(filePath, useGenDir: true)
         }
         let modulemapPaths = try generatedFiles
             .filter { filePath, _ in filePath.path.extension == "modulemap" }
@@ -431,7 +431,7 @@ extension Generator {
             let linkFiles = try target.linkerInputs.staticLibraries
                 .map { filePath in
                     return """
-\(try filePathResolver.resolve(filePath, useBuildDir: false, mode: .srcRoot))
+\(try filePathResolver.resolve(filePath, useGenDir: true, mode: .srcRoot))
 
 """
                 }

--- a/tools/generator/src/Generator+SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator+SetTargetConfigurations.swift
@@ -141,7 +141,10 @@ Target "\(id)" not found in `pbxTargets`
             buildSettings["TARGET_NAME"] = target.name
 
             if let infoPlist = target.infoPlist {
-                var infoPlistPath = try filePathResolver.resolve(infoPlist)
+                var infoPlistPath = try filePathResolver.resolve(
+                    infoPlist,
+                    useGenDir: true
+                )
                 
                 // If the plist is generated, use the patched version that
                 // removes a specific key that causes a warning when building
@@ -159,7 +162,7 @@ Target "\(id)" not found in `pbxTargets`
                     entitlements,
                     // Path needs to use `$(GEN_DIR)` to ensure XCBuild picks it
                     // up on first generation
-                    useBuildDir: false
+                    useGenDir: true
                 )
                 buildSettings["CODE_SIGN_ENTITLEMENTS"] = entitlementsPath
                     .string.quoted
@@ -170,7 +173,7 @@ Target "\(id)" not found in `pbxTargets`
             }
 
             if let pch = target.inputs.pch {
-                let pchPath = try filePathResolver.resolve(pch)
+                let pchPath = try filePathResolver.resolve(pch, useGenDir: true)
 
                 buildSettings["GCC_PREFIX_HEADER"] = pchPath.string.quoted
             }


### PR DESCRIPTION
While these don't see to need it like `CODE_SIGN_ENTITLEMENTS` does, it makes it more clear these are using copied generated files, and it sets a nice pattern to prevent issues from popping up in the future (especially if XCBuild decides to care about these files).