### PR TITLE
Filter folders from rsynclist

### DIFF
--- a/tools/generator/src/Generator+CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator+CreateFilesAndGroups.swift
@@ -435,7 +435,11 @@ extension Generator {
                 useOriginalGeneratedFiles: true
             )
         }
-        let rsyncPaths = generatedFiles.map { filePath, _ in filePath.path }
+        let rsyncPaths = generatedFiles
+            .filter { filePath, _ in
+                return !filePath.path.isFolderTypeFileSource
+            }
+            .map { filePath, _ in filePath.path }
         let copiedGeneratedPaths = try generatedFiles.map { filePath, _ in
             // We need to use `$(GEN_DIR)` instead of `$(BUILD_DIR)` here to
             // match the project navigator. This is only needed for files


### PR DESCRIPTION
A project that has a custom rule which generates a `xcassets` with a `AppIcon.appiconset` fails to build due to the fact that `rsynclist` contained the generated `xcassets` but `generated_inputs` didn't. We need to filter out the folders from the generated files list for this to work correctly.