### PR TITLE
Fix non-launchable product references in Project navigator

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -191,7 +191,7 @@
 		823A0A913DE6BBF3286D06E6 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		86B6FAB2FF4A94053E4D470E /* ExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		8ADB9E176B3AB4F6354A1167 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		8F8B001AB6315D99F13FAC92 /* libCoreUtilsObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCoreUtilsObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8F8B001AB6315D99F13FAC92 /* libCoreUtilsObjC.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libCoreUtilsObjC.a; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/libCoreUtilsObjC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		936C89D0AECF460936BF9489 /* app.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = app.entitlements; sourceTree = "<group>"; };
 		9BF5CE4ADD5163F5308F8626 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9D61CBAFE2C78BDC7960D5A4 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
@@ -205,7 +205,7 @@
 		BA50CCA5E622A3EB4718BC1B /* Library.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Library.h; sourceTree = "<group>"; };
 		BA542B31DC88C70950011E86 /* ExternalFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExternalFramework.framework; sourceTree = "<group>"; };
 		C6DFECB6D814B2CE3ADA51CD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		CC8E3F6E9A6B44248BD06712 /* libUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC8E3F6E9A6B44248BD06712 /* libUtils.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libUtils.a; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/libUtils.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CFC9A2A1615D8DCB6AF8914F /* Example_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example_entitlements.entitlements; sourceTree = "<group>"; };
 		D027F83636D3D6C6ABBF375F /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
 		D165E542DE0036D69F5A152B /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
@@ -218,7 +218,7 @@
 		E9ED685D3A056C10F6A99CCD /* Utils.bundle */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Utils.bundle; sourceTree = "<group>"; };
 		EF7A41BCADD5C386F325375B /* PreviewAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = PreviewAssets.xcassets; sourceTree = "<group>"; };
 		F3D27BBBDD5DEF87214D8019 /* ExampleFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExampleFramework.framework; sourceTree = "<group>"; };
-		F7A2777E8293F6B63DA51836 /* libTestingUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTestingUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		F7A2777E8293F6B63DA51836 /* libTestingUtils.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libTestingUtils.a; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/libTestingUtils.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FC2955D9470E1B14AF63D754 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		FCD60791E48BE478D91B90E5 /* Library.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Library.swift.modulemap; sourceTree = "<group>"; };
 		FCE9A475E64859A8A1FBE603 /* libImportableLibrary.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libImportableLibrary.a; sourceTree = "<group>"; };
@@ -637,7 +637,6 @@
 			);
 			name = Utils;
 			productName = Utils;
-			productReference = CC8E3F6E9A6B44248BD06712 /* libUtils.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		64AE6000A6317B9C077F3B1E /* CoreUtilsObjC */ = {
@@ -653,7 +652,6 @@
 			);
 			name = CoreUtilsObjC;
 			productName = CoreUtilsObjC;
-			productReference = 8F8B001AB6315D99F13FAC92 /* libCoreUtilsObjC.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		7E5DFA29686635FDE423D8F4 /* ExampleObjcTests.__internal__.__test_bundle */ = {
@@ -748,7 +746,6 @@
 			);
 			name = TestingUtils;
 			productName = TestingUtils;
-			productReference = F7A2777E8293F6B63DA51836 /* libTestingUtils.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "64AE6000A6317B9C077F3B1E"
-                     BuildableName = "libCoreUtilsObjC.a"
+                     BuildableName = "CoreUtilsObjC"
                      BlueprintName = "CoreUtilsObjC"
                      ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "64AE6000A6317B9C077F3B1E"
-               BuildableName = "libCoreUtilsObjC.a"
+               BuildableName = "CoreUtilsObjC"
                BlueprintName = "CoreUtilsObjC"
                ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
             </BuildableReference>

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/TestingUtils.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/TestingUtils.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "F175A7E1019A952CA7F66BBC"
-                     BuildableName = "libTestingUtils.a"
+                     BuildableName = "TestingUtils"
                      BlueprintName = "TestingUtils"
                      ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F175A7E1019A952CA7F66BBC"
-               BuildableName = "libTestingUtils.a"
+               BuildableName = "TestingUtils"
                BlueprintName = "TestingUtils"
                ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
             </BuildableReference>

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/Utils.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/Utils.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "34820134F30D904FFA06D27A"
-                     BuildableName = "libUtils.a"
+                     BuildableName = "Utils"
                      BlueprintName = "Utils"
                      ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "34820134F30D904FFA06D27A"
-               BuildableName = "libUtils.a"
+               BuildableName = "Utils"
                BlueprintName = "Utils"
                ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
             </BuildableReference>

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 		04B7FF83EC448D16A88FA827 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		0551D3402BBFA018916880AC /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		082E81D1A4883526CA3B52D8 /* ExampleFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExampleFramework.framework; sourceTree = "<group>"; };
-		087B3E45AA9A7430D1BEC9B8 /* ExampleResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		087B3E45AA9A7430D1BEC9B8 /* ExampleResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = ExampleResources.bundle; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-ede36487cf61/bin/ExampleResources/ExampleResources.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0AC7E49CD6F2F86EFC4F09E8 /* TestingUtils.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = TestingUtils.swift.modulemap; sourceTree = "<group>"; };
 		0D4BE40B12E61F0EBADF1EF0 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		104ECD97B1C1B9C4DF3F9949 /* ExampleObjcTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleObjcTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -244,7 +244,7 @@
 		44BB25020D8FACC865B72D37 /* Answer.swift.stencil */ = {isa = PBXFileReference; path = Answer.swift.stencil; sourceTree = "<group>"; };
 		4EFD481E747FFE235872FEBE /* nested */ = {isa = PBXFileReference; lastKnownFileType = folder; path = nested; sourceTree = "<group>"; };
 		52D5C019D7FE1B131E3E26FC /* Library.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Library.h; sourceTree = "<group>"; };
-		56019D124B91E38AF4906E11 /* ExternalResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExternalResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		56019D124B91E38AF4906E11 /* ExternalResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = ExternalResources.bundle; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-ede36487cf61/bin/external/examples_ios_app_external/ExternalResources.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
 		56CABDA09B231335D1A65F54 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
 		5C2D4A62829A12CF82C8CAFF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		66FD903A85D9EC8C1EBDC3C2 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
@@ -276,13 +276,13 @@
 		D90FB752C15E622C61D662C4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DE4E55DA7325F65B7598D64D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DF687E5CFDD353365469C4A0 /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
-		E788B1C7B112FB6941BD4C12 /* libUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E788B1C7B112FB6941BD4C12 /* libUtils.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libUtils.a; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-ede36487cf61/bin/Utils/libUtils.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E96B6D79A5EE347B1D1525A5 /* CoreUtilsObjC.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = CoreUtilsObjC.swift.modulemap; sourceTree = "<group>"; };
 		E9FA397CF373D551969DCA9F /* libImportableLibrary.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libImportableLibrary.a; sourceTree = "<group>"; };
 		EC7CDEE9BB4DCF113F3A632C /* Model2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model2.xcdatamodel; sourceTree = "<group>"; };
-		F0C6F70E20391113754D1FA5 /* libTestingUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTestingUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		F0C6F70E20391113754D1FA5 /* libTestingUtils.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libTestingUtils.a; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-ede36487cf61/bin/TestingUtils/libTestingUtils.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F7010BA0970E72123DBC46EA /* Example_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example_entitlements.entitlements; sourceTree = "<group>"; };
-		FD0A412F6FD34BAD4615ACB5 /* libCoreUtilsObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCoreUtilsObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		FD0A412F6FD34BAD4615ACB5 /* libCoreUtilsObjC.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libCoreUtilsObjC.a; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-ede36487cf61/bin/CoreUtilsObjC/libCoreUtilsObjC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -689,7 +689,6 @@
 			);
 			name = ExampleResources;
 			productName = ExampleResources;
-			productReference = 087B3E45AA9A7430D1BEC9B8 /* ExampleResources.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
 		42A7256A505DA3DFEA69C941 /* TestingUtils */ = {
@@ -706,7 +705,6 @@
 			);
 			name = TestingUtils;
 			productName = TestingUtils;
-			productReference = F0C6F70E20391113754D1FA5 /* libTestingUtils.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		42E984F26D5B4ECBE0F0F076 /* Utils */ = {
@@ -723,7 +721,6 @@
 			);
 			name = Utils;
 			productName = Utils;
-			productReference = E788B1C7B112FB6941BD4C12 /* libUtils.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		4BF4D16D8EFD29114BC29B92 /* ExampleObjcTests.__internal__.__test_bundle */ = {
@@ -801,7 +798,6 @@
 			);
 			name = ExternalResources;
 			productName = ExternalResources;
-			productReference = 56019D124B91E38AF4906E11 /* ExternalResources.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
 		A0257519AD63A69C6DF51958 /* CoreUtilsObjC */ = {
@@ -817,7 +813,6 @@
 			);
 			name = CoreUtilsObjC;
 			productName = CoreUtilsObjC;
-			productReference = FD0A412F6FD34BAD4615ACB5 /* libCoreUtilsObjC.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		BDC5BB543739DEC8809249F9 /* ExampleUITests.__internal__.__test_bundle */ = {

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A0257519AD63A69C6DF51958"
-               BuildableName = "libCoreUtilsObjC.a"
+               BuildableName = "CoreUtilsObjC"
                BlueprintName = "CoreUtilsObjC"
                ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
             </BuildableReference>

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleResources.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleResources.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "225701F2BB3EA192424F07FE"
-               BuildableName = "ExampleResources.bundle"
+               BuildableName = "ExampleResources"
                BlueprintName = "ExampleResources"
                ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
             </BuildableReference>

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExternalResources.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExternalResources.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "9EEE562EF383D06390A55602"
-               BuildableName = "ExternalResources.bundle"
+               BuildableName = "ExternalResources"
                BlueprintName = "ExternalResources"
                ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
             </BuildableReference>

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/TestingUtils.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/TestingUtils.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "42A7256A505DA3DFEA69C941"
-               BuildableName = "libTestingUtils.a"
+               BuildableName = "TestingUtils"
                BlueprintName = "TestingUtils"
                ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
             </BuildableReference>

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/Utils.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/Utils.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "42E984F26D5B4ECBE0F0F076"
-               BuildableName = "libUtils.a"
+               BuildableName = "Utils"
                BlueprintName = "Utils"
                ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -85,15 +85,15 @@
 		1FA9CAC061B4F491CEBDF60A /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		26866FEDF67CD3FA66FFAB17 /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
 		2F2B12BDC30B75C3CD2012BD /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
-		3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		43CB090CE80B33F7C6C1C7F6 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
-		5CEC67C55F51736AB9F17063 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		5CEC67C55F51736AB9F17063 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/examples_cc_external/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		82E8E5D354CD9B769C1DD508 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
 		8D73636373B8CDD4BE62C0A5 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
 		8EEF31F83F9AF990435CC135 /* tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tool; sourceTree = BUILT_PRODUCTS_DIR; };
 		9411DCDC5C6F92122299107F /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
 		941A754D1FBB5ACD78B4C755 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
-		CDA701F96A5177E4188BEA69 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		CDA701F96A5177E4188BEA69 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib2/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E179886B32A8D20BA0FD517F /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		F360F9D030E464AA774319E0 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
 		FB0F020B344E60F89B31265D /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
@@ -236,7 +236,6 @@
 			);
 			name = "@examples_cc_external//:lib_impl";
 			productName = lib_impl;
-			productReference = 3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		27EDD304E889980DC176FF62 /* tool */ = {
@@ -272,7 +271,6 @@
 			);
 			name = "//examples/cc/lib2:lib_impl";
 			productName = lib_impl;
-			productReference = 5CEC67C55F51736AB9F17063 /* liblib_impl.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		E180851AE3E1EEC8C4944F10 /* //examples/cc/lib:lib_impl */ = {
@@ -288,7 +286,6 @@
 			);
 			name = "//examples/cc/lib:lib_impl";
 			productName = lib_impl;
-			productReference = CDA701F96A5177E4188BEA69 /* liblib_impl.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */

--- a/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
+++ b/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "0CEAA3455274D4DE9B4B82BF"
-                     BuildableName = "liblib_impl.a"
+                     BuildableName = "lib_impl"
                      BlueprintName = "@examples_cc_external//:lib_impl"
                      ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "0CEAA3455274D4DE9B4B82BF"
-               BuildableName = "liblib_impl.a"
+               BuildableName = "lib_impl"
                BlueprintName = "@examples_cc_external//:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "373A62571D2CA8826AD4F92C"
-                     BuildableName = "liblib_impl.a"
+                     BuildableName = "lib_impl"
                      BlueprintName = "//examples/cc/lib2:lib_impl"
                      ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "373A62571D2CA8826AD4F92C"
-               BuildableName = "liblib_impl.a"
+               BuildableName = "lib_impl"
                BlueprintName = "//examples/cc/lib2:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "E180851AE3E1EEC8C4944F10"
-                     BuildableName = "liblib_impl.a"
+                     BuildableName = "lib_impl"
                      BlueprintName = "//examples/cc/lib:lib_impl"
                      ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E180851AE3E1EEC8C4944F10"
-               BuildableName = "liblib_impl.a"
+               BuildableName = "lib_impl"
                BlueprintName = "//examples/cc/lib:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
@@ -82,17 +82,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		01934C980471E67330AC657C /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		01934C980471E67330AC657C /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-0376e8cd69e6/bin/external/examples_cc_external/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0282BFF13FDF4BED1663D2AF /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
 		054732C7DCF543EED5337D81 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
 		19B81294B60CEC2BA6843380 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
 		1E24825205C7C82ED0184DEA /* tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tool; sourceTree = BUILT_PRODUCTS_DIR; };
 		31620B8F4712C7D8A23356B9 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		4C8095547A55E1C477C2E094 /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
-		61D4E93D586B426B1BE67C73 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		61D4E93D586B426B1BE67C73 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-0376e8cd69e6/bin/examples/cc/lib/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		72DD4925E3FB6AE32B7ACADA /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
 		887E70CEDC5A85E62FB23126 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
-		8C467A9CF11D6BFFA7FEE894 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8C467A9CF11D6BFFA7FEE894 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-0376e8cd69e6/bin/examples/cc/lib2/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		921187174A58741CF8ADCCD9 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
 		BD77ACEF34FC7AFD41A09A4A /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
 		D9A7460F2FC6BC68BC6B7D6A /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
@@ -236,7 +236,6 @@
 			);
 			name = "@examples_cc_external//:lib_impl";
 			productName = lib_impl;
-			productReference = 61D4E93D586B426B1BE67C73 /* liblib_impl.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		B2EDA6BA27C01B7B8423DADB /* //examples/cc/lib2:lib_impl */ = {
@@ -252,7 +251,6 @@
 			);
 			name = "//examples/cc/lib2:lib_impl";
 			productName = lib_impl;
-			productReference = 01934C980471E67330AC657C /* liblib_impl.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		BCD9FA95C7CBE2A799AC3DF9 /* //examples/cc/lib:lib_impl */ = {
@@ -268,7 +266,6 @@
 			);
 			name = "//examples/cc/lib:lib_impl";
 			productName = lib_impl;
-			productReference = 8C467A9CF11D6BFFA7FEE894 /* liblib_impl.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		EC6A68AC956C60AA25485960 /* tool */ = {

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "9DF8EA4260F38FC7243F6241"
-               BuildableName = "liblib_impl.a"
+               BuildableName = "lib_impl"
                BlueprintName = "@examples_cc_external//:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B2EDA6BA27C01B7B8423DADB"
-               BuildableName = "liblib_impl.a"
+               BuildableName = "lib_impl"
                BlueprintName = "//examples/cc/lib2:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BCD9FA95C7CBE2A799AC3DF9"
-               BuildableName = "liblib_impl.a"
+               BuildableName = "lib_impl"
                BlueprintName = "//examples/cc/lib:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -105,10 +105,10 @@
 		061F2388C98C7C8A40A50744 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
 		12C3BFE593A8E590FD298519 /* LibSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LibSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CE87466AFFDC6606F8518F8 /* SwiftGreetingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftGreetingsTests.swift; sourceTree = "<group>"; };
-		26385BC3A03088371FF9B69F /* libprivate_lib.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libprivate_lib.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		26385BC3A03088371FF9B69F /* libprivate_lib.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libprivate_lib.a; path = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/libprivate_lib.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A44BF8F252A4102EA584307 /* lib.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = lib.m; sourceTree = "<group>"; };
 		2D85BE28EA2A37C7DEC17BFB /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
-		3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F18976D8538975B332CAC08 /* private_lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = private_lib.c; sourceTree = "<group>"; };
 		537B806ECAA55F19DAFDF318 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		70E39C0BDE73FBB3E0447A9C /* lib_impl.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = lib_impl.swift.modulemap; sourceTree = "<group>"; };
@@ -122,7 +122,7 @@
 		E3938AB43AEB959A432DB9EF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _BazelForcedCompile_.swift; sourceTree = DERIVED_FILE_DIR; };
 		F5B8CDF37038F1DAA6B0A624 /* private_lib.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = private_lib.swift.modulemap; sourceTree = "<group>"; };
-		F93835BAA75A671D6D3361A9 /* liblib_swift.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_swift.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		F93835BAA75A671D6D3361A9 /* liblib_swift.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_swift.a; path = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_swift.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FBCE39FCE2639759A7946083 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -397,7 +397,6 @@
 			);
 			name = lib_swift;
 			productName = lib_swift;
-			productReference = F93835BAA75A671D6D3361A9 /* liblib_swift.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		BC691472A2BC47F8E1D5D637 /* lib_impl */ = {
@@ -413,7 +412,6 @@
 			);
 			name = lib_impl;
 			productName = lib_impl;
-			productReference = 3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		E56E8F91E4327755D5B09E30 /* LibSwiftTests.__internal__.__test_bundle */ = {
@@ -447,7 +445,6 @@
 			);
 			name = private_lib;
 			productName = private_lib;
-			productReference = 26385BC3A03088371FF9B69F /* libprivate_lib.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/lib_impl.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/lib_impl.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "BC691472A2BC47F8E1D5D637"
-                     BuildableName = "liblib_impl.a"
+                     BuildableName = "lib_impl"
                      BlueprintName = "lib_impl"
                      ReferencedContainer = "container:test/fixtures/command_line/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BC691472A2BC47F8E1D5D637"
-               BuildableName = "liblib_impl.a"
+               BuildableName = "lib_impl"
                BlueprintName = "lib_impl"
                ReferencedContainer = "container:test/fixtures/command_line/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/lib_swift.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/lib_swift.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "8E3B6C47A6106921076BC573"
-                     BuildableName = "liblib_swift.a"
+                     BuildableName = "lib_swift"
                      BlueprintName = "lib_swift"
                      ReferencedContainer = "container:test/fixtures/command_line/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8E3B6C47A6106921076BC573"
-               BuildableName = "liblib_swift.a"
+               BuildableName = "lib_swift"
                BlueprintName = "lib_swift"
                ReferencedContainer = "container:test/fixtures/command_line/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/private_lib.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/private_lib.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "EAFF1E96A87B75E6BA080719"
-                     BuildableName = "libprivate_lib.a"
+                     BuildableName = "private_lib"
                      BlueprintName = "private_lib"
                      ReferencedContainer = "container:test/fixtures/command_line/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "EAFF1E96A87B75E6BA080719"
-               BuildableName = "libprivate_lib.a"
+               BuildableName = "private_lib"
                BlueprintName = "private_lib"
                ReferencedContainer = "container:test/fixtures/command_line/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -106,8 +106,8 @@
 		2F2C9A4A2948FD3A6EA210D1 /* private_lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private_lib.h; sourceTree = "<group>"; };
 		4090886057A83A932E74D440 /* private_lib.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = private_lib.swift.modulemap; sourceTree = "<group>"; };
 		5C5C8BE9CB34B10B3D9FF611 /* lib_swift.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = lib_swift.swift.modulemap; sourceTree = "<group>"; };
-		61D4E93D586B426B1BE67C73 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_impl.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		70C5E43F5F81562B9428709C /* liblib_swift.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = liblib_swift.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		61D4E93D586B426B1BE67C73 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0039aacf5cee/bin/examples/command_line/lib/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		70C5E43F5F81562B9428709C /* liblib_swift.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_swift.a; path = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0039aacf5cee/bin/examples/command_line/lib/liblib_swift.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7703BC6D5949A71AA4B20322 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
 		773C663163BCEEE83AFD551F /* lib_impl.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = lib_impl.swift.modulemap; sourceTree = "<group>"; };
 		782EFB0F35839BA9778CEB6A /* private_lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = private_lib.c; sourceTree = "<group>"; };
@@ -117,7 +117,7 @@
 		B45E624D6CB9A25AD05AA3EB /* lib.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = lib.m; sourceTree = "<group>"; };
 		BE5F89CF78F0E7C26F1539FC /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
 		CEA1DFE38FE902756F4C6FF3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		D04DA2A609AD72919E00E6F6 /* libprivate_lib.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libprivate_lib.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		D04DA2A609AD72919E00E6F6 /* libprivate_lib.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libprivate_lib.a; path = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0039aacf5cee/bin/examples/command_line/lib/libprivate_lib.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4E23788130BC4E7FCB9DB99 /* LibSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LibSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F079AF4E09A6C7D7089DE38F /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		F7195ED6E5A6C3B8F36B42A6 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
@@ -382,7 +382,6 @@
 			);
 			name = lib_swift;
 			productName = lib_swift;
-			productReference = 70C5E43F5F81562B9428709C /* liblib_swift.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		8329F08BE01D4CC32B819CE9 /* lib_impl */ = {
@@ -398,7 +397,6 @@
 			);
 			name = lib_impl;
 			productName = lib_impl;
-			productReference = 61D4E93D586B426B1BE67C73 /* liblib_impl.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		BB180DABF9AB371C353A7F0D /* private_lib */ = {
@@ -414,7 +412,6 @@
 			);
 			name = private_lib;
 			productName = private_lib;
-			productReference = D04DA2A609AD72919E00E6F6 /* libprivate_lib.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		EC6A68AC956C60AA25485960 /* tool */ = {

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_impl.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_impl.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8329F08BE01D4CC32B819CE9"
-               BuildableName = "liblib_impl.a"
+               BuildableName = "lib_impl"
                BlueprintName = "lib_impl"
                ReferencedContainer = "container:test/fixtures/command_line/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_swift.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_swift.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "195FCD65F4EB377830E3E996"
-               BuildableName = "liblib_swift.a"
+               BuildableName = "lib_swift"
                BlueprintName = "lib_swift"
                ReferencedContainer = "container:test/fixtures/command_line/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/private_lib.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/private_lib.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BB180DABF9AB371C353A7F0D"
-               BuildableName = "libprivate_lib.a"
+               BuildableName = "private_lib"
                BlueprintName = "private_lib"
                ReferencedContainer = "container:test/fixtures/command_line/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -458,7 +458,7 @@
 		350D61290C1B602B60DA483A /* PBXAggregateTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXAggregateTarget.swift; sourceTree = "<group>"; };
 		35445591FE5C7D2FCEF9533F /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		356817EF2BC65A89F7FB439C /* UserNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotifications.swift; sourceTree = "<group>"; };
-		3BCF6545A3BFB3B32552A669 /* libAEXML.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAEXML.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3BCF6545A3BFB3B32552A669 /* libAEXML.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libAEXML.a; path = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/libAEXML.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C03DA1E6BE6639739CB623F /* OrderedSet+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Hashable.swift"; sourceTree = "<group>"; };
 		3CEA06E5C81DCD25281036C7 /* PBXGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXGroup.swift; sourceTree = "<group>"; };
 		3DBD527BA62C0B5EDF789F71 /* Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sorting.swift; sourceTree = "<group>"; };
@@ -484,8 +484,8 @@
 		58F2246D7AB62C07E1D092E7 /* XCScheme+SerialAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+SerialAction.swift"; sourceTree = "<group>"; };
 		5A0D02295BBDD7113D940406 /* ReferenceGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferenceGenerator.swift; sourceTree = "<group>"; };
 		5E517675E70186E73924EB60 /* XCScheme+TestableReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+TestableReference.swift"; sourceTree = "<group>"; };
-		5E7B2DB807B1509ABDD69E31 /* libXCTestDynamicOverlay.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libXCTestDynamicOverlay.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		5FBDAA5A97ECD9AA378B9305 /* libCustomDump.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCustomDump.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		5E7B2DB807B1509ABDD69E31 /* libXCTestDynamicOverlay.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libXCTestDynamicOverlay.a; path = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5FBDAA5A97ECD9AA378B9305 /* libCustomDump.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libCustomDump.a; path = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6115DA196ED2ABFA8FCB7BD1 /* _HashTable+Bucket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+Bucket.swift"; sourceTree = "<group>"; };
 		6130F9568982104094E3C618 /* Bool+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bool+Extras.swift"; sourceTree = "<group>"; };
 		61681F3C9FD6052FDD18510B /* _HashTable+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+CustomStringConvertible.swift"; sourceTree = "<group>"; };
@@ -530,7 +530,7 @@
 		865D483D2084AABC408B35CD /* Generator+AddTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+AddTargets.swift"; sourceTree = "<group>"; };
 		86D81D32EB64919C01CE7321 /* KeyedDecodingContainer+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Additions.swift"; sourceTree = "<group>"; };
 		87C0073B2B714F5319BE5A11 /* _HashTable+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+Testing.swift"; sourceTree = "<group>"; };
-		87D5D2AB0B152D5CA6FB9ADF /* libgenerator.library.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libgenerator.library.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		87D5D2AB0B152D5CA6FB9ADF /* libgenerator.library.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libgenerator.library.a; path = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/libgenerator.library.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		889B803E192ED98560009C6D /* OrderedSet+Partial SetAlgebra+Basics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial SetAlgebra+Basics.swift"; sourceTree = "<group>"; };
 		8986F9BDAD8DB56D61CBB787 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		8A718E3E604EF56C4193D1A3 /* OrderedDictionary+Elements+SubSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Elements+SubSequence.swift"; sourceTree = "<group>"; };
@@ -556,7 +556,7 @@
 		9E80C203DC9A482C0F657AE7 /* Generator+ProcessTargetMerges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+ProcessTargetMerges.swift"; sourceTree = "<group>"; };
 		9F395A784F145A641B09FC95 /* PBXBatchUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBatchUpdater.swift; sourceTree = "<group>"; };
 		A0C6BD71C5B59C200AE8F91C /* PBXFileReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXFileReference.swift; sourceTree = "<group>"; };
-		A0ED50B45C327F01289522B0 /* libPathKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPathKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A0ED50B45C327F01289522B0 /* libPathKit.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libPathKit.a; path = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/libPathKit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A1B9525BCADA7A75978D1FCC /* CollectionDifference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionDifference.swift; sourceTree = "<group>"; };
 		A20E781CE891F4AB4B0E4C30 /* Dictionary+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extras.swift"; sourceTree = "<group>"; };
 		A39A39D49FD8DA86F447684A /* OrderedSet+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Codable.swift"; sourceTree = "<group>"; };
@@ -599,7 +599,7 @@
 		C5B0A0B7C1D6A4838956E41C /* Path+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+Extensions.swift"; sourceTree = "<group>"; };
 		C680A79739F778E13D555285 /* AnyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyType.swift; sourceTree = "<group>"; };
 		C6E1E2200AB2DCA91F4999CE /* FilePathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePathResolver.swift; sourceTree = "<group>"; };
-		C7281BBDA526D590DB2E6B19 /* libXcodeProj.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libXcodeProj.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		C7281BBDA526D590DB2E6B19 /* libXcodeProj.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libXcodeProj.a; path = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8FF7F282D79BCC8C890152C /* OrderedSet+Partial SetAlgebra+Operations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial SetAlgebra+Operations.swift"; sourceTree = "<group>"; };
 		C9558541CFD5066169CA9773 /* Generator+CreateProducts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateProducts.swift"; sourceTree = "<group>"; };
 		C9B9DF12DB21E355D72FC72A /* OrderedSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedSet.swift; sourceTree = "<group>"; };
@@ -637,7 +637,7 @@
 		F0725D1FE9D931F37B2F6AA3 /* DTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTO.swift; sourceTree = "<group>"; };
 		F0AD1D57FD4037EC5BB72645 /* XCSharedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCSharedData.swift; sourceTree = "<group>"; };
 		F238F3E44302DBE53FF70525 /* Fixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fixtures.swift; sourceTree = "<group>"; };
-		F30BDE4E484ED0AD847BE4C5 /* libOrderedCollections.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOrderedCollections.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		F30BDE4E484ED0AD847BE4C5 /* libOrderedCollections.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libOrderedCollections.a; path = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/libOrderedCollections.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F37821F06B32120001F7E12D /* PBXLegacyTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXLegacyTarget.swift; sourceTree = "<group>"; };
 		F3ABC392655DF64BC82D0F4E /* PBXProductType+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXProductType+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		F4ABCD1903D2A2F3FAE064BC /* WorkspaceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSettings.swift; sourceTree = "<group>"; };
@@ -1301,7 +1301,6 @@
 			);
 			name = OrderedCollections;
 			productName = OrderedCollections;
-			productReference = F30BDE4E484ED0AD847BE4C5 /* libOrderedCollections.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		302F4C6E9EE3F09D4809EF0A /* CustomDump */ = {
@@ -1319,7 +1318,6 @@
 			);
 			name = CustomDump;
 			productName = CustomDump;
-			productReference = 5FBDAA5A97ECD9AA378B9305 /* libCustomDump.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		4A2EC1B2D6969F717CB890DE /* PathKit */ = {
@@ -1336,7 +1334,6 @@
 			);
 			name = PathKit;
 			productName = PathKit;
-			productReference = A0ED50B45C327F01289522B0 /* libPathKit.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		85C876DB90D51CD225023BB2 /* generator */ = {
@@ -1371,7 +1368,6 @@
 			);
 			name = AEXML;
 			productName = AEXML;
-			productReference = 3BCF6545A3BFB3B32552A669 /* libAEXML.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		979D12680661F4B864602CE6 /* tests */ = {
@@ -1407,7 +1403,6 @@
 			);
 			name = XCTestDynamicOverlay;
 			productName = XCTestDynamicOverlay;
-			productReference = 5E7B2DB807B1509ABDD69E31 /* libXCTestDynamicOverlay.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		A09CE18EBBDAC65CD0C6B7D1 /* XcodeProj */ = {
@@ -1426,7 +1421,6 @@
 			);
 			name = XcodeProj;
 			productName = XcodeProj;
-			productReference = C7281BBDA526D590DB2E6B19 /* libXcodeProj.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		F12050E30563A81EEBB2EA9B /* generator.library */ = {
@@ -1446,7 +1440,6 @@
 			);
 			name = generator.library;
 			productName = generator.library;
-			productReference = 87D5D2AB0B152D5CA6FB9ADF /* libgenerator.library.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/AEXML.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/AEXML.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "886150B3C63D0DBEF9BB4E6B"
-                     BuildableName = "libAEXML.a"
+                     BuildableName = "AEXML"
                      BlueprintName = "AEXML"
                      ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "886150B3C63D0DBEF9BB4E6B"
-               BuildableName = "libAEXML.a"
+               BuildableName = "AEXML"
                BlueprintName = "AEXML"
                ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/CustomDump.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/CustomDump.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "302F4C6E9EE3F09D4809EF0A"
-                     BuildableName = "libCustomDump.a"
+                     BuildableName = "CustomDump"
                      BlueprintName = "CustomDump"
                      ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "302F4C6E9EE3F09D4809EF0A"
-               BuildableName = "libCustomDump.a"
+               BuildableName = "CustomDump"
                BlueprintName = "CustomDump"
                ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/OrderedCollections.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/OrderedCollections.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "023B2C041CD79AF5B2FDAFE1"
-                     BuildableName = "libOrderedCollections.a"
+                     BuildableName = "OrderedCollections"
                      BlueprintName = "OrderedCollections"
                      ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "023B2C041CD79AF5B2FDAFE1"
-               BuildableName = "libOrderedCollections.a"
+               BuildableName = "OrderedCollections"
                BlueprintName = "OrderedCollections"
                ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/PathKit.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/PathKit.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "4A2EC1B2D6969F717CB890DE"
-                     BuildableName = "libPathKit.a"
+                     BuildableName = "PathKit"
                      BlueprintName = "PathKit"
                      ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4A2EC1B2D6969F717CB890DE"
-               BuildableName = "libPathKit.a"
+               BuildableName = "PathKit"
                BlueprintName = "PathKit"
                ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/XCTestDynamicOverlay.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/XCTestDynamicOverlay.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "9DF90F35406923EA23C68CFC"
-                     BuildableName = "libXCTestDynamicOverlay.a"
+                     BuildableName = "XCTestDynamicOverlay"
                      BlueprintName = "XCTestDynamicOverlay"
                      ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "9DF90F35406923EA23C68CFC"
-               BuildableName = "libXCTestDynamicOverlay.a"
+               BuildableName = "XCTestDynamicOverlay"
                BlueprintName = "XCTestDynamicOverlay"
                ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/XcodeProj.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/XcodeProj.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "A09CE18EBBDAC65CD0C6B7D1"
-                     BuildableName = "libXcodeProj.a"
+                     BuildableName = "XcodeProj"
                      BlueprintName = "XcodeProj"
                      ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A09CE18EBBDAC65CD0C6B7D1"
-               BuildableName = "libXcodeProj.a"
+               BuildableName = "XcodeProj"
                BlueprintName = "XcodeProj"
                ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.library.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.library.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "F12050E30563A81EEBB2EA9B"
-                     BuildableName = "libgenerator.library.a"
+                     BuildableName = "generator.library"
                      BlueprintName = "generator.library"
                      ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F12050E30563A81EEBB2EA9B"
-               BuildableName = "libgenerator.library.a"
+               BuildableName = "generator.library"
                BlueprintName = "generator.library"
                ReferencedContainer = "container:test/fixtures/generator/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -395,8 +395,8 @@
 /* Begin PBXFileReference section */
 		006BA29C0C61C275AD3E5F44 /* PBXProject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProject.swift; sourceTree = "<group>"; };
 		016123E30A6AE3BE1D9FC323 /* _HashTable+Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+Constants.swift"; sourceTree = "<group>"; };
-		01F7979EAE7C1D8DEAEB8B63 /* libOrderedCollections.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libOrderedCollections.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		026DBBF837F683191890587B /* libAEXML.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libAEXML.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		01F7979EAE7C1D8DEAEB8B63 /* libOrderedCollections.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libOrderedCollections.a; path = "bazel-out/darwin_x86_64-dbg-ST-0376e8cd69e6/bin/external/com_github_apple_swift_collections/libOrderedCollections.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		026DBBF837F683191890587B /* libAEXML.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libAEXML.a; path = "bazel-out/darwin_x86_64-dbg-ST-0376e8cd69e6/bin/external/com_github_tadija_aexml/libAEXML.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		03610C8A88B668CC0E52047B /* CommentedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentedString.swift; sourceTree = "<group>"; };
 		036C24C34D6A40418EF9FF68 /* PopulateMainGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopulateMainGroupTests.swift; sourceTree = "<group>"; };
 		04C10134D4D243B8C7B6C714 /* _HashTable+BucketIterator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+BucketIterator.swift"; sourceTree = "<group>"; };
@@ -457,14 +457,14 @@
 		377079BB67AC44EAAF5625DF /* Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sorting.swift; sourceTree = "<group>"; };
 		39D97BF140AD29497D75D5A2 /* GeneratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratorTests.swift; sourceTree = "<group>"; };
 		3C3B4F8F76D6E7E466DF0BCB /* XCScheme+TestItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+TestItem.swift"; sourceTree = "<group>"; };
-		3C5481AFA2D7E3DECBAFE9CB /* libgenerator.library.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libgenerator.library.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C5481AFA2D7E3DECBAFE9CB /* libgenerator.library.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libgenerator.library.a; path = "bazel-out/darwin_x86_64-dbg-ST-0376e8cd69e6/bin/tools/generator/libgenerator.library.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CC45BC1DD67C50E86FEE9DC /* PBXFileReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXFileReference.swift; sourceTree = "<group>"; };
 		3D850DED77E2FF12781EB199 /* Decoders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoders.swift; sourceTree = "<group>"; };
 		3F3EB849AA377331B54327E0 /* XCScheme+SerialAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+SerialAction.swift"; sourceTree = "<group>"; };
 		4412107ACE8EBEC22DB50106 /* CustomDumpStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDumpStringConvertible.swift; sourceTree = "<group>"; };
-		444D6B248F6FEC2A738BFC6C /* libXCTestDynamicOverlay.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libXCTestDynamicOverlay.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		444D6B248F6FEC2A738BFC6C /* libXCTestDynamicOverlay.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libXCTestDynamicOverlay.a; path = "bazel-out/darwin_x86_64-dbg-ST-0376e8cd69e6/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		449EA625E3DCBAA1CD781318 /* PBXGroup+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXGroup+Extensions.swift"; sourceTree = "<group>"; };
-		469CF9DFF63FD8C4A17E9BBD /* libCustomDump.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCustomDump.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		469CF9DFF63FD8C4A17E9BBD /* libCustomDump.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libCustomDump.a; path = "bazel-out/darwin_x86_64-dbg-ST-0376e8cd69e6/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		46FAB1B8F9AB1BD009B78FA6 /* Generator+CreateXcodeProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateXcodeProj.swift"; sourceTree = "<group>"; };
 		4796B5647870377961BBE65A /* Dump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dump.swift; sourceTree = "<group>"; };
 		485E69699461E1A9CFC892D1 /* XCScheme+ProfileAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+ProfileAction.swift"; sourceTree = "<group>"; };
@@ -551,7 +551,7 @@
 		91CA42EA2FD819A62257BC98 /* XCBreakpointList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCBreakpointList.swift; sourceTree = "<group>"; };
 		91FAEBD49D872651BA24005E /* FilePathResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePathResolver.swift; sourceTree = "<group>"; };
 		92CA9BF8DE4218EEF99B853E /* _UnsafeBitset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _UnsafeBitset.swift; sourceTree = "<group>"; };
-		93EBD264DCB549DA92034585 /* libPathKit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPathKit.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		93EBD264DCB549DA92034585 /* libPathKit.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libPathKit.a; path = "bazel-out/darwin_x86_64-dbg-ST-0376e8cd69e6/bin/external/com_github_kylef_pathkit/libPathKit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		94B1B07B1780ED7297DD889B /* XCScheme+ArchiveAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+ArchiveAction.swift"; sourceTree = "<group>"; };
 		99DAF8494DCC143CFA9CC1DD /* Mirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mirror.swift; sourceTree = "<group>"; };
 		99F1E8A6B15665DC88FDE6F0 /* XCVersionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCVersionGroup.swift; sourceTree = "<group>"; };
@@ -617,7 +617,7 @@
 		DEF08408AA24ED19A83FA6BD /* BuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPhase.swift; sourceTree = "<group>"; };
 		DF412834424270C2378B9C0E /* LinkerInputs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkerInputs.swift; sourceTree = "<group>"; };
 		DF90B3C2D109FB81429CDF63 /* GameKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameKit.swift; sourceTree = "<group>"; };
-		E1495BEC2B30A0F9420D60D9 /* libXcodeProj.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libXcodeProj.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1495BEC2B30A0F9420D60D9 /* libXcodeProj.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libXcodeProj.a; path = "bazel-out/darwin_x86_64-dbg-ST-0376e8cd69e6/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E16B6BF78C679DF554D56E1B /* XCWorkspaceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceData.swift; sourceTree = "<group>"; };
 		E200ED9999C2E4E55C7EC34E /* CreateProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateProjectTests.swift; sourceTree = "<group>"; };
 		E22FB6646E89CD0F8B7C2C39 /* XCScheme+EnvironmentVariable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+EnvironmentVariable.swift"; sourceTree = "<group>"; };
@@ -1292,7 +1292,6 @@
 			);
 			name = XcodeProj;
 			productName = XcodeProj;
-			productReference = E1495BEC2B30A0F9420D60D9 /* libXcodeProj.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		299DA591171C10F8AF73F244 /* PathKit */ = {
@@ -1308,7 +1307,6 @@
 			);
 			name = PathKit;
 			productName = PathKit;
-			productReference = 93EBD264DCB549DA92034585 /* libPathKit.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		2FED647E7A6091DF616D345B /* generator */ = {
@@ -1344,7 +1342,6 @@
 			);
 			name = generator.library;
 			productName = generator.library;
-			productReference = 3C5481AFA2D7E3DECBAFE9CB /* libgenerator.library.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		AFE4D24E5783CFEA55476089 /* AEXML */ = {
@@ -1360,7 +1357,6 @@
 			);
 			name = AEXML;
 			productName = AEXML;
-			productReference = 026DBBF837F683191890587B /* libAEXML.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		B0128CCFCF9E56DA6D808193 /* OrderedCollections */ = {
@@ -1376,7 +1372,6 @@
 			);
 			name = OrderedCollections;
 			productName = OrderedCollections;
-			productReference = 01F7979EAE7C1D8DEAEB8B63 /* libOrderedCollections.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		CE60FB500B781C8126957C5A /* XCTestDynamicOverlay */ = {
@@ -1392,7 +1387,6 @@
 			);
 			name = XCTestDynamicOverlay;
 			productName = XCTestDynamicOverlay;
-			productReference = 444D6B248F6FEC2A738BFC6C /* libXCTestDynamicOverlay.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		CFD3DFAB502EFF52937E5E51 /* CustomDump */ = {
@@ -1409,7 +1403,6 @@
 			);
 			name = CustomDump;
 			productName = CustomDump;
-			productReference = 469CF9DFF63FD8C4A17E9BBD /* libCustomDump.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		F5FCEC7426929BDA7F9F1875 /* tests */ = {

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/AEXML.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/AEXML.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "AFE4D24E5783CFEA55476089"
-               BuildableName = "libAEXML.a"
+               BuildableName = "AEXML"
                BlueprintName = "AEXML"
                ReferencedContainer = "container:test/fixtures/generator/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/CustomDump.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/CustomDump.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CFD3DFAB502EFF52937E5E51"
-               BuildableName = "libCustomDump.a"
+               BuildableName = "CustomDump"
                BlueprintName = "CustomDump"
                ReferencedContainer = "container:test/fixtures/generator/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/OrderedCollections.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/OrderedCollections.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B0128CCFCF9E56DA6D808193"
-               BuildableName = "libOrderedCollections.a"
+               BuildableName = "OrderedCollections"
                BlueprintName = "OrderedCollections"
                ReferencedContainer = "container:test/fixtures/generator/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/PathKit.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/PathKit.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "299DA591171C10F8AF73F244"
-               BuildableName = "libPathKit.a"
+               BuildableName = "PathKit"
                BlueprintName = "PathKit"
                ReferencedContainer = "container:test/fixtures/generator/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/XCTestDynamicOverlay.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/XCTestDynamicOverlay.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "CE60FB500B781C8126957C5A"
-               BuildableName = "libXCTestDynamicOverlay.a"
+               BuildableName = "XCTestDynamicOverlay"
                BlueprintName = "XCTestDynamicOverlay"
                ReferencedContainer = "container:test/fixtures/generator/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/XcodeProj.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/XcodeProj.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "19FA71657765A036575B20D8"
-               BuildableName = "libXcodeProj.a"
+               BuildableName = "XcodeProj"
                BlueprintName = "XcodeProj"
                ReferencedContainer = "container:test/fixtures/generator/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.library.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.library.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "3A4021D8F5FC68CD4FB8B6F1"
-               BuildableName = "libgenerator.library.a"
+               BuildableName = "generator.library"
                BlueprintName = "generator.library"
                ReferencedContainer = "container:test/fixtures/generator/bwx.xcodeproj">
             </BuildableReference>

--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -84,7 +84,9 @@ Product for target "\(id)" not found in `products`
                 name: disambiguatedTarget.name,
                 buildPhases: buildPhases.compactMap { $0 },
                 productName: target.product.name,
-                product: product,
+                // We remove the link on non-launchable products to allow the
+                // correct path to be respected
+                product: target.product.type.isLaunchable ? product: nil,
                 productType: target.product.type
             )
             pbxProj.add(object: pbxTarget)

--- a/tools/generator/src/Generator+CreateProducts.swift
+++ b/tools/generator/src/Generator+CreateProducts.swift
@@ -8,10 +8,35 @@ extension Generator {
     ) -> (Products, PBXGroup) {
         var products = Products()
         for (id, target) in targets {
+            let fileType: String?
+            let name: String?
+            let path: String?
+            if target.product.type.isLaunchable {
+                fileType = target.product.type.fileType
+                name = nil
+                path = target.product.path.path.lastComponent
+            } else {
+                if target.product.type == .staticLibrary {
+                    // This filetype is used to make the icon match what it
+                    // would be if it was associated with a product (which it
+                    // won't be)
+                    fileType = "compiled.mach-o.dylib"
+                } else {
+                    fileType = target.product.type.fileType
+                }
+
+                // We need to fix the path for non-launchable products, since we
+                // override `DEPLOYMENT_LOCATION` and `BUILT_PRODUCTS_DIR`
+                // for them
+                name = target.product.path.path.lastComponent
+                path = "bazel-out/\(target.product.path.path)"
+            }
+
             let product = PBXFileReference(
                 sourceTree: .buildProductsDir,
-                explicitFileType: target.product.type.fileType,
-                path: target.product.path.path.lastComponent,
+                name: name,
+                explicitFileType: fileType,
+                path: path,
                 includeInIndex: false
             )
             pbxProj.add(object: product)

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -764,8 +764,9 @@ a/imported.a
                 filePath: .generated("z/A.a")
             ): PBXFileReference(
                 sourceTree: .buildProductsDir,
-                explicitFileType: PBXProductType.staticLibrary.fileType,
-                path: "A.a",
+                name: "A.a",
+                explicitFileType: "compiled.mach-o.dylib",
+                path: "bazel-out/z/A.a",
                 includeInIndex: false
             ),
             Products.ProductKeys(
@@ -782,8 +783,9 @@ a/imported.a
                 filePath: .generated("a/b.framework")
             ): PBXFileReference(
                 sourceTree: .buildProductsDir,
+                name: "b.framework",
                 explicitFileType: PBXProductType.staticFramework.fileType,
-                path: "b.framework",
+                path: "bazel-out/a/b.framework",
                 includeInIndex: false
             ),
             Products.ProductKeys(
@@ -809,8 +811,9 @@ a/imported.a
                 filePath: .generated("a/c.a")
             ): PBXFileReference(
                 sourceTree: .buildProductsDir,
-                explicitFileType: PBXProductType.staticLibrary.fileType,
-                path: "c.a",
+                name: "c.a",
+                explicitFileType: "compiled.mach-o.dylib",
+                path: "bazel-out/a/c.a",
                 includeInIndex: false
             ),
             Products.ProductKeys(
@@ -827,8 +830,9 @@ a/imported.a
                 filePath: .generated("e1/E.a")
             ): PBXFileReference(
                 sourceTree: .buildProductsDir,
-                explicitFileType: PBXProductType.staticLibrary.fileType,
-                path: "E.a",
+                name: "E.a",
+                explicitFileType: "compiled.mach-o.dylib",
+                path: "bazel-out/e1/E.a",
                 includeInIndex: false
             ),
             Products.ProductKeys(
@@ -836,8 +840,9 @@ a/imported.a
                 filePath: .generated("e2/E.a")
             ): PBXFileReference(
                 sourceTree: .buildProductsDir,
-                explicitFileType: PBXProductType.staticLibrary.fileType,
-                path: "E.a",
+                name: "E.a",
+                explicitFileType: "compiled.mach-o.dylib",
+                path: "bazel-out/e2/E.a",
                 includeInIndex: false
             ),
             Products.ProductKeys(
@@ -845,8 +850,9 @@ a/imported.a
                 filePath: .generated("r1/R1.bundle")
             ): PBXFileReference(
                 sourceTree: .buildProductsDir,
+                name: "R1.bundle",
                 explicitFileType: PBXProductType.bundle.fileType,
-                path: "R1.bundle",
+                path: "bazel-out/r1/R1.bundle",
                 includeInIndex: false
             ),
         ])
@@ -1282,7 +1288,7 @@ done < "$SCRIPT_INPUT_FILE_LIST_0"
                 name: disambiguatedTargets["A 1"]!.name,
                 buildPhases: buildPhases["A 1"] ?? [],
                 productName: "a",
-                product: products.byTarget["A 1"],
+                product: nil,
                 productType: .staticLibrary
             ),
             "A 2": PBXNativeTarget(
@@ -1296,7 +1302,7 @@ done < "$SCRIPT_INPUT_FILE_LIST_0"
                 name: disambiguatedTargets["B 1"]!.name,
                 buildPhases: buildPhases["B 1"] ?? [],
                 productName: "b",
-                product: products.byTarget["B 1"],
+                product: nil,
                 productType: .staticFramework
             ),
             "B 2": PBXNativeTarget(
@@ -1317,7 +1323,7 @@ done < "$SCRIPT_INPUT_FILE_LIST_0"
                 name: disambiguatedTargets["C 1"]!.name,
                 buildPhases: buildPhases["C 1"] ?? [],
                 productName: "c",
-                product: products.byTarget["C 1"],
+                product: nil,
                 productType: .staticLibrary
             ),
             "C 2": PBXNativeTarget(
@@ -1331,21 +1337,21 @@ done < "$SCRIPT_INPUT_FILE_LIST_0"
                 name: disambiguatedTargets["E1"]!.name,
                 buildPhases: buildPhases["E1"] ?? [],
                 productName: "E1",
-                product: products.byTarget["E1"],
+                product: nil,
                 productType: .staticLibrary
             ),
             "E2": PBXNativeTarget(
                 name: disambiguatedTargets["E2"]!.name,
                 buildPhases: buildPhases["E2"] ?? [],
                 productName: "E2",
-                product: products.byTarget["E2"],
+                product: nil,
                 productType: .staticLibrary
             ),
             "R 1": PBXNativeTarget(
                 name: disambiguatedTargets["R 1"]!.name,
                 buildPhases: buildPhases["R 1"] ?? [],
                 productName: "R 1",
-                product: products.byTarget["R 1"],
+                product: nil,
                 productType: .bundle
             ),
         ]


### PR DESCRIPTION
#373 accidentally broke the product references for non-launchable products. This change fixes them by adjusting their path. It also has to unlink them from the targets that create them, otherwise Xcode "helpfully" ignores our explicit paths.

| Before | After |
|-|-|
| <img width="204" src="https://user-images.githubusercontent.com/158658/169052462-a3a0ac97-ead1-46a6-a403-9ba4dc61158c.png"> | <img width="208" src="https://user-images.githubusercontent.com/158658/169052497-837c2386-5988-4eed-b44b-b2ee81706485.png"> |

