### PR TITLE
Stop generating Info.plists when building with Bazel

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1294,7 +1294,6 @@
 					"__TIME__=\"redacted\"",
 					AWESOME,
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -1434,7 +1433,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/CoreUtilsObjC",
 					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",
@@ -1507,7 +1505,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/CoreUtilsObjC",
 					"$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",

--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -479,7 +479,6 @@
 					"__TIME__=\"redacted\"",
 					"EXTERNAL_SECRET_3=\\\"Goodbye\\\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/examples_cc_external/private",
 					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/examples_cc_external/private",
@@ -541,7 +540,6 @@
 					"__TIME__=\"redacted\"",
 					"SECRET_3=\\\"Hello\\\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(PROJECT_DIR)/examples/cc/lib/private",
 					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib/private",
@@ -616,7 +614,6 @@
 					"SECRET_2=\\\"World!\\\"",
 					"EXTERNAL_SECRET_2=\\\"World?\\\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -689,7 +686,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -781,7 +781,6 @@
 					"SECRET_3=\\\"Hello\\\"",
 					"SECRET_2=\\\"World!\\\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -855,7 +854,6 @@
 					"SECRET_3=\\\"Hello\\\"",
 					"SECRET_2=\\\"World!\\\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -917,7 +915,6 @@
 					"SECRET_3=\\\"Hello\\\"",
 					"SECRET_2=\\\"World!\\\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"\"$(PROJECT_DIR)/examples/command_line/lib/dir with space\"",
 					"\"$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/dir with space\"",
@@ -1091,7 +1088,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -2137,7 +2137,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -2206,7 +2205,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -2264,7 +2262,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -2354,7 +2351,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -2411,7 +2407,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -2472,7 +2467,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -2534,7 +2528,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -2590,7 +2583,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",
@@ -2652,7 +2644,6 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-fstack-protector",

--- a/tools/generator/src/BuildMode.swift
+++ b/tools/generator/src/BuildMode.swift
@@ -4,6 +4,13 @@ enum BuildMode: String {
 }
 
 extension BuildMode {
+    var allowsGeneratedInfoPlists: Bool {
+        switch self {
+        case .xcode: return true
+        case .bazel: return false
+        }
+    }
+
     /// `true` if when building with Bazel we use run scripts.
     ///
     /// Building with Bazel via a proxy doesn't use run scripts.

--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -69,6 +69,7 @@ struct Environment {
     let setTargetConfigurations: (
         _ pbxProj: PBXProj,
         _ disambiguatedTargets: [TargetID: DisambiguatedTarget],
+        _ buildMode: BuildMode,
         _ pbxTargets: [TargetID: PBXTarget],
         _ filePathResolver: FilePathResolver
     ) throws -> Void

--- a/tools/generator/src/Generator+SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator+SetTargetConfigurations.swift
@@ -11,6 +11,7 @@ extension Generator {
     static func setTargetConfigurations(
         in pbxProj: PBXProj,
         for disambiguatedTargets: [TargetID: DisambiguatedTarget],
+        buildMode: BuildMode,
         pbxTargets: [TargetID: PBXTarget],
         filePathResolver: FilePathResolver
     ) throws {
@@ -163,8 +164,8 @@ $(CONFIGURATION_BUILD_DIR)
                     infoPlistPath.replaceExtension("xcode.plist")
                 }
                 buildSettings["INFOPLIST_FILE"] = infoPlistPath.string.quoted
-            } else {
-              buildSettings["GENERATE_INFOPLIST_FILE"] = true
+            } else if buildMode.allowsGeneratedInfoPlists {
+                buildSettings["GENERATE_INFOPLIST_FILE"] = true
             }
 
             if let entitlements = target.entitlements {

--- a/tools/generator/src/Generator.swift
+++ b/tools/generator/src/Generator.swift
@@ -130,6 +130,7 @@ Was unable to merge "\(srcTarget.label) \
         try environment.setTargetConfigurations(
             pbxProj,
             disambiguatedTargets,
+            buildMode,
             pbxTargets,
             filePathResolver
         )

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -353,6 +353,7 @@ Was unable to merge "//:Y (a1b2c)" into "//:Z (1a2b3)"
         struct SetTargetConfigurationsCalled: Equatable {
             let pbxProj: PBXProj
             let disambiguatedTargets: [TargetID: DisambiguatedTarget]
+            let buildMode: BuildMode
             let pbxTargets: [TargetID: PBXTarget]
             let filePathResolver: FilePathResolver
         }
@@ -361,12 +362,14 @@ Was unable to merge "//:Y (a1b2c)" into "//:Z (1a2b3)"
         func setTargetConfigurations(
             in pbxProj: PBXProj,
             for disambiguatedTargets: [TargetID: DisambiguatedTarget],
+            buildMode: BuildMode,
             pbxTargets: [TargetID: PBXTarget],
             filePathResolver: FilePathResolver
         ) {
             setTargetConfigurationsCalled.append(.init(
                 pbxProj: pbxProj,
                 disambiguatedTargets: disambiguatedTargets,
+                buildMode: buildMode,
                 pbxTargets: pbxTargets,
                 filePathResolver: filePathResolver
             ))
@@ -376,6 +379,7 @@ Was unable to merge "//:Y (a1b2c)" into "//:Z (1a2b3)"
             SetTargetConfigurationsCalled(
                 pbxProj: pbxProj,
                 disambiguatedTargets: disambiguatedTargets,
+                buildMode: buildMode,
                 pbxTargets: pbxTargets,
                 filePathResolver: filePathResolver
             ),

--- a/tools/generator/test/SetTargetConfigurations.swift
+++ b/tools/generator/test/SetTargetConfigurations.swift
@@ -33,6 +33,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
         try Generator.setTargetConfigurations(
             in: pbxProj,
             for: disambiguatedTargets,
+            buildMode: .xcode,
             pbxTargets: pbxTargets,
             filePathResolver: Self.filePathResolverFixture
         )
@@ -208,6 +209,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
         try Generator.setTargetConfigurations(
             in: pbxProj,
             for: disambiguatedTargets,
+            buildMode: .xcode,
             pbxTargets: pbxTargets,
             filePathResolver: Self.filePathResolverFixture
         )


### PR DESCRIPTION
This reduces rsync churn for targets without Info.plists, like `cc_test` targets.