### PR TITLE
Prevent extra output group building with `BazelDependencies` scheme

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Set Bazel Build Output Groups"
+               scriptText = "if [[ -s &quot;$BAZEL_BUILD_OUTPUT_GROUPS_FILE&quot; ]]; then&#10;    rm &quot;$BAZEL_BUILD_OUTPUT_GROUPS_FILE&quot;&#10;fi&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "7E7D155EBCA520F35DEA3571"
+                     BuildableName = "BazelDependencies"
+                     BlueprintName = "BazelDependencies"
+                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
+++ b/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Set Bazel Build Output Groups"
+               scriptText = "if [[ -s &quot;$BAZEL_BUILD_OUTPUT_GROUPS_FILE&quot; ]]; then&#10;    rm &quot;$BAZEL_BUILD_OUTPUT_GROUPS_FILE&quot;&#10;fi&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "7E7D155EBCA520F35DEA3571"
+                     BuildableName = "BazelDependencies"
+                     BlueprintName = "BazelDependencies"
+                     ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Set Bazel Build Output Groups"
+               scriptText = "if [[ -s &quot;$BAZEL_BUILD_OUTPUT_GROUPS_FILE&quot; ]]; then&#10;    rm &quot;$BAZEL_BUILD_OUTPUT_GROUPS_FILE&quot;&#10;fi&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "7E7D155EBCA520F35DEA3571"
+                     BuildableName = "BazelDependencies"
+                     BlueprintName = "BazelDependencies"
+                     ReferencedContainer = "container:test/fixtures/command_line/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Set Bazel Build Output Groups"
+               scriptText = "if [[ -s &quot;$BAZEL_BUILD_OUTPUT_GROUPS_FILE&quot; ]]; then&#10;    rm &quot;$BAZEL_BUILD_OUTPUT_GROUPS_FILE&quot;&#10;fi&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "7E7D155EBCA520F35DEA3571"
+                     BuildableName = "BazelDependencies"
+                     BlueprintName = "BazelDependencies"
+                     ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
@@ -5,6 +5,24 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Set Bazel Build Output Groups"
+               scriptText = "if [[ -s &quot;$BAZEL_BUILD_OUTPUT_GROUPS_FILE&quot; ]]; then&#10;    rm &quot;$BAZEL_BUILD_OUTPUT_GROUPS_FILE&quot;&#10;fi&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "7E7D155EBCA520F35DEA3571"
+                     BuildableName = "BazelDependencies"
+                     BlueprintName = "BazelDependencies"
+                     ReferencedContainer = "container:test/fixtures/tvos_app/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"


### PR DESCRIPTION
The `BazelDependencies` scheme wouldn't touch the `$BAZEL_BUILD_OUTPUT_GROUPS_FILE` file, which means the `BazelDependencies` target would rebuild whatever was last built, instead of only generated files. Now the `BazelDependencies` scheme deletes the `$BAZEL_BUILD_OUTPUT_GROUPS_FILE` file.