### PR TITLE
Remove extra parameter from function

### DIFF
--- a/xcodeproj/internal/resources.bzl
+++ b/xcodeproj/internal/resources.bzl
@@ -217,7 +217,6 @@ def _add_unprocessed_resources(
                 bundle_metadata = bundle_metadata,
                 generated = generated,
                 xccurrentversions = xccurrentversions,
-                extra_files = extra_files,
             )
             continue
 


### PR DESCRIPTION
This was causing project generations to fail for me in a project I'm testing it with.