### PR TITLE
Upgrade `rules_bazel_integration_test` to 0.7.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,6 +106,15 @@ buildifier_prebuilt_register_toolchains()
 # Bazel Integration Test
 
 http_archive(
+    name = "cgrindel_bazel_starlib",
+    sha256 = "f61c83d78754ce3abe562fbac54b3a055e4c80c209f5de7938f1773312fe2cfe",
+    strip_prefix = "bazel-starlib-0.7.0",
+    urls = [
+        "http://github.com/cgrindel/bazel-starlib/archive/v0.7.0.tar.gz",
+    ],
+)
+
+http_archive(
     name = "contrib_rules_bazel_integration_test",
     sha256 = "ab9bbf776b5874f8a02f639fec2fbb3e3eefa4403cf861ae00d7c7e4d757f9ff",
     strip_prefix = "rules_bazel_integration_test-0.6.2",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,20 +106,11 @@ buildifier_prebuilt_register_toolchains()
 # Bazel Integration Test
 
 http_archive(
-    name = "cgrindel_bazel_starlib",
-    sha256 = "f61c83d78754ce3abe562fbac54b3a055e4c80c209f5de7938f1773312fe2cfe",
-    strip_prefix = "bazel-starlib-0.7.0",
-    urls = [
-        "http://github.com/cgrindel/bazel-starlib/archive/v0.7.0.tar.gz",
-    ],
-)
-
-http_archive(
     name = "contrib_rules_bazel_integration_test",
-    sha256 = "ab9bbf776b5874f8a02f639fec2fbb3e3eefa4403cf861ae00d7c7e4d757f9ff",
-    strip_prefix = "rules_bazel_integration_test-0.6.2",
+    sha256 = "24e5e8f388bec2da0975cfda6073ed0174a4f62cb874b5dc8037c98faa6acdfd",
+    strip_prefix = "rules_bazel_integration_test-0.7.0",
     urls = [
-        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/v0.6.2.tar.gz",
+        "http://github.com/bazel-contrib/rules_bazel_integration_test/archive/v0.7.0.tar.gz",
     ],
 )
 

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -9,9 +9,7 @@ actions:
         branches:
           - "main"
     bazel_commands:
-      # `--noincompatible_disallow_empty_glob` is to work around an issue in
-      # "cgrindel_bazel_starlib/bzlformat/private/bzlformat_pkg.bzl"
-      - "build --config=workflows --noincompatible_disallow_empty_glob //..."
+      - "build --config=workflows //..."
 
   - name: Test
     os: "darwin"
@@ -36,9 +34,7 @@ actions:
           - "main"
     bazel_commands:
       - "clean"
-      # `--noincompatible_disallow_empty_glob` is to work around an issue in
-      # "cgrindel_bazel_starlib/bzlformat/private/bzlformat_pkg.bzl"
-      - "test --config=workflows --noincompatible_disallow_empty_glob //:all_integration_tests"
+      - "test --config=workflows //:all_integration_tests"
 
   - name: Buildifier Lint
     triggers:


### PR DESCRIPTION
Related to cgrindel/bazel-starlib#140.

This PR should allow `bazel test //...` to be successful.