### PR TITLE
Remove no longer needed `InputFileAttributesInfo.excluded`

### DIFF
--- a/xcodeproj/internal/default_input_file_attributes_aspect.bzl
+++ b/xcodeproj/internal/default_input_file_attributes_aspect.bzl
@@ -48,7 +48,6 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
     else:
         srcs = ()
 
-    excluded = ("deps")
     non_arc_srcs = ()
     hdrs = ()
     pch = None
@@ -61,7 +60,6 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
             "deps": [target_type.compile],
             "interface_deps": [target_type.compile],
         }
-        excluded = ("deps", "interface_deps")
         hdrs = ("hdrs", "textual_hdrs")
     elif ctx.rule.kind == "cc_import":
         xcode_targets = {}
@@ -70,7 +68,6 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
             "deps": [target_type.compile],
             "runtime_deps": [target_type.compile],
         }
-        excluded = ("deps", "runtime_deps")
         non_arc_srcs = ("non_arc_srcs")
         hdrs = ("hdrs", "textual_hdrs")
         pch = "pch"
@@ -81,7 +78,6 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
             "deps": [target_type.compile],
             "private_deps": [target_type.compile],
         }
-        excluded = ("deps", "private_deps")
     elif ctx.rule.kind == "apple_resource_bundle":
         xcode_targets = {}
 
@@ -111,7 +107,6 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
         InputFileAttributesInfo(
             target_type = this_target_type,
             xcode_targets = xcode_targets,
-            excluded = excluded,
             non_arc_srcs = non_arc_srcs,
             srcs = srcs,
             hdrs = hdrs,

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -64,9 +64,8 @@ def _collect_transitive_uncategorized(info):
         return depset()
     return info.inputs.uncategorized
 
-def _should_ignore_attr(attr, *, excluded_attrs):
+def _should_ignore_attr(attr):
     return (
-        attr in excluded_attrs or
         # We don't want to include implicit dependencies
         attr.startswith("_") or
         # These are actually Starklark methods, so ignore them
@@ -253,21 +252,19 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md
             return
         transitive_extra_files.append(dep[XcodeProjInfo].inputs.uncategorized)
 
-    excluded_attrs = attrs_info.excluded
-
     for attr in dir(ctx.rule.files):
-        if _should_ignore_attr(attr, excluded_attrs = excluded_attrs):
+        if _should_ignore_attr(attr):
             continue
         for file in getattr(ctx.rule.files, attr):
             _handle_file(file, attr = attr)
 
     for attr in dir(ctx.rule.file):
-        if _should_ignore_attr(attr, excluded_attrs = excluded_attrs):
+        if _should_ignore_attr(attr):
             continue
         _handle_file(getattr(ctx.rule.file, attr), attr = attr)
 
     for attr in dir(ctx.rule.attr):
-        if _should_ignore_attr(attr, excluded_attrs = excluded_attrs):
+        if _should_ignore_attr(attr):
             continue
         dep = getattr(ctx.rule.attr, attr, None)
         if type(dep) == "Target":

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -27,11 +27,6 @@ An attribute name (or `None`) to collect the bundle id string from.
 An attribute name (or `None`) to collect `File`s from for the
 `entitlements`-like attribute.
 """,
-        "excluded": """\
-A sequence of attribute names to not collect `File`s from. This should generally
-be `deps` and `deps`-like attributes. The goal is to exclude attributes that
-have generated products (e.g. ".swiftmodule" or ".a" files) as outputs.
-""",
         "infoplists": """\
 A sequence of attribute names to collect `File`s from for the `infoplists`-like
 attributes.


### PR DESCRIPTION
With the resource file collection rework, we no longer need the special logic around excluded dependencies.