### PR TITLE
Fix `BuildSettingConditional` comparisons against itself

### DIFF
--- a/tools/generator/src/BuildSettingConditional.swift
+++ b/tools/generator/src/BuildSettingConditional.swift
@@ -42,7 +42,7 @@ extension BuildSettingConditional: Comparable {
             let lhsPlatform = lhs.platform, let rhsPlatform = rhs.platform
         else {
             // Sort `.any` first
-            return lhs.platform == nil
+            return lhs.platform == nil && rhs.platform != nil
         }
 
         guard lhsPlatform.environment == rhsPlatform.environment else {
@@ -57,7 +57,7 @@ extension BuildSettingConditional: Comparable {
         }
 
         // Sort Apple Silicon first
-        return lhsPlatform.arch == "arm64"
+        return lhsPlatform.arch == "arm64" && rhsPlatform.arch != "arm64"
     }
 }
 

--- a/tools/generator/test/BuildSettingConditionalTests.swift
+++ b/tools/generator/test/BuildSettingConditionalTests.swift
@@ -29,7 +29,24 @@ final class BuildSettingConditionalTests: XCTestCase {
         "any": .any,
     ]
 
-    func test_comparable() {
+    func test_comparable() throws {
+        // Arrange
+
+        let conditionalA = try XCTUnwrap(Self.conditionals["A"])
+        let conditionalAny = BuildSettingConditional.any
+
+        // Assert
+
+        XCTAssertFalse(conditionalA < conditionalA)
+        XCTAssertEqual(conditionalA, conditionalA)
+        XCTAssertFalse(conditionalA > conditionalA)
+
+        XCTAssertFalse(conditionalAny < conditionalAny)
+        XCTAssertEqual(conditionalAny, conditionalAny)
+        XCTAssertFalse(conditionalAny > conditionalAny)
+    }
+
+    func test_sort() {
         // Arrange
 
         let conditionals = Self.conditionals

--- a/tools/generator/test/BuildSettingConditionalTests.swift
+++ b/tools/generator/test/BuildSettingConditionalTests.swift
@@ -29,10 +29,10 @@ final class BuildSettingConditionalTests: XCTestCase {
         "any": .any,
     ]
 
-    func test_comparable() throws {
+    func test_comparable() {
         // Arrange
 
-        let conditionalA = try XCTUnwrap(Self.conditionals["A"])
+        let conditionalA = Self.conditionals["A"]!
         let conditionalAny = BuildSettingConditional.any
 
         // Assert


### PR DESCRIPTION
So that a conditional isn't both equal and less than itself at the same time.

I'm not sure if this would ever manifest itself in a real way, but it violates the `Comparable` contract.