### PR TITLE
Fix off-by-one Info.plist handling

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
@@ -1,4 +1,4 @@
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/Example/Example-intermediates/Info.xcode.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/Example/Example-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
@@ -1,4 +1,4 @@
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/Example/Example-intermediates/Info.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/Example/Example-intermediates/Info.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-cabd535f549f/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
@@ -1,4 +1,4 @@
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.xcode.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
@@ -1,4 +1,4 @@
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
-$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/Example/Example-intermediates/Info.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_ios-ios_x86_64-fastbuild-ST-d3e756bfe7fd/bin/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
@@ -1,1 +1,1 @@
-$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-063ae0f2d4dd/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-063ae0f2d4dd/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
@@ -1,1 +1,1 @@
-$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-063ae0f2d4dd/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-063ae0f2d4dd/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
@@ -1,1 +1,1 @@
-$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
@@ -1,1 +1,1 @@
-$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_macos-darwin_x86_64-fastbuild-ST-8946c8252059/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
@@ -1,3 +1,3 @@
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
@@ -1,3 +1,3 @@
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-483c3f289319/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/infoplists.fixed.xcfilelist
@@ -1,3 +1,3 @@
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist

--- a/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/infoplists.xcfilelist
@@ -1,3 +1,3 @@
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
-$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/Example/Example-intermediates/Info.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.plist
+$(GEN_DIR)/applebin_tvos-tvos_x86_64-fastbuild-ST-4e14a11cd4e6/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.plist

--- a/tools/generator/src/Generator+CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator+CreateFilesAndGroups.swift
@@ -386,7 +386,7 @@ extension Generator {
         let copiedGeneratedPaths = try generatedFiles.map { filePath, _ in
             // We need to use `$(GEN_DIR)` instead of `$(BUILD_DIR)` here to
             // match the project navigator. This is only needed for files
-            // referenced by `PBXBuildFile`.
+            // referenced by `PBXBuildFile` or have specific build settings.
             return try filePathResolver.resolve(filePath, useGenDir: true)
         }
         let modulemapPaths = try generatedFiles
@@ -400,7 +400,10 @@ extension Generator {
                 return filePath.path.lastComponent == "Info.plist"
             }
             .map { filePath, _ in
-                return try filePathResolver.resolve(filePath)
+                // We need to use `$(GEN_DIR)` instead of `$(BUILD_DIR)` here to
+                // match the project navigator. This is only needed for files
+                // referenced by `PBXBuildFile` or have specific build settings.
+                return try filePathResolver.resolve(filePath, useGenDir: true)
             }
         let fixedInfoPlistPaths = infoPlistPaths.map { path in
             return path.replacingExtension("xcode.plist")


### PR DESCRIPTION
So it seems this one does need to use `GEN_DIR` as well, it was just masked by a different change.

Fixes a bug caused by #375.