### PR TITLE
Move Configuration distinguisher logic up a level

### DIFF
--- a/tools/generator/test/DisambiguateTargetsTests.swift
+++ b/tools/generator/test/DisambiguateTargetsTests.swift
@@ -442,8 +442,8 @@ final class DisambiguateTargetsTests: XCTestCase {
             ),
         ]
         let expectedTargetNames: [TargetID: String] = [
-            "A 1": "A (iOS, \(Target.prettyConfiguration("1")))",
-            "A 2": "A (iOS, \(Target.prettyConfiguration("2")))",
+            "A 1": "A (iOS) (\(Target.prettyConfiguration("1")))",
+            "A 2": "A (iOS) (\(Target.prettyConfiguration("2")))",
             "A 3": "A (macOS)",
             "B": "B",
         ]


### PR DESCRIPTION
This changes the configuration to be on it's own in the name:

```
A (iOS) (abcde)
```

instead of:

```
A (iOS, abcde)
```

This is needed to support consolidated targets, which will have something like this when a configuration needs to be displayed:

```
A (iOS, tvOS) (abcde)
```