### PR TITLE
Refactor `linter_input_files.get_primary_static_library` to return a `File`

### DIFF
--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -258,7 +258,7 @@ def _get_primary_static_library(linker_inputs):
         linker_inputs: A value returned from `linker_input_files.collect`.
 
     Returns:
-        The `file_path` of the primary static library, or `None`.
+        The `File` of the primary static library, or `None`.
     """
 
     # Ideally we would only return the static library that is owned by this
@@ -266,11 +266,11 @@ def _get_primary_static_library(linker_inputs):
     # outputs it. So far the first library has always been the correct one.
     if linker_inputs._objc:
         for library in linker_inputs._objc.library.to_list():
-            return file_path(library)
+            return library
     elif linker_inputs._cc_info:
         linker_inputs = linker_inputs._cc_info.linking_context.linker_inputs
         for input in linker_inputs.to_list():
-            return file_path(input.libraries[0].static_library)
+            return input.libraries[0].static_library
     return None
 
 linker_input_files = struct(

--- a/xcodeproj/internal/product.bzl
+++ b/xcodeproj/internal/product.bzl
@@ -38,7 +38,8 @@ def process_product(
     elif target[DefaultInfo].files_to_run.executable:
         fp = file_path(target[DefaultInfo].files_to_run.executable)
     elif CcInfo in target:
-        fp = linker_input_files.get_primary_static_library(linker_inputs)
+        library = linker_input_files.get_primary_static_library(linker_inputs)
+        fp = file_path(library) if library else None
     else:
         fp = None
 


### PR DESCRIPTION
This will be used by future Focused Projects work.