### PR TITLE
Fix copying of resource bundles

### DIFF
--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 		04B7FF83EC448D16A88FA827 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		0551D3402BBFA018916880AC /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		082E81D1A4883526CA3B52D8 /* ExampleFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExampleFramework.framework; sourceTree = "<group>"; };
-		087B3E45AA9A7430D1BEC9B8 /* ExampleResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = ExampleResources.bundle; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-ede36487cf61/bin/ExampleResources/ExampleResources.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+		087B3E45AA9A7430D1BEC9B8 /* ExampleResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		0AC7E49CD6F2F86EFC4F09E8 /* TestingUtils.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = TestingUtils.swift.modulemap; sourceTree = "<group>"; };
 		0D4BE40B12E61F0EBADF1EF0 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		104ECD97B1C1B9C4DF3F9949 /* ExampleObjcTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleObjcTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -244,7 +244,7 @@
 		44BB25020D8FACC865B72D37 /* Answer.swift.stencil */ = {isa = PBXFileReference; path = Answer.swift.stencil; sourceTree = "<group>"; };
 		4EFD481E747FFE235872FEBE /* nested */ = {isa = PBXFileReference; lastKnownFileType = folder; path = nested; sourceTree = "<group>"; };
 		52D5C019D7FE1B131E3E26FC /* Library.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Library.h; sourceTree = "<group>"; };
-		56019D124B91E38AF4906E11 /* ExternalResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = ExternalResources.bundle; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-ede36487cf61/bin/external/examples_ios_app_external/ExternalResources.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+		56019D124B91E38AF4906E11 /* ExternalResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExternalResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		56CABDA09B231335D1A65F54 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
 		5C2D4A62829A12CF82C8CAFF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		66FD903A85D9EC8C1EBDC3C2 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
@@ -689,6 +689,7 @@
 			);
 			name = ExampleResources;
 			productName = ExampleResources;
+			productReference = 087B3E45AA9A7430D1BEC9B8 /* ExampleResources.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
 		42A7256A505DA3DFEA69C941 /* TestingUtils */ = {
@@ -798,6 +799,7 @@
 			);
 			name = ExternalResources;
 			productName = ExternalResources;
+			productReference = 56019D124B91E38AF4906E11 /* ExternalResources.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
 		A0257519AD63A69C6DF51958 /* CoreUtilsObjC */ = {

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleResources.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleResources.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "225701F2BB3EA192424F07FE"
-               BuildableName = "ExampleResources"
+               BuildableName = "ExampleResources.bundle"
                BlueprintName = "ExampleResources"
                ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
             </BuildableReference>

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExternalResources.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExternalResources.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "9EEE562EF383D06390A55602"
-               BuildableName = "ExternalResources"
+               BuildableName = "ExternalResources.bundle"
                BlueprintName = "ExternalResources"
                ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
             </BuildableReference>

--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -84,9 +84,8 @@ Product for target "\(id)" not found in `products`
                 name: disambiguatedTarget.name,
                 buildPhases: buildPhases.compactMap { $0 },
                 productName: target.product.name,
-                // We remove the link on non-launchable products to allow the
-                // correct path to be respected
-                product: target.product.type.isLaunchable ? product: nil,
+                product: target.product.type.setsAssociatedProduct ?
+                    product : nil,
                 productType: target.product.type
             )
             pbxProj.add(object: pbxTarget)

--- a/tools/generator/src/Generator+CreateProducts.swift
+++ b/tools/generator/src/Generator+CreateProducts.swift
@@ -11,7 +11,7 @@ extension Generator {
             let fileType: String?
             let name: String?
             let path: String?
-            if target.product.type.isLaunchable {
+            if target.product.type.setsAssociatedProduct {
                 fileType = target.product.type.fileType
                 name = nil
                 path = target.product.path.path.lastComponent
@@ -25,9 +25,9 @@ extension Generator {
                     fileType = target.product.type.fileType
                 }
 
-                // We need to fix the path for non-launchable products, since we
-                // override `DEPLOYMENT_LOCATION` and `BUILT_PRODUCTS_DIR`
-                // for them
+                // We need to fix the path for deployment location products,
+                // since we override `DEPLOYMENT_LOCATION` and
+                // `BUILT_PRODUCTS_DIR` for them
                 name = target.product.path.path.lastComponent
                 path = "bazel-out/\(target.product.path.path)"
             }

--- a/tools/generator/src/PBXProductType+Extensions.swift
+++ b/tools/generator/src/PBXProductType+Extensions.swift
@@ -213,6 +213,12 @@ extension PBXProductType {
         }
     }
 
+    var setsAssociatedProduct: Bool {
+        // We remove the association for non-bundle products to allow the
+        // correct path to be shown in the project navigator
+        return isLaunchable || isBundle
+    }
+
     // MARK: Bazel-specific Environment Variable Functions
 
     var bazelLaunchEnvironmentVariables: [XCScheme.EnvironmentVariable]? {

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -783,9 +783,8 @@ a/imported.a
                 filePath: .generated("a/b.framework")
             ): PBXFileReference(
                 sourceTree: .buildProductsDir,
-                name: "b.framework",
                 explicitFileType: PBXProductType.staticFramework.fileType,
-                path: "bazel-out/a/b.framework",
+                path: "b.framework",
                 includeInIndex: false
             ),
             Products.ProductKeys(
@@ -850,9 +849,8 @@ a/imported.a
                 filePath: .generated("r1/R1.bundle")
             ): PBXFileReference(
                 sourceTree: .buildProductsDir,
-                name: "R1.bundle",
                 explicitFileType: PBXProductType.bundle.fileType,
-                path: "bazel-out/r1/R1.bundle",
+                path: "R1.bundle",
                 includeInIndex: false
             ),
         ])
@@ -1304,7 +1302,7 @@ done < "$SCRIPT_INPUT_FILE_LIST_0"
                 name: disambiguatedTargets["B 1"]!.name,
                 buildPhases: buildPhases["B 1"] ?? [],
                 productName: "b",
-                product: nil,
+                product: products.byTarget["B 1"],
                 productType: .staticFramework
             ),
             "B 2": PBXNativeTarget(
@@ -1353,7 +1351,7 @@ done < "$SCRIPT_INPUT_FILE_LIST_0"
                 name: disambiguatedTargets["R 1"]!.name,
                 buildPhases: buildPhases["R 1"] ?? [],
                 productName: "R 1",
-                product: nil,
+                product: products.byTarget["R 1"],
                 productType: .bundle
             ),
         ]


### PR DESCRIPTION
This partially reverts e5ccba4edd16dd13335a8ceaa6457c7648c1173a for bundles. Seems Xcode will use the `BUILT_PRODUCTS_DIR` of the app if this product association isn't setup. We might be able to fix this another way in the future.