### PR TITLE
Use a generated file in the multiplatform example

### DIFF
--- a/examples/multiplatform/Lib/BUILD
+++ b/examples/multiplatform/Lib/BUILD
@@ -2,8 +2,14 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 
 swift_library(
     name = "Lib",
-    srcs = ["Lib.swift"],
+    srcs = [":gen_Lib.swift"],
     module_name = "Lib",
     tags = ["manual"],
     visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "gen_Lib.swift",
+    outs = ["Lib.swift"],
+    cmd = "echo 'public let greeting = \"Hello, world!\"' > $@",
 )

--- a/examples/multiplatform/Lib/Lib.swift
+++ b/examples/multiplatform/Lib/Lib.swift
@@ -1,1 +1,0 @@
-public let greeting = "Hello, world!"

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -24,25 +24,25 @@
 
 /* Begin PBXBuildFile section */
 		0425CCFCCD1FE1ECEDCA1226 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4FED84E16539192393AF06C /* ContentView.swift */; };
+		2652E46187D68BA7FC5F329A /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AACB22E5F4B160E9CD14629 /* Lib.swift */; };
+		320AB8BDC1C33D102825BB35 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B1C1315331D8C35661567C /* Lib.swift */; };
+		3A8A4BCF92C278F74487AE52 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1792082FAECED2C023297BF2 /* Lib.swift */; };
 		4026DA28A4B2DCB480467C8F /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		41731BDC24BE872323FEA0E3 /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 416D7556BFEC26938A62BA77 /* iOSApp.swift */; };
 		4E214A0EB55985D3ED1C80F2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 451AB65F903A79F644C34E4F /* ContentView.swift */; };
 		6360FF396B49E1B6632C1FD0 /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		665F77C9222300A8F41DACC7 /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		6C89B018AC1296F321FE0E77 /* tvOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E89AED11EAA442900F8C9C96 /* tvOSApp.swift */; };
-		7995F69C6E3B1969CD0D93EA /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = D741EA60B6740EC2A6839B53 /* Lib.swift */; };
+		6D2F1ADF4920720C18D5A33B /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5818C3CCD50CE380C7447BA5 /* Lib.swift */; };
 		7BD877C49FD76A8E2622EA3D /* watchOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC3BD6C219E6E5167618EBD9 /* watchOSApp.swift */; };
 		8595E830B7AC432730FD9BD6 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0561945EBB23E334B7EC83E3 /* main.swift */; };
 		A6269C02FE150BA5AF5127C6 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C7184778C265E6AF5491B6 /* ContentView.swift */; };
-		AEEDCEB1251F840959F4E34B /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = D741EA60B6740EC2A6839B53 /* Lib.swift */; };
 		B4D41F7E0C65354F7E1086CB /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		C0410183B2A47BD134098700 /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		C3F80F355B01BEA0D54145EC /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		C5602D0F0E22F02A64BBFA35 /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		D11B89AB1C17492A09D6941B /* CompileStub.m in Sources */ = {isa = PBXBuildFile; fileRef = E06CA54BB3677E9BBC8A5D94 /* CompileStub.m */; };
 		E0E96DF94A3CD3E134AE28B4 /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
-		EB9DAEA91D1FA5AE722332B0 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = D741EA60B6740EC2A6839B53 /* Lib.swift */; };
-		EF3B3CAA453EFEABDEBA2FC7 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = D741EA60B6740EC2A6839B53 /* Lib.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -142,7 +142,9 @@
 /* Begin PBXFileReference section */
 		0451EEEFF755708B88527A18 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		0561945EBB23E334B7EC83E3 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		0AACB22E5F4B160E9CD14629 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		10EEE6AAC5A4958188DD58C4 /* Version.bundle_version */ = {isa = PBXFileReference; path = Version.bundle_version; sourceTree = "<group>"; };
+		1792082FAECED2C023297BF2 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		17C68CB3AB068C4D32CB53C7 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		1B5A0430B943510A260B7A6F /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		24AED6734D2F89E7339E6F86 /* libLib.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libLib.a; path = "bazel-out/watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/Lib/libLib.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -155,6 +157,8 @@
 		451AB65F903A79F644C34E4F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		4C12EC5DEC4D43C5D3C98EC9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5145CBFF79C7C7D6179B1D1E /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		53B1C1315331D8C35661567C /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
+		5818C3CCD50CE380C7447BA5 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		5C92EF372D6603E10056CDAD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		615FEA1D812BBDBB28015D2D /* watchOSAppExtension_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = watchOSAppExtension_entitlements.entitlements; sourceTree = "<group>"; };
 		72D28C7591B96DD2BC258BD9 /* watchOSApp.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = watchOSApp.zip; sourceTree = "<group>"; };
@@ -178,7 +182,6 @@
 		C7C481AFC425258DCEC6C6A7 /* watchOSAppExtension.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = watchOSAppExtension.zip; sourceTree = "<group>"; };
 		C9839B245FE2AD82F977E567 /* iOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC49DD52D15916B4DF023F15 /* watchOSApp_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = watchOSApp_entitlements.entitlements; sourceTree = "<group>"; };
-		D741EA60B6740EC2A6839B53 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		D7CC5CE744AFD0A5E15D6AEC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		DCAD2E3EA0F9B2B9A58A4F90 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		DDD8B97AA93AE8B902A67A36 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -192,6 +195,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
+		120A103C123A2167EB3E5F50 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				977C281B58F1A186FC84C044 /* multiplatform */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
 		190FF03214F9D91799A28F00 /* PreviewContent */ = {
 			isa = PBXGroup;
 			children = (
@@ -208,6 +219,14 @@
 			path = bin;
 			sourceTree = "<group>";
 		};
+		1CBB95DBE8A44BC1D878A3AE /* macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630 */ = {
+			isa = PBXGroup;
+			children = (
+				99E5BF86007DDB7C651C326E /* bin */,
+			);
+			path = "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630";
+			sourceTree = "<group>";
+		};
 		209B2AF2B7E96EB186A020E3 /* tvOSApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -215,6 +234,22 @@
 				E41EB23E721678713E15D38B /* tvOSApp_entitlements.entitlements */,
 			);
 			path = tvOSApp;
+			sourceTree = "<group>";
+		};
+		29DDE6B1C8501F08A8205DC0 /* multiplatform */ = {
+			isa = PBXGroup;
+			children = (
+				456AFDBDB5170C6ED7FB8887 /* Lib */,
+			);
+			path = multiplatform;
+			sourceTree = "<group>";
+		};
+		2AC8284F9EEF6854CC6B8340 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				29DDE6B1C8501F08A8205DC0 /* multiplatform */,
+			);
+			path = examples;
 			sourceTree = "<group>";
 		};
 		35D4F17CD70FAF103EF9DE84 /* multiplatform */ = {
@@ -225,12 +260,44 @@
 			path = multiplatform;
 			sourceTree = "<group>";
 		};
+		38416F9883EB8704E051838C /* watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-73754738665f */ = {
+			isa = PBXGroup;
+			children = (
+				4E2852E71E1500F567EB3BF2 /* bin */,
+			);
+			path = "watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-73754738665f";
+			sourceTree = "<group>";
+		};
+		3C0C5393F3DF621FC82C3C12 /* Lib */ = {
+			isa = PBXGroup;
+			children = (
+				5818C3CCD50CE380C7447BA5 /* Lib.swift */,
+			);
+			path = Lib;
+			sourceTree = "<group>";
+		};
+		3EA17334B52CF1D5CD9C0ABA /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				120A103C123A2167EB3E5F50 /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
 		4148203960324E164944EDF7 /* examples */ = {
 			isa = PBXGroup;
 			children = (
 				35D4F17CD70FAF103EF9DE84 /* multiplatform */,
 			);
 			path = examples;
+			sourceTree = "<group>";
+		};
+		456AFDBDB5170C6ED7FB8887 /* Lib */ = {
+			isa = PBXGroup;
+			children = (
+				53B1C1315331D8C35661567C /* Lib.swift */,
+			);
+			path = Lib;
 			sourceTree = "<group>";
 		};
 		4934D5F188D09581B2BD5F17 /* watchOSApp-intermediates */ = {
@@ -262,6 +329,14 @@
 			path = multiplatform;
 			sourceTree = "<group>";
 		};
+		4E2852E71E1500F567EB3BF2 /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				7F9196E183B68811F4C1578B /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
 		593E7C82FAAD94A7E6A04318 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -278,13 +353,36 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		5BA196589518BE4DDC5B941D /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				6A486C454E80F1FABC295491 /* multiplatform */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		5BCC3684B05CECA893D10436 /* ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-000eec03138d */ = {
+			isa = PBXGroup;
+			children = (
+				640C13D42BAEFAEF62A7E18B /* bin */,
+			);
+			path = "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-000eec03138d";
+			sourceTree = "<group>";
+		};
 		6343005A4B9B57A35AB9894A /* Lib */ = {
 			isa = PBXGroup;
 			children = (
 				5145CBFF79C7C7D6179B1D1E /* BUILD */,
-				D741EA60B6740EC2A6839B53 /* Lib.swift */,
 			);
 			path = Lib;
+			sourceTree = "<group>";
+		};
+		640C13D42BAEFAEF62A7E18B /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				2AC8284F9EEF6854CC6B8340 /* examples */,
+			);
+			path = bin;
 			sourceTree = "<group>";
 		};
 		6810A7AAD6E619127B25CF6E /* watchOSAppExtension */ = {
@@ -298,6 +396,22 @@
 				AC3BD6C219E6E5167618EBD9 /* watchOSApp.swift */,
 			);
 			path = watchOSAppExtension;
+			sourceTree = "<group>";
+		};
+		6A486C454E80F1FABC295491 /* multiplatform */ = {
+			isa = PBXGroup;
+			children = (
+				B14A5D822990CA14DF473F44 /* Lib */,
+			);
+			path = multiplatform;
+			sourceTree = "<group>";
+		};
+		6ABC583BFC86BA995C37102F /* Lib */ = {
+			isa = PBXGroup;
+			children = (
+				1792082FAECED2C023297BF2 /* Lib.swift */,
+			);
+			path = Lib;
 			sourceTree = "<group>";
 		};
 		6FF0FDB0EB6579AA368363F0 /* tvOSApp-intermediates */ = {
@@ -314,6 +428,14 @@
 				4148203960324E164944EDF7 /* examples */,
 			);
 			path = bin;
+			sourceTree = "<group>";
+		};
+		7F9196E183B68811F4C1578B /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				AA527D86C160EC09AFC89C50 /* multiplatform */,
+			);
+			path = examples;
 			sourceTree = "<group>";
 		};
 		80F36E6204D1D2E79A12FE4C /* examples */ = {
@@ -340,6 +462,14 @@
 			path = examples;
 			sourceTree = "<group>";
 		};
+		8F445BD1493D45E500234749 /* tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1 */ = {
+			isa = PBXGroup;
+			children = (
+				3EA17334B52CF1D5CD9C0ABA /* bin */,
+			);
+			path = "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1";
+			sourceTree = "<group>";
+		};
 		95E28990BA88EA9EBB6C4A19 /* iOSApp-intermediates */ = {
 			isa = PBXGroup;
 			children = (
@@ -358,6 +488,14 @@
 			path = watchOSAppExtension;
 			sourceTree = "<group>";
 		};
+		977C281B58F1A186FC84C044 /* multiplatform */ = {
+			isa = PBXGroup;
+			children = (
+				6ABC583BFC86BA995C37102F /* Lib */,
+			);
+			path = multiplatform;
+			sourceTree = "<group>";
+		};
 		985410D8C298A478783BA59B /* tvOSApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -369,6 +507,14 @@
 				E89AED11EAA442900F8C9C96 /* tvOSApp.swift */,
 			);
 			path = tvOSApp;
+			sourceTree = "<group>";
+		};
+		99E5BF86007DDB7C651C326E /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				5BA196589518BE4DDC5B941D /* examples */,
+			);
+			path = bin;
 			sourceTree = "<group>";
 		};
 		A081680974BED6648B333384 /* PreviewContent */ = {
@@ -399,12 +545,28 @@
 			path = watchOSApp;
 			sourceTree = "<group>";
 		};
+		AA527D86C160EC09AFC89C50 /* multiplatform */ = {
+			isa = PBXGroup;
+			children = (
+				3C0C5393F3DF621FC82C3C12 /* Lib */,
+			);
+			path = multiplatform;
+			sourceTree = "<group>";
+		};
 		AFD9956070B6C3233A61BC8B /* PreviewContent */ = {
 			isa = PBXGroup;
 			children = (
 				8EC039E4ABE4875858ECD261 /* Preview Assets.xcassets */,
 			);
 			path = PreviewContent;
+			sourceTree = "<group>";
+		};
+		B14A5D822990CA14DF473F44 /* Lib */ = {
+			isa = PBXGroup;
+			children = (
+				0AACB22E5F4B160E9CD14629 /* Lib.swift */,
+			);
+			path = Lib;
 			sourceTree = "<group>";
 		};
 		BB34C210E2A56E7B96B81F9A /* examples */ = {
@@ -446,6 +608,10 @@
 				C7282780C9069476B161DAA7 /* applebin_ios-ios_x86_64-dbg-ST-000eec03138d */,
 				F6CC21B8B4DF5357F4D31247 /* applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1 */,
 				C331E9909F4C8C0F672463DF /* applebin_watchos-watchos_i386-dbg-ST-73754738665f */,
+				5BCC3684B05CECA893D10436 /* ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-000eec03138d */,
+				1CBB95DBE8A44BC1D878A3AE /* macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630 */,
+				8F445BD1493D45E500234749 /* tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1 */,
+				38416F9883EB8704E051838C /* watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-73754738665f */,
 			);
 			name = "Bazel Generated Files";
 			path = test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir;
@@ -993,7 +1159,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B4D41F7E0C65354F7E1086CB /* _BazelForcedCompile_.swift in Sources */,
-				AEEDCEB1251F840959F4E34B /* Lib.swift in Sources */,
+				3A8A4BCF92C278F74487AE52 /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1002,7 +1168,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				665F77C9222300A8F41DACC7 /* _BazelForcedCompile_.swift in Sources */,
-				7995F69C6E3B1969CD0D93EA /* Lib.swift in Sources */,
+				320AB8BDC1C33D102825BB35 /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1039,7 +1205,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C5602D0F0E22F02A64BBFA35 /* _BazelForcedCompile_.swift in Sources */,
-				EF3B3CAA453EFEABDEBA2FC7 /* Lib.swift in Sources */,
+				2652E46187D68BA7FC5F329A /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1048,7 +1214,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6360FF396B49E1B6632C1FD0 /* _BazelForcedCompile_.swift in Sources */,
-				EB9DAEA91D1FA5AE722332B0 /* Lib.swift in Sources */,
+				6D2F1ADF4920720C18D5A33B /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -10,3 +10,7 @@ $(GEN_DIR)/applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multip
 $(GEN_DIR)/applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 $(GEN_DIR)/applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 $(GEN_DIR)/applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip
+$(GEN_DIR)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-000eec03138d/bin/examples/multiplatform/Lib/Lib.swift
+$(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Lib/Lib.swift
+$(GEN_DIR)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/multiplatform/Lib/Lib.swift
+$(GEN_DIR)/watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/Lib/Lib.swift

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -10,3 +10,7 @@ applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/wat
 applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip
+ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-000eec03138d/bin/examples/multiplatform/Lib/Lib.swift
+macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Lib/Lib.swift
+tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/multiplatform/Lib/Lib.swift
+watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/Lib/Lib.swift

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -10,3 +10,7 @@ $(BAZEL_OUT)/applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/mult
 $(BAZEL_OUT)/applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 $(BAZEL_OUT)/applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip
+$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-000eec03138d/bin/examples/multiplatform/Lib/Lib.swift
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Lib/Lib.swift
+$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/multiplatform/Lib/Lib.swift
+$(BAZEL_OUT)/watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/Lib/Lib.swift

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -170,7 +170,10 @@
             "info_plist": null,
             "inputs": {
                 "srcs": [
-                    "examples/multiplatform/Lib/Lib.swift"
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-000eec03138d/bin/examples/multiplatform/Lib/Lib.swift",
+                        "t": "g"
+                    }
                 ]
             },
             "is_swift": true,
@@ -271,7 +274,10 @@
             "info_plist": null,
             "inputs": {
                 "srcs": [
-                    "examples/multiplatform/Lib/Lib.swift"
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Lib/Lib.swift",
+                        "t": "g"
+                    }
                 ]
             },
             "is_swift": true,
@@ -371,7 +377,10 @@
             "info_plist": null,
             "inputs": {
                 "srcs": [
-                    "examples/multiplatform/Lib/Lib.swift"
+                    {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/multiplatform/Lib/Lib.swift",
+                        "t": "g"
+                    }
                 ]
             },
             "is_swift": true,
@@ -472,7 +481,10 @@
             "info_plist": null,
             "inputs": {
                 "srcs": [
-                    "examples/multiplatform/Lib/Lib.swift"
+                    {
+                        "_": "watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-73754738665f/bin/examples/multiplatform/Lib/Lib.swift",
+                        "t": "g"
+                    }
                 ]
             },
             "is_swift": true,

--- a/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
@@ -29,18 +29,18 @@
 		39FE596A18105235919707F9 /* tvOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F2FC43BDB211622F991234 /* tvOSApp.swift */; };
 		3B4FBAEBCEAAF6DF9161CEA7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571673AD5562DFA4AB138EB8 /* ContentView.swift */; };
 		3DA2238D1AE0C4DE3F8700B6 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CC801C96D3ED6985981681F9 /* Preview Assets.xcassets */; };
-		6024E2A9B8A3386774157608 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7570C9510D99DB4A0B694A8 /* Lib.swift */; };
+		43CF9E54E6387851CDC75373 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8BA79C441283245ABE67694 /* Lib.swift */; };
+		52DD14D7EEBBFB0BD64B8E61 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64AE19447389D7B6B9BEC81E /* Lib.swift */; };
 		62CFF6C7D0DCE936662E389C /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D295FECC5CF307D463F8CBD4 /* Preview Assets.xcassets */; };
-		66C88AD9EA13C03CFF7D6574 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7570C9510D99DB4A0B694A8 /* Lib.swift */; };
 		672612624F95412422292B68 /* watchOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF973F3635AEB0E5B3101EA8 /* watchOSApp.swift */; };
+		68653D318692620A3C721048 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009E681E4EEDAB1135CE4A68 /* Lib.swift */; };
 		6BB33EE1FF138449161F329C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E47A83139A3569C6FA232A95 /* Assets.xcassets */; };
 		71EC4F6CE5FD79BF0EE2B2A8 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 20CD51DEB2E26EC7377B9F16 /* Preview Assets.xcassets */; };
 		7A35253D15168D745B41DAC5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0ADD9182447B9BBC9D04FD /* ContentView.swift */; };
 		7BADA8103BB4E09B7735582D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2CC294F18473B4B7357EB8BB /* Assets.xcassets */; };
 		7C8352CD4AC2E75F882BD1B4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C519DF0E014F293F71D3BBD3 /* ContentView.swift */; };
 		83A0C23B7C0DFFF7EEC59CAB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3A9B77D60580C4AD4C0BF5FC /* Assets.xcassets */; };
-		B6D7C97F69C2C054BA88F184 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7570C9510D99DB4A0B694A8 /* Lib.swift */; };
-		E95F5FCB22F35C0C8C07652F /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7570C9510D99DB4A0B694A8 /* Lib.swift */; };
+		92AB6729557ADA0A9494283E /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7169AFBDF5B1DB47FAD7E0AF /* Lib.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -138,6 +138,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		009E681E4EEDAB1135CE4A68 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		08F18312CEA72043B7783D1F /* watchOSAppExtension_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = watchOSAppExtension_entitlements.entitlements; sourceTree = "<group>"; };
 		14C9ACBD60C49872D43B34A8 /* CompileStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CompileStub.m; sourceTree = "<group>"; };
 		20CD51DEB2E26EC7377B9F16 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -158,6 +159,8 @@
 		57DED4191C90C7A853FF2A4E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
 		5808BF0F847CC0BF0E1128FB /* watchOSAppExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = watchOSAppExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		646773A9CB58451F7E5016D2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		64AE19447389D7B6B9BEC81E /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
+		7169AFBDF5B1DB47FAD7E0AF /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		81A2718CC1EF53E50BDD4909 /* watchOSApp.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = watchOSApp.zip; sourceTree = "<group>"; };
 		84D2483892E8EF0354DF0D4E /* Tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Tool; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E0ADD9182447B9BBC9D04FD /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -165,10 +168,10 @@
 		92D308E922DF792BCF148850 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		94B4E46AB654CACC5E8E5C55 /* iOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9739550C79EA12398392E26C /* tvOSApp_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = tvOSApp_entitlements.entitlements; sourceTree = "<group>"; };
+		A8BA79C441283245ABE67694 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		B8EE097BA523AA6A79268BDA /* libLib.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libLib.a; path = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0039aacf5cee/bin/examples/multiplatform/Lib/libLib.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C200516B205F70419C263339 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		C519DF0E014F293F71D3BBD3 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		C7570C9510D99DB4A0B694A8 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		CC801C96D3ED6985981681F9 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		D05F392CABFB9D136406F852 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		D295FECC5CF307D463F8CBD4 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -189,6 +192,22 @@
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
+		003B1FF45748353B53E7DD1D /* multiplatform */ = {
+			isa = PBXGroup;
+			children = (
+				85818D223161DDC8BAF43163 /* Lib */,
+			);
+			path = multiplatform;
+			sourceTree = "<group>";
+		};
+		018565965359C2FA437EC773 /* macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0039aacf5cee */ = {
+			isa = PBXGroup;
+			children = (
+				EA1035DE042E08B6C35B6612 /* bin */,
+			);
+			path = "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0039aacf5cee";
+			sourceTree = "<group>";
+		};
 		1156F30F1563FA24E5AF4F9E /* watchOSAppExtension */ = {
 			isa = PBXGroup;
 			children = (
@@ -234,6 +253,14 @@
 			path = tvOSApp;
 			sourceTree = "<group>";
 		};
+		24914CB4D2F90D614600C373 /* Lib */ = {
+			isa = PBXGroup;
+			children = (
+				A8BA79C441283245ABE67694 /* Lib.swift */,
+			);
+			path = Lib;
+			sourceTree = "<group>";
+		};
 		2AF0ABDBE1BB727A046F3214 /* applebin_ios-ios_x86_64-dbg-ST-5497495606d5 */ = {
 			isa = PBXGroup;
 			children = (
@@ -250,6 +277,14 @@
 			path = bin;
 			sourceTree = "<group>";
 		};
+		3041A40F43DEEF6F1733DDE6 /* multiplatform */ = {
+			isa = PBXGroup;
+			children = (
+				AFFCA190B90EFBB2AA4EA33E /* Lib */,
+			);
+			path = multiplatform;
+			sourceTree = "<group>";
+		};
 		319735E3F7CB10A29474FC79 /* multiplatform */ = {
 			isa = PBXGroup;
 			children = (
@@ -261,6 +296,14 @@
 				8BF3224C812615B4EFCA1E42 /* watchOSAppExtension */,
 			);
 			path = multiplatform;
+			sourceTree = "<group>";
+		};
+		369B561DC1EC2A19990447DD /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				F3B0DD8A78BA9797EC8F201C /* multiplatform */,
+			);
+			path = examples;
 			sourceTree = "<group>";
 		};
 		3FC3C3D9DB560D326ADFA4D9 /* PreviewContent */ = {
@@ -295,6 +338,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		501E1104293E357C177425D4 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				86988E459FE2AE775CA8E9B1 /* multiplatform */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
 		538ACAE415EDA08CD863C7B3 /* tvOSApp-intermediates */ = {
 			isa = PBXGroup;
 			children = (
@@ -320,6 +371,14 @@
 			path = test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj;
 			sourceTree = "<group>";
 		};
+		6BFF7A52282E6D7022E1F5D7 /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				369B561DC1EC2A19990447DD /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
 		6D99B0195063D8EF7F1A1ABB /* watchOSAppExtension-intermediates */ = {
 			isa = PBXGroup;
 			children = (
@@ -334,6 +393,14 @@
 				2EF6A9343B0F0B2A72A45CD3 /* bin */,
 			);
 			path = "applebin_tvos-tvos_x86_64-dbg-ST-c9bb83621c65";
+			sourceTree = "<group>";
+		};
+		6E941F46C5B04969F1479729 /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				501E1104293E357C177425D4 /* examples */,
+			);
+			path = bin;
 			sourceTree = "<group>";
 		};
 		6EC08E5A53687FA9CC96F847 /* applebin_watchos-watchos_i386-dbg-ST-f72632014f89 */ = {
@@ -355,12 +422,36 @@
 			);
 			sourceTree = "<group>";
 		};
+		7D841ED41AC2974590A9A357 /* watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-f72632014f89 */ = {
+			isa = PBXGroup;
+			children = (
+				6BFF7A52282E6D7022E1F5D7 /* bin */,
+			);
+			path = "watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-f72632014f89";
+			sourceTree = "<group>";
+		};
 		849D22FB95BCA7F198F79EEC /* watchOSApp-intermediates */ = {
 			isa = PBXGroup;
 			children = (
 				32FEB66D7D8E818B2340CB47 /* Info.plist */,
 			);
 			path = "watchOSApp-intermediates";
+			sourceTree = "<group>";
+		};
+		85818D223161DDC8BAF43163 /* Lib */ = {
+			isa = PBXGroup;
+			children = (
+				009E681E4EEDAB1135CE4A68 /* Lib.swift */,
+			);
+			path = Lib;
+			sourceTree = "<group>";
+		};
+		86988E459FE2AE775CA8E9B1 /* multiplatform */ = {
+			isa = PBXGroup;
+			children = (
+				939BEB0CAE3982DB6E58F6EB /* Lib */,
+			);
+			path = multiplatform;
 			sourceTree = "<group>";
 		};
 		86E3AA094AC3498BEDC1D673 /* examples */ = {
@@ -384,12 +475,28 @@
 			path = watchOSAppExtension;
 			sourceTree = "<group>";
 		};
+		8F80512324184463F84D6FCC /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				3041A40F43DEEF6F1733DDE6 /* multiplatform */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
 		92B352E7C3A6F28BCE78E11B /* examples */ = {
 			isa = PBXGroup;
 			children = (
 				54279F0C879FA2F87E677C19 /* multiplatform */,
 			);
 			path = examples;
+			sourceTree = "<group>";
+		};
+		939BEB0CAE3982DB6E58F6EB /* Lib */ = {
+			isa = PBXGroup;
+			children = (
+				7169AFBDF5B1DB47FAD7E0AF /* Lib.swift */,
+			);
+			path = Lib;
 			sourceTree = "<group>";
 		};
 		97D37ED8A4B325E33973A8E0 /* tvOSApp */ = {
@@ -423,6 +530,14 @@
 			path = bin;
 			sourceTree = "<group>";
 		};
+		9EF6D95A1B4EA064EA04CF14 /* ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5497495606d5 */ = {
+			isa = PBXGroup;
+			children = (
+				CAF52869E6E55DA6AF89FD83 /* bin */,
+			);
+			path = "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5497495606d5";
+			sourceTree = "<group>";
+		};
 		A3EFC5C6A37393D82140D078 /* multiplatform */ = {
 			isa = PBXGroup;
 			children = (
@@ -437,7 +552,6 @@
 			isa = PBXGroup;
 			children = (
 				C200516B205F70419C263339 /* BUILD */,
-				C7570C9510D99DB4A0B694A8 /* Lib.swift */,
 			);
 			path = Lib;
 			sourceTree = "<group>";
@@ -448,9 +562,21 @@
 				2AF0ABDBE1BB727A046F3214 /* applebin_ios-ios_x86_64-dbg-ST-5497495606d5 */,
 				6E74EADC77596EAF6371C3E3 /* applebin_tvos-tvos_x86_64-dbg-ST-c9bb83621c65 */,
 				6EC08E5A53687FA9CC96F847 /* applebin_watchos-watchos_i386-dbg-ST-f72632014f89 */,
+				9EF6D95A1B4EA064EA04CF14 /* ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5497495606d5 */,
+				018565965359C2FA437EC773 /* macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0039aacf5cee */,
+				DE6B2447BF66854774C64DA8 /* tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c9bb83621c65 */,
+				7D841ED41AC2974590A9A357 /* watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-f72632014f89 */,
 			);
 			name = "Bazel Generated Files";
 			path = test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir;
+			sourceTree = "<group>";
+		};
+		AFFCA190B90EFBB2AA4EA33E /* Lib */ = {
+			isa = PBXGroup;
+			children = (
+				64AE19447389D7B6B9BEC81E /* Lib.swift */,
+			);
+			path = Lib;
 			sourceTree = "<group>";
 		};
 		B1C22B953DFF3FAC69F93BC4 /* watchOSApp */ = {
@@ -481,6 +607,14 @@
 			path = Tool;
 			sourceTree = "<group>";
 		};
+		CAF52869E6E55DA6AF89FD83 /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				D698BFB4214C845A7811B61B /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
 		D4969B1F49009841C3A93B74 /* examples */ = {
 			isa = PBXGroup;
 			children = (
@@ -497,11 +631,35 @@
 			path = "iOSApp-intermediates";
 			sourceTree = "<group>";
 		};
+		D698BFB4214C845A7811B61B /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				003B1FF45748353B53E7DD1D /* multiplatform */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
 		D9AAB93A5135F69103554470 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		DE6B2447BF66854774C64DA8 /* tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c9bb83621c65 */ = {
+			isa = PBXGroup;
+			children = (
+				6E941F46C5B04969F1479729 /* bin */,
+			);
+			path = "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c9bb83621c65";
+			sourceTree = "<group>";
+		};
+		EA1035DE042E08B6C35B6612 /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				8F80512324184463F84D6FCC /* examples */,
+			);
+			path = bin;
 			sourceTree = "<group>";
 		};
 		EEDF98B8EA8816E95972FAB4 /* iOSApp */ = {
@@ -518,6 +676,14 @@
 				CC801C96D3ED6985981681F9 /* Preview Assets.xcassets */,
 			);
 			path = PreviewContent;
+			sourceTree = "<group>";
+		};
+		F3B0DD8A78BA9797EC8F201C /* multiplatform */ = {
+			isa = PBXGroup;
+			children = (
+				24914CB4D2F90D614600C373 /* Lib */,
+			);
+			path = multiplatform;
 			sourceTree = "<group>";
 		};
 		F823FA05032576486D2A52A5 /* iOSApp */ = {
@@ -869,7 +1035,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6024E2A9B8A3386774157608 /* Lib.swift in Sources */,
+				68653D318692620A3C721048 /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -894,7 +1060,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				66C88AD9EA13C03CFF7D6574 /* Lib.swift in Sources */,
+				92AB6729557ADA0A9494283E /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -919,7 +1085,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E95F5FCB22F35C0C8C07652F /* Lib.swift in Sources */,
+				52DD14D7EEBBFB0BD64B8E61 /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -927,7 +1093,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B6D7C97F69C2C054BA88F184 /* Lib.swift in Sources */,
+				43CF9E54E6387851CDC75373 /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -10,3 +10,7 @@ $(GEN_DIR)/applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multip
 $(GEN_DIR)/applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 $(GEN_DIR)/applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 $(GEN_DIR)/applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip
+$(GEN_DIR)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5497495606d5/bin/examples/multiplatform/Lib/Lib.swift
+$(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0039aacf5cee/bin/examples/multiplatform/Lib/Lib.swift
+$(GEN_DIR)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c9bb83621c65/bin/examples/multiplatform/Lib/Lib.swift
+$(GEN_DIR)/watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/Lib/Lib.swift

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -10,3 +10,7 @@ applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/wat
 applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip
+ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5497495606d5/bin/examples/multiplatform/Lib/Lib.swift
+macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0039aacf5cee/bin/examples/multiplatform/Lib/Lib.swift
+tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c9bb83621c65/bin/examples/multiplatform/Lib/Lib.swift
+watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/Lib/Lib.swift

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -10,3 +10,7 @@ $(BAZEL_OUT)/applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/mult
 $(BAZEL_OUT)/applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 $(BAZEL_OUT)/applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip
+$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5497495606d5/bin/examples/multiplatform/Lib/Lib.swift
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0039aacf5cee/bin/examples/multiplatform/Lib/Lib.swift
+$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c9bb83621c65/bin/examples/multiplatform/Lib/Lib.swift
+$(BAZEL_OUT)/watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/Lib/Lib.swift

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -152,7 +152,10 @@
             "info_plist": null,
             "inputs": {
                 "srcs": [
-                    "examples/multiplatform/Lib/Lib.swift"
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5497495606d5/bin/examples/multiplatform/Lib/Lib.swift",
+                        "t": "g"
+                    }
                 ]
             },
             "is_swift": true,
@@ -238,7 +241,10 @@
             "info_plist": null,
             "inputs": {
                 "srcs": [
-                    "examples/multiplatform/Lib/Lib.swift"
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0039aacf5cee/bin/examples/multiplatform/Lib/Lib.swift",
+                        "t": "g"
+                    }
                 ]
             },
             "is_swift": true,
@@ -323,7 +329,10 @@
             "info_plist": null,
             "inputs": {
                 "srcs": [
-                    "examples/multiplatform/Lib/Lib.swift"
+                    {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c9bb83621c65/bin/examples/multiplatform/Lib/Lib.swift",
+                        "t": "g"
+                    }
                 ]
             },
             "is_swift": true,
@@ -409,7 +418,10 @@
             "info_plist": null,
             "inputs": {
                 "srcs": [
-                    "examples/multiplatform/Lib/Lib.swift"
+                    {
+                        "_": "watchos-i386-min7.0-applebin_watchos-watchos_i386-dbg-ST-f72632014f89/bin/examples/multiplatform/Lib/Lib.swift",
+                        "t": "g"
+                    }
                 ]
             },
             "is_swift": true,


### PR DESCRIPTION
Generated files are one of the trickiest things to handle with consolidated targets, so we should have an example of it in our fixtures.