### PR TITLE
Work towards removing the need for `InputFileAttributesInfo.excluded`

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		55E65A7323E456CDEBA791E6 /* Greeting.swift.stencil */ = {isa = PBXFileReference; path = Greeting.swift.stencil; sourceTree = "<group>"; };
 		577BC07B4F6E580BDB13B5B1 /* CoreUtils.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreUtils.pch; sourceTree = "<group>"; };
 		62BA266605A71726F9EF2A78 /* nested */ = {isa = PBXFileReference; lastKnownFileType = folder; path = nested; sourceTree = "<group>"; };
+		6602B63E152B03A28F98567A /* merge.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = merge.sh; sourceTree = "<group>"; };
 		72FDDAA6D06AEFA8D20DFEF6 /* CoreUtilsObjC.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = CoreUtilsObjC.swift.modulemap; sourceTree = "<group>"; };
 		823A0A913DE6BBF3286D06E6 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		86B6FAB2FF4A94053E4D470E /* ExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
@@ -347,6 +348,7 @@
 				48F0B3D39D176B90AE9F2C8A /* Answer.swift.stencil */,
 				1104D414730D2DC8DC9DD9E9 /* BUILD */,
 				55E65A7323E456CDEBA791E6 /* Greeting.swift.stencil */,
+				6602B63E152B03A28F98567A /* merge.sh */,
 			);
 			path = TestingUtils;
 			sourceTree = "<group>";

--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -70,6 +70,7 @@
         "TestingUtils/BUILD",
         "TestingUtils/Greeting.swift.stencil",
         "TestingUtils/Answer.swift.stencil",
+        "TestingUtils/merge.sh",
         "ExampleTests/BUILD",
         {
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/TestingUtils.swift.modulemap",

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		A890FF7B719F233595AEE73E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A9184C9EF35257FEA88CF306 /* TestingUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestingUtils.swift; sourceTree = "<group>"; };
 		AE960EFF7013DD45F88383CC /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B496B3A01C258FC609A9FD36 /* merge.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = merge.sh; sourceTree = "<group>"; };
 		B69AF786B804E6CD15F61528 /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE5F89CF78F0E7C26F1539FC /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
 		C5B3BDEA35D66615774EF182 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
@@ -544,6 +545,7 @@
 				44BB25020D8FACC865B72D37 /* Answer.swift.stencil */,
 				9316517AE659EC3FD3542664 /* BUILD */,
 				1FD92C95D6623911CFD690F3 /* Greeting.swift.stencil */,
+				B496B3A01C258FC609A9FD36 /* merge.sh */,
 			);
 			path = TestingUtils;
 			sourceTree = "<group>";

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -46,6 +46,7 @@
         "TestingUtils/BUILD",
         "TestingUtils/Greeting.swift.stencil",
         "TestingUtils/Answer.swift.stencil",
+        "TestingUtils/merge.sh",
         "ExampleTests/BUILD",
         {
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-ede36487cf61/bin/TestingUtils/TestingUtils.swift.modulemap",

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -14,6 +14,14 @@
     "extra_files": [
         "examples/command_line/lib/BUILD",
         {
+            "_": "examples_command_line_external/ExternalFramework.framework",
+            "t": "e"
+        },
+        {
+            "_": "examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
+            "t": "e"
+        },
+        {
             "_": "examples_command_line_external/ImportableLibrary/Library.h",
             "t": "e"
         },
@@ -35,6 +43,7 @@
         },
         "examples/command_line/lib/dir with space/lib.h",
         "examples/command_line/third_party/BUILD",
+        "examples/command_line/third_party/ExampleFramework.framework",
         "examples/command_line/tool/BUILD",
         "examples/command_line/tool/Info.plist",
         "examples/command_line/Tests/BUILD",

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -14,6 +14,14 @@
     "extra_files": [
         "examples/command_line/lib/BUILD",
         {
+            "_": "examples_command_line_external/ExternalFramework.framework",
+            "t": "e"
+        },
+        {
+            "_": "examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
+            "t": "e"
+        },
+        {
             "_": "examples_command_line_external/ImportableLibrary/Library.h",
             "t": "e"
         },
@@ -35,6 +43,7 @@
         },
         "examples/command_line/lib/dir with space/lib.h",
         "examples/command_line/third_party/BUILD",
+        "examples/command_line/third_party/ExampleFramework.framework",
         "examples/command_line/tool/BUILD",
         "examples/command_line/tool/Info.plist",
         "examples/command_line/Tests/BUILD",

--- a/xcodeproj/internal/default_input_file_attributes_aspect.bzl
+++ b/xcodeproj/internal/default_input_file_attributes_aspect.bzl
@@ -56,6 +56,7 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
     else:
         srcs = ()
 
+    excluded = ("deps")
     non_arc_srcs = ()
     hdrs = ()
     pch = None
@@ -68,7 +69,7 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
             "deps": [target_type.compile, target_type.resources],
             "interface_deps": [target_type.compile],
         }
-        excluded = ("deps", "interface_deps", "win_def_file")
+        excluded = ("deps", "interface_deps")
         hdrs = ("hdrs", "textual_hdrs")
         resources = {
             "deps": [target_type.compile, target_type.resources],
@@ -76,7 +77,6 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
         }
     elif ctx.rule.kind == "cc_import":
         xcode_targets = {}
-        excluded = ("shared_library", "static_library")
     elif ctx.rule.kind == "objc_library":
         xcode_targets = {
             "deps": [target_type.compile, target_type.resources],
@@ -89,12 +89,10 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
         pch = "pch"
         resources = {
             "deps": [target_type.compile, target_type.resources],
-            "runtime_deps": [target_type.compile],
             "data": [target_type.resources],
         }
     elif ctx.rule.kind == "objc_import":
         xcode_targets = {}
-        excluded = ("archives")
     elif ctx.rule.kind == "swift_library":
         xcode_targets = {
             "deps": [target_type.compile, target_type.resources],
@@ -104,31 +102,25 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
         excluded = ("deps", "private_deps")
         resources = {
             "deps": [target_type.compile, target_type.resources],
-            "private_deps": [target_type.compile],
             "data": [target_type.resources],
         }
     elif (ctx.rule.kind == "apple_resource_group" or
           ctx.rule.kind == "apple_resource_bundle"):
         xcode_targets = {"resources": [target_type.resources]}
-        excluded = ()
         resources = {"resources": [target_type.resources]}
         structured_resources = ("structured_resources")
     elif ctx.rule.kind == "apple_bundle_import":
         xcode_targets = {}
-        excluded = ()
         bundle_imports = ("bundle_imports")
     elif ctx.rule.kind == "genrule":
         xcode_targets = {}
-        excluded = ("tools")
     elif AppleBundleInfo in target:
         xcode_targets = {
             "deps": [target_type.compile, target_type.resources],
             "resources": [target_type.resources],
         }
-        excluded = ["deps", "extensions", "frameworks", "provisioning_profile"]
         if _is_test_target(target):
             xcode_targets["test_host"] = [target_type.compile]
-            excluded.append("test_host")
         provisioning_profile = "provisioning_profile"
         resources = {
             "deps": [target_type.compile, target_type.resources],
@@ -136,11 +128,9 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
         }
     elif AppleFrameworkImportInfo in target:
         xcode_targets = {"deps": [target_type.compile, target_type.resources]}
-        excluded = ("deps", "framework_imports")
         resources = {"deps": [target_type.compile, target_type.resources]}
     else:
         xcode_targets = {"deps": [this_target_type, target_type.resources]}
-        excluded = ("deps")
         resources = {"deps": [this_target_type, target_type.resources]}
 
     return [


### PR DESCRIPTION
This change causes imported frameworks and libraries to be included in `extraFiles`, even though they are already included in `linkerInputs`. This is already the case for modulemaps as well, they are already included in `modulemaps`. In a future change we can probably prune things from `extraFiles` that we have collected elsewhere.

A refactor of how we handle resource file collection will allow us to fully remove `InputFileAttributesInfo.excluded`, and the `_SUSPECT_GENERATED_EXTENSIONS` check as well.