### PR TITLE
Group sub-consolidations

### DIFF
--- a/tools/generator/src/BuildSettingConditional.swift
+++ b/tools/generator/src/BuildSettingConditional.swift
@@ -48,25 +48,7 @@ extension BuildSettingConditional: Comparable {
             return lhs.platform == nil && rhs.platform != nil
         }
 
-        guard lhsPlatform.os == rhsPlatform.os else {
-            return lhsPlatform.os < rhsPlatform.os
-        }
-
-        guard lhsPlatform.environment == rhsPlatform.environment else {
-            // Sort simulator first
-            switch (lhsPlatform.environment, rhsPlatform.environment) {
-            case ("Simulator", _): return true
-            case (_, "Simulator"): return false
-            case (nil, _): return true
-            case (_, nil): return false
-            case ("Device", _): return true
-            case (_, "Device"): return false
-            default: return false
-            }
-        }
-
-        // Sort Apple Silicon first
-        return lhsPlatform.arch == "arm64" && rhsPlatform.arch != "arm64"
+        return lhsPlatform < rhsPlatform
     }
 }
 

--- a/tools/generator/src/DTO.swift
+++ b/tools/generator/src/DTO.swift
@@ -56,6 +56,40 @@ struct Platform: Equatable, Hashable, Decodable {
     let environment: String?
 }
 
+extension Platform: Comparable {
+    static func < (lhs: Platform, rhs: Platform) -> Bool {
+        guard lhs.os == rhs.os else {
+            return lhs.os < rhs.os
+        }
+
+        guard lhs.minimumOsVersion == rhs.minimumOsVersion else {
+            return lhs.minimumOsVersion
+                .compare(rhs.minimumOsVersion, options: .numeric)
+                == .orderedAscending
+        }
+
+        guard lhs.environment == rhs.environment else {
+            // Sort simulator first
+            switch (lhs.environment, rhs.environment) {
+            case ("Simulator", _): return true
+            case (_, "Simulator"): return false
+            case (nil, _): return true
+            case (_, nil): return false
+            case ("Device", _): return true
+            case (_, "Device"): return false
+            default: return false
+            }
+        }
+
+        guard lhs.arch != "arm64" else {
+            // Sort Apple Silicon first
+            return rhs.arch != "arm64"
+        }
+
+        return lhs.arch < rhs.arch
+    }
+}
+
 extension Platform.OS: Comparable {
     static func < (lhs: Platform.OS, rhs: Platform.OS) -> Bool {
         switch (lhs, rhs) {

--- a/tools/generator/test/ConsolidateTargetsTest.swift
+++ b/tools/generator/test/ConsolidateTargetsTest.swift
@@ -218,19 +218,37 @@ final class ConsolidateTargetsTests: XCTestCase {
         // Arrange
 
         let targets: [TargetID: Target] = [
-            "A": .mock(
+            "A1": .mock(
                 platform: .simulator(minimumOsVersion: "11.0"),
-                product: .init(type: .staticLibrary, name: "T", path: "A/T")
+                product: .init(type: .staticLibrary, name: "A", path: "1/A")
             ),
-            "B": .mock(
+            "A2": .mock(
                 platform: .device(minimumOsVersion: "12.0"),
-                product: .init(type: .staticLibrary, name: "T", path: "B/T")
+                product: .init(type: .staticLibrary, name: "A", path: "2/A")
+            ),
+            "B1": .mock(
+                platform: .simulator(minimumOsVersion: "13.0"),
+                product: .init(type: .staticLibrary, name: "B", path: "S13/B")
+            ),
+            "B2": .mock(
+                platform: .device(minimumOsVersion: "13.0"),
+                product: .init(type: .staticLibrary, name: "B", path: "D13/B")
+            ),
+            "B3": .mock(
+                platform: .simulator(minimumOsVersion: "13.2"),
+                product: .init(type: .staticLibrary, name: "B", path: "S13.2/B")
+            ),
+            "B4": .mock(
+                platform: .device(minimumOsVersion: "13.2"),
+                product: .init(type: .staticLibrary, name: "B", path: "D13.2/B")
             ),
         ]
         let expectedConsolidatedTargets = ConsolidatedTargets(
             allTargets: targets,
             keys: [
-                ["A", "B"],
+                ["A1", "A2"],
+                ["B1", "B2"],
+                ["B3", "B4"],
             ]
         )
         let expectedMessagesLogged: [StubLogger.MessageLogged] = []

--- a/tools/generator/test/DisambiguateTargetsTests.swift
+++ b/tools/generator/test/DisambiguateTargetsTests.swift
@@ -778,7 +778,7 @@ A (iOS) (\(ProductTypeComponents.prettyConfigurations(["2"])))
         let expectedTargetNames: [ConsolidatedTarget.Key: String] = [
             .init(["A 1", "A 2", "A 3"]): "A",
             .init(["B 1", "B 2", "B 3"]): """
-B (iOS 13.0 Simulator, iOS 11.0 Device, tvOS)
+B (iOS 11.0 Device, iOS 13.0 Simulator, tvOS)
 """,
             "B 4": "B (iOS 14.0)",
         ]


### PR DESCRIPTION
Before this change, if you have minimum OS differences in your tree, and environment differences, you would get 3 consolidated targets instead of two (one proper consolidation and then 2 non-consolidated target). Now the consolidation tries to group like targets together more. Things can still get odd if you somehow have unique configurations of a target, as this just performs a simple sort and bucket for now.