### PR TITLE
Set scheme version based on elements used

### DIFF
--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleObjcTests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleObjcTests.__internal__.__test_bundle.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleResources.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleResources.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExternalResources.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExternalResources.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/TestingUtils.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/TestingUtils.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/Utils.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/Utils.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/LibSwiftTests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/LibSwiftTests.__internal__.__test_bundle.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_impl.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_impl.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_swift.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_swift.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/private_lib.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/private_lib.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/AEXML.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/AEXML.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/CustomDump.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/CustomDump.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/OrderedCollections.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/OrderedCollections.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/PathKit.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/PathKit.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/XCTestDynamicOverlay.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/XCTestDynamicOverlay.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/XcodeProj.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/XcodeProj.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.library.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.library.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/tests.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/tests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(iOS).xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(iOS).xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(macOS).xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(macOS).xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(tvOS).xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(tvOS).xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(watchOS).xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(watchOS).xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/watchOSAppExtension.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/watchOSAppExtension.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/BazelDependencies.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1320"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/tools/generator/src/Generator+CreateXCSchemes.swift
+++ b/tools/generator/src/Generator+CreateXCSchemes.swift
@@ -18,9 +18,10 @@ extension Generator {
         }
     }
 
-    // GH399: Derive the defaultLastUpgradeVersion and defaultVersion.
+    // GH399: Derive the defaultLastUpgradeVersion
     private static let defaultLastUpgradeVersion = "1320"
-    private static let defaultVersion = "1.7"
+    private static let baseVersion = "1.3"
+    private static let lldbInitVersion = "1.7"
 
     /// Creates an `XCScheme` for the specified target.
     private static func createXCScheme(
@@ -100,7 +101,7 @@ extension Generator {
         return XCScheme(
             name: pbxTarget.schemeName,
             lastUpgradeVersion: defaultLastUpgradeVersion,
-            version: defaultVersion,
+            version: buildMode.requiresLLDBInit ? lldbInitVersion : baseVersion,
             buildAction: buildAction,
             testAction: testAction,
             launchAction: launchAction,


### PR DESCRIPTION
Part of #421.

Seems that the scheme version should only be `1.7` if it uses `customLLDBInitFile`.