### PR TITLE
Add `BuildSettingConditional`

### DIFF
--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		08BDB7C9B414A51A9260F683 /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F972F9B12146B979CA3E0318 /* PBXProject.swift */; };
 		08FD41A51102F53B418BD3CE /* JSONDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F851023E4F4913D1E369CE /* JSONDecoding.swift */; };
 		096B05250E4C2E55D79A268D /* XCScheme+BuildableReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02819512A69FF33D58EBA61C /* XCScheme+BuildableReference.swift */; };
+		0A22A35B5C2350A27CA5A895 /* BuildSettingConditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08416B4EDA557D797F63BB4F /* BuildSettingConditionalTests.swift */; };
 		0A904F2FB1E7254686796387 /* PBXReferenceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0152B8A419980E27BD7EE5FB /* PBXReferenceProxy.swift */; };
 		0B5033389291A3C98DAB6E41 /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7F0486AC72B3E68F194D01 /* PathKit.swift */; };
 		0BFA0A77F5504DCED931F795 /* FilePathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E1E2200AB2DCA91F4999CE /* FilePathResolver.swift */; };
@@ -241,6 +242,7 @@
 		E03D87E9889E3039B602C0D7 /* OrderedDictionary+CustomDebugStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED0F122B168D474ADA615A76 /* OrderedDictionary+CustomDebugStringConvertible.swift */; };
 		E1C8DD75EBE5491687687657 /* XCScheme+StoreKitConfigurationFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC122F4DE7028197FE1C177 /* XCScheme+StoreKitConfigurationFileReference.swift */; };
 		E2339489F3322934D224B39B /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3504926798E0F993FC929F /* Parser.swift */; };
+		E296F8785FF730A70F61CB6A /* BuildSettingConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5638047BDE3BC92B3CE6C189 /* BuildSettingConditional.swift */; };
 		E34D297ACAC512E3C961FB43 /* XCScheme+TestPlanReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB97F8B9DCAC47C22823253 /* XCScheme+TestPlanReference.swift */; };
 		E573DCC118186C0FAB27ECD3 /* Generator+CreateProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9558541CFD5066169CA9773 /* Generator+CreateProducts.swift */; };
 		E69C15430624375DCD37079E /* Generator+Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE9C68C0607CFD069F19187 /* Generator+Main.swift */; };
@@ -415,6 +417,7 @@
 		05B56CD9E6641A10324B096B /* Generator+WriteXcodeProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+WriteXcodeProj.swift"; sourceTree = "<group>"; };
 		0654DDFDA028387BCAF843F8 /* XCScheme+TestItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+TestItem.swift"; sourceTree = "<group>"; };
 		073FBA88B39294943DB5E5A4 /* XCScheme+LocationScenarioReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+LocationScenarioReference.swift"; sourceTree = "<group>"; };
+		08416B4EDA557D797F63BB4F /* BuildSettingConditionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettingConditionalTests.swift; sourceTree = "<group>"; };
 		0A4D52AC31EC4DFDF84F48FF /* BuildMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildMode.swift; sourceTree = "<group>"; };
 		0B1A9C414C17FC0CB546CCF5 /* XCScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCScheme.swift; sourceTree = "<group>"; };
 		0D06530EE100F0FBF5366BC5 /* PBXRezBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXRezBuildPhase.swift; sourceTree = "<group>"; };
@@ -478,6 +481,7 @@
 		5480C26E62F605559F11D71C /* OrderedDictionary+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Codable.swift"; sourceTree = "<group>"; };
 		55071574526ADBF7683AB165 /* CoreImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreImage.swift; sourceTree = "<group>"; };
 		55C093347C9C5CF3D5426C9A /* OrderedSet+Partial RangeReplaceableCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial RangeReplaceableCollection.swift"; sourceTree = "<group>"; };
+		5638047BDE3BC92B3CE6C189 /* BuildSettingConditional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettingConditional.swift; sourceTree = "<group>"; };
 		57369B9A38B6DCB2216526AE /* Generator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generator.swift; sourceTree = "<group>"; };
 		57B23BC150E3266757707492 /* XCScheme+CommandLineArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+CommandLineArguments.swift"; sourceTree = "<group>"; };
 		57CD85080B3E34F2529D7CB8 /* PBXProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProj.swift; sourceTree = "<group>"; };
@@ -811,6 +815,7 @@
 			children = (
 				0A4D52AC31EC4DFDF84F48FF /* BuildMode.swift */,
 				49925538DB74BB9BE745F17F /* BuildSetting.swift */,
+				5638047BDE3BC92B3CE6C189 /* BuildSettingConditional.swift */,
 				F0725D1FE9D931F37B2F6AA3 /* DTO.swift */,
 				30D832D39987A4A2D6FC32FC /* Environment.swift */,
 				1C7DE6268B49662138FC0C90 /* Errors.swift */,
@@ -1058,6 +1063,7 @@
 			children = (
 				DACBE49740AB347EFAE8EC00 /* AddTargetsTests.swift */,
 				35445591FE5C7D2FCEF9533F /* BUILD */,
+				08416B4EDA557D797F63BB4F /* BuildSettingConditionalTests.swift */,
 				A42EAB1A5AEF651AF8F6F865 /* CreateFilesAndGroupsTests.swift */,
 				A40EB7581064768B08E6C529 /* CreateProductsTest.swift */,
 				6A9607F1AB28FE727DED4651 /* CreateProjectTests.swift */,
@@ -1821,6 +1827,7 @@
 			files = (
 				F9312E0C5F409E17F509CC96 /* _BazelForcedCompile_.swift in Sources */,
 				75B34A42A3528868C8D25993 /* AddTargetsTests.swift in Sources */,
+				0A22A35B5C2350A27CA5A895 /* BuildSettingConditionalTests.swift in Sources */,
 				6BEEFB6F9ABBD9DE61F18D20 /* CreateFilesAndGroupsTests.swift in Sources */,
 				72A3C7DA6BF74DE5F2EFC28C /* CreateProductsTest.swift in Sources */,
 				8D60F9D1D81FEDCE8DDF6B73 /* CreateProjectTests.swift in Sources */,
@@ -1867,6 +1874,7 @@
 				25439613FB7D1BD428EED6A1 /* _BazelForcedCompile_.swift in Sources */,
 				ABD3CC0D018E5D848875B287 /* BuildMode.swift in Sources */,
 				BC91F35AD1E15D616E4CC164 /* BuildSetting.swift in Sources */,
+				E296F8785FF730A70F61CB6A /* BuildSettingConditional.swift in Sources */,
 				7D2E840E973AA9E5F5898CF0 /* DTO.swift in Sources */,
 				E9F48F2CD252695AAFAB1EB0 /* Environment.swift in Sources */,
 				83B8755AB81932C2FE256B16 /* Errors.swift in Sources */,

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -209,6 +209,7 @@
             "inputs": {
                 "srcs": [
                     "tools/generator/test/AddTargetsTests.swift",
+                    "tools/generator/test/BuildSettingConditionalTests.swift",
                     "tools/generator/test/CreateFilesAndGroupsTests.swift",
                     "tools/generator/test/CreateProductsTest.swift",
                     "tools/generator/test/CreateProjectTests.swift",
@@ -472,6 +473,7 @@
                 "srcs": [
                     "tools/generator/src/BuildMode.swift",
                     "tools/generator/src/BuildSetting.swift",
+                    "tools/generator/src/BuildSettingConditional.swift",
                     "tools/generator/src/DTO.swift",
                     "tools/generator/src/Environment.swift",
                     "tools/generator/src/Errors.swift",

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		0ECB525A51FEB74588AAC93B /* Generator+CreateXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E95084ACBED4858D5559E399 /* Generator+CreateXCSchemes.swift */; };
 		114337D1EE92A54BD108429D /* XCScheme+SerialAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3EB849AA377331B54327E0 /* XCScheme+SerialAction.swift */; };
 		1288DA0AB3DA8C0A7757FC13 /* BuildSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D96374AEC70A27090561C1A7 /* BuildSetting.swift */; };
+		130CE1601B9654CC0320CD9C /* BuildSettingConditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E71029096D6AC34B84A74A /* BuildSettingConditionalTests.swift */; };
 		1310313F22DBFF5FDC0124B2 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0917D4CE41302D9DE4C953AE /* Box.swift */; };
 		161DD546A712F07C31E4B557 /* OrderedSet+UnorderedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 112B87FF9C843E171D58BB93 /* OrderedSet+UnorderedView.swift */; };
 		17095A82BB4FE7CDA90E3415 /* Dictionary+Enumerate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C47A5DE4BE5C9A1D3F71691 /* Dictionary+Enumerate.swift */; };
@@ -259,6 +260,7 @@
 		FAB13E3F45AE78F09CE60F4F /* XCScheme+RemoteRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6438679FD6AB31C5C30165ED /* XCScheme+RemoteRunnable.swift */; };
 		FBC1C2F7977EC950A5A8FBFC /* Generator+ProcessTargetMerges.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57109CEAC1C92656CA79300 /* Generator+ProcessTargetMerges.swift */; };
 		FBD6CC5399F54335BAC4AD08 /* XCSwiftPackageProductDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2432A0EDFA23A5A28222A6E /* XCSwiftPackageProductDependency.swift */; };
+		FC8F414E5E27000A18EA2767 /* BuildSettingConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7331459DA932906C5CB4EF4 /* BuildSettingConditional.swift */; };
 		FE0441491AA47513CF076348 /* XCScheme+BuildableReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38B898A6742977CE8C0E174 /* XCScheme+BuildableReference.swift */; };
 		FFBF629A61596A5CC71D8612 /* FilePathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FAEBD49D872651BA24005E /* FilePathResolver.swift */; };
 /* End PBXBuildFile section */
@@ -561,6 +563,7 @@
 		9FF2ABBD0B6B98E3FDA61828 /* Speech.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Speech.swift; sourceTree = "<group>"; };
 		A0F8185DC1A11CB7F0BF8D23 /* PBXHeadersBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXHeadersBuildPhase.swift; sourceTree = "<group>"; };
 		A6C4C6E0602ADE6E5FBAE206 /* PBXAggregateTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXAggregateTarget.swift; sourceTree = "<group>"; };
+		A7331459DA932906C5CB4EF4 /* BuildSettingConditional.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettingConditional.swift; sourceTree = "<group>"; };
 		A736DF0EDF5D152163A2C7AE /* XCRemoteSwiftPackageReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCRemoteSwiftPackageReference.swift; sourceTree = "<group>"; };
 		A84BD9EDF510637C6C2BB269 /* _HashTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _HashTable.swift; sourceTree = "<group>"; };
 		A8C5EDE827922E2C3C04DA62 /* _Hashtable+Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_Hashtable+Header.swift"; sourceTree = "<group>"; };
@@ -637,6 +640,7 @@
 		F10D89FCF7B5FEC2EB96BB01 /* PBXBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildPhase.swift; sourceTree = "<group>"; };
 		F1E252313444698DA3574515 /* OrderedSet+RandomAccessCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+RandomAccessCollection.swift"; sourceTree = "<group>"; };
 		F328B736C7AF330724A15666 /* Generator+CreateFilesAndGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Generator+CreateFilesAndGroups.swift"; sourceTree = "<group>"; };
+		F4E71029096D6AC34B84A74A /* BuildSettingConditionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettingConditionalTests.swift; sourceTree = "<group>"; };
 		F52B40BE9E5A13756AD20F88 /* DTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DTO.swift; sourceTree = "<group>"; };
 		F989E51F5A4A6F6C61A92D70 /* _HashTable+Bucket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+Bucket.swift"; sourceTree = "<group>"; };
 		FA83272F166637CFAFC4C79C /* OrderedDictionary+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Hashable.swift"; sourceTree = "<group>"; };
@@ -781,6 +785,7 @@
 			children = (
 				37060CBDC54D48ADDEEA0274 /* AddTargetsTests.swift */,
 				A8C917E9D54ACB73DF3F6EAA /* BUILD */,
+				F4E71029096D6AC34B84A74A /* BuildSettingConditionalTests.swift */,
 				06589BA8CA823F86E64B2417 /* CreateFilesAndGroupsTests.swift */,
 				798455D7A824BAB585C1E8EB /* CreateProductsTest.swift */,
 				E200ED9999C2E4E55C7EC34E /* CreateProjectTests.swift */,
@@ -1150,6 +1155,7 @@
 			children = (
 				6BA209AD9DAC1037A641D772 /* BuildMode.swift */,
 				D96374AEC70A27090561C1A7 /* BuildSetting.swift */,
+				A7331459DA932906C5CB4EF4 /* BuildSettingConditional.swift */,
 				F52B40BE9E5A13756AD20F88 /* DTO.swift */,
 				CE7C8330C0BB8964775949E8 /* Environment.swift */,
 				1D5358A8116F9302A3808730 /* Errors.swift */,
@@ -1594,6 +1600,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D1FF2A2A272865879D4B94D2 /* AddTargetsTests.swift in Sources */,
+				130CE1601B9654CC0320CD9C /* BuildSettingConditionalTests.swift in Sources */,
 				250DE90578C454256F39C418 /* CreateFilesAndGroupsTests.swift in Sources */,
 				D28AD805F11C60A1A2CEBE5A /* CreateProductsTest.swift in Sources */,
 				0B06F16B6814BDD36D863BDF /* CreateProjectTests.swift in Sources */,
@@ -1646,6 +1653,7 @@
 			files = (
 				C83A047E2CB813C95C6BDC13 /* BuildMode.swift in Sources */,
 				1288DA0AB3DA8C0A7757FC13 /* BuildSetting.swift in Sources */,
+				FC8F414E5E27000A18EA2767 /* BuildSettingConditional.swift in Sources */,
 				735D5210F46BBA12E2A5F882 /* DTO.swift in Sources */,
 				0280FDEBEC56D58315C6B86D /* Environment.swift in Sources */,
 				24C289F49E45CC97DEA82E4D /* Errors.swift in Sources */,

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -204,6 +204,7 @@
             "inputs": {
                 "srcs": [
                     "tools/generator/test/AddTargetsTests.swift",
+                    "tools/generator/test/BuildSettingConditionalTests.swift",
                     "tools/generator/test/CreateFilesAndGroupsTests.swift",
                     "tools/generator/test/CreateProductsTest.swift",
                     "tools/generator/test/CreateProjectTests.swift",
@@ -447,6 +448,7 @@
                 "srcs": [
                     "tools/generator/src/BuildMode.swift",
                     "tools/generator/src/BuildSetting.swift",
+                    "tools/generator/src/BuildSettingConditional.swift",
                     "tools/generator/src/DTO.swift",
                     "tools/generator/src/Environment.swift",
                     "tools/generator/src/Errors.swift",

--- a/tools/generator/src/BuildSettingConditional.swift
+++ b/tools/generator/src/BuildSettingConditional.swift
@@ -1,0 +1,68 @@
+struct BuildSettingConditional: Equatable, Hashable {
+    static let any: Self = .init(platform: nil)
+
+    private let platform: Platform?
+}
+
+extension BuildSettingConditional {
+    init(platform: Platform) {
+        self.platform = platform
+    }
+
+    func conditionalize(_ key: String) -> String {
+        guard let platform = platform else {
+            return key
+        }
+
+        var components = [key]
+        if archConditionalAllowed(on: key) {
+            components.append("[arch=\(platform.arch)]")
+        }
+        if sdkConditionalAllowed(on: key) {
+            components.append("[sdk=\(platform.name)]")
+        }
+        return components.joined()
+    }
+
+    private func archConditionalAllowed(on key: String) -> Bool {
+        return key != "ARCHS"
+    }
+
+    private func sdkConditionalAllowed(on key: String) -> Bool {
+        return key != "SDKROOT"
+    }
+}
+
+extension BuildSettingConditional: Comparable {
+    static func < (
+        lhs: BuildSettingConditional,
+        rhs: BuildSettingConditional
+    ) -> Bool {
+        guard
+            let lhsPlatform = lhs.platform, let rhsPlatform = rhs.platform
+        else {
+            // Sort `.any` first
+            return lhs.platform == nil
+        }
+
+        guard lhsPlatform.environment == rhsPlatform.environment else {
+            // Sort simulator first
+            switch (lhsPlatform.environment, rhsPlatform.environment) {
+            case ("Simulator", _): return true
+            case (_, "Simulator"): return false
+            case (nil, _), ("Device", _): return true
+            case (_, nil), (_, "Device"): return false
+            default: return false
+            }
+        }
+
+        // Sort Apple Silicon first
+        return lhsPlatform.arch == "arm64"
+    }
+}
+
+extension Target {
+    var buildSettingConditional: BuildSettingConditional {
+        return BuildSettingConditional(platform: platform)
+    }
+}

--- a/tools/generator/src/DTO.swift
+++ b/tools/generator/src/DTO.swift
@@ -41,7 +41,7 @@ struct Product: Equatable, Decodable {
     let path: FilePath
 }
 
-struct Platform: Equatable, Decodable {
+struct Platform: Equatable, Hashable, Decodable {
     enum OS: String, Decodable {
         case macOS = "macos"
         case iOS = "ios"

--- a/tools/generator/test/BuildSettingConditionalTests.swift
+++ b/tools/generator/test/BuildSettingConditionalTests.swift
@@ -1,0 +1,129 @@
+import CustomDump
+import XCTest
+
+@testable import generator
+
+final class BuildSettingConditionalTests: XCTestCase {
+    static let conditionals: [String: BuildSettingConditional] = [
+        "A": .init(platform: .init(
+            name: "A",
+            os: .iOS,
+            arch: "arm64",
+            minimumOsVersion: "11.0",
+            environment: "Simulator"
+        )),
+        "B": .init(platform: .init(
+            name: "B",
+            os: .iOS,
+            arch: "x86_64",
+            minimumOsVersion: "11.0",
+            environment: "Simulator"
+        )),
+        "C": .init(platform: .init(
+            name: "C",
+            os: .iOS,
+            arch: "arm64",
+            minimumOsVersion: "11.0",
+            environment: nil
+        )),
+        "any": .any,
+    ]
+
+    func test_comparable() {
+        // Arrange
+
+        let conditionals = Self.conditionals
+        let expectedSortedConditionals = [
+            conditionals["any"]!,
+            conditionals["A"]!,
+            conditionals["B"]!,
+            conditionals["C"]!,
+        ]
+
+        // Act
+
+        let sortedConditionals = conditionals.values.sorted()
+
+        // Assert
+
+        XCTAssertNoDifference(sortedConditionals, expectedSortedConditionals)
+    }
+
+    func test_conditionalize_normal() {
+        // Arrange
+
+        let buildSettingKey = "SOME_SETTING"
+        let conditionals = Self.conditionals
+        let expectedConditionalizedKeys = [
+            "SOME_SETTING",
+            "SOME_SETTING[arch=arm64][sdk=A]",
+            "SOME_SETTING[arch=x86_64][sdk=B]",
+            "SOME_SETTING[arch=arm64][sdk=C]",
+        ]
+
+        // Act
+
+        let conditionalizedKeys = [
+            conditionals["any"]!.conditionalize(buildSettingKey),
+            conditionals["A"]!.conditionalize(buildSettingKey),
+            conditionals["B"]!.conditionalize(buildSettingKey),
+            conditionals["C"]!.conditionalize(buildSettingKey),
+        ]
+
+        // Assert
+
+        XCTAssertNoDifference(conditionalizedKeys, expectedConditionalizedKeys)
+    }
+
+    func test_conditionalize_archs() {
+        // Arrange
+
+        let buildSettingKey = "ARCHS"
+        let conditionals = Self.conditionals
+        let expectedConditionalizedKeys = [
+            "ARCHS",
+            "ARCHS[sdk=A]",
+            "ARCHS[sdk=B]",
+            "ARCHS[sdk=C]",
+        ]
+
+        // Act
+
+        let conditionalizedKeys = [
+            conditionals["any"]!.conditionalize(buildSettingKey),
+            conditionals["A"]!.conditionalize(buildSettingKey),
+            conditionals["B"]!.conditionalize(buildSettingKey),
+            conditionals["C"]!.conditionalize(buildSettingKey),
+        ]
+
+        // Assert
+
+        XCTAssertNoDifference(conditionalizedKeys, expectedConditionalizedKeys)
+    }
+
+    func test_conditionalize_sdkroot() {
+        // Arrange
+
+        let buildSettingKey = "SDKROOT"
+        let conditionals = Self.conditionals
+        let expectedConditionalizedKeys = [
+            "SDKROOT",
+            "SDKROOT[arch=arm64]",
+            "SDKROOT[arch=x86_64]",
+            "SDKROOT[arch=arm64]",
+        ]
+
+        // Act
+
+        let conditionalizedKeys = [
+            conditionals["any"]!.conditionalize(buildSettingKey),
+            conditionals["A"]!.conditionalize(buildSettingKey),
+            conditionals["B"]!.conditionalize(buildSettingKey),
+            conditionals["C"]!.conditionalize(buildSettingKey),
+        ]
+
+        // Assert
+
+        XCTAssertNoDifference(conditionalizedKeys, expectedConditionalizedKeys)
+    }
+}


### PR DESCRIPTION
`BuildSettingConditional` will be used by consolidated targets, along with `BuildSetting`s, to specify per-configuration build settings.