### PR TITLE
Fix non-`--define=apple.experimental.tree_artifact_outputs=1` syncing bug

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -35,7 +35,10 @@ else
       ]]; then
         mkdir -p "$expanded_dest"
         rm -rf "${expanded_dest:?}/"
-        unzip -q "$archive" -d "$expanded_dest"
+        echo "Extracting $archive to $expanded_dest"
+        # Set timestamps (-DD) to allow rsync to work properly, since Bazel
+        # zeroes out timestamps in the archive
+        unzip -q -DD "$archive" -d "$expanded_dest"
         echo "$sha" > "$sha_output"
       fi
       cd "$product_parent_dir"

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -35,7 +35,10 @@ else
       ]]; then
         mkdir -p "$expanded_dest"
         rm -rf "${expanded_dest:?}/"
-        unzip -q "$archive" -d "$expanded_dest"
+        echo "Extracting $archive to $expanded_dest"
+        # Set timestamps (-DD) to allow rsync to work properly, since Bazel
+        # zeroes out timestamps in the archive
+        unzip -q -DD "$archive" -d "$expanded_dest"
         echo "$sha" > "$sha_output"
       fi
       cd "$product_parent_dir"

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -35,7 +35,10 @@ else
       ]]; then
         mkdir -p "$expanded_dest"
         rm -rf "${expanded_dest:?}/"
-        unzip -q "$archive" -d "$expanded_dest"
+        echo "Extracting $archive to $expanded_dest"
+        # Set timestamps (-DD) to allow rsync to work properly, since Bazel
+        # zeroes out timestamps in the archive
+        unzip -q -DD "$archive" -d "$expanded_dest"
         echo "$sha" > "$sha_output"
       fi
       cd "$product_parent_dir"

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -35,7 +35,10 @@ else
       ]]; then
         mkdir -p "$expanded_dest"
         rm -rf "${expanded_dest:?}/"
-        unzip -q "$archive" -d "$expanded_dest"
+        echo "Extracting $archive to $expanded_dest"
+        # Set timestamps (-DD) to allow rsync to work properly, since Bazel
+        # zeroes out timestamps in the archive
+        unzip -q -DD "$archive" -d "$expanded_dest"
         echo "$sha" > "$sha_output"
       fi
       cd "$product_parent_dir"

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -35,7 +35,10 @@ else
       ]]; then
         mkdir -p "$expanded_dest"
         rm -rf "${expanded_dest:?}/"
-        unzip -q "$archive" -d "$expanded_dest"
+        echo "Extracting $archive to $expanded_dest"
+        # Set timestamps (-DD) to allow rsync to work properly, since Bazel
+        # zeroes out timestamps in the archive
+        unzip -q -DD "$archive" -d "$expanded_dest"
         echo "$sha" > "$sha_output"
       fi
       cd "$product_parent_dir"

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -35,7 +35,10 @@ else
       ]]; then
         mkdir -p "$expanded_dest"
         rm -rf "${expanded_dest:?}/"
-        unzip -q "$archive" -d "$expanded_dest"
+        echo "Extracting $archive to $expanded_dest"
+        # Set timestamps (-DD) to allow rsync to work properly, since Bazel
+        # zeroes out timestamps in the archive
+        unzip -q -DD "$archive" -d "$expanded_dest"
         echo "$sha" > "$sha_output"
       fi
       cd "$product_parent_dir"

--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -35,7 +35,10 @@ else
       ]]; then
         mkdir -p "$expanded_dest"
         rm -rf "${expanded_dest:?}/"
-        unzip -q "$archive" -d "$expanded_dest"
+        echo "Extracting $archive to $expanded_dest"
+        # Set timestamps (-DD) to allow rsync to work properly, since Bazel
+        # zeroes out timestamps in the archive
+        unzip -q -DD "$archive" -d "$expanded_dest"
         echo "$sha" > "$sha_output"
       fi
       cd "$product_parent_dir"


### PR DESCRIPTION
Bazel built zips have zeroed out timestamps. So if any unarchived items had the same modified size as before a change, rsync wouldn't copy them over. We now set the timestamps to be the time we unzip.