### PR TITLE
Rename `InputFileAttributesInfo` to `XcodeProjAutomaticTargetProcessingInfo`

### DIFF
--- a/xcodeproj/internal/default_input_file_attributes_aspect.bzl
+++ b/xcodeproj/internal/default_input_file_attributes_aspect.bzl
@@ -6,7 +6,7 @@ load(
     "AppleBundleInfo",
     "AppleFrameworkImportInfo",
 )
-load(":providers.bzl", "InputFileAttributesInfo", "target_type")
+load(":providers.bzl", "XcodeProjAutomaticTargetProcessingInfo", "target_type")
 
 # Utility
 
@@ -38,7 +38,7 @@ def _is_test_target(target):
 # Aspects
 
 def _default_input_file_attributes_aspect_impl(target, ctx):
-    if InputFileAttributesInfo in target:
+    if XcodeProjAutomaticTargetProcessingInfo in target:
         return []
 
     this_target_type = _get_target_type(target = target)
@@ -104,7 +104,7 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
         xcode_targets = {"deps": [this_target_type]}
 
     return [
-        InputFileAttributesInfo(
+        XcodeProjAutomaticTargetProcessingInfo(
             target_type = this_target_type,
             xcode_targets = xcode_targets,
             non_arc_srcs = non_arc_srcs,

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -1,34 +1,18 @@
-""" Functions for processing library targets """
+"""Functions for processing library targets."""
 
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
-load(
-    ":build_settings.bzl",
-    "get_product_module_name",
-)
+load(":build_settings.bzl", "get_product_module_name")
 load(":collections.bzl", "set_if_true")
 load(":configuration.bzl", "get_configuration")
-load(
-    ":files.bzl",
-    "join_paths_ignoring_empty",
-)
+load(":files.bzl", "join_paths_ignoring_empty")
 load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "process_opts")
 load(":output_files.bzl", "output_files")
 load(":platform.bzl", "platform_info")
-load(
-    ":providers.bzl",
-    "InputFileAttributesInfo",
-)
-load(
-    ":processed_target.bzl",
-    "processed_target",
-    "xcode_target",
-)
-load(
-    ":product.bzl",
-    "process_product",
-)
+load(":providers.bzl", "XcodeProjAutomaticTargetProcessingInfo")
+load(":processed_target.bzl", "processed_target", "xcode_target")
+load(":product.bzl", "process_product")
 load(":search_paths.bzl", "process_search_paths")
 load(":target_id.bzl", "get_id")
 load(
@@ -54,7 +38,7 @@ def process_library_target(*, ctx, target, transitive_infos):
     Returns:
         The value returned from `processed_target`.
     """
-    attrs_info = target[InputFileAttributesInfo]
+    automatic_target_info = target[XcodeProjAutomaticTargetProcessingInfo]
 
     configuration = get_configuration(ctx)
     label = target.label
@@ -80,7 +64,7 @@ def process_library_target(*, ctx, target, transitive_infos):
         get_product_module_name(ctx = ctx, target = target),
     )
     dependencies = process_dependencies(
-        attrs_info = attrs_info,
+        automatic_target_info = automatic_target_info,
         transitive_infos = transitive_infos,
     )
 
@@ -142,7 +126,7 @@ def process_library_target(*, ctx, target, transitive_infos):
         platform = platform,
         bundle_resources = bundle_resources,
         is_bundle = False,
-        attrs_info = attrs_info,
+        automatic_target_info = automatic_target_info,
         additional_files = modulemaps.files,
         transitive_infos = transitive_infos,
         avoid_deps = [],
@@ -173,7 +157,7 @@ def process_library_target(*, ctx, target, transitive_infos):
     )
 
     return processed_target(
-        attrs_info = attrs_info,
+        automatic_target_info = automatic_target_info,
         dependencies = dependencies,
         inputs = inputs,
         linker_inputs = linker_inputs,

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -4,7 +4,7 @@ load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "create_opts_search_paths")
 load(":output_files.bzl", "output_files")
-load(":providers.bzl", "InputFileAttributesInfo")
+load(":providers.bzl", "XcodeProjAutomaticTargetProcessingInfo")
 load(":processed_target.bzl", "processed_target")
 load(":search_paths.bzl", "process_search_paths")
 load(":target_properties.bzl", "process_dependencies")
@@ -24,12 +24,12 @@ def process_non_xcode_target(*, ctx, target, transitive_infos):
     cc_info = target[CcInfo] if CcInfo in target else None
     objc = target[apple_common.Objc] if apple_common.Objc in target else None
 
-    attrs_info = target[InputFileAttributesInfo]
+    automatic_target_info = target[XcodeProjAutomaticTargetProcessingInfo]
 
     return processed_target(
-        attrs_info = attrs_info,
+        automatic_target_info = automatic_target_info,
         dependencies = process_dependencies(
-            attrs_info = attrs_info,
+            automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
         ),
         inputs = input_files.collect(
@@ -38,7 +38,7 @@ def process_non_xcode_target(*, ctx, target, transitive_infos):
             platform = None,
             bundle_resources = False,
             is_bundle = False,
-            attrs_info = attrs_info,
+            automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
             avoid_deps = [],
         ),
@@ -48,7 +48,7 @@ def process_non_xcode_target(*, ctx, target, transitive_infos):
             is_xcode_target = False,
         ),
         outputs = output_files.merge(
-            attrs_info = attrs_info,
+            automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
         ),
         search_paths = process_search_paths(

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -8,7 +8,7 @@ load(":output_group_map.bzl", "output_group_map")
 def _create(
         *,
         direct_outputs = None,
-        attrs_info = None,
+        automatic_target_info = None,
         transitive_infos,
         should_produce_dto = False):
     """Creates the internal data structure of the `output_files` module.
@@ -16,7 +16,8 @@ def _create(
     Args:
         direct_outputs: A value returned from `_get_outputs`, or `None` if
             the outputs are being merged.
-        attrs_info: The `InputFileAttributesInfo` for the target.
+        automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
+            the target.
         transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
             dependencies of the current target.
         should_produce_dto: If `True`, `outputs_files.to_dto` will return
@@ -59,8 +60,11 @@ def _create(
         transitive = [
             info.outputs._transitive_build
             for attr, info in transitive_infos
-            if (not attrs_info or
-                info.target_type in attrs_info.xcode_targets.get(attr, [None]))
+            if (not automatic_target_info or
+                info.target_type in automatic_target_info.xcode_targets.get(
+                    attr,
+                    [None],
+                ))
         ],
     )
 
@@ -69,8 +73,11 @@ def _create(
         transitive = [
             info.outputs._transitive_index
             for attr, info in transitive_infos
-            if (not attrs_info or
-                info.target_type in attrs_info.xcode_targets.get(attr, [None]))
+            if (not automatic_target_info or
+                info.target_type in automatic_target_info.xcode_targets.get(
+                    attr,
+                    [None],
+                ))
         ],
     )
 
@@ -87,8 +94,11 @@ def _create(
         transitive = [
             info.outputs._output_group_list
             for attr, info in transitive_infos
-            if (not attrs_info or
-                info.target_type in attrs_info.xcode_targets.get(attr, [None]))
+            if (not automatic_target_info or
+                info.target_type in automatic_target_info.xcode_targets.get(
+                    attr,
+                    [None],
+                ))
         ],
     )
 
@@ -236,11 +246,12 @@ def _collect(
         transitive_infos = transitive_infos,
     )
 
-def _merge(*, attrs_info, transitive_infos):
+def _merge(*, automatic_target_info, transitive_infos):
     """Creates merged outputs.
 
     Args:
-        attrs_info: The `InputFileAttributesInfo` for the target.
+        automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
+            the target.
         transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
             dependencies of the current target.
 
@@ -249,7 +260,10 @@ def _merge(*, attrs_info, transitive_infos):
         values include the outputs of the transitive dependencies, via
         `transitive_infos` (e.g. `generated` and `extra_files`).
     """
-    return _create(transitive_infos = transitive_infos, attrs_info = attrs_info)
+    return _create(
+        transitive_infos = transitive_infos,
+        automatic_target_info = automatic_target_info,
+    )
 
 def _to_dto(outputs):
     direct_outputs = outputs._direct_outputs

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -10,7 +10,7 @@ load(":providers.bzl", "target_type")
 
 def processed_target(
         *,
-        attrs_info,
+        automatic_target_info,
         dependencies,
         inputs,
         linker_inputs,
@@ -24,7 +24,8 @@ def processed_target(
     """Generates the return value for target processing functions.
 
     Args:
-        attrs_info: The `InputFileAttributesInfo` for the target.
+        automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
+            the target.
         dependencies: A `list` of target ids of direct dependencies of this
             target.
         inputs: A value as returned from `input_files.collect` that will
@@ -49,7 +50,7 @@ def processed_target(
         A `struct` containing fields for each argument.
     """
     return struct(
-        attrs_info = attrs_info,
+        automatic_target_info = automatic_target_info,
         dependencies = dependencies,
         inputs = inputs,
         linker_inputs = linker_inputs,

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -8,8 +8,14 @@ but if you want to write your own custom rules that interact with these
 rules, then you will use these providers to communicate between them.
 """
 
-InputFileAttributesInfo = provider(
-    "Specifies how input files of a target are collected.",
+XcodeProjAutomaticTargetProcessingInfo = provider(
+    """\
+Provides needed information about a target to allow rules_xcodeproj to
+automatically process it.
+
+If you need more control over how a target or it's dependencies are processed,
+return a `XcodeProjInfo` provider instance instead.
+""",
     fields = {
         "bundle_id": """\
 An attribute name (or `None`) to collect the bundle id string from.

--- a/xcodeproj/internal/provisioning_profiles.bzl
+++ b/xcodeproj/internal/provisioning_profiles.bzl
@@ -7,8 +7,8 @@ load(
 load(":collections.bzl", "set_if_true")
 load(":providers.bzl", "XcodeProjProvisioningProfileInfo")
 
-def _process_attr(*, ctx, attrs_info, build_settings):
-    attr = attrs_info.provisioning_profile
+def _process_attr(*, ctx, automatic_target_info, build_settings):
+    attr = automatic_target_info.provisioning_profile
     if not attr:
         return
 

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -9,7 +9,7 @@ load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "create_opts_search_paths")
 load(":output_files.bzl", "output_files")
 load(":processed_target.bzl", "processed_target", "xcode_target")
-load(":providers.bzl", "InputFileAttributesInfo")
+load(":providers.bzl", "XcodeProjAutomaticTargetProcessingInfo")
 load(":product.bzl", "process_product")
 load(":search_paths.bzl", "process_search_paths")
 load(":target_id.bzl", "get_id")
@@ -127,12 +127,12 @@ def process_resource_target(*, ctx, target, transitive_infos):
     label = target.label
     id = get_id(label = label, configuration = configuration)
 
-    attrs_info = target[InputFileAttributesInfo]
+    automatic_target_info = target[XcodeProjAutomaticTargetProcessingInfo]
 
     return processed_target(
-        attrs_info = attrs_info,
+        automatic_target_info = automatic_target_info,
         dependencies = process_dependencies(
-            attrs_info = attrs_info,
+            automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
         ),
         inputs = input_files.collect(
@@ -141,7 +141,7 @@ def process_resource_target(*, ctx, target, transitive_infos):
             platform = None,
             bundle_resources = False,
             is_bundle = False,
-            attrs_info = attrs_info,
+            automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
             avoid_deps = [],
         ),
@@ -151,13 +151,16 @@ def process_resource_target(*, ctx, target, transitive_infos):
             is_xcode_target = False,
         ),
         outputs = output_files.merge(
-            attrs_info = attrs_info,
+            automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
         ),
         resource_bundle_informations = [
             struct(
                 id = id,
-                bundle_id = getattr(ctx.rule.attr, attrs_info.bundle_id),
+                bundle_id = getattr(
+                    ctx.rule.attr,
+                    automatic_target_info.bundle_id,
+                ),
             ),
         ],
         search_paths = process_search_paths(

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -32,11 +32,11 @@ def should_include_outputs(ctx):
     """
     return ctx.attr._build_mode[BuildSettingInfo].value != "xcode"
 
-def process_dependencies(*, attrs_info, transitive_infos):
+def process_dependencies(*, automatic_target_info, transitive_infos):
     """ Logic for processing target dependencies
 
     Args:
-        attrs_info: Attribute information
+        automatic_target_info: Attribute information
         transitive_infos: Transitive information of the deps
 
     Returns:
@@ -45,8 +45,11 @@ def process_dependencies(*, attrs_info, transitive_infos):
     direct_dependencies = []
     transitive_dependencies = []
     for attr, info in transitive_infos:
-        if not (not attrs_info or
-                info.target_type in attrs_info.xcode_targets.get(attr, [None])):
+        if not (not automatic_target_info or
+                info.target_type in automatic_target_info.xcode_targets.get(
+                    attr,
+                    [None],
+                )):
             continue
         if info.target:
             direct_dependencies.append(info.target.id)

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -13,7 +13,11 @@ load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "process_opts")
 load(":output_files.bzl", "output_files")
 load(":platform.bzl", "platform_info")
-load(":providers.bzl", "InputFileAttributesInfo", "XcodeProjInfo")
+load(
+    ":providers.bzl",
+    "XcodeProjAutomaticTargetProcessingInfo",
+    "XcodeProjInfo",
+)
 load(":processed_target.bzl", "processed_target", "xcode_target")
 load(":product.bzl", "process_product")
 load(":provisioning_profiles.bzl", "provisioning_profiles")
@@ -154,13 +158,13 @@ def process_top_level_target(*, ctx, target, bundle_info, transitive_infos):
     Returns:
         The value returned from `processed_target`.
     """
-    attrs_info = target[InputFileAttributesInfo]
+    automatic_target_info = target[XcodeProjAutomaticTargetProcessingInfo]
 
     configuration = get_configuration(ctx)
     label = target.label
     id = get_id(label = label, configuration = configuration)
     dependencies = process_dependencies(
-        attrs_info = attrs_info,
+        automatic_target_info = automatic_target_info,
         transitive_infos = transitive_infos,
     )
     test_host = getattr(ctx.rule.attr, "test_host", None)
@@ -186,7 +190,7 @@ def process_top_level_target(*, ctx, target, bundle_info, transitive_infos):
 
     provisioning_profiles.process_attr(
         ctx = ctx,
-        attrs_info = attrs_info,
+        automatic_target_info = automatic_target_info,
         build_settings = build_settings,
     )
 
@@ -219,7 +223,7 @@ def process_top_level_target(*, ctx, target, bundle_info, transitive_infos):
         platform = platform,
         is_bundle = is_bundle,
         bundle_resources = bundle_resources,
-        attrs_info = attrs_info,
+        automatic_target_info = automatic_target_info,
         additional_files = additional_files,
         transitive_infos = transitive_infos,
         avoid_deps = avoid_deps,
@@ -324,7 +328,7 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
     )
 
     return processed_target(
-        attrs_info = attrs_info,
+        automatic_target_info = automatic_target_info,
         dependencies = dependencies,
         inputs = inputs,
         linker_inputs = linker_inputs,

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -119,7 +119,9 @@ def _write_xccurrentversions(*, ctx, xccurrentversion_files):
     ctx.actions.write(
         containers_file,
         "".join([
-            json.encode(file_path_to_dto(file_path(file, path = file.dirname))) + "\n"
+            json.encode(
+                file_path_to_dto(file_path(file, path = file.dirname)),
+            ) + "\n"
             for file in xccurrentversion_files
         ]),
     )
@@ -278,7 +280,7 @@ def _xcodeproj_impl(ctx):
         transitive_infos = [(None, info) for info in infos],
     )
     outputs = output_files.merge(
-        attrs_info = None,
+        automatic_target_info = None,
         transitive_infos = [(None, info) for info in infos],
     )
 

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -121,7 +121,7 @@ def _skip_target(*, deps, transitive_infos):
     """
     return _target_info_fields(
         dependencies = process_dependencies(
-            attrs_info = None,
+            automatic_target_info = None,
             transitive_infos = transitive_infos,
         ),
         inputs = input_files.merge(
@@ -134,7 +134,7 @@ def _skip_target(*, deps, transitive_infos):
             ],
         ),
         outputs = output_files.merge(
-            attrs_info = None,
+            automatic_target_info = None,
             transitive_infos = transitive_infos,
         ),
         linker_inputs = linker_input_files.merge(deps = deps),
@@ -222,7 +222,10 @@ def _create_xcodeprojinfo(*, ctx, target, transitive_infos):
                 info.non_mergable_targets
                 for attr, info in transitive_infos
                 if (info.target_type in
-                    processed_target.attrs_info.xcode_targets.get(attr, [None]))
+                    processed_target.automatic_target_info.xcode_targets.get(
+                        attr,
+                        [None],
+                    ))
             ],
         ),
         outputs = processed_target.outputs,
@@ -232,7 +235,10 @@ def _create_xcodeprojinfo(*, ctx, target, transitive_infos):
                 info.potential_target_merges
                 for attr, info in transitive_infos
                 if (info.target_type in
-                    processed_target.attrs_info.xcode_targets.get(attr, [None]))
+                    processed_target.automatic_target_info.xcode_targets.get(
+                        attr,
+                        [None],
+                    ))
             ],
         ),
         resource_bundle_informations = depset(
@@ -241,19 +247,25 @@ def _create_xcodeprojinfo(*, ctx, target, transitive_infos):
                 info.resource_bundle_informations
                 for attr, info in transitive_infos
                 if (info.target_type in
-                    processed_target.attrs_info.xcode_targets.get(attr, [None]))
+                    processed_target.automatic_target_info.xcode_targets.get(
+                        attr,
+                        [None],
+                    ))
             ],
         ),
         search_paths = processed_target.search_paths,
         target = processed_target.target,
-        target_type = processed_target.attrs_info.target_type,
+        target_type = processed_target.automatic_target_info.target_type,
         xcode_targets = depset(
             processed_target.xcode_targets,
             transitive = [
                 info.xcode_targets
                 for attr, info in transitive_infos
                 if (info.target_type in
-                    processed_target.attrs_info.xcode_targets.get(attr, [None]))
+                    processed_target.automatic_target_info.xcode_targets.get(
+                        attr,
+                        [None],
+                    ))
             ],
         ),
     )

--- a/xcodeproj/xcodeproj.bzl
+++ b/xcodeproj/xcodeproj.bzl
@@ -2,12 +2,12 @@
 
 load(
     "//xcodeproj/internal:providers.bzl",
-    _InputFileAttributesInfo = "InputFileAttributesInfo",
+    _XcodeProjAutomaticTargetProcessingInfo = "XcodeProjAutomaticTargetProcessingInfo",
 )
 load("//xcodeproj/internal:xcodeproj.bzl", _xcodeproj = "xcodeproj")
 
 # Re-exporting providers
-InputFileAttributesInfo = _InputFileAttributesInfo
+XcodeProjAutomaticTargetProcessingInfo = _XcodeProjAutomaticTargetProcessingInfo
 
 # Re-exporting rules
 xcodeproj = _xcodeproj


### PR DESCRIPTION
The new name better reflects its new purpose.