### PR TITLE
Fix `buildableName` for disambiguated non-toplevel targets

### DIFF
--- a/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
+++ b/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "0CEAA3455274D4DE9B4B82BF"
-                     BuildableName = "lib_impl"
+                     BuildableName = "@examples_cc_external//:lib_impl"
                      BlueprintName = "@examples_cc_external//:lib_impl"
                      ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "0CEAA3455274D4DE9B4B82BF"
-               BuildableName = "lib_impl"
+               BuildableName = "@examples_cc_external//:lib_impl"
                BlueprintName = "@examples_cc_external//:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "373A62571D2CA8826AD4F92C"
-                     BuildableName = "lib_impl"
+                     BuildableName = "//examples/cc/lib2:lib_impl"
                      BlueprintName = "//examples/cc/lib2:lib_impl"
                      ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "373A62571D2CA8826AD4F92C"
-               BuildableName = "lib_impl"
+               BuildableName = "//examples/cc/lib2:lib_impl"
                BlueprintName = "//examples/cc/lib2:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "E180851AE3E1EEC8C4944F10"
-                     BuildableName = "lib_impl"
+                     BuildableName = "//examples/cc/lib:lib_impl"
                      BlueprintName = "//examples/cc/lib:lib_impl"
                      ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "E180851AE3E1EEC8C4944F10"
-               BuildableName = "lib_impl"
+               BuildableName = "//examples/cc/lib:lib_impl"
                BlueprintName = "//examples/cc/lib:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "9DF8EA4260F38FC7243F6241"
-               BuildableName = "lib_impl"
+               BuildableName = "@examples_cc_external//:lib_impl"
                BlueprintName = "@examples_cc_external//:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B2EDA6BA27C01B7B8423DADB"
-               BuildableName = "lib_impl"
+               BuildableName = "//examples/cc/lib2:lib_impl"
                BlueprintName = "//examples/cc/lib2:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "BCD9FA95C7CBE2A799AC3DF9"
-               BuildableName = "lib_impl"
+               BuildableName = "//examples/cc/lib:lib_impl"
                BlueprintName = "//examples/cc/lib:lib_impl"
                ReferencedContainer = "container:test/fixtures/cc/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(iOS).xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(iOS).xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "F5BF80BFBFC7570B02664402"
-                     BuildableName = "Lib"
+                     BuildableName = "Lib (iOS)"
                      BlueprintName = "Lib (iOS)"
                      ReferencedContainer = "container:test/fixtures/multiplatform/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F5BF80BFBFC7570B02664402"
-               BuildableName = "Lib"
+               BuildableName = "Lib (iOS)"
                BlueprintName = "Lib (iOS)"
                ReferencedContainer = "container:test/fixtures/multiplatform/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(macOS).xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(macOS).xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "212DC2E05ECB4330F8D97046"
-                     BuildableName = "Lib"
+                     BuildableName = "Lib (macOS)"
                      BlueprintName = "Lib (macOS)"
                      ReferencedContainer = "container:test/fixtures/multiplatform/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "212DC2E05ECB4330F8D97046"
-               BuildableName = "Lib"
+               BuildableName = "Lib (macOS)"
                BlueprintName = "Lib (macOS)"
                ReferencedContainer = "container:test/fixtures/multiplatform/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(tvOS).xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(tvOS).xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "57F1E76BC3F37BD9B3D84351"
-                     BuildableName = "Lib"
+                     BuildableName = "Lib (tvOS)"
                      BlueprintName = "Lib (tvOS)"
                      ReferencedContainer = "container:test/fixtures/multiplatform/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "57F1E76BC3F37BD9B3D84351"
-               BuildableName = "Lib"
+               BuildableName = "Lib (tvOS)"
                BlueprintName = "Lib (tvOS)"
                ReferencedContainer = "container:test/fixtures/multiplatform/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(watchOS).xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(watchOS).xcscheme
@@ -15,7 +15,7 @@
                   <BuildableReference
                      BuildableIdentifier = "primary"
                      BlueprintIdentifier = "83D00AD7532094902D925C83"
-                     BuildableName = "Lib"
+                     BuildableName = "Lib (watchOS)"
                      BlueprintName = "Lib (watchOS)"
                      ReferencedContainer = "container:test/fixtures/multiplatform/bwb.xcodeproj">
                   </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "83D00AD7532094902D925C83"
-               BuildableName = "Lib"
+               BuildableName = "Lib (watchOS)"
                BlueprintName = "Lib (watchOS)"
                ReferencedContainer = "container:test/fixtures/multiplatform/bwb.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(iOS).xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(iOS).xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F97BE328A0015387DDEA9011"
-               BuildableName = "Lib"
+               BuildableName = "Lib (iOS)"
                BlueprintName = "Lib (iOS)"
                ReferencedContainer = "container:test/fixtures/multiplatform/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(macOS).xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(macOS).xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7801220D7904E391298DA71F"
-               BuildableName = "Lib"
+               BuildableName = "Lib (macOS)"
                BlueprintName = "Lib (macOS)"
                ReferencedContainer = "container:test/fixtures/multiplatform/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(tvOS).xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(tvOS).xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "99AE110BF4C94FEA9B13F147"
-               BuildableName = "Lib"
+               BuildableName = "Lib (tvOS)"
                BlueprintName = "Lib (tvOS)"
                ReferencedContainer = "container:test/fixtures/multiplatform/bwx.xcodeproj">
             </BuildableReference>

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(watchOS).xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(watchOS).xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D094AA317C2527FB0FCC5015"
-               BuildableName = "Lib"
+               BuildableName = "Lib (watchOS)"
                BlueprintName = "Lib (watchOS)"
                ReferencedContainer = "container:test/fixtures/multiplatform/bwx.xcodeproj">
             </BuildableReference>

--- a/tools/generator/src/PBXTarget+Extensions.swift
+++ b/tools/generator/src/PBXTarget+Extensions.swift
@@ -2,13 +2,8 @@ import Foundation
 import XcodeProj
 
 public extension PBXTarget {
-    func getBuildableName() throws -> String {
-        guard let buildableName = (product?.path ?? productName) else {
-            throw PreconditionError(message: """
-`product` path and `productName` not set on target (\(name))
-""")
-        }
-        return buildableName
+    var buildableName: String {
+        return product?.path ?? name
     }
 
     func createBuildableReference(
@@ -17,7 +12,7 @@ public extension PBXTarget {
         return .init(
             referencedContainer: referencedContainer,
             blueprint: self,
-            buildableName: try getBuildableName(),
+            buildableName: buildableName,
             blueprintName: name
         )
     }

--- a/tools/generator/test/PBXTarget+ExtensionsTests.swift
+++ b/tools/generator/test/PBXTarget+ExtensionsTests.swift
@@ -22,31 +22,15 @@ class PBXTargetExtensionsTests: XCTestCase {
         productName: "MyChicken"
     )
 
-    func test_getBuildableName_withProductPath() throws {
-        let buildableName = try pbxTarget.getBuildableName()
+    func test_getBuildableName_withProductPath() {
+        let buildableName = pbxTarget.buildableName
         XCTAssertEqual(buildableName, "MyChicken.app")
     }
 
-    func test_getBuildableName_withoutProductPathWithProductName() throws {
+    func test_getBuildableName_withoutProductPath() {
         pbxTarget.product = nil
-        let buildableName = try pbxTargetWithoutProduct.getBuildableName()
-        XCTAssertEqual(buildableName, "MyChicken")
-    }
-
-    func test_getBuildableName_withoutProductPathAndProductName() throws {
-        pbxTargetWithoutProduct.productName = nil
-        XCTAssertThrowsError(try pbxTargetWithoutProduct.getBuildableName()) { error in
-            guard let preconditionError = error as? PreconditionError else {
-                XCTFail(
-                    "The thrown error was not a `PreconditionError`. \(error)"
-                )
-                return
-            }
-            XCTAssertEqual(
-                preconditionError.message,
-                "`product` path and `productName` not set on target (chicken)"
-            )
-        }
+        let buildableName = pbxTargetWithoutProduct.buildableName
+        XCTAssertEqual(buildableName, "chicken")
     }
 
     func test_createBuildableReference() throws {
@@ -57,7 +41,7 @@ class PBXTargetExtensionsTests: XCTestCase {
         let expected = XCScheme.BuildableReference(
             referencedContainer: "\(referencedContainer)",
             blueprint: pbxTarget,
-            buildableName: try pbxTarget.getBuildableName(),
+            buildableName: pbxTarget.buildableName,
             blueprintName: pbxTarget.name
         )
         XCTAssertEqual(buildableReference, expected)


### PR DESCRIPTION
Part of https://github.com/buildbuddy-io/rules_xcodeproj/issues/421.

Non-toplevel targets need to use the target name, not the product name. This is only an issue when the target name is disambiguated.