### PR TITLE
Disambiguate targets less

### DIFF
--- a/tools/generator/test/DisambiguateTargetsTests.swift
+++ b/tools/generator/test/DisambiguateTargetsTests.swift
@@ -112,7 +112,7 @@ final class DisambiguateTargetsTests: XCTestCase {
                 product: .init(type: .application, name: "A", path: "")
             ),
             "A 2": Target.mock(
-                platform: .device(os: .watchOS),
+                platform: .simulator(os: .watchOS),
                 product: .init(type: .watch2App, name: "A", path: "")
             ),
             "B": Target.mock(
@@ -184,11 +184,11 @@ final class DisambiguateTargetsTests: XCTestCase {
 
         let targets: [TargetID: Target] = [
             "A 1": Target.mock(
-                platform: .device(minimumOsVersion: "15.1"),
+                platform: .device(arch: "arm64", minimumOsVersion: "15.1"),
                 product: .init(type: .staticLibrary, name: "A", path: "")
             ),
             "A 2": Target.mock(
-                platform: .device(minimumOsVersion: "13.2"),
+                platform: .simulator(arch: "x86_64", minimumOsVersion: "13.2"),
                 product: .init(type: .staticLibrary, name: "A", path: "")
             ),
             "B": Target.mock(
@@ -222,11 +222,11 @@ final class DisambiguateTargetsTests: XCTestCase {
 
         let targets: [TargetID: Target] = [
             "A 1": Target.mock(
-                platform: .device(),
+                platform: .device(arch: "arm64"),
                 product: .init(type: .staticLibrary, name: "A", path: "")
             ),
             "A 2": Target.mock(
-                platform: .simulator(),
+                platform: .simulator(arch: "x86_64"),
                 product: .init(type: .staticLibrary, name: "A", path: "")
             ),
             "B": Target.mock(


### PR DESCRIPTION
Fixes #450.

Before this change we would add more to target names than needed, in particular we would add architecture when environment was enough, or add environment when minimum OS version was enough.