### PR TITLE
Use the correct version of swiftc for BwB SwiftUI Previews

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
@@ -22,6 +22,7 @@ do
 
   *.preview-thunk.dylib)
     # Pass through for SwiftUI Preview thunk compilation
+    # TODO: Make this work with custom toolchains
     exec "$developer_dir/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" "${passthrough_args[@]}"
     ;;
   esac

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
@@ -2,21 +2,36 @@
 
 import json
 import os
+import re
 import subprocess
 import sys
 from typing import List
 
+DEVELOPER_DIR_PATTERN = r'(.*?/Contents/Developer)/.*'
+
 def _main() -> None:
-    if sys.argv[1:] == ["-v"]:
+    args = sys.argv
+
+    if args[1:] == ["-v"]:
         os.system("swiftc -v")
         return
 
     # Pass through for SwiftUI Preview thunk compilation
-    if (any(arg.endswith(".preview-thunk.swift") for arg in sys.argv) and
-        "-output-file-map" not in sys.argv):
-        exit(subprocess.run(["swiftc"] + sys.argv[1:], check=False).returncode)
+    if (any(arg.endswith(".preview-thunk.swift") for arg in args) and
+        "-output-file-map" not in args):
+        flag = args.index("-sdk")
+        sdk_path = args[flag + 1]
+        match = re.fullmatch(DEVELOPER_DIR_PATTERN, sdk_path)
+        if not match:
+            raise RuntimeError("Failed to parse DEVELOPER_DIR from -sdk")
 
-    _touch_deps_files(sys.argv)
+        # TODO: Make this work with custom toolchains
+        developer_dir = match.group(1)
+        swiftc = f"{developer_dir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"
+
+        exit(subprocess.run([swiftc] + args[1:], check=False).returncode)
+
+    _touch_deps_files(args)
 
 
 def _touch_deps_files(args: List[str]) -> None:

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
@@ -22,6 +22,7 @@ do
 
   *.preview-thunk.dylib)
     # Pass through for SwiftUI Preview thunk compilation
+    # TODO: Make this work with custom toolchains
     exec "$developer_dir/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" "${passthrough_args[@]}"
     ;;
   esac

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
@@ -2,21 +2,36 @@
 
 import json
 import os
+import re
 import subprocess
 import sys
 from typing import List
 
+DEVELOPER_DIR_PATTERN = r'(.*?/Contents/Developer)/.*'
+
 def _main() -> None:
-    if sys.argv[1:] == ["-v"]:
+    args = sys.argv
+
+    if args[1:] == ["-v"]:
         os.system("swiftc -v")
         return
 
     # Pass through for SwiftUI Preview thunk compilation
-    if (any(arg.endswith(".preview-thunk.swift") for arg in sys.argv) and
-        "-output-file-map" not in sys.argv):
-        exit(subprocess.run(["swiftc"] + sys.argv[1:], check=False).returncode)
+    if (any(arg.endswith(".preview-thunk.swift") for arg in args) and
+        "-output-file-map" not in args):
+        flag = args.index("-sdk")
+        sdk_path = args[flag + 1]
+        match = re.fullmatch(DEVELOPER_DIR_PATTERN, sdk_path)
+        if not match:
+            raise RuntimeError("Failed to parse DEVELOPER_DIR from -sdk")
 
-    _touch_deps_files(sys.argv)
+        # TODO: Make this work with custom toolchains
+        developer_dir = match.group(1)
+        swiftc = f"{developer_dir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"
+
+        exit(subprocess.run([swiftc] + args[1:], check=False).returncode)
+
+    _touch_deps_files(args)
 
 
 def _touch_deps_files(args: List[str]) -> None:

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
@@ -22,6 +22,7 @@ do
 
   *.preview-thunk.dylib)
     # Pass through for SwiftUI Preview thunk compilation
+    # TODO: Make this work with custom toolchains
     exec "$developer_dir/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" "${passthrough_args[@]}"
     ;;
   esac

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
@@ -2,21 +2,36 @@
 
 import json
 import os
+import re
 import subprocess
 import sys
 from typing import List
 
+DEVELOPER_DIR_PATTERN = r'(.*?/Contents/Developer)/.*'
+
 def _main() -> None:
-    if sys.argv[1:] == ["-v"]:
+    args = sys.argv
+
+    if args[1:] == ["-v"]:
         os.system("swiftc -v")
         return
 
     # Pass through for SwiftUI Preview thunk compilation
-    if (any(arg.endswith(".preview-thunk.swift") for arg in sys.argv) and
-        "-output-file-map" not in sys.argv):
-        exit(subprocess.run(["swiftc"] + sys.argv[1:], check=False).returncode)
+    if (any(arg.endswith(".preview-thunk.swift") for arg in args) and
+        "-output-file-map" not in args):
+        flag = args.index("-sdk")
+        sdk_path = args[flag + 1]
+        match = re.fullmatch(DEVELOPER_DIR_PATTERN, sdk_path)
+        if not match:
+            raise RuntimeError("Failed to parse DEVELOPER_DIR from -sdk")
 
-    _touch_deps_files(sys.argv)
+        # TODO: Make this work with custom toolchains
+        developer_dir = match.group(1)
+        swiftc = f"{developer_dir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"
+
+        exit(subprocess.run([swiftc] + args[1:], check=False).returncode)
+
+    _touch_deps_files(args)
 
 
 def _touch_deps_files(args: List[str]) -> None:

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
@@ -22,6 +22,7 @@ do
 
   *.preview-thunk.dylib)
     # Pass through for SwiftUI Preview thunk compilation
+    # TODO: Make this work with custom toolchains
     exec "$developer_dir/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" "${passthrough_args[@]}"
     ;;
   esac

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
@@ -2,21 +2,36 @@
 
 import json
 import os
+import re
 import subprocess
 import sys
 from typing import List
 
+DEVELOPER_DIR_PATTERN = r'(.*?/Contents/Developer)/.*'
+
 def _main() -> None:
-    if sys.argv[1:] == ["-v"]:
+    args = sys.argv
+
+    if args[1:] == ["-v"]:
         os.system("swiftc -v")
         return
 
     # Pass through for SwiftUI Preview thunk compilation
-    if (any(arg.endswith(".preview-thunk.swift") for arg in sys.argv) and
-        "-output-file-map" not in sys.argv):
-        exit(subprocess.run(["swiftc"] + sys.argv[1:], check=False).returncode)
+    if (any(arg.endswith(".preview-thunk.swift") for arg in args) and
+        "-output-file-map" not in args):
+        flag = args.index("-sdk")
+        sdk_path = args[flag + 1]
+        match = re.fullmatch(DEVELOPER_DIR_PATTERN, sdk_path)
+        if not match:
+            raise RuntimeError("Failed to parse DEVELOPER_DIR from -sdk")
 
-    _touch_deps_files(sys.argv)
+        # TODO: Make this work with custom toolchains
+        developer_dir = match.group(1)
+        swiftc = f"{developer_dir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"
+
+        exit(subprocess.run([swiftc] + args[1:], check=False).returncode)
+
+    _touch_deps_files(args)
 
 
 def _touch_deps_files(args: List[str]) -> None:

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
@@ -22,6 +22,7 @@ do
 
   *.preview-thunk.dylib)
     # Pass through for SwiftUI Preview thunk compilation
+    # TODO: Make this work with custom toolchains
     exec "$developer_dir/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" "${passthrough_args[@]}"
     ;;
   esac

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
@@ -2,21 +2,36 @@
 
 import json
 import os
+import re
 import subprocess
 import sys
 from typing import List
 
+DEVELOPER_DIR_PATTERN = r'(.*?/Contents/Developer)/.*'
+
 def _main() -> None:
-    if sys.argv[1:] == ["-v"]:
+    args = sys.argv
+
+    if args[1:] == ["-v"]:
         os.system("swiftc -v")
         return
 
     # Pass through for SwiftUI Preview thunk compilation
-    if (any(arg.endswith(".preview-thunk.swift") for arg in sys.argv) and
-        "-output-file-map" not in sys.argv):
-        exit(subprocess.run(["swiftc"] + sys.argv[1:], check=False).returncode)
+    if (any(arg.endswith(".preview-thunk.swift") for arg in args) and
+        "-output-file-map" not in args):
+        flag = args.index("-sdk")
+        sdk_path = args[flag + 1]
+        match = re.fullmatch(DEVELOPER_DIR_PATTERN, sdk_path)
+        if not match:
+            raise RuntimeError("Failed to parse DEVELOPER_DIR from -sdk")
 
-    _touch_deps_files(sys.argv)
+        # TODO: Make this work with custom toolchains
+        developer_dir = match.group(1)
+        swiftc = f"{developer_dir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"
+
+        exit(subprocess.run([swiftc] + args[1:], check=False).returncode)
+
+    _touch_deps_files(args)
 
 
 def _touch_deps_files(args: List[str]) -> None:

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/ld.sh
@@ -22,6 +22,7 @@ do
 
   *.preview-thunk.dylib)
     # Pass through for SwiftUI Preview thunk compilation
+    # TODO: Make this work with custom toolchains
     exec "$developer_dir/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" "${passthrough_args[@]}"
     ;;
   esac

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/swiftc.py
@@ -2,21 +2,36 @@
 
 import json
 import os
+import re
 import subprocess
 import sys
 from typing import List
 
+DEVELOPER_DIR_PATTERN = r'(.*?/Contents/Developer)/.*'
+
 def _main() -> None:
-    if sys.argv[1:] == ["-v"]:
+    args = sys.argv
+
+    if args[1:] == ["-v"]:
         os.system("swiftc -v")
         return
 
     # Pass through for SwiftUI Preview thunk compilation
-    if (any(arg.endswith(".preview-thunk.swift") for arg in sys.argv) and
-        "-output-file-map" not in sys.argv):
-        exit(subprocess.run(["swiftc"] + sys.argv[1:], check=False).returncode)
+    if (any(arg.endswith(".preview-thunk.swift") for arg in args) and
+        "-output-file-map" not in args):
+        flag = args.index("-sdk")
+        sdk_path = args[flag + 1]
+        match = re.fullmatch(DEVELOPER_DIR_PATTERN, sdk_path)
+        if not match:
+            raise RuntimeError("Failed to parse DEVELOPER_DIR from -sdk")
 
-    _touch_deps_files(sys.argv)
+        # TODO: Make this work with custom toolchains
+        developer_dir = match.group(1)
+        swiftc = f"{developer_dir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"
+
+        exit(subprocess.run([swiftc] + args[1:], check=False).returncode)
+
+    _touch_deps_files(args)
 
 
 def _touch_deps_files(args: List[str]) -> None:

--- a/xcodeproj/internal/bazel_integration_files/ld.sh
+++ b/xcodeproj/internal/bazel_integration_files/ld.sh
@@ -22,6 +22,7 @@ do
 
   *.preview-thunk.dylib)
     # Pass through for SwiftUI Preview thunk compilation
+    # TODO: Make this work with custom toolchains
     exec "$developer_dir/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang" "${passthrough_args[@]}"
     ;;
   esac

--- a/xcodeproj/internal/bazel_integration_files/swiftc.py
+++ b/xcodeproj/internal/bazel_integration_files/swiftc.py
@@ -2,21 +2,36 @@
 
 import json
 import os
+import re
 import subprocess
 import sys
 from typing import List
 
+DEVELOPER_DIR_PATTERN = r'(.*?/Contents/Developer)/.*'
+
 def _main() -> None:
-    if sys.argv[1:] == ["-v"]:
+    args = sys.argv
+
+    if args[1:] == ["-v"]:
         os.system("swiftc -v")
         return
 
     # Pass through for SwiftUI Preview thunk compilation
-    if (any(arg.endswith(".preview-thunk.swift") for arg in sys.argv) and
-        "-output-file-map" not in sys.argv):
-        exit(subprocess.run(["swiftc"] + sys.argv[1:], check=False).returncode)
+    if (any(arg.endswith(".preview-thunk.swift") for arg in args) and
+        "-output-file-map" not in args):
+        flag = args.index("-sdk")
+        sdk_path = args[flag + 1]
+        match = re.fullmatch(DEVELOPER_DIR_PATTERN, sdk_path)
+        if not match:
+            raise RuntimeError("Failed to parse DEVELOPER_DIR from -sdk")
 
-    _touch_deps_files(sys.argv)
+        # TODO: Make this work with custom toolchains
+        developer_dir = match.group(1)
+        swiftc = f"{developer_dir}/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"
+
+        exit(subprocess.run([swiftc] + args[1:], check=False).returncode)
+
+    _touch_deps_files(args)
 
 
 def _touch_deps_files(args: List[str]) -> None:


### PR DESCRIPTION
This is the same logic that we use in the ld stub, for the same reason: the `PATH` and `DEVELOPER_DIR` isn't set correctly for us, so we have to infer what `DEVELOPER_DIR` is. We also force the use of the default toolchain, which means this currently doesn't work correctly with custom toolchains.