### PR TITLE
Add -debug-prefix-map to _SWIFTC_SKIP_OPTS

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -174,6 +174,7 @@ def process_compiler_opts_test_suite(name):
     ## Swift:
     # Anything with __BAZEL_XCODE_
     # -Ipath
+    # -debug-prefix-map
     # -emit-module-path
     # -emit-object
     # -enable-batch-mode
@@ -230,6 +231,8 @@ def process_compiler_opts_test_suite(name):
             "-output-file-map",
             "path",
             "-passthrough",
+            "-debug-prefix-map",
+            "__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR",
             "-emit-module-path",
             "path",
             "-passthrough",

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -29,6 +29,7 @@ _SWIFTC_SKIP_OPTS = {
     # TODO: Make sure we should skip _all_ of these
     "-Xfrontend": 2,
     "-Xwrapped-swift": 1,
+    "-debug-prefix-map": 2,
     "-emit-module-path": 2,
     "-emit-object": 1,
     "-enable-batch-mode": 1,


### PR DESCRIPTION
This addresses a compilation error when building a generated project using Build with Xcode.
```
error: values for '-debug-prefix-map' must be in the format 'original=remapped', but '-sdk' was provided
```
When options came through like the following:
```
-debug-prefix-map
__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR
```
the `__BAZEL_XCODE_DEVELOPER_DIR__=DEVELOPER_DIR` value was being filtered out leaving the `-debug-prefix-map` without its required second value.

This fix adds `-debug-prefix-map` to the set of options that should be skipped for processing.
