### PR TITLE
Stop adding provisioning profiles to Project navigator

### DIFF
--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -141,7 +141,6 @@
 		3AC69858583169F87F19CEA0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		416D7556BFEC26938A62BA77 /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
 		451AB65F903A79F644C34E4F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		4C215101AD3DD834ABA30B90 /* iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision */ = {isa = PBXFileReference; path = "iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision"; sourceTree = "<group>"; };
 		5145CBFF79C7C7D6179B1D1E /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		5C92EF372D6603E10056CDAD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		6BC5119BB4DC1384F16B95C7 /* watchOSApp.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = watchOSApp.zip; sourceTree = "<group>"; };
@@ -156,7 +155,6 @@
 		9065B04356832B39E95AA885 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9427A227944F4D18102ADE4F /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		95EAAF0384D20903614054AA /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
-		9696F6FFE79D5C59630FC162 /* iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision */ = {isa = PBXFileReference; path = "iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision"; sourceTree = "<group>"; };
 		99C79CA8BF8DBF31ED1958B3 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		9B92DB0A68A3B511E0B4527D /* libLib.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libLib.a; path = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Lib/libLib.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A0501EF726150AD19D2758EF /* watchOSAppExtension.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = watchOSAppExtension.zip; sourceTree = "<group>"; };
@@ -166,7 +164,6 @@
 		A888E2361B64B76E81875CE1 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		AC3BD6C219E6E5167618EBD9 /* watchOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = watchOSApp.swift; sourceTree = "<group>"; };
 		ADBEAB2C84FEA499584D9C18 /* watchOSAppExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = watchOSAppExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		ADDDE6CD7EFEAE326135EF66 /* iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision */ = {isa = PBXFileReference; path = "iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision"; sourceTree = "<group>"; };
 		AE377F4630CA8B3FB47192AC /* watchOSAppExtension.zip */ = {isa = PBXFileReference; lastKnownFileType = archive.zip; path = watchOSAppExtension.zip; sourceTree = "<group>"; };
 		AEAF27AFD092967E95A4E88C /* Version.bundle_version */ = {isa = PBXFileReference; path = Version.bundle_version; sourceTree = "<group>"; };
 		AF1A1C154F7C2DB997EC29C7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -177,7 +174,6 @@
 		BA434FCC8289C0C8F756C803 /* iOSApp_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iOSApp_entitlements.entitlements; sourceTree = "<group>"; };
 		BF82839A39A167B3C6668EDF /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		C2A152505C080E82E6F2D44A /* Tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Tool; sourceTree = BUILT_PRODUCTS_DIR; };
-		C579E7BE67BAE4C556FE4C49 /* tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision */ = {isa = PBXFileReference; path = "tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision"; sourceTree = "<group>"; };
 		C9839B245FE2AD82F977E567 /* iOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA48A9050553966B2025597A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		CDD23F68BA68D644EBBA7592 /* watchOSAppExtension_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = watchOSAppExtension_entitlements.entitlements; sourceTree = "<group>"; };
@@ -219,7 +215,6 @@
 			isa = PBXGroup;
 			children = (
 				703A1F4497B9286207D08C3A /* watchOSApp-intermediates */,
-				ADDDE6CD7EFEAE326135EF66 /* iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision */,
 				2F093C6D6D8A0AD025D99B52 /* watchOSApp_entitlements.entitlements */,
 				D3CD2693891F897AA7150476 /* watchOSApp.zip */,
 			);
@@ -408,7 +403,6 @@
 			isa = PBXGroup;
 			children = (
 				82023CA698A41D87DFA8CB23 /* iOSApp-intermediates */,
-				9696F6FFE79D5C59630FC162 /* iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision */,
 				120042F8236B90616C49AFDD /* iOSApp_entitlements.entitlements */,
 				DC452D1E313533129C01F3E3 /* Version.bundle_version */,
 			);
@@ -687,7 +681,6 @@
 			isa = PBXGroup;
 			children = (
 				9057AEEEC2BF61DB3684417F /* watchOSAppExtension-intermediates */,
-				4C215101AD3DD834ABA30B90 /* iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision */,
 				7C9F8E5FEAD5CE19BCD0DD54 /* watchOSAppExtension_entitlements.entitlements */,
 				A0501EF726150AD19D2758EF /* watchOSAppExtension.zip */,
 			);
@@ -932,7 +925,6 @@
 			isa = PBXGroup;
 			children = (
 				C8B82A0B2637FA7A86EFE584 /* tvOSApp-intermediates */,
-				C579E7BE67BAE4C556FE4C49 /* tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision */,
 				7EC0F8698823EC93F5D32A21 /* tvOSApp_entitlements.entitlements */,
 			);
 			path = tvOSApp;

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -1,21 +1,17 @@
-$(GEN_DIR)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 $(GEN_DIR)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 $(GEN_DIR)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 $(GEN_DIR)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/Version.bundle_version
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/Version.bundle_version
-$(GEN_DIR)/applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 $(GEN_DIR)/applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 $(GEN_DIR)/applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/iOSApp/Version.bundle_version
-$(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/watchOSApp_entitlements.entitlements
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/watchOSApp-intermediates/Info.plist
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/watchOSApp.zip
-$(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -1,21 +1,17 @@
-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/Version.bundle_version
 applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/Version.bundle_version
-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/iOSApp/Version.bundle_version
-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision
 applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/watchOSApp_entitlements.entitlements
 applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/watchOSApp-intermediates/Info.plist
 applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/watchOSApp.zip
-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision
 applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,21 +1,17 @@
-$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 $(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 $(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/Version.bundle_version
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/Version.bundle_version
-$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/iOSApp/Version.bundle_version
-$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/watchOSApp_entitlements.entitlements
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/watchOSApp-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/watchOSApp.zip
-$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -20,10 +20,6 @@
         "examples/multiplatform/iOSApp/Assets.xcassets/AppIcon.appiconset/Contents.json",
         "examples/multiplatform/iOSApp/Info.plist",
         {
-            "_": "applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision",
-            "t": "g"
-        },
-        {
             "_": "applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/Version.bundle_version",
             "t": "g"
         },
@@ -61,10 +57,6 @@
         "examples/multiplatform/tvOSApp/Assets.xcassets/Contents.json",
         "examples/multiplatform/tvOSApp/Info.plist",
         {
-            "_": "applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision",
-            "t": "g"
-        },
-        {
             "_": "applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist",
             "t": "g"
         },
@@ -87,10 +79,6 @@
             "t": "g"
         },
         "examples/multiplatform/watchOSApp/Info.plist",
-        {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision",
-            "t": "g"
-        },
         {
             "_": "applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/iOSApp/Version.bundle_version",
             "t": "g"
@@ -133,10 +121,6 @@
         "examples/multiplatform/watchOSAppExtension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json",
         "examples/multiplatform/watchOSAppExtension/Assets.xcassets/Contents.json",
         "examples/multiplatform/watchOSAppExtension/Info.plist",
-        {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision",
-            "t": "g"
-        },
         {
             "_": "applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist",
             "t": "g"

--- a/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
@@ -150,21 +150,17 @@
 		571673AD5562DFA4AB138EB8 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		57DED4191C90C7A853FF2A4E /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
 		5808BF0F847CC0BF0E1128FB /* watchOSAppExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = watchOSAppExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		61ABF5DB856CDA93091F8A21 /* tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision */ = {isa = PBXFileReference; path = "tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision"; sourceTree = "<group>"; };
 		64AE19447389D7B6B9BEC81E /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		74CE77708B3D15FA2BCAB0D6 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		763746B7E174FD54C578969C /* watchOSApp_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = watchOSApp_entitlements.entitlements; sourceTree = "<group>"; };
 		796DB6B864AF4EFFBC3F8849 /* Version.bundle_version */ = {isa = PBXFileReference; path = Version.bundle_version; sourceTree = "<group>"; };
 		81A6D193BFF39B6A336051F7 /* watchOSAppExtension_entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = watchOSAppExtension_entitlements.entitlements; sourceTree = "<group>"; };
 		84D2483892E8EF0354DF0D4E /* Tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Tool; sourceTree = BUILT_PRODUCTS_DIR; };
-		89A5597668B3DA128D0A9147 /* iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision */ = {isa = PBXFileReference; path = "iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision"; sourceTree = "<group>"; };
 		8E0ADD9182447B9BBC9D04FD /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		8F1EE8FBE47D232F64888B5C /* iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision */ = {isa = PBXFileReference; path = "iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision"; sourceTree = "<group>"; };
 		909CC2C241F4540F5E294662 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9122AA9420DF1DC7CEA6891D /* Version.bundle_version */ = {isa = PBXFileReference; path = Version.bundle_version; sourceTree = "<group>"; };
 		94B4E46AB654CACC5E8E5C55 /* iOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6191AB3CB5D88EABB075490 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		A6A32E6D4A755E88A2E9DC0A /* iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision */ = {isa = PBXFileReference; path = "iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision"; sourceTree = "<group>"; };
 		A6B3AB6691877451BCADD42A /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		A7D982498A23C227E0F92061 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A9ED7F0279D8C4E01358E285 /* Version.bundle_version */ = {isa = PBXFileReference; path = Version.bundle_version; sourceTree = "<group>"; };
@@ -359,7 +355,6 @@
 			isa = PBXGroup;
 			children = (
 				F04BF1345516F4CDC39E91CC /* watchOSAppExtension-intermediates */,
-				8F1EE8FBE47D232F64888B5C /* iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision */,
 				381C43DEBE0C92B63F3D590B /* watchOSAppExtension_entitlements.entitlements */,
 				FF3E8827016B882A76B5EC13 /* watchOSAppExtension.zip */,
 			);
@@ -505,7 +500,6 @@
 			isa = PBXGroup;
 			children = (
 				9AEAE98CDF4257171E1EFE64 /* iOSApp-intermediates */,
-				89A5597668B3DA128D0A9147 /* iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision */,
 				1118895EBE141E30968A9104 /* iOSApp_entitlements.entitlements */,
 				A9ED7F0279D8C4E01358E285 /* Version.bundle_version */,
 			);
@@ -596,7 +590,6 @@
 			isa = PBXGroup;
 			children = (
 				2EF9BBD84A8A1D91268B27E0 /* watchOSApp-intermediates */,
-				A6A32E6D4A755E88A2E9DC0A /* iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision */,
 				063155AA19E757FB2E40B426 /* watchOSApp_entitlements.entitlements */,
 				D77542B2B16F5AA77ECBB45D /* watchOSApp.zip */,
 			);
@@ -870,7 +863,6 @@
 			isa = PBXGroup;
 			children = (
 				2D766DB12AD566485024A5EC /* tvOSApp-intermediates */,
-				61ABF5DB856CDA93091F8A21 /* tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision */,
 				C75CD97A5BBE066947F77FD2 /* tvOSApp_entitlements.entitlements */,
 			);
 			path = tvOSApp;

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -1,21 +1,17 @@
-$(GEN_DIR)/applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 $(GEN_DIR)/applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 $(GEN_DIR)/applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 $(GEN_DIR)/applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/Version.bundle_version
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-765845ae47bc/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-765845ae47bc/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-765845ae47bc/bin/examples/multiplatform/iOSApp/Version.bundle_version
-$(GEN_DIR)/applebin_tvos-tvos_arm64-dbg-ST-aaa1b3aaed8c/bin/examples/multiplatform/tvOSApp/tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 $(GEN_DIR)/applebin_tvos-tvos_arm64-dbg-ST-aaa1b3aaed8c/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 $(GEN_DIR)/applebin_tvos-tvos_arm64-dbg-ST-aaa1b3aaed8c/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-50452e3360d6/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-50452e3360d6/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/iOSApp/Version.bundle_version
-$(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/watchOSApp_entitlements.entitlements
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/watchOSApp-intermediates/Info.plist
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/watchOSApp.zip
-$(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.rsynclist
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.rsynclist
@@ -1,21 +1,17 @@
-applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/Version.bundle_version
 applebin_ios-ios_x86_64-dbg-ST-765845ae47bc/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 applebin_ios-ios_x86_64-dbg-ST-765845ae47bc/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 applebin_ios-ios_x86_64-dbg-ST-765845ae47bc/bin/examples/multiplatform/iOSApp/Version.bundle_version
-applebin_tvos-tvos_arm64-dbg-ST-aaa1b3aaed8c/bin/examples/multiplatform/tvOSApp/tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 applebin_tvos-tvos_arm64-dbg-ST-aaa1b3aaed8c/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 applebin_tvos-tvos_arm64-dbg-ST-aaa1b3aaed8c/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 applebin_tvos-tvos_x86_64-dbg-ST-50452e3360d6/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 applebin_tvos-tvos_x86_64-dbg-ST-50452e3360d6/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/iOSApp/Version.bundle_version
-applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision
 applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/watchOSApp_entitlements.entitlements
 applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/watchOSApp-intermediates/Info.plist
 applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/watchOSApp.zip
-applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision
 applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,21 +1,17 @@
-$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 $(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 $(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/Version.bundle_version
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-765845ae47bc/bin/examples/multiplatform/iOSApp/iOSApp_entitlements.entitlements
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-765845ae47bc/bin/examples/multiplatform/iOSApp/iOSApp-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-765845ae47bc/bin/examples/multiplatform/iOSApp/Version.bundle_version
-$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-aaa1b3aaed8c/bin/examples/multiplatform/tvOSApp/tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-aaa1b3aaed8c/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-aaa1b3aaed8c/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-50452e3360d6/bin/examples/multiplatform/tvOSApp/tvOSApp_entitlements.entitlements
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-50452e3360d6/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/iOSApp/Version.bundle_version
-$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/watchOSApp_entitlements.entitlements
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/watchOSApp-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/watchOSApp.zip
-$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension_entitlements.entitlements
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist
 $(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -17,10 +17,6 @@
         "examples/multiplatform/iOSApp/Assets.xcassets/AppIcon.appiconset/Contents.json",
         "examples/multiplatform/iOSApp/Info.plist",
         {
-            "_": "applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision",
-            "t": "g"
-        },
-        {
             "_": "applebin_ios-ios_arm64-dbg-ST-0437e361c6ef/bin/examples/multiplatform/iOSApp/Version.bundle_version",
             "t": "g"
         },
@@ -55,10 +51,6 @@
         "examples/multiplatform/tvOSApp/BUILD",
         "examples/multiplatform/tvOSApp/Info.plist",
         {
-            "_": "applebin_tvos-tvos_arm64-dbg-ST-aaa1b3aaed8c/bin/examples/multiplatform/tvOSApp/tvOS Team Provisioning Profile: io.buildbuddy.example.mobileprovision",
-            "t": "g"
-        },
-        {
             "_": "applebin_tvos-tvos_arm64-dbg-ST-aaa1b3aaed8c/bin/examples/multiplatform/tvOSApp/tvOSApp-intermediates/Info.plist",
             "t": "g"
         },
@@ -81,10 +73,6 @@
             "t": "g"
         },
         "examples/multiplatform/watchOSApp/Info.plist",
-        {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSApp/iOS Team Provisioning Profile: io.buildbuddy.example.watch.mobileprovision",
-            "t": "g"
-        },
         {
             "_": "applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/iOSApp/Version.bundle_version",
             "t": "g"
@@ -115,10 +103,6 @@
         },
         "examples/multiplatform/watchOSAppExtension/BUILD",
         "examples/multiplatform/watchOSAppExtension/Info.plist",
-        {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/iOS Team Provisioning Profile: io.buildbuddy.example.watch.extension.mobileprovision",
-            "t": "g"
-        },
         {
             "_": "applebin_watchos-watchos_arm64_32-dbg-ST-c095a2469ceb/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension-intermediates/Info.plist",
             "t": "g"

--- a/xcodeproj/internal/default_input_file_attributes_aspect.bzl
+++ b/xcodeproj/internal/default_input_file_attributes_aspect.bzl
@@ -125,7 +125,7 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
             "deps": [target_type.compile, target_type.resources],
             "resources": [target_type.resources],
         }
-        excluded = ["deps", "extensions", "frameworks"]
+        excluded = ["deps", "extensions", "frameworks", "provisioning_profile"]
         if _is_test_target(target):
             xcode_targets["test_host"] = [target_type.compile]
             excluded.append("test_host")

--- a/xcodeproj/internal/provisioning_profiles.bzl
+++ b/xcodeproj/internal/provisioning_profiles.bzl
@@ -10,7 +10,7 @@ load(":providers.bzl", "XcodeProjProvisioningProfileInfo")
 def _process_attr(*, ctx, attrs_info, build_settings):
     attr = attrs_info.provisioning_profile
     if not attr:
-        return None
+        return
 
     provisioning_profile_target = getattr(ctx.rule.attr, attr)
     if (provisioning_profile_target and
@@ -25,9 +25,6 @@ def _process_attr(*, ctx, attrs_info, build_settings):
         is_xcode_managed = False
         team_id = None
         name = None
-
-    # We don't want to show the copied managed profile in the Project navigator
-    file = None if is_xcode_managed else getattr(ctx.rule.file, attr)
 
     set_if_true(
         build_settings,
@@ -47,8 +44,6 @@ def _process_attr(*, ctx, attrs_info, build_settings):
         "CODE_SIGN_IDENTITY",
         ctx.fragments.objc.signing_certificate_name,
     )
-
-    return file
 
 def _create_profileinfo(*, target, is_xcode_managed = False):
     if AppleProvisioningProfileInfo in target:

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -191,13 +191,11 @@ def process_top_level_target(*, ctx, target, bundle_info, transitive_infos):
         entitlements_file_path = file_path(entitlements_file)
         additional_files.append(entitlements_file)
 
-    provisioning_file = provisioning_profiles.process_attr(
+    provisioning_profiles.process_attr(
         ctx = ctx,
         attrs_info = attrs_info,
         build_settings = build_settings,
     )
-    if provisioning_file:
-        additional_files.append(provisioning_file)
 
     bundle_resources = should_bundle_resources(ctx = ctx)
 


### PR DESCRIPTION
We don't ever do anything with the files, so they don't need to be in the Project navigator.