### PR TITLE
Sort `nil` version of device `environment` lower

### DIFF
--- a/tools/generator/src/BuildSettingConditional.swift
+++ b/tools/generator/src/BuildSettingConditional.swift
@@ -51,8 +51,10 @@ extension BuildSettingConditional: Comparable {
             switch (lhsPlatform.environment, rhsPlatform.environment) {
             case ("Simulator", _): return true
             case (_, "Simulator"): return false
-            case (nil, _), ("Device", _): return true
-            case (_, nil), (_, "Device"): return false
+            case (nil, _): return true
+            case (_, nil): return false
+            case ("Device", _): return true
+            case (_, "Device"): return false
             default: return false
             }
         }


### PR DESCRIPTION
Similar to #476.

Longer term `environment` will be removed in favor of using `Platform.name`.