### PR TITLE
Fix merging logic with spaces

### DIFF
--- a/xcodeproj/internal/output_group_map.bzl
+++ b/xcodeproj/internal/output_group_map.bzl
@@ -129,9 +129,10 @@ def _write_map(*, ctx, name, files, toplevel_cache_buster):
 
     ctx.actions.run_shell(
         command = """
+set -euo pipefail
 readonly output="$1"
 shift
-cat $@ > "$output"
+cat "$@" > "$output"
 """,
         arguments = [
             output.path,


### PR DESCRIPTION
This should fix some errors due to files containing spaces in their path not being copied correctly.