### PR TITLE
Remove non-existent PrioritityQueue target from Swift collections

### DIFF
--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -182,12 +182,6 @@ swift_library(
     srcs = glob(["Sources/OrderedCollections/**/*.swift"]),
     visibility = ["//visibility:public"],
 )
-
-swift_library(
-    name = "PriorityQueueModule",
-    srcs = glob(["Sources/PriorityQueueModule/**/*.swift"]),
-    visibility = ["//visibility:public"],
-)
 """,
         sha256 = "b18c522aff4241160f60bcd0695702657c7862512c994c260a7d63f15a8450d8",
         strip_prefix = "swift-collections-1.0.2",


### PR DESCRIPTION
Found via setting `--incompatible_disallow_empty_glob`

`PriorityQueueModule` does not exist in Swift collections 1.0.2