### PR TITLE
Add `XcodeProjAutomaticTargetProcessingInfo.should_generate_target`

### DIFF
--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -10,7 +10,6 @@ load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "process_opts")
 load(":output_files.bzl", "output_files")
 load(":platform.bzl", "platform_info")
-load(":providers.bzl", "XcodeProjAutomaticTargetProcessingInfo")
 load(":processed_target.bzl", "processed_target", "xcode_target")
 load(":product.bzl", "process_product")
 load(":search_paths.bzl", "process_search_paths")
@@ -26,20 +25,25 @@ load(
     "should_include_outputs",
 )
 
-def process_library_target(*, ctx, target, transitive_infos):
+def process_library_target(
+        *,
+        ctx,
+        target,
+        automatic_target_info,
+        transitive_infos):
     """Gathers information about a library target.
 
     Args:
         ctx: The aspect context.
         target: The `Target` to process.
+        automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
+            `target`.
         transitive_infos: A `list` of `depset`s of `XcodeProjInfo`s from the
             transitive dependencies of `target`.
 
     Returns:
         The value returned from `processed_target`.
     """
-    automatic_target_info = target[XcodeProjAutomaticTargetProcessingInfo]
-
     configuration = get_configuration(ctx)
     label = target.label
     id = get_id(label = label, configuration = configuration)

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -10,18 +10,24 @@ load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "create_opts_search_paths")
 load(":output_files.bzl", "output_files")
-load(":providers.bzl", "XcodeProjAutomaticTargetProcessingInfo")
 load(":processed_target.bzl", "processed_target")
 load(":search_paths.bzl", "process_search_paths")
 load(":target_id.bzl", "get_id")
 load(":target_properties.bzl", "process_dependencies")
 
-def process_non_xcode_target(*, ctx, target, transitive_infos):
+def process_non_xcode_target(
+        *,
+        ctx,
+        target,
+        automatic_target_info,
+        transitive_infos):
     """Gathers information about a non-Xcode target.
 
     Args:
         ctx: The aspect context.
         target: The `Target` to process.
+        automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
+            `target`.
         transitive_infos: A `list` of `depset`s of `XcodeProjInfo`s from the
             transitive dependencies of `target`.
 
@@ -30,8 +36,6 @@ def process_non_xcode_target(*, ctx, target, transitive_infos):
     """
     cc_info = target[CcInfo] if CcInfo in target else None
     objc = target[apple_common.Objc] if apple_common.Objc in target else None
-
-    automatic_target_info = target[XcodeProjAutomaticTargetProcessingInfo]
 
     if AppleResourceBundleInfo in target and AppleResourceInfo not in target:
         # `apple_bundle_import` returns a `AppleResourceBundleInfo` and also

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -44,6 +44,11 @@ attribute.
 An attribute name (or `None`) to collect `File`s from for the
 `provisioning_profile`-like attribute.
 """,
+        "should_generate_target": """\
+Whether or an Xcode target should be generated for this target. Even if this
+value is `False`, setting values for the other attributes can cause inputs to be
+collected and shown in the Xcode project.
+""",
         "srcs": """\
 A sequence of attribute names to collect `File`s from for `srcs`-like
 attributes.

--- a/xcodeproj/internal/targets.bzl
+++ b/xcodeproj/internal/targets.bzl
@@ -2,7 +2,6 @@
 
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleBundleInfo",
     "IosXcTestBundleInfo",
     "MacosXcTestBundleInfo",
     "TvosXcTestBundleInfo",
@@ -55,36 +54,6 @@ def _is_test_bundle(target, deps):
         _is_test_bundle_with_provider(target, deps, WatchosXcTestBundleInfo)
     )
 
-def _should_become_xcode_target(target):
-    """Determines if the given target should be included in the Xcode project.
-
-    Args:
-        target: The `Target` to check.
-
-    Returns:
-        `False` if `target` shouldn't become an actual target in the generated
-        Xcode project. Resource bundles are a current example of this, as we
-        only include their files in the project, but we don't create targets
-        for them.
-    """
-
-    # Top-level bundles
-    if AppleBundleInfo in target:
-        return True
-
-    # Libraries
-    # Targets that don't produce files are ignored (e.g. imports)
-    if CcInfo in target and target.files != depset():
-        return True
-
-    # Command-line tools
-    executable = target[DefaultInfo].files_to_run.executable
-    if executable and not executable.is_source:
-        return True
-
-    return False
-
 targets = struct(
     is_test_bundle = _is_test_bundle,
-    should_become_xcode_target = _should_become_xcode_target,
 )

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -13,11 +13,7 @@ load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "process_opts")
 load(":output_files.bzl", "output_files")
 load(":platform.bzl", "platform_info")
-load(
-    ":providers.bzl",
-    "XcodeProjAutomaticTargetProcessingInfo",
-    "XcodeProjInfo",
-)
+load(":providers.bzl", "XcodeProjInfo")
 load(":processed_target.bzl", "processed_target", "xcode_target")
 load(":product.bzl", "process_product")
 load(":provisioning_profiles.bzl", "provisioning_profiles")
@@ -145,12 +141,20 @@ def _process_test_host(test_host):
         return test_host[XcodeProjInfo]
     return None
 
-def process_top_level_target(*, ctx, target, bundle_info, transitive_infos):
+def process_top_level_target(
+        *,
+        ctx,
+        target,
+        automatic_target_info,
+        bundle_info,
+        transitive_infos):
     """Gathers information about a top-level target.
 
     Args:
         ctx: The aspect context.
         target: The `Target` to process.
+        automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
+            `target`.
         bundle_info: The `AppleBundleInfo` provider for `target`, or `None`.
         transitive_infos: A `list` of `depset`s of `XcodeProjInfo`s from the
             transitive dependencies of `target`.
@@ -158,8 +162,6 @@ def process_top_level_target(*, ctx, target, bundle_info, transitive_infos):
     Returns:
         The value returned from `processed_target`.
     """
-    automatic_target_info = target[XcodeProjAutomaticTargetProcessingInfo]
-
     configuration = get_configuration(ctx)
     label = target.label
     id = get_id(label = label, configuration = configuration)

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -10,7 +10,12 @@ load(":linker_input_files.bzl", "linker_input_files")
 load(":non_xcode_targets.bzl", "process_non_xcode_target")
 load(":opts.bzl", "create_opts_search_paths")
 load(":output_files.bzl", "output_files")
-load(":providers.bzl", "XcodeProjInfo", "target_type")
+load(
+    ":providers.bzl",
+    "XcodeProjAutomaticTargetProcessingInfo",
+    "XcodeProjInfo",
+    "target_type",
+)
 load(":processed_target.bzl", "processed_target")
 load(":search_paths.bzl", "process_search_paths")
 load(":targets.bzl", "targets")
@@ -177,16 +182,20 @@ def _create_xcodeprojinfo(*, ctx, target, transitive_infos):
         A `dict` of fields to be merged into the `XcodeProjInfo`. See
         `_target_info_fields`.
     """
-    if not targets.should_become_xcode_target(target):
+    automatic_target_info = target[XcodeProjAutomaticTargetProcessingInfo]
+
+    if not automatic_target_info.should_generate_target:
         processed_target = process_non_xcode_target(
             ctx = ctx,
             target = target,
+            automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
         )
     elif AppleBundleInfo in target:
         processed_target = process_top_level_target(
             ctx = ctx,
             target = target,
+            automatic_target_info = automatic_target_info,
             bundle_info = target[AppleBundleInfo],
             transitive_infos = transitive_infos,
         )
@@ -194,6 +203,7 @@ def _create_xcodeprojinfo(*, ctx, target, transitive_infos):
         processed_target = process_top_level_target(
             ctx = ctx,
             target = target,
+            automatic_target_info = automatic_target_info,
             bundle_info = None,
             transitive_infos = transitive_infos,
         )
@@ -201,6 +211,7 @@ def _create_xcodeprojinfo(*, ctx, target, transitive_infos):
         processed_target = process_library_target(
             ctx = ctx,
             target = target,
+            automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
         )
 


### PR DESCRIPTION
This moves the logic of determining if a target should become an Xcode target out of a hard coded function and into the provider.

It also slightly changes the behavior only generating targets by default for the rules we provide default information for. This causes "unsupported" rules like `swift_proto_library` to no longer become incomplete Xcode targets. A later change will adjust the generator to handle these use cases better.