### PR TITLE
Apply filtering logic to `generated` `extra_files`, and `xccurrentversions` as well

### DIFF
--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -12,14 +12,6 @@
     },
     "configuration": "darwin_x86_64-dbg-ST-59f3be6ef3d4",
     "extra_files": [
-        {
-            "_": "examples_ios_app_external/bundles/Utils.bundle",
-            "f": true,
-            "t": "e"
-        },
-        "third_party/BUILD",
-        "CoreUtilsObjC/BUILD",
-        "Utils/BUILD",
         "ExampleResources/BUILD",
         "ExampleResources/Info.plist",
         "ExampleResources/Assets.xcassets/Contents.json",
@@ -30,6 +22,14 @@
             "f": true
         },
         "Example/BUILD",
+        {
+            "_": "examples_ios_app_external/bundles/Utils.bundle",
+            "f": true,
+            "t": "e"
+        },
+        "third_party/BUILD",
+        "CoreUtilsObjC/BUILD",
+        "Utils/BUILD",
         {
             "_": "examples_ios_app_external/ImportableLibrary/Library.h",
             "t": "e"

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -12,12 +12,12 @@
     },
     "configuration": "darwin_x86_64-dbg-ST-093a4da7acd4",
     "extra_files": [
-        "third_party/BUILD",
-        "CoreUtilsObjC/BUILD",
-        "Utils/BUILD",
         "ExampleResources/BUILD",
         "ExampleResources/Info.plist",
         "Example/BUILD",
+        "third_party/BUILD",
+        "CoreUtilsObjC/BUILD",
+        "Utils/BUILD",
         {
             "_": "examples_ios_app_external/ImportableLibrary/Library.h",
             "t": "e"

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -313,7 +313,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md
             xccurrentversions,
             transitive = [
                 info.inputs.xccurrentversions
-                for _, info in transitive_infos
+                for attr, info in transitive_infos
+                if (not attrs_info or
+                    info.target_type in
+                    attrs_info.xcode_targets.get(attr, [None]))
             ],
         ),
         contains_generated_files = bool(generated),
@@ -331,7 +334,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md
             extra_files,
             transitive = flatten([
                 _collect_transitive_extra_files(info)
-                for _, info in transitive_infos
+                for attr, info in transitive_infos
+                if (not attrs_info or
+                    info.target_type in
+                    attrs_info.xcode_targets.get(attr, [None]))
             ]),
         ),
     )
@@ -390,7 +396,10 @@ def _merge(*, attrs_info, transitive_infos):
         xccurrentversions = depset(
             transitive = [
                 info.inputs.xccurrentversions
-                for _, info in transitive_infos
+                for attr, info in transitive_infos
+                if (not attrs_info or
+                    info.target_type in
+                    attrs_info.xcode_targets.get(attr, [None]))
             ],
         ),
         generated = depset(
@@ -405,7 +414,10 @@ def _merge(*, attrs_info, transitive_infos):
         extra_files = depset(
             transitive = [
                 info.inputs.extra_files
-                for _, info in transitive_infos
+                for attr, info in transitive_infos
+                if (not attrs_info or
+                    info.target_type in
+                    attrs_info.xcode_targets.get(attr, [None]))
             ],
         ),
     )

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -321,7 +321,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md
             generated,
             transitive = [
                 info.inputs.generated
-                for _, info in transitive_infos
+                for attr, info in transitive_infos
+                if (not attrs_info or
+                    info.target_type in
+                    attrs_info.xcode_targets.get(attr, [None]))
             ],
         ),
         extra_files = depset(
@@ -393,7 +396,10 @@ def _merge(*, attrs_info, transitive_infos):
         generated = depset(
             transitive = [
                 info.inputs.generated
-                for _, info in transitive_infos
+                for attr, info in transitive_infos
+                if (not attrs_info or
+                    info.target_type in
+                    attrs_info.xcode_targets.get(attr, [None]))
             ],
         ),
         extra_files = depset(


### PR DESCRIPTION
This prevents the `generated_inputs` output group from having unnecessary files in it. This filtering is very redundant, and error prone (as shown by this and previous changes applying missing filtering). This will get addressed with the forthcoming input file collection refactor.