### PR TITLE
Use `copts_for_current_compilation_mode`

### DIFF
--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -507,6 +507,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -517,6 +518,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -569,6 +573,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -579,6 +584,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -640,6 +648,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -650,6 +659,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -713,6 +725,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -723,6 +736,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",

--- a/test/fixtures/cc/bwb_spec.json
+++ b/test/fixtures/cc/bwb_spec.json
@@ -42,6 +42,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -51,7 +52,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -141,6 +145,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -150,7 +155,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -237,6 +245,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -246,7 +255,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -374,6 +386,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -383,7 +396,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",

--- a/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
@@ -491,6 +491,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -501,6 +502,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -595,6 +599,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -605,6 +610,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -659,6 +667,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -669,6 +678,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -738,6 +750,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -748,6 +761,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",

--- a/test/fixtures/cc/bwx_spec.json
+++ b/test/fixtures/cc/bwx_spec.json
@@ -42,6 +42,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -51,7 +52,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -141,6 +145,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -150,7 +155,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -237,6 +245,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -246,7 +255,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -369,6 +381,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -378,7 +391,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -866,6 +866,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -876,6 +877,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -890,7 +894,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/external/examples_command_line_external/Library.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/private_lib.swift.xcode.modulemap -g -Fexternal/examples_command_line_external -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/external/examples_command_line_external/Library.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/private_lib.swift.xcode.modulemap -g -Fexternal/examples_command_line_external -static";
 				PRODUCT_MODULE_NAME = LibSwift;
 				PRODUCT_NAME = lib_swift;
 				SDKROOT = macosx;
@@ -941,6 +945,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -951,6 +956,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1014,6 +1022,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1024,6 +1033,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1094,6 +1106,7 @@
 				INFOPLIST_FILE = "$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1104,6 +1117,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1122,7 +1138,7 @@
 					"$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/external/examples_command_line_external/Library.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_swift.swift.xcode.modulemap -g -Fexternal/examples_command_line_external -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/external/examples_command_line_external/Library.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_swift.swift.xcode.modulemap -g -Fexternal/examples_command_line_external -static";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
 				PRODUCT_MODULE_NAME = LibSwiftTestsLib;
 				PRODUCT_NAME = LibSwiftTests;
@@ -1204,6 +1220,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1214,6 +1231,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -200,6 +200,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -209,7 +210,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -346,6 +350,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -355,7 +360,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -438,6 +446,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -447,7 +456,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -582,6 +594,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -591,7 +604,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -790,6 +806,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -799,7 +816,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -823,6 +823,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -833,6 +834,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -847,7 +851,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/external/examples_command_line_external/Library.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/private_lib.swift.xcode.modulemap -g -Fexternal/examples_command_line_external -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/external/examples_command_line_external/Library.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/private_lib.swift.xcode.modulemap -g -Fexternal/examples_command_line_external -static";
 				PRODUCT_MODULE_NAME = LibSwift;
 				PRODUCT_NAME = lib_swift;
 				SDKROOT = macosx;
@@ -886,6 +890,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -896,6 +901,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -951,6 +959,7 @@
 				INFOPLIST_FILE = "$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -961,6 +970,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -979,7 +991,7 @@
 					"$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/external/examples_command_line_external/Library.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_swift.swift.xcode.modulemap -g -Fexternal/examples_command_line_external -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_impl.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/external/examples_command_line_external/Library.swift.xcode.modulemap -Xcc -fmodule-map-file=$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_swift.swift.xcode.modulemap -g -Fexternal/examples_command_line_external -static";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
 				PRODUCT_MODULE_NAME = LibSwiftTestsLib;
 				PRODUCT_NAME = LibSwiftTests;
@@ -1070,6 +1082,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1080,6 +1093,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1143,6 +1159,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1153,6 +1170,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -195,6 +195,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -204,7 +205,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -326,6 +330,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -335,7 +340,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -418,6 +426,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -427,7 +436,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -543,6 +555,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -552,7 +565,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -746,6 +762,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -755,7 +772,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -2215,6 +2215,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2225,6 +2226,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2239,7 +2243,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = PathKit;
 				PRODUCT_NAME = PathKit;
 				SDKROOT = macosx;
@@ -2284,6 +2288,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2294,6 +2299,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2308,7 +2316,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = XcodeProj;
 				PRODUCT_NAME = XcodeProj;
 				SDKROOT = macosx;
@@ -2343,6 +2351,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2353,6 +2362,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2367,7 +2379,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = AEXML;
 				PRODUCT_NAME = AEXML;
 				SDKROOT = macosx;
@@ -2443,6 +2455,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2453,6 +2466,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2467,7 +2483,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = XCTestDynamicOverlay;
 				PRODUCT_NAME = XCTestDynamicOverlay;
 				SDKROOT = macosx;
@@ -2501,6 +2517,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2511,6 +2528,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2525,7 +2545,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = CustomDump;
 				PRODUCT_NAME = CustomDump;
 				SDKROOT = macosx;
@@ -2564,6 +2584,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2574,6 +2595,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2592,7 +2616,7 @@
 					"$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/test/tests.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = tests;
 				PRODUCT_NAME = tests;
 				SDKROOT = macosx;
@@ -2627,6 +2651,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2637,6 +2662,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2651,7 +2679,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = OrderedCollections;
 				PRODUCT_NAME = OrderedCollections;
 				SDKROOT = macosx;
@@ -2747,6 +2775,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2757,6 +2786,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2771,7 +2803,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = generator;
 				PRODUCT_NAME = generator.library;
 				SDKROOT = macosx;

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -165,6 +165,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -174,7 +175,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -427,6 +431,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -436,7 +441,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -587,6 +595,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -596,7 +605,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -885,6 +897,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -894,7 +907,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -987,6 +1003,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -996,7 +1013,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1192,6 +1212,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1201,7 +1222,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1294,6 +1318,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1303,7 +1328,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1412,6 +1440,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1421,7 +1450,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -2035,6 +2035,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2045,6 +2046,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2059,7 +2063,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = CustomDump;
 				PRODUCT_NAME = CustomDump;
 				SDKROOT = macosx;
@@ -2094,6 +2098,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2104,6 +2109,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2118,7 +2126,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = XcodeProj;
 				PRODUCT_NAME = XcodeProj;
 				SDKROOT = macosx;
@@ -2153,6 +2161,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2163,6 +2172,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2177,7 +2189,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = generator;
 				PRODUCT_NAME = generator.library;
 				SDKROOT = macosx;
@@ -2285,6 +2297,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2295,6 +2308,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2309,7 +2325,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = XCTestDynamicOverlay;
 				PRODUCT_NAME = XCTestDynamicOverlay;
 				SDKROOT = macosx;
@@ -2346,6 +2362,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2356,6 +2373,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2374,7 +2394,7 @@
 					"$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-ccd9595da841/tools/generator/test/tests.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = tests;
 				PRODUCT_NAME = tests;
 				SDKROOT = macosx;
@@ -2409,6 +2429,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2419,6 +2440,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2433,7 +2457,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = PathKit;
 				PRODUCT_NAME = PathKit;
 				SDKROOT = macosx;
@@ -2467,6 +2491,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2477,6 +2502,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2491,7 +2519,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = OrderedCollections;
 				PRODUCT_NAME = OrderedCollections;
 				SDKROOT = macosx;
@@ -2560,6 +2588,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -2570,6 +2599,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -2584,7 +2616,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = AEXML;
 				PRODUCT_NAME = AEXML;
 				SDKROOT = macosx;

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -160,6 +160,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -169,7 +170,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -402,6 +406,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -411,7 +416,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -547,6 +555,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -556,7 +565,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -830,6 +842,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -839,7 +852,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -917,6 +933,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -926,7 +943,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1107,6 +1127,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1116,7 +1137,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1194,6 +1218,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1203,7 +1228,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1297,6 +1325,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1306,7 +1335,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -1518,6 +1518,7 @@
 					"@executable_path/Frameworks",
 				);
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1528,6 +1529,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1551,7 +1555,7 @@
 					"$(INTERNAL_DIR)/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iOSApp/iOSApp.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
 				PRODUCT_MODULE_NAME = iOSApp;
 				PRODUCT_NAME = iOSApp;
@@ -1599,6 +1603,7 @@
 				"INCLUDED_SOURCE_FILE_NAMES[sdk=watchos*]" = "$(WATCHOS_FILES)";
 				"INCLUDED_SOURCE_FILE_NAMES[sdk=watchsimulator*]" = "$(WATCHSIMULATOR_FILES)";
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1609,6 +1614,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1623,7 +1631,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = Lib;
 				PRODUCT_NAME = Lib;
 				SDKROOT = watchos;
@@ -1677,6 +1685,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1687,6 +1696,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1710,7 +1722,7 @@
 					"$(INTERNAL_DIR)/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.watch.extension;
 				PRODUCT_MODULE_NAME = watchOSAppExtension;
 				PRODUCT_NAME = watchOSAppExtension;
@@ -1781,6 +1793,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MACOSX_FILES = "$(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Lib/Lib.swift";
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1791,6 +1804,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1805,7 +1821,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = Lib;
 				PRODUCT_NAME = Lib;
 				SDKROOT = macosx;
@@ -1856,6 +1872,7 @@
 					"@executable_path/Frameworks",
 				);
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1866,6 +1883,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1889,7 +1909,7 @@
 					"$(INTERNAL_DIR)/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
 				PRODUCT_MODULE_NAME = iOSApp;
 				PRODUCT_NAME = tvOSApp;
@@ -1941,6 +1961,7 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1951,6 +1972,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1969,7 +1993,7 @@
 					"$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/multiplatform/Tool/Tool.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = Tool;
 				PRODUCT_NAME = Tool;
 				SDKROOT = macosx;

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -127,6 +127,7 @@
                 ],
                 "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -136,7 +137,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -229,6 +233,7 @@
                 ],
                 "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -238,7 +243,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -332,6 +340,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -341,7 +350,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -433,6 +445,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -442,7 +455,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -535,6 +551,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -544,7 +561,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -638,6 +658,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -647,7 +668,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -740,6 +764,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -749,7 +774,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -937,6 +965,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -946,7 +975,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1243,6 +1275,7 @@
                 ],
                 "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1252,7 +1285,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1350,6 +1386,7 @@
                 ],
                 "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1359,7 +1396,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1655,6 +1695,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1664,7 +1705,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1762,6 +1806,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1771,7 +1816,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -2240,6 +2288,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -2249,7 +2298,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -2347,6 +2399,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -2356,7 +2409,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",

--- a/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
@@ -1499,6 +1499,7 @@
 					"@executable_path/Frameworks",
 				);
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1509,6 +1510,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1532,7 +1536,7 @@
 					"$(INTERNAL_DIR)/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/iOSApp/iOSApp.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
 				PRODUCT_MODULE_NAME = iOSApp;
 				PRODUCT_NAME = iOSApp;
@@ -1582,6 +1586,7 @@
 					"@executable_path/Frameworks",
 				);
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1592,6 +1597,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1615,7 +1623,7 @@
 					"$(INTERNAL_DIR)/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
 				PRODUCT_MODULE_NAME = iOSApp;
 				PRODUCT_NAME = tvOSApp;
@@ -1662,6 +1670,7 @@
 				"INCLUDED_SOURCE_FILE_NAMES[sdk=watchos*]" = "$(WATCHOS_FILES)";
 				"INCLUDED_SOURCE_FILE_NAMES[sdk=watchsimulator*]" = "$(WATCHSIMULATOR_FILES)";
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1672,6 +1681,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1686,7 +1698,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = Lib;
 				PRODUCT_NAME = Lib;
 				SDKROOT = watchos;
@@ -1760,6 +1772,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1770,6 +1783,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1788,7 +1804,7 @@
 					"$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/multiplatform/Tool/Tool.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = Tool;
 				PRODUCT_NAME = Tool;
 				SDKROOT = macosx;
@@ -1836,6 +1852,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1846,6 +1863,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1869,7 +1889,7 @@
 					"$(INTERNAL_DIR)/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList",
 					"-ObjC",
 				);
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.watch.extension;
 				PRODUCT_MODULE_NAME = watchOSAppExtension;
 				PRODUCT_NAME = watchOSAppExtension;
@@ -1936,6 +1956,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MACOSX_FILES = "$(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Lib/Lib.swift";
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -1946,6 +1967,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -1960,7 +1984,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_MODULE_NAME = Lib;
 				PRODUCT_NAME = Lib;
 				SDKROOT = macosx;

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -107,6 +107,7 @@
                 ],
                 "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -116,7 +117,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -194,6 +198,7 @@
                 ],
                 "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -203,7 +208,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -282,6 +290,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -291,7 +300,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -368,6 +380,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -377,7 +390,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -455,6 +471,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -464,7 +481,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -543,6 +563,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -552,7 +573,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -630,6 +654,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -639,7 +664,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -807,6 +835,7 @@
                 ],
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -816,7 +845,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1102,6 +1134,7 @@
                 ],
                 "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1111,7 +1144,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1194,6 +1230,7 @@
                 ],
                 "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1203,7 +1240,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1486,6 +1526,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1495,7 +1536,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -1578,6 +1622,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -1587,7 +1632,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -2059,6 +2107,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -2068,7 +2117,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -2151,6 +2203,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -2160,7 +2213,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -625,6 +625,7 @@
 				);
 				INFOPLIST_FILE = "$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -635,6 +636,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -649,7 +653,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.uitests;
 				PRODUCT_MODULE_NAME = ExampleUITests;
 				PRODUCT_NAME = ExampleUITests;
@@ -749,6 +753,7 @@
 					"@executable_path/Frameworks",
 				);
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -759,6 +764,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -773,7 +781,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
 				PRODUCT_MODULE_NAME = Example;
 				PRODUCT_NAME = Example;
@@ -815,6 +823,7 @@
 				);
 				INFOPLIST_FILE = "$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -825,6 +834,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -839,7 +851,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.tests;
 				PRODUCT_MODULE_NAME = ExampleTests;
 				PRODUCT_NAME = ExampleTests;

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -167,6 +167,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -176,7 +177,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -365,6 +369,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -374,7 +379,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -569,6 +577,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -578,7 +587,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",

--- a/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
@@ -549,6 +549,7 @@
 				);
 				INFOPLIST_FILE = "$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -559,6 +560,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -573,7 +577,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.uitests;
 				PRODUCT_MODULE_NAME = ExampleUITests;
 				PRODUCT_NAME = ExampleUITests;
@@ -625,6 +629,7 @@
 				);
 				INFOPLIST_FILE = "$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle-intermediates/Info.xcode.plist";
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -635,6 +640,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -649,7 +657,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.tests;
 				PRODUCT_MODULE_NAME = ExampleTests;
 				PRODUCT_NAME = ExampleTests;
@@ -696,6 +704,7 @@
 					"@executable_path/Frameworks",
 				);
 				OTHER_CFLAGS = (
+					"-DDEBUG=1",
 					"-fstack-protector",
 					"-Wall",
 					"-Wthread-safety",
@@ -706,6 +715,9 @@
 					"-pthread",
 					"-no-canonical-prefixes",
 					"-Wno-builtin-macro-redefined",
+					"-fstack-protector",
+					"-fstack-protector-all",
+					"-g",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
@@ -720,7 +732,7 @@
 					"-Wno-builtin-macro-redefined",
 				);
 				OTHER_LDFLAGS = "-ObjC";
-				OTHER_SWIFT_FLAGS = "-Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -g -static";
+				OTHER_SWIFT_FLAGS = "-Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -Wall -Xcc -Wthread-safety -Xcc -Wself-assign -Xcc -fno-omit-frame-pointer -Xcc -no-canonical-prefixes -Xcc -pthread -Xcc -no-canonical-prefixes -Xcc -Wno-builtin-macro-redefined -Xcc -fstack-protector -Xcc -fstack-protector-all -g -static";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
 				PRODUCT_MODULE_NAME = Example;
 				PRODUCT_NAME = Example;

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -162,6 +162,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -171,7 +172,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -340,6 +344,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -349,7 +354,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",
@@ -524,6 +532,7 @@
                     "__TIME__=\"redacted\""
                 ],
                 "OTHER_CFLAGS": [
+                    "-DDEBUG=1",
                     "-fstack-protector",
                     "-Wall",
                     "-Wthread-safety",
@@ -533,7 +542,10 @@
                     "-no-canonical-prefixes",
                     "-pthread",
                     "-no-canonical-prefixes",
-                    "-Wno-builtin-macro-redefined"
+                    "-Wno-builtin-macro-redefined",
+                    "-fstack-protector",
+                    "-fstack-protector-all",
+                    "-g"
                 ],
                 "OTHER_CPLUSPLUSFLAGS": [
                     "-fstack-protector",

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -109,6 +109,8 @@ def _get_unprocessed_compiler_opts(*, ctx, target):
 
     user_copts = []
     user_swiftcopts = []
+    objc = ctx.fragments.objc
+    objc_copts = []
     if SwiftInfo in target:
         # Rule level swiftcopts are included in action.argv below
         user_swiftcopts = getattr(ctx.rule.attr, "copts", [])
@@ -117,6 +119,7 @@ def _get_unprocessed_compiler_opts(*, ctx, target):
             values = user_swiftcopts,
             attribute_name = "copts",
         )
+        objc_copts = _objc_fragment_copts(objc)
     elif CcInfo in target:
         user_copts = getattr(ctx.rule.attr, "copts", [])
         user_copts = _expand_make_variables(
@@ -124,6 +127,7 @@ def _get_unprocessed_compiler_opts(*, ctx, target):
             values = user_copts,
             attribute_name = "copts",
         )
+        objc_copts = _objc_fragment_copts(objc)
 
     raw_swiftcopts = []
     for action in target.actions:
@@ -134,7 +138,7 @@ def _get_unprocessed_compiler_opts(*, ctx, target):
     cpp = ctx.fragments.cpp
 
     return (
-        base_copts + cpp.copts + cpp.conlyopts + user_copts,
+        base_copts + cpp.copts + cpp.conlyopts + user_copts + objc_copts,
         base_cxxopts + cpp.copts + cpp.cxxopts + user_copts,
         raw_swiftcopts,
         user_swiftcopts,
@@ -776,6 +780,17 @@ def _xcode_std_value(std):
         # Xcode encodes "c++11" as "c++0x"
         return std[:-2] + "0x"
     return std
+
+def _objc_fragment_copts(objc_fragment):
+    """Returns all copts from the provided objc fragment
+
+    Args:
+        objc_fragment: The objc fragment.
+
+    Returns:
+        A `list` of compiler flags
+    """
+    return objc_fragment.copts_for_current_compilation_mode + objc_fragment.copts
 
 # API
 


### PR DESCRIPTION
Uses `copts_for_current_compilation_mode` and `ctx.fragments.objc.copts`
to set compiler flags
for objc and swift compilation