### PR TITLE
Convert output `nil` checks to computed properties

### DIFF
--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -466,7 +466,7 @@ extension Outputs {
             return []
         }
 
-        if swift != nil {
+        if hasSwiftOutputs {
             return [.internal(Generator.bazelForcedSwiftCompilePath)]
         }
 
@@ -474,7 +474,7 @@ extension Outputs {
     }
 
     fileprivate var outputPaths: [String] {
-        if swift != nil {
+        if hasSwiftOutputs {
             return [
                 "$(DERIVED_FILE_DIR)/\(Generator.bazelForcedSwiftCompilePath)",
             ]
@@ -488,7 +488,7 @@ extension Outputs {
         productBasename: String,
         filePathResolver: FilePathResolver
     ) throws -> String? {
-        guard product != nil || swift != nil else {
+        guard hasOutputs else {
             return nil
         }
 

--- a/tools/generator/src/Outputs.swift
+++ b/tools/generator/src/Outputs.swift
@@ -34,6 +34,18 @@ struct Outputs: Equatable {
 }
 
 extension Outputs {
+    var hasOutputs: Bool {
+        return hasSwiftOutputs || hasProductOutput
+    }
+
+    var hasProductOutput: Bool {
+        return product != nil
+    }
+
+    var hasSwiftOutputs: Bool {
+        return swift != nil
+    }
+
     mutating func merge(_ other: Outputs) {
         swift = other.swift
     }


### PR DESCRIPTION
This makes the transition to consolidated targets easier, as they won't have access to the actual outputs, but still need to know if there are outputs of certain types.