### PR TITLE
Add `DisambiguatedTargets` wrapper type

### DIFF
--- a/tools/generator/src/Environment.swift
+++ b/tools/generator/src/Environment.swift
@@ -45,7 +45,7 @@ struct Environment {
 
     let disambiguateTargets: (
         _ targets: [TargetID: Target]
-    ) -> [TargetID: DisambiguatedTarget]
+    ) -> DisambiguatedTargets
 
     let addBazelDependenciesTarget: (
         _ pbxProj: PBXProj,
@@ -58,7 +58,7 @@ struct Environment {
 
     let addTargets: (
         _ pbxProj: PBXProj,
-        _ disambiguatedTargets: [TargetID: DisambiguatedTarget],
+        _ disambiguatedTargets: DisambiguatedTargets,
         _ buildMode: BuildMode,
         _ products: Products,
         _ files: [FilePath: File],
@@ -68,14 +68,14 @@ struct Environment {
 
     let setTargetConfigurations: (
         _ pbxProj: PBXProj,
-        _ disambiguatedTargets: [TargetID: DisambiguatedTarget],
+        _ disambiguatedTargets: DisambiguatedTargets,
         _ buildMode: BuildMode,
         _ pbxTargets: [TargetID: PBXTarget],
         _ filePathResolver: FilePathResolver
     ) throws -> Void
 
     let setTargetDependencies: (
-        _ disambiguatedTargets: [TargetID: DisambiguatedTarget],
+        _ disambiguatedTargets: DisambiguatedTargets,
         _ pbxTargets: [TargetID: PBXTarget]
     ) throws -> Void
 

--- a/tools/generator/src/Generator+AddTargets.swift
+++ b/tools/generator/src/Generator+AddTargets.swift
@@ -4,7 +4,7 @@ import XcodeProj
 extension Generator {
     static func addTargets(
         in pbxProj: PBXProj,
-        for disambiguatedTargets: [TargetID: DisambiguatedTarget],
+        for disambiguatedTargets: DisambiguatedTargets,
         buildMode: BuildMode,
         products: Products,
         files: [FilePath: File],
@@ -13,10 +13,10 @@ extension Generator {
     ) throws -> [TargetID: PBXTarget] {
         let pbxProject = pbxProj.rootObject!
 
-        let sortedDisambiguatedTargets = disambiguatedTargets
+        let sortedDisambiguatedTargets = disambiguatedTargets.targets
             .sortedLocalizedStandard(\.value.name)
         var pbxTargets = Dictionary<TargetID, PBXTarget>(
-            minimumCapacity: disambiguatedTargets.count
+            minimumCapacity: sortedDisambiguatedTargets.count
         )
         for (id, disambiguatedTarget) in sortedDisambiguatedTargets {
             let target = disambiguatedTarget.target

--- a/tools/generator/src/Generator+DisambiguateTargets.swift
+++ b/tools/generator/src/Generator+DisambiguateTargets.swift
@@ -14,11 +14,14 @@ struct DisambiguatedTarget: Equatable {
     let target: Target
 }
 
+struct DisambiguatedTargets: Equatable {
+    let targets: [TargetID: DisambiguatedTarget]
+}
+
 extension Generator {
-    /// Returns a mapping of target ids to `DisambiguatedTarget`s.
     static func disambiguateTargets(
         _ targets: [TargetID: Target]
-    ) -> [TargetID: DisambiguatedTarget] {
+    ) -> DisambiguatedTargets {
         // Gather all information needed to distinguish the targets
         var labelsByName: [String: Set<String>] = [:]
         var names: [String: TargetComponents] = [:]
@@ -57,7 +60,9 @@ extension Generator {
             )
         }
 
-        return uniqueValues
+        return DisambiguatedTargets(
+            targets: uniqueValues
+        )
     }
 }
 

--- a/tools/generator/src/Generator+SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator+SetTargetConfigurations.swift
@@ -10,12 +10,12 @@ extension Generator {
     /// settings related to test hosts need to reference other targets.
     static func setTargetConfigurations(
         in pbxProj: PBXProj,
-        for disambiguatedTargets: [TargetID: DisambiguatedTarget],
+        for disambiguatedTargets: DisambiguatedTargets,
         buildMode: BuildMode,
         pbxTargets: [TargetID: PBXTarget],
         filePathResolver: FilePathResolver
     ) throws {
-        for (id, disambiguatedTarget) in disambiguatedTargets {
+        for (id, disambiguatedTarget) in disambiguatedTargets.targets {
             guard let pbxTarget = pbxTargets[id] else {
                 throw PreconditionError(message: """
 Target "\(id)" not found in `pbxTargets`
@@ -286,14 +286,14 @@ $(CONFIGURATION_BUILD_DIR)
 
     private static func handleTestHost(
         for target: Target,
-        disambiguatedTargets: [TargetID: DisambiguatedTarget],
+        disambiguatedTargets: DisambiguatedTargets,
         pbxTargets: [TargetID: PBXTarget],
         attributes: inout [String: Any],
         buildSettings: inout [String: BuildSetting]
     ) throws {
         if let testHostID = target.testHost {
             guard
-                let testHost = disambiguatedTargets[testHostID]?.target
+                let testHost = disambiguatedTargets.targets[testHostID]?.target
             else {
                 throw PreconditionError(message: """
 Test host target with id "\(testHostID)" not found in `disambiguatedTargets`

--- a/tools/generator/src/Generator+SetTargetDependencies.swift
+++ b/tools/generator/src/Generator+SetTargetDependencies.swift
@@ -7,10 +7,10 @@ extension Generator {
     /// This is separate from `addTargets()` to ensure that all
     /// `PBXNativeTarget`s have been created first.
     static func setTargetDependencies(
-        disambiguatedTargets: [TargetID: DisambiguatedTarget],
+        disambiguatedTargets: DisambiguatedTargets,
         pbxTargets: [TargetID: PBXTarget]
     ) throws {
-        for (id, disambiguatedTarget) in disambiguatedTargets {
+        for (id, disambiguatedTarget) in disambiguatedTargets.targets {
             guard let pbxTarget = pbxTargets.nativeTarget(id) else {
                 throw PreconditionError(message: """
 Target "\(id)" not found in `pbxTargets`

--- a/tools/generator/test/DisambiguateTargetsTests.swift
+++ b/tools/generator/test/DisambiguateTargetsTests.swift
@@ -49,11 +49,11 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.name),
+            disambiguatedTargets.targets.mapValues(\.name),
             expectedTargetNames
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.target),
+            disambiguatedTargets.targets.mapValues(\.target),
             targets
         )
     }
@@ -94,11 +94,11 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.name),
+            disambiguatedTargets.targets.mapValues(\.name),
             expectedTargetNames
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.target),
+            disambiguatedTargets.targets.mapValues(\.target),
             targets
         )
     }
@@ -144,11 +144,11 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.name),
+            disambiguatedTargets.targets.mapValues(\.name),
             expectedTargetNames
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.target),
+            disambiguatedTargets.targets.mapValues(\.target),
             targets
         )
     }
@@ -194,11 +194,11 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.name),
+            disambiguatedTargets.targets.mapValues(\.name),
             expectedTargetNames
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.target),
+            disambiguatedTargets.targets.mapValues(\.target),
             targets
         )
     }
@@ -244,11 +244,11 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.name),
+            disambiguatedTargets.targets.mapValues(\.name),
             expectedTargetNames
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.target),
+            disambiguatedTargets.targets.mapValues(\.target),
             targets
         )
     }
@@ -294,11 +294,11 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.name),
+            disambiguatedTargets.targets.mapValues(\.name),
             expectedTargetNames
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.target),
+            disambiguatedTargets.targets.mapValues(\.target),
             targets
         )
     }
@@ -344,11 +344,11 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.name),
+            disambiguatedTargets.targets.mapValues(\.name),
             expectedTargetNames
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.target),
+            disambiguatedTargets.targets.mapValues(\.target),
             targets
         )
     }
@@ -405,11 +405,11 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.name),
+            disambiguatedTargets.targets.mapValues(\.name),
             expectedTargetNames
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.target),
+            disambiguatedTargets.targets.mapValues(\.target),
             targets
         )
     }
@@ -457,11 +457,11 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.name),
+            disambiguatedTargets.targets.mapValues(\.name),
             expectedTargetNames
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.target),
+            disambiguatedTargets.targets.mapValues(\.target),
             targets
         )
     }
@@ -521,11 +521,11 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.name),
+            disambiguatedTargets.targets.mapValues(\.name),
             expectedTargetNames
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.target),
+            disambiguatedTargets.targets.mapValues(\.target),
             targets
         )
     }
@@ -585,11 +585,11 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.name),
+            disambiguatedTargets.targets.mapValues(\.name),
             expectedTargetNames
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.mapValues(\.target),
+            disambiguatedTargets.targets.mapValues(\.target),
             targets
         )
     }

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -215,7 +215,7 @@ enum Fixtures {
 
     static func disambiguatedTargets(
         _ targets: [TargetID: Target]
-    ) -> [TargetID: DisambiguatedTarget] {
+    ) -> DisambiguatedTargets {
         var disambiguatedTargets = Dictionary<TargetID, DisambiguatedTarget>(
             minimumCapacity: targets.count
         )
@@ -225,7 +225,9 @@ enum Fixtures {
                 target: target
             )
         }
-        return disambiguatedTargets
+        return DisambiguatedTargets(
+            targets: disambiguatedTargets
+        )
     }
 
     static func pbxProj() -> PBXProj {
@@ -1104,7 +1106,7 @@ done < "$SCRIPT_INPUT_FILE_LIST_0"
 
     static func pbxTargets(
         in pbxProj: PBXProj,
-        disambiguatedTargets: [TargetID: DisambiguatedTarget],
+        disambiguatedTargets: DisambiguatedTargets,
         files: [FilePath: File],
         products: Products,
         filePathResolver: FilePathResolver,
@@ -1286,70 +1288,70 @@ done < "$SCRIPT_INPUT_FILE_LIST_0"
 
         let pbxNativeTargets: [TargetID: PBXNativeTarget] = [
             "A 1": PBXNativeTarget(
-                name: disambiguatedTargets["A 1"]!.name,
+                name: disambiguatedTargets.targets["A 1"]!.name,
                 buildPhases: buildPhases["A 1"] ?? [],
                 productName: "a",
                 product: nil,
                 productType: .staticLibrary
             ),
             "A 2": PBXNativeTarget(
-                name: disambiguatedTargets["A 2"]!.name,
+                name: disambiguatedTargets.targets["A 2"]!.name,
                 buildPhases: buildPhases["A 2"] ?? [],
                 productName: "A",
                 product: products.byTarget["A 2"],
                 productType: .application
             ),
             "B 1": PBXNativeTarget(
-                name: disambiguatedTargets["B 1"]!.name,
+                name: disambiguatedTargets.targets["B 1"]!.name,
                 buildPhases: buildPhases["B 1"] ?? [],
                 productName: "b",
                 product: products.byTarget["B 1"],
                 productType: .staticFramework
             ),
             "B 2": PBXNativeTarget(
-                name: disambiguatedTargets["B 2"]!.name,
+                name: disambiguatedTargets.targets["B 2"]!.name,
                 buildPhases: buildPhases["B 2"] ?? [],
                 productName: "B",
                 product: products.byTarget["B 2"],
                 productType: .unitTestBundle
             ),
             "B 3": PBXNativeTarget(
-                name: disambiguatedTargets["B 3"]!.name,
+                name: disambiguatedTargets.targets["B 3"]!.name,
                 buildPhases: buildPhases["B 3"] ?? [],
                 productName: "B3",
                 product: products.byTarget["B 3"],
                 productType: .uiTestBundle
             ),
             "C 1": PBXNativeTarget(
-                name: disambiguatedTargets["C 1"]!.name,
+                name: disambiguatedTargets.targets["C 1"]!.name,
                 buildPhases: buildPhases["C 1"] ?? [],
                 productName: "c",
                 product: nil,
                 productType: .staticLibrary
             ),
             "C 2": PBXNativeTarget(
-                name: disambiguatedTargets["C 2"]!.name,
+                name: disambiguatedTargets.targets["C 2"]!.name,
                 buildPhases: buildPhases["C 2"] ?? [],
                 productName: "d",
                 product: products.byTarget["C 2"],
                 productType: .commandLineTool
             ),
             "E1": PBXNativeTarget(
-                name: disambiguatedTargets["E1"]!.name,
+                name: disambiguatedTargets.targets["E1"]!.name,
                 buildPhases: buildPhases["E1"] ?? [],
                 productName: "E1",
                 product: nil,
                 productType: .staticLibrary
             ),
             "E2": PBXNativeTarget(
-                name: disambiguatedTargets["E2"]!.name,
+                name: disambiguatedTargets.targets["E2"]!.name,
                 buildPhases: buildPhases["E2"] ?? [],
                 productName: "E2",
                 product: nil,
                 productType: .staticLibrary
             ),
             "R 1": PBXNativeTarget(
-                name: disambiguatedTargets["R 1"]!.name,
+                name: disambiguatedTargets.targets["R 1"]!.name,
                 buildPhases: buildPhases["R 1"] ?? [],
                 productName: "R 1",
                 product: products.byTarget["R 1"],
@@ -1408,7 +1410,7 @@ done < "$SCRIPT_INPUT_FILE_LIST_0"
     static func pbxTargets(
         in pbxProj: PBXProj,
         targets: [TargetID: Target]
-    ) -> ([TargetID: PBXTarget], [TargetID : DisambiguatedTarget]) {
+    ) -> ([TargetID: PBXTarget], DisambiguatedTargets) {
         let pbxProject = pbxProj.rootObject!
         let mainGroup = pbxProject.mainGroup!
 

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -54,12 +54,14 @@ final class GeneratorTests: XCTestCase {
                 product: .init(type: .application, name: "Z", path: "")
             ),
         ]
-        let disambiguatedTargets: [TargetID: DisambiguatedTarget] = [
-            "A": .init(
-                name: "A (3456a)",
-                target: mergedTargets["Y"]!
-            ),
-        ]
+        let disambiguatedTargets = DisambiguatedTargets(
+            targets: [
+                "A": .init(
+                    name: "A (3456a)",
+                    target: mergedTargets["Y"]!
+                ),
+            ]
+        )
         let (files, filesAndGroups) = Fixtures.files(
             in: pbxProj,
             internalDirectoryName: internalDirectoryName,
@@ -250,7 +252,7 @@ Was unable to merge "//:Y (a1b2c)" into "//:Z (1a2b3)"
         var disambiguateTargetsCalled: [DisambiguateTargetsCalled] = []
         func disambiguateTargets(
             targets: [TargetID: Target]
-        ) -> [TargetID: DisambiguatedTarget] {
+        ) -> DisambiguatedTargets {
             disambiguateTargetsCalled.append(.init(
                 targets: targets
             ))
@@ -308,7 +310,7 @@ Was unable to merge "//:Y (a1b2c)" into "//:Z (1a2b3)"
 
         struct AddTargetsCalled: Equatable {
             let pbxProj: PBXProj
-            let disambiguatedTargets: [TargetID: DisambiguatedTarget]
+            let disambiguatedTargets: DisambiguatedTargets
             let buildMode: BuildMode
             let products: Products
             let files: [FilePath: File]
@@ -319,7 +321,7 @@ Was unable to merge "//:Y (a1b2c)" into "//:Z (1a2b3)"
         var addTargetsCalled: [AddTargetsCalled] = []
         func addTargets(
             in pbxProj: PBXProj,
-            for disambiguatedTargets: [TargetID: DisambiguatedTarget],
+            for disambiguatedTargets: DisambiguatedTargets,
             buildMode: BuildMode,
             products: Products,
             files: [FilePath: File],
@@ -352,7 +354,7 @@ Was unable to merge "//:Y (a1b2c)" into "//:Z (1a2b3)"
 
         struct SetTargetConfigurationsCalled: Equatable {
             let pbxProj: PBXProj
-            let disambiguatedTargets: [TargetID: DisambiguatedTarget]
+            let disambiguatedTargets: DisambiguatedTargets
             let buildMode: BuildMode
             let pbxTargets: [TargetID: PBXTarget]
             let filePathResolver: FilePathResolver
@@ -361,7 +363,7 @@ Was unable to merge "//:Y (a1b2c)" into "//:Z (1a2b3)"
         var setTargetConfigurationsCalled: [SetTargetConfigurationsCalled] = []
         func setTargetConfigurations(
             in pbxProj: PBXProj,
-            for disambiguatedTargets: [TargetID: DisambiguatedTarget],
+            for disambiguatedTargets: DisambiguatedTargets,
             buildMode: BuildMode,
             pbxTargets: [TargetID: PBXTarget],
             filePathResolver: FilePathResolver
@@ -388,13 +390,13 @@ Was unable to merge "//:Y (a1b2c)" into "//:Z (1a2b3)"
         // MARK: setTargetDependencies()
 
         struct SetTargetDependenciesCalled: Equatable {
-            let disambiguatedTargets: [TargetID: DisambiguatedTarget]
+            let disambiguatedTargets: DisambiguatedTargets
             let pbxTargets: [TargetID: PBXTarget]
         }
 
         var setTargetDependenciesCalled: [SetTargetDependenciesCalled] = []
         func setTargetDependencies(
-            disambiguatedTargets: [TargetID: DisambiguatedTarget],
+            disambiguatedTargets: DisambiguatedTargets,
             pbxTargets: [TargetID: PBXTarget]
         ) {
             setTargetDependenciesCalled.append(SetTargetDependenciesCalled(

--- a/tools/generator/test/SetTargetConfigurations.swift
+++ b/tools/generator/test/SetTargetConfigurations.swift
@@ -54,16 +54,16 @@ final class SetTargetConfigurationsTests: XCTestCase {
             expectedLdRunpathSearchPaths: [String]?
         )]
     ) -> (
-        disambiguatedTargets: [TargetID: DisambiguatedTarget],
+        disambiguatedTargets: DisambiguatedTargets,
         pbxTargets: [TargetID: PBXNativeTarget],
         expectedLdRunpathSearchPaths: [TargetID: [String]?]
     ) {
-        var disambiguatedTargets: [TargetID: DisambiguatedTarget] = [:]
+        var targets: [TargetID: DisambiguatedTarget] = [:]
         var pbxTargets: [TargetID: PBXNativeTarget] = [:]
         var ldRunpathSearchPaths: [TargetID: [String]?] = [:]
         for input in inputs {
             let id = TargetID("\(input.os)-\(input.productType)")
-            disambiguatedTargets[id] = DisambiguatedTarget(
+            targets[id] = DisambiguatedTarget(
                 name: id.rawValue,
                 target: Target.mock(
                     platform: .init(
@@ -85,7 +85,9 @@ final class SetTargetConfigurationsTests: XCTestCase {
         }
 
         return (
-            disambiguatedTargets,
+            DisambiguatedTargets(
+                targets: targets
+            ),
             pbxTargets,
             ldRunpathSearchPaths
         )


### PR DESCRIPTION
For now this just has the single `targets` property. Consolidated targets will add more properties to it.