### PR TITLE
Convert `platform` into a Starlark module

### DIFF
--- a/test/internal/platform/BUILD
+++ b/test/internal/platform/BUILD
@@ -1,10 +1,10 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
-    ":generate_platform_information_tests.bzl",
-    "generate_platform_information_test_suite",
+    ":platform_info_to_dto_tests.bzl",
+    "platform_info_to_dto_test_suite",
 )
 
-generate_platform_information_test_suite(name = "generate_platform_information")
+platform_info_to_dto_test_suite(name = "platform_info_to_dto")
 
 test_suite(name = "platform")
 

--- a/test/internal/platform/platform_info_to_dto_tests.bzl
+++ b/test/internal/platform/platform_info_to_dto_tests.bzl
@@ -4,22 +4,20 @@ load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load("//test:utils.bzl", "stringify_dict")
 
 # buildifier: disable=bzl-visibility
-load("//xcodeproj/internal:platform.bzl", "testable")
+load("//xcodeproj/internal:platform.bzl", "platform_info")
 
-generate_platform_information = testable.generate_platform_information
-
-def _generate_platform_information_test_impl(ctx):
+def _platform_info_to_dto_test_impl(ctx):
     env = unittest.begin(ctx)
 
     build_settings = {}
-    platform = generate_platform_information(
-        platform = getattr(apple_common.platform, ctx.attr.platform_key),
-        arch = ctx.attr.arch,
-        minimum_os_version = ctx.attr.minimum_os_version,
-        minimum_deployment_os_version = ctx.attr.minimum_deployment_os_version,
-        build_settings = build_settings,
+    platform = struct(
+        _platform = getattr(apple_common.platform, ctx.attr.platform_key),
+        _arch = ctx.attr.arch,
+        _minimum_os_version = ctx.attr.minimum_os_version,
+        _minimum_deployment_os_version = ctx.attr.minimum_deployment_os_version,
     )
-    string_platform = stringify_dict(platform)
+    dto = platform_info.to_dto(platform, build_settings = build_settings)
+    string_platform = stringify_dict(dto)
     string_build_settings = stringify_dict(build_settings)
 
     asserts.equals(
@@ -37,8 +35,8 @@ def _generate_platform_information_test_impl(ctx):
 
     return unittest.end(env)
 
-generate_platform_information_test = unittest.make(
-    impl = _generate_platform_information_test_impl,
+platform_info_to_dto_test = unittest.make(
+    impl = _platform_info_to_dto_test_impl,
     attrs = {
         "arch": attr.string(mandatory = True),
         "expected_build_settings": attr.string_dict(mandatory = True),
@@ -49,8 +47,8 @@ generate_platform_information_test = unittest.make(
     },
 )
 
-def generate_platform_information_test_suite(name):
-    """Test suite for `generate_platform_information`.
+def platform_info_to_dto_test_suite(name):
+    """Test suite for `platform_info.to_dto`.
 
     Args:
         name: The base name to be used in things created by this macro. Also the
@@ -68,7 +66,7 @@ def generate_platform_information_test_suite(name):
             expected_platform_dict,
             expected_build_settings):
         test_names.append(name)
-        generate_platform_information_test(
+        platform_info_to_dto_test(
             name = name,
             platform_key = platform_key,
             arch = arch,

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -15,7 +15,7 @@ load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "process_opts")
 load(":output_files.bzl", "output_files")
-load(":platform.bzl", "process_platform")
+load(":platform.bzl", "platform_info")
 load(
     ":providers.bzl",
     "InputFileAttributesInfo",
@@ -119,10 +119,9 @@ def process_library_target(*, ctx, target, transitive_infos):
         [],
     )
 
-    platform = process_platform(
+    platform = platform_info.collect(
         ctx = ctx,
         minimum_deployment_os_version = None,
-        build_settings = build_settings,
     )
     product = process_product(
         target = target,

--- a/xcodeproj/internal/platform.bzl
+++ b/xcodeproj/internal/platform.bzl
@@ -17,62 +17,16 @@ _PLATFORM_NAME = {
     apple_common.platform.watchos_simulator: "watchsimulator",
 }
 
-def _generate_platform_information(
-        *,
-        platform,
-        arch,
-        minimum_os_version,
-        minimum_deployment_os_version,
-        build_settings):
-    """Generates the platform information for a given platform.
-
-    Args:
-        platform: An `apple_platform`. See
-            https://bazel.build/rules/lib/apple_platform.
-        arch: A cpu architecture string. See
-            https://bazel.build/rules/lib/apple#single_arch_cpu.
-        minimum_os_version: A string of the minimum OS version. See
-            https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_application-minimum_os_version.
-        minimum_deployment_os_version: A string of the minimum deployment OS
-            version. See https://github.com/bazelbuild/rules_apple/blob/master/doc/rules-ios.md#ios_application-minimum_deployment_os_version.
-        build_settings: A mutable `dict` that will be updated with Xcode build
-            settings.
-
-    Returns:
-        A `dict` of platform information.
-    """
-    platform_type = platform.platform_type
-    is_device = platform.is_device
-
-    platform_dict = {
-        "name": _PLATFORM_NAME[platform],
-        "os": str(platform_type),
-        "arch": arch,
-        "minimum_os_version": minimum_os_version,
-    }
-    if not is_device:
-        platform_dict["environment"] = "Simulator"
-
-    build_settings[_DEPLOYMENT_TARGET_KEY[platform_type]] = (
-        minimum_deployment_os_version if minimum_deployment_os_version else minimum_os_version
-    )
-
-    return platform_dict
-
-# API
-
-def process_platform(*, ctx, minimum_deployment_os_version, build_settings):
-    """Generates information about a target's platform.
+def _collect(*, ctx, minimum_deployment_os_version):
+    """Collects information about a target's platform.
 
     Args:
         ctx: The aspect context.
         minimum_deployment_os_version: The minimum deployment OS version for the
             target.
-        build_settings: A mutable `dict` that will be updated with Xcode build
-            settings.
 
     Returns:
-        A `dict` of platform information.
+        An opaque `struct` to be used with `platform_info.to_dto`.
     """
     apple_fragment = ctx.fragments.apple
     platform = apple_fragment.single_arch_platform
@@ -81,15 +35,45 @@ def process_platform(*, ctx, minimum_deployment_os_version, build_settings):
         xcode_config.minimum_os_for_platform_type(platform.platform_type),
     )
 
-    return _generate_platform_information(
-        platform = platform,
-        arch = apple_fragment.single_arch_cpu,
-        minimum_os_version = minimum_os_version,
-        minimum_deployment_os_version = minimum_deployment_os_version,
-        build_settings = build_settings,
+    return struct(
+        _platform = platform,
+        _arch = apple_fragment.single_arch_cpu,
+        _minimum_os_version = minimum_os_version,
+        _minimum_deployment_os_version = minimum_deployment_os_version,
     )
 
-# These functions are exposed only for access in unit tests.
-testable = struct(
-    generate_platform_information = _generate_platform_information,
+def _to_dto(platform, *, build_settings):
+    """Generates a target DTO value for a platform.
+
+    Args:
+        platform: A value returned from `platform_info.collect`.
+        build_settings: A mutable `dict` that will be updated with Xcode build
+            settings.
+    """
+    arch = platform._arch
+    os_version = platform._minimum_os_version
+    deployment_os_version = platform._minimum_deployment_os_version
+    platform = platform._platform
+
+    platform_type = platform.platform_type
+    is_device = platform.is_device
+
+    dto = {
+        "name": _PLATFORM_NAME[platform],
+        "os": str(platform_type),
+        "arch": arch,
+        "minimum_os_version": os_version,
+    }
+    if not is_device:
+        dto["environment"] = "Simulator"
+
+    build_settings[_DEPLOYMENT_TARGET_KEY[platform_type]] = (
+        deployment_os_version if deployment_os_version else os_version
+    )
+
+    return dto
+
+platform_info = struct(
+    collect = _collect,
+    to_dto = _to_dto,
 )

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -4,6 +4,7 @@ load(":files.bzl", "file_path_to_dto")
 load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":output_files.bzl", "output_files")
+load(":platform.bzl", "platform_info")
 load(":product.bzl", "product_to_dto")
 load(":providers.bzl", "target_type")
 load(":resource_bundle_products.bzl", "resource_bundle_products")
@@ -125,12 +126,17 @@ def xcode_target(
         to create a json array string, possibly joining multiples of these
         strings with `","`.
     """
+    platform_dto = platform_info.to_dto(
+        platform,
+        build_settings = build_settings,
+    )
+
     target = json.encode(struct(
         name = name,
         label = str(label),
         configuration = configuration,
         package_bin_dir = package_bin_dir,
-        platform = platform,
+        platform = platform_dto,
         product = product_to_dto(product),
         is_swift = is_swift,
         test_host = test_host,

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -12,7 +12,7 @@ load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "create_opts_search_paths")
 load(":output_files.bzl", "output_files")
-load(":platform.bzl", "process_platform")
+load(":platform.bzl", "platform_info")
 load(
     ":providers.bzl",
     "InputFileAttributesInfo",
@@ -87,10 +87,9 @@ def process_resource_target(*, ctx, target, transitive_infos):
         is_xcode_target = True,
     )
 
-    platform = process_platform(
+    platform = platform_info.collect(
         ctx = ctx,
         minimum_deployment_os_version = None,
-        build_settings = build_settings,
     )
     product = process_product(
         target = target,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -12,7 +12,7 @@ load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "process_opts")
 load(":output_files.bzl", "output_files")
-load(":platform.bzl", "process_platform")
+load(":platform.bzl", "platform_info")
 load(":providers.bzl", "InputFileAttributesInfo", "XcodeProjInfo")
 load(":processed_target.bzl", "processed_target", "xcode_target")
 load(":product.bzl", "process_product")
@@ -289,10 +289,9 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
         get_targeted_device_family(getattr(ctx.rule.attr, "families", [])),
     )
 
-    platform = process_platform(
+    platform = platform_info.collect(
         ctx = ctx,
         minimum_deployment_os_version = props.minimum_deployment_os_version,
-        build_settings = build_settings,
     )
     product = process_product(
         target = target,


### PR DESCRIPTION
This is needed for the `AppleResourceInfo` collection rework.