### PR TITLE
Rename `required_links` to `non_mergable_targets`

### DIFF
--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -178,8 +178,6 @@ def process_library_target(*, ctx, target, transitive_infos):
         inputs = inputs,
         linker_inputs = linker_inputs,
         outputs = outputs,
-        potential_target_merges = None,
-        required_links = None,
         search_paths = search_paths,
         target = struct(
             id = id,

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -51,8 +51,6 @@ def process_non_xcode_target(*, ctx, target, transitive_infos):
             attrs_info = attrs_info,
             transitive_infos = transitive_infos,
         ),
-        potential_target_merges = None,
-        required_links = None,
         search_paths = process_search_paths(
             cc_info = cc_info,
             objc = objc,

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -14,9 +14,9 @@ def processed_target(
         dependencies,
         inputs,
         linker_inputs,
+        non_mergable_targets = None,
         outputs,
-        potential_target_merges,
-        required_links,
+        potential_target_merges = None,
         resource_bundle_informations = None,
         search_paths,
         target,
@@ -32,12 +32,12 @@ def processed_target(
         linker_inputs: A value returned from `linker_input_files.collect`
             that will provide values for the `XcodeProjInfo.linker_inputs`
             field.
+        non_mergable_targets: An optional `list` of strings that will be in the
+            `XcodeProjInfo.non_mergable_targets` `depset`.
         outputs: A value as returned from `output_files.collect` that will
             provide values for the `XcodeProjInfo.outputs` field.
         potential_target_merges: An optional `list` of `struct`s that will be in
             the `XcodeProjInfo.potential_target_merges` `depset`.
-        required_links: An optional `list` of strings that will be in the
-            `XcodeProjInfo.required_links` `depset`.
         resource_bundle_informations: An optional `list` of `struct`s that will
             be in the `XcodeProjInfo.resource_bundle_informations` `depset`.
         search_paths: The value returned from `_process_search_paths`.
@@ -53,9 +53,9 @@ def processed_target(
         dependencies = dependencies,
         inputs = inputs,
         linker_inputs = linker_inputs,
+        non_mergable_targets = non_mergable_targets,
         outputs = outputs,
         potential_target_merges = potential_target_merges,
-        required_links = required_links,
         resource_bundle_informations = resource_bundle_informations,
         search_paths = search_paths,
         target = target,

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -75,13 +75,13 @@ A value returned from `linker_input_files.collect`.
 A `depset` of structs with 'src' and 'dest' fields. The 'src' field is the id of
 the target that can be merged into the target with the id of the 'dest' field.
 """,
+        "non_mergable_targets": """\
+A `depset` of all static library files that are linked into top-level targets
+besides their primary top-level targets.
+""",
         "outputs": """\
 A value returned from `output_files.collect`, that contains information about
 the output files for this target and its transitive dependencies.
-""",
-        "required_links": """\
-A `depset` of all static library files that are linked into top-level targets
-besides their primary top-level targets.
 """,
         "resource_bundle_informations": """\
 A `depset` of `struct`s with information used to generate resource bundles,

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -154,8 +154,6 @@ def process_resource_target(*, ctx, target, transitive_infos):
             attrs_info = attrs_info,
             transitive_infos = transitive_infos,
         ),
-        potential_target_merges = None,
-        required_links = None,
         resource_bundle_informations = [
             struct(
                 id = id,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -276,7 +276,7 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
         mergeable_label = None
 
     static_libraries = linker_input_files.get_static_libraries(linker_inputs)
-    required_links = [
+    non_mergable_targets = [
         library
         for library in static_libraries
         if mergeable_label and library.owner != mergeable_label
@@ -323,9 +323,9 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
         dependencies = dependencies,
         inputs = inputs,
         linker_inputs = linker_inputs,
+        non_mergable_targets = non_mergable_targets,
         outputs = outputs,
         potential_target_merges = potential_target_merges,
-        required_links = required_links,
         search_paths = search_paths,
         target = struct(
             id = id,

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -27,26 +27,26 @@ def _write_json_spec(*, ctx, project_name, configuration, inputs, infos):
     )
 
     extra_files = inputs.extra_files
+    non_mergable_targets = depset(
+        transitive = [info.non_mergable_targets for info in infos],
+    )
     potential_target_merges = depset(
         transitive = [info.potential_target_merges for info in infos],
-    )
-    required_links = depset(
-        transitive = [info.required_links for info in infos],
     )
     xcode_targets = depset(
         resource_bundle_xcode_targets,
         transitive = [info.xcode_targets for info in infos],
     )
 
-    required_links_set = sets.make([
+    non_mergable_targets_set = sets.make([
         file_path(file)
-        for file in required_links.to_list()
+        for file in non_mergable_targets.to_list()
     ])
 
     target_merges = {}
     invalid_target_merges = {}
     for merge in potential_target_merges.to_list():
-        if sets.contains(required_links_set, merge.src.product_path):
+        if sets.contains(non_mergable_targets_set, merge.src.product_path):
             destinations = invalid_target_merges.get(merge.src.id, [])
             destinations.append(merge.dest)
             invalid_target_merges[merge.src.id] = destinations


### PR DESCRIPTION
Better reflects the reason we are tracking them.