### PR TITLE
Fix breakpoints for indexing based paths

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 
 readonly exec_root="$1"
 
+readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/Index/Build/Intermediates.noindex"
+readonly workspace_name="${exec_root##*/}"
+readonly index_exec_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+
+readonly index_bazel_out="$index_exec_root/bazel-out"
+readonly index_external="$index_exec_root/external"
+
 # Load ~/.lldbinit if it exists
 if [[ -f "$HOME/.lldbinit" ]]; then
   echo "command source ~/.lldbinit"
@@ -20,7 +27,9 @@ echo "platform settings -w \"$exec_root\""
 # This needs to cause the files to match exactly what Xcode set for breakpoints,
 # which is why we don't use `$exec_root` here. Xcode will set the path based
 # on the way you opened a file. If you open a file via the Project navigator,
-# it will use the paths specified below.
+# or indexing (e.g. Jump to Definition), it will use the paths specified below.
 echo "settings set target.source-map ./bazel-out/ \"$GEN_DIR\""
+echo "settings append target.source-map ./bazel-out/ \"$index_bazel_out\""
 echo "settings append target.source-map ./external/ \"$BAZEL_EXTERNAL\""
+echo "settings append target.source-map ./external/ \"$index_external\""
 echo "settings append target.source-map ./ \"$SRCROOT\""

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 
 readonly exec_root="$1"
 
+readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/Index/Build/Intermediates.noindex"
+readonly workspace_name="${exec_root##*/}"
+readonly index_exec_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+
+readonly index_bazel_out="$index_exec_root/bazel-out"
+readonly index_external="$index_exec_root/external"
+
 # Load ~/.lldbinit if it exists
 if [[ -f "$HOME/.lldbinit" ]]; then
   echo "command source ~/.lldbinit"
@@ -20,7 +27,9 @@ echo "platform settings -w \"$exec_root\""
 # This needs to cause the files to match exactly what Xcode set for breakpoints,
 # which is why we don't use `$exec_root` here. Xcode will set the path based
 # on the way you opened a file. If you open a file via the Project navigator,
-# it will use the paths specified below.
+# or indexing (e.g. Jump to Definition), it will use the paths specified below.
 echo "settings set target.source-map ./bazel-out/ \"$GEN_DIR\""
+echo "settings append target.source-map ./bazel-out/ \"$index_bazel_out\""
 echo "settings append target.source-map ./external/ \"$BAZEL_EXTERNAL\""
+echo "settings append target.source-map ./external/ \"$index_external\""
 echo "settings append target.source-map ./ \"$SRCROOT\""

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 
 readonly exec_root="$1"
 
+readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/Index/Build/Intermediates.noindex"
+readonly workspace_name="${exec_root##*/}"
+readonly index_exec_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+
+readonly index_bazel_out="$index_exec_root/bazel-out"
+readonly index_external="$index_exec_root/external"
+
 # Load ~/.lldbinit if it exists
 if [[ -f "$HOME/.lldbinit" ]]; then
   echo "command source ~/.lldbinit"
@@ -20,7 +27,9 @@ echo "platform settings -w \"$exec_root\""
 # This needs to cause the files to match exactly what Xcode set for breakpoints,
 # which is why we don't use `$exec_root` here. Xcode will set the path based
 # on the way you opened a file. If you open a file via the Project navigator,
-# it will use the paths specified below.
+# or indexing (e.g. Jump to Definition), it will use the paths specified below.
 echo "settings set target.source-map ./bazel-out/ \"$GEN_DIR\""
+echo "settings append target.source-map ./bazel-out/ \"$index_bazel_out\""
 echo "settings append target.source-map ./external/ \"$BAZEL_EXTERNAL\""
+echo "settings append target.source-map ./external/ \"$index_external\""
 echo "settings append target.source-map ./ \"$SRCROOT\""

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 
 readonly exec_root="$1"
 
+readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/Index/Build/Intermediates.noindex"
+readonly workspace_name="${exec_root##*/}"
+readonly index_exec_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+
+readonly index_bazel_out="$index_exec_root/bazel-out"
+readonly index_external="$index_exec_root/external"
+
 # Load ~/.lldbinit if it exists
 if [[ -f "$HOME/.lldbinit" ]]; then
   echo "command source ~/.lldbinit"
@@ -20,7 +27,9 @@ echo "platform settings -w \"$exec_root\""
 # This needs to cause the files to match exactly what Xcode set for breakpoints,
 # which is why we don't use `$exec_root` here. Xcode will set the path based
 # on the way you opened a file. If you open a file via the Project navigator,
-# it will use the paths specified below.
+# or indexing (e.g. Jump to Definition), it will use the paths specified below.
 echo "settings set target.source-map ./bazel-out/ \"$GEN_DIR\""
+echo "settings append target.source-map ./bazel-out/ \"$index_bazel_out\""
 echo "settings append target.source-map ./external/ \"$BAZEL_EXTERNAL\""
+echo "settings append target.source-map ./external/ \"$index_external\""
 echo "settings append target.source-map ./ \"$SRCROOT\""

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 
 readonly exec_root="$1"
 
+readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/Index/Build/Intermediates.noindex"
+readonly workspace_name="${exec_root##*/}"
+readonly index_exec_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+
+readonly index_bazel_out="$index_exec_root/bazel-out"
+readonly index_external="$index_exec_root/external"
+
 # Load ~/.lldbinit if it exists
 if [[ -f "$HOME/.lldbinit" ]]; then
   echo "command source ~/.lldbinit"
@@ -20,7 +27,9 @@ echo "platform settings -w \"$exec_root\""
 # This needs to cause the files to match exactly what Xcode set for breakpoints,
 # which is why we don't use `$exec_root` here. Xcode will set the path based
 # on the way you opened a file. If you open a file via the Project navigator,
-# it will use the paths specified below.
+# or indexing (e.g. Jump to Definition), it will use the paths specified below.
 echo "settings set target.source-map ./bazel-out/ \"$GEN_DIR\""
+echo "settings append target.source-map ./bazel-out/ \"$index_bazel_out\""
 echo "settings append target.source-map ./external/ \"$BAZEL_EXTERNAL\""
+echo "settings append target.source-map ./external/ \"$index_external\""
 echo "settings append target.source-map ./ \"$SRCROOT\""

--- a/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
+++ b/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 
 readonly exec_root="$1"
 
+readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/Index/Build/Intermediates.noindex"
+readonly workspace_name="${exec_root##*/}"
+readonly index_exec_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+
+readonly index_bazel_out="$index_exec_root/bazel-out"
+readonly index_external="$index_exec_root/external"
+
 # Load ~/.lldbinit if it exists
 if [[ -f "$HOME/.lldbinit" ]]; then
   echo "command source ~/.lldbinit"
@@ -20,7 +27,9 @@ echo "platform settings -w \"$exec_root\""
 # This needs to cause the files to match exactly what Xcode set for breakpoints,
 # which is why we don't use `$exec_root` here. Xcode will set the path based
 # on the way you opened a file. If you open a file via the Project navigator,
-# it will use the paths specified below.
+# or indexing (e.g. Jump to Definition), it will use the paths specified below.
 echo "settings set target.source-map ./bazel-out/ \"$GEN_DIR\""
+echo "settings append target.source-map ./bazel-out/ \"$index_bazel_out\""
 echo "settings append target.source-map ./external/ \"$BAZEL_EXTERNAL\""
+echo "settings append target.source-map ./external/ \"$index_external\""
 echo "settings append target.source-map ./ \"$SRCROOT\""


### PR DESCRIPTION
Ideally indexing results would bring you to the same location as the Project navigator, but until we fix that (if we even can), this change adds indexing based `bazel-out/` and `external/` directories to `target.source-map`.