### PR TITLE
Refractor `linker_input_files.merge`

### DIFF
--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -3,7 +3,6 @@
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load(":collections.bzl", "flatten", "set_if_true")
 load(":files.bzl", "file_path", "file_path_to_dto")
-load(":providers.bzl", "XcodeProjInfo")
 
 def _collect_for_non_top_level(*, cc_info, objc, is_xcode_target):
     """Collects linker input files for a non top level target.
@@ -30,11 +29,13 @@ def _collect_for_non_top_level(*, cc_info, objc, is_xcode_target):
         xcode_library_targets = [],
     )
 
-def _collect_for_top_level(*, deps, avoid_linker_inputs):
+def _collect_for_top_level(*, transitive_linker_inputs, avoid_linker_inputs):
     """Collects linker input files for a top level library target.
 
     Args:
-        deps: `ctx.attr.deps` of the target.
+        transitive_linker_inputs: A `list` of `(target(), XcodeProjInfo)` tuples
+            of transitive dependencies that should have their linker inputs
+            merged.
         avoid_linker_inputs: A value returned from
             `linker_input_files.collect_for_top_level`. These inputs will be
             excluded from the return list.
@@ -43,15 +44,20 @@ def _collect_for_top_level(*, deps, avoid_linker_inputs):
         A value similar to the one returned from
         `linker_input_files.collect_for_non_top_level`.
     """
-    return _merge(deps = deps, avoid_linker_inputs = avoid_linker_inputs)
+    return _merge(
+        transitive_linker_inputs = transitive_linker_inputs,
+        avoid_linker_inputs = avoid_linker_inputs,
+    )
 
-def _merge(*, deps, avoid_linker_inputs = None):
+def _merge(*, transitive_linker_inputs, avoid_linker_inputs = None):
     """Merges linker input files from the deps of a target.
 
     This should only be used by targets that are being skipped.
 
     Args:
-        deps: `ctx.attr.deps` of the target.
+        transitive_linker_inputs: A `list` of `(target(), XcodeProjInfo)` tuples
+            of transitive dependencies that should have their linker inputs
+            merged.
         avoid_linker_inputs: A value returned from
             `linker_input_files.collect_for_top_level`. These inputs will be
             excluded from the return list.
@@ -64,16 +70,16 @@ def _merge(*, deps, avoid_linker_inputs = None):
     # Ideally we could use `merge_linking_contexts`, but it's private API
     cc_info = cc_common.merge_cc_infos(
         cc_infos = [
-            dep[XcodeProjInfo].linker_inputs._cc_info
-            for dep in deps
-            if dep[XcodeProjInfo].linker_inputs._cc_info
+            linker_inputs._cc_info
+            for _, linker_inputs in transitive_linker_inputs
+            if linker_inputs._cc_info
         ],
     )
 
     objc_providers = [
-        dep[XcodeProjInfo].linker_inputs._objc
-        for dep in deps
-        if dep[XcodeProjInfo].linker_inputs._objc
+        linker_inputs._objc
+        for _, linker_inputs in transitive_linker_inputs
+        if linker_inputs._objc
     ]
     if objc_providers:
         objc = apple_common.new_objc_provider(providers = objc_providers)
@@ -81,9 +87,9 @@ def _merge(*, deps, avoid_linker_inputs = None):
         objc = None
 
     xcode_library_targets = [
-        dep[XcodeProjInfo].target
-        for dep in deps
-        if dep[XcodeProjInfo].linker_inputs._is_xcode_library_target
+        target
+        for target, linker_inputs in transitive_linker_inputs
+        if linker_inputs._is_xcode_library_target
     ]
 
     return struct(

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -170,7 +170,6 @@ def process_top_level_target(*, ctx, target, bundle_info, transitive_infos):
     test_host = getattr(ctx.rule.attr, "test_host", None)
     test_host_target_info = _process_test_host(test_host)
 
-    deps = getattr(ctx.rule.attr, "deps", [])
     avoid_deps = [test_host] if test_host else []
 
     additional_files = []
@@ -257,7 +256,11 @@ def process_top_level_target(*, ctx, target, bundle_info, transitive_infos):
         avoid_linker_inputs = None
 
     linker_inputs = linker_input_files.collect_for_top_level(
-        deps = deps,
+        transitive_linker_inputs = [
+            (dep[XcodeProjInfo].target, dep[XcodeProjInfo].linker_inputs)
+            # TODO: Get attr name from `XcodeProjAutomaticTargetProcessingInfo`
+            for dep in getattr(ctx.rule.attr, "deps", [])
+        ],
         avoid_linker_inputs = avoid_linker_inputs,
     )
     xcode_library_targets = linker_inputs.xcode_library_targets

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -135,7 +135,12 @@ def _skip_target(*, deps, transitive_infos):
             automatic_target_info = None,
             transitive_infos = transitive_infos,
         ),
-        linker_inputs = linker_input_files.merge(deps = deps),
+        linker_inputs = linker_input_files.merge(
+            transitive_linker_inputs = [
+                (dep[XcodeProjInfo].target, dep[XcodeProjInfo].linker_inputs)
+                for dep in deps
+            ],
+        ),
         potential_target_merges = depset(
             transitive = [
                 info.potential_target_merges


### PR DESCRIPTION
This is to support a future use case where we want to merge linker inputs for a slightly different use case related to Focused Projects.