### PR TITLE
Prevent error when "running" a test scheme

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleObjcTests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleObjcTests.__internal__.__test_bundle.xcscheme
@@ -24,6 +24,20 @@
          </ExecutionAction>
       </PreActions>
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7E5DFA29686635FDE423D8F4"
+               BuildableName = "ExampleObjcTests.xctest"
+               BlueprintName = "ExampleObjcTests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -55,8 +69,7 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       customLLDBInitFile = "$(BAZEL_LLDB_INIT)">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7E5DFA29686635FDE423D8F4"
@@ -64,7 +77,7 @@
             BlueprintName = "ExampleObjcTests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -72,16 +85,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7E5DFA29686635FDE423D8F4"
-            BuildableName = "ExampleObjcTests.xctest"
-            BlueprintName = "ExampleObjcTests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
@@ -24,6 +24,20 @@
          </ExecutionAction>
       </PreActions>
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D133FDFF63F008FDDB07BE99"
+               BuildableName = "ExampleTests.xctest"
+               BlueprintName = "ExampleTests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -55,8 +69,7 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       customLLDBInitFile = "$(BAZEL_LLDB_INIT)">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "D133FDFF63F008FDDB07BE99"
@@ -64,7 +77,7 @@
             BlueprintName = "ExampleTests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -72,16 +85,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D133FDFF63F008FDDB07BE99"
-            BuildableName = "ExampleTests.xctest"
-            BlueprintName = "ExampleTests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
@@ -24,6 +24,20 @@
          </ExecutionAction>
       </PreActions>
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BBF4D59A51801FF17E35E34E"
+               BuildableName = "ExampleUITests.xctest"
+               BlueprintName = "ExampleUITests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -55,8 +69,7 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       customLLDBInitFile = "$(BAZEL_LLDB_INIT)">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BBF4D59A51801FF17E35E34E"
@@ -64,7 +77,7 @@
             BlueprintName = "ExampleUITests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -72,16 +85,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BBF4D59A51801FF17E35E34E"
-            BuildableName = "ExampleUITests.xctest"
-            BlueprintName = "ExampleUITests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleObjcTests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleObjcTests.__internal__.__test_bundle.xcscheme
@@ -6,6 +6,20 @@
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4BF4D16D8EFD29114BC29B92"
+               BuildableName = "ExampleObjcTests.xctest"
+               BlueprintName = "ExampleObjcTests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -36,8 +50,7 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4BF4D16D8EFD29114BC29B92"
@@ -45,7 +58,7 @@
             BlueprintName = "ExampleObjcTests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -53,16 +66,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "4BF4D16D8EFD29114BC29B92"
-            BuildableName = "ExampleObjcTests.xctest"
-            BlueprintName = "ExampleObjcTests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
@@ -6,6 +6,20 @@
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5742A33EA302007E9758E24B"
+               BuildableName = "ExampleTests.xctest"
+               BlueprintName = "ExampleTests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -36,8 +50,7 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5742A33EA302007E9758E24B"
@@ -45,7 +58,7 @@
             BlueprintName = "ExampleTests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -53,16 +66,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5742A33EA302007E9758E24B"
-            BuildableName = "ExampleTests.xctest"
-            BlueprintName = "ExampleTests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
@@ -6,6 +6,20 @@
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BDC5BB543739DEC8809249F9"
+               BuildableName = "ExampleUITests.xctest"
+               BlueprintName = "ExampleUITests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -36,8 +50,7 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDC5BB543739DEC8809249F9"
@@ -45,7 +58,7 @@
             BlueprintName = "ExampleUITests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -53,16 +66,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BDC5BB543739DEC8809249F9"
-            BuildableName = "ExampleUITests.xctest"
-            BlueprintName = "ExampleUITests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/LibSwiftTests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/LibSwiftTests.__internal__.__test_bundle.xcscheme
@@ -24,6 +24,20 @@
          </ExecutionAction>
       </PreActions>
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E56E8F91E4327755D5B09E30"
+               BuildableName = "LibSwiftTests.xctest"
+               BlueprintName = "LibSwiftTests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/command_line/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -55,8 +69,7 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       customLLDBInitFile = "$(BAZEL_LLDB_INIT)">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "E56E8F91E4327755D5B09E30"
@@ -64,7 +77,7 @@
             BlueprintName = "LibSwiftTests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/command_line/bwb.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -72,16 +85,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "E56E8F91E4327755D5B09E30"
-            BuildableName = "LibSwiftTests.xctest"
-            BlueprintName = "LibSwiftTests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/command_line/bwb.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/LibSwiftTests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/LibSwiftTests.__internal__.__test_bundle.xcscheme
@@ -6,6 +6,20 @@
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0290E727C546D76C651A3B2D"
+               BuildableName = "LibSwiftTests.xctest"
+               BlueprintName = "LibSwiftTests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/command_line/bwx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -36,8 +50,7 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "0290E727C546D76C651A3B2D"
@@ -45,7 +58,7 @@
             BlueprintName = "LibSwiftTests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/command_line/bwx.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -53,16 +66,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "0290E727C546D76C651A3B2D"
-            BuildableName = "LibSwiftTests.xctest"
-            BlueprintName = "LibSwiftTests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/command_line/bwx.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/tests.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/tests.xcscheme
@@ -24,6 +24,20 @@
          </ExecutionAction>
       </PreActions>
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "979D12680661F4B864602CE6"
+               BuildableName = "tests.xctest"
+               BlueprintName = "tests"
+               ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -55,8 +69,7 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       customLLDBInitFile = "$(BAZEL_LLDB_INIT)">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "979D12680661F4B864602CE6"
@@ -64,7 +77,7 @@
             BlueprintName = "tests"
             ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -72,16 +85,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "979D12680661F4B864602CE6"
-            BuildableName = "tests.xctest"
-            BlueprintName = "tests"
-            ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/tests.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/tests.xcscheme
@@ -6,6 +6,20 @@
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F5FCEC7426929BDA7F9F1875"
+               BuildableName = "tests.xctest"
+               BlueprintName = "tests"
+               ReferencedContainer = "container:test/fixtures/generator/bwx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -36,8 +50,7 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "F5FCEC7426929BDA7F9F1875"
@@ -45,7 +58,7 @@
             BlueprintName = "tests"
             ReferencedContainer = "container:test/fixtures/generator/bwx.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -53,16 +66,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "F5FCEC7426929BDA7F9F1875"
-            BuildableName = "tests.xctest"
-            BlueprintName = "tests"
-            ReferencedContainer = "container:test/fixtures/generator/bwx.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
@@ -24,6 +24,20 @@
          </ExecutionAction>
       </PreActions>
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D133FDFF63F008FDDB07BE99"
+               BuildableName = "ExampleTests.xctest"
+               BlueprintName = "ExampleTests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/tvos_app/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -55,8 +69,7 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       customLLDBInitFile = "$(BAZEL_LLDB_INIT)">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "D133FDFF63F008FDDB07BE99"
@@ -64,7 +77,7 @@
             BlueprintName = "ExampleTests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/tvos_app/bwb.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -72,16 +85,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D133FDFF63F008FDDB07BE99"
-            BuildableName = "ExampleTests.xctest"
-            BlueprintName = "ExampleTests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/tvos_app/bwb.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
@@ -24,6 +24,20 @@
          </ExecutionAction>
       </PreActions>
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BBF4D59A51801FF17E35E34E"
+               BuildableName = "ExampleUITests.xctest"
+               BlueprintName = "ExampleUITests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/tvos_app/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -55,8 +69,7 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       customLLDBInitFile = "$(BAZEL_LLDB_INIT)">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BBF4D59A51801FF17E35E34E"
@@ -64,7 +77,7 @@
             BlueprintName = "ExampleUITests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/tvos_app/bwb.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -72,16 +85,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BBF4D59A51801FF17E35E34E"
-            BuildableName = "ExampleUITests.xctest"
-            BlueprintName = "ExampleUITests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/tvos_app/bwb.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
@@ -6,6 +6,20 @@
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5742A33EA302007E9758E24B"
+               BuildableName = "ExampleTests.xctest"
+               BlueprintName = "ExampleTests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/tvos_app/bwx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -36,8 +50,7 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5742A33EA302007E9758E24B"
@@ -45,7 +58,7 @@
             BlueprintName = "ExampleTests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/tvos_app/bwx.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -53,16 +66,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5742A33EA302007E9758E24B"
-            BuildableName = "ExampleTests.xctest"
-            BlueprintName = "ExampleTests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/tvos_app/bwx.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
@@ -6,6 +6,20 @@
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BDC5BB543739DEC8809249F9"
+               BuildableName = "ExampleUITests.xctest"
+               BlueprintName = "ExampleUITests.__internal__.__test_bundle"
+               ReferencedContainer = "container:test/fixtures/tvos_app/bwx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -36,8 +50,7 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "BDC5BB543739DEC8809249F9"
@@ -45,7 +58,7 @@
             BlueprintName = "ExampleUITests.__internal__.__test_bundle"
             ReferencedContainer = "container:test/fixtures/tvos_app/bwx.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"
@@ -53,16 +66,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "BDC5BB543739DEC8809249F9"
-            BuildableName = "ExampleUITests.xctest"
-            BlueprintName = "ExampleUITests.__internal__.__test_bundle"
-            ReferencedContainer = "container:test/fixtures/tvos_app/bwx.xcodeproj">
-         </BuildableReference>
-      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/tools/generator/test/CreateXCSchemesTests.swift
+++ b/tools/generator/test/CreateXCSchemesTests.swift
@@ -19,6 +19,7 @@ class CreateXCSchemesTests: XCTestCase {
         shouldExpectBuildActionEntries: Bool,
         shouldExpectTestables: Bool,
         shouldExpectBuildableProductRunnable: Bool,
+        shouldExpectLaunchMacroExpansion: Bool,
         shouldExpectCustomLLDBInitFile: Bool,
         file: StaticString = #filePath,
         line: UInt = #line
@@ -47,6 +48,8 @@ class CreateXCSchemesTests: XCTestCase {
         let expectedBuildableReference = try target.createBuildableReference(
             referencedContainer: filePathResolver.containerReference
         )
+        let expectedLaunchMacroExpansion = shouldExpectLaunchMacroExpansion ?
+            expectedBuildableReference : nil
         let expectedBuildPreActions: [XCScheme.ExecutionAction] =
             shouldExpectBuildPreActions ?
             [.init(
@@ -136,7 +139,7 @@ echo "b $BAZEL_TARGET_ID" > "$BAZEL_BUILD_OUTPUT_GROUPS_FILE"
         }
         XCTAssertNil(
             testAction.macroExpansion,
-            "macroExpansion was not nil for \(scheme.name)",
+            "testAction.macroExpansion was not nil for \(scheme.name)",
             file: file,
             line: line
         )
@@ -174,6 +177,13 @@ echo "b $BAZEL_TARGET_ID" > "$BAZEL_BUILD_OUTPUT_GROUPS_FILE"
             launchAction.runnable,
             expectedBuildableProductRunnable,
             "runnable did not match for \(scheme.name)",
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            launchAction.macroExpansion,
+            expectedLaunchMacroExpansion,
+            "launchAction.macroExpansion did not match for \(scheme.name)",
             file: file,
             line: line
         )
@@ -252,6 +262,7 @@ echo "b $BAZEL_TARGET_ID" > "$BAZEL_BUILD_OUTPUT_GROUPS_FILE"
             shouldExpectBuildActionEntries: true,
             shouldExpectTestables: false,
             shouldExpectBuildableProductRunnable: false,
+            shouldExpectLaunchMacroExpansion: false,
             shouldExpectCustomLLDBInitFile: false
         )
 
@@ -263,17 +274,19 @@ echo "b $BAZEL_TARGET_ID" > "$BAZEL_BUILD_OUTPUT_GROUPS_FILE"
             shouldExpectBuildActionEntries: true,
             shouldExpectTestables: false,
             shouldExpectBuildableProductRunnable: false,
+            shouldExpectLaunchMacroExpansion: false,
             shouldExpectCustomLLDBInitFile: false
         )
 
-        // Testable and launchable
+        // Launchable, testable
         try assertScheme(
             schemesDict: schemesDict,
             targetID: "B 2",
             shouldExpectBuildPreActions: false,
-            shouldExpectBuildActionEntries: false,
+            shouldExpectBuildActionEntries: true,
             shouldExpectTestables: true,
-            shouldExpectBuildableProductRunnable: true,
+            shouldExpectBuildableProductRunnable: false,
+            shouldExpectLaunchMacroExpansion: true,
             shouldExpectCustomLLDBInitFile: false
         )
 
@@ -285,6 +298,7 @@ echo "b $BAZEL_TARGET_ID" > "$BAZEL_BUILD_OUTPUT_GROUPS_FILE"
             shouldExpectBuildActionEntries: true,
             shouldExpectTestables: false,
             shouldExpectBuildableProductRunnable: true,
+            shouldExpectLaunchMacroExpansion: false,
             shouldExpectCustomLLDBInitFile: false
         )
     }
@@ -307,6 +321,7 @@ echo "b $BAZEL_TARGET_ID" > "$BAZEL_BUILD_OUTPUT_GROUPS_FILE"
             shouldExpectBuildActionEntries: true,
             shouldExpectTestables: false,
             shouldExpectBuildableProductRunnable: false,
+            shouldExpectLaunchMacroExpansion: false,
             shouldExpectCustomLLDBInitFile: true
         )
 
@@ -318,17 +333,19 @@ echo "b $BAZEL_TARGET_ID" > "$BAZEL_BUILD_OUTPUT_GROUPS_FILE"
             shouldExpectBuildActionEntries: true,
             shouldExpectTestables: false,
             shouldExpectBuildableProductRunnable: false,
+            shouldExpectLaunchMacroExpansion: false,
             shouldExpectCustomLLDBInitFile: true
         )
 
-        // Testable and launchable
+        // Launchable, testable
         try assertScheme(
             schemesDict: schemesDict,
             targetID: "B 2",
             shouldExpectBuildPreActions: true,
-            shouldExpectBuildActionEntries: false,
+            shouldExpectBuildActionEntries: true,
             shouldExpectTestables: true,
-            shouldExpectBuildableProductRunnable: true,
+            shouldExpectBuildableProductRunnable: false,
+            shouldExpectLaunchMacroExpansion: true,
             shouldExpectCustomLLDBInitFile: true
         )
 
@@ -340,6 +357,7 @@ echo "b $BAZEL_TARGET_ID" > "$BAZEL_BUILD_OUTPUT_GROUPS_FILE"
             shouldExpectBuildActionEntries: true,
             shouldExpectTestables: false,
             shouldExpectBuildableProductRunnable: true,
+            shouldExpectLaunchMacroExpansion: false,
             shouldExpectCustomLLDBInitFile: true
         )
     }


### PR DESCRIPTION
This unsets the executable for the launch action of a test target scheme.