### PR TITLE
Reorder build setting conditionals

### DIFF
--- a/tools/generator/src/BuildSettingConditional.swift
+++ b/tools/generator/src/BuildSettingConditional.swift
@@ -14,12 +14,13 @@ extension BuildSettingConditional {
             return key
         }
 
+        // The order here is the order that Xcode likes them (sdk before arch)
         var components = [key]
-        if archConditionalAllowed(on: key) {
-            components.append("[arch=\(platform.arch)]")
-        }
         if sdkConditionalAllowed(on: key) {
             components.append("[sdk=\(platform.name)]")
+        }
+        if archConditionalAllowed(on: key) {
+            components.append("[arch=\(platform.arch)]")
         }
         return components.joined()
     }

--- a/tools/generator/test/BuildSettingConditionalTests.swift
+++ b/tools/generator/test/BuildSettingConditionalTests.swift
@@ -73,9 +73,9 @@ final class BuildSettingConditionalTests: XCTestCase {
         let conditionals = Self.conditionals
         let expectedConditionalizedKeys = [
             "SOME_SETTING",
-            "SOME_SETTING[arch=arm64][sdk=A]",
-            "SOME_SETTING[arch=x86_64][sdk=B]",
-            "SOME_SETTING[arch=arm64][sdk=C]",
+            "SOME_SETTING[sdk=A][arch=arm64]",
+            "SOME_SETTING[sdk=B][arch=x86_64]",
+            "SOME_SETTING[sdk=C][arch=arm64]",
         ]
 
         // Act


### PR DESCRIPTION
Xcode prefers `sdk` before `arch`.