### PR TITLE
Include outputs of non-Xcode projects in the generated inputs output group

### DIFF
--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -90,6 +90,14 @@ the target that can be merged into the target with the id of the 'dest' field.
 A `depset` of all static library files that are linked into top-level targets
 besides their primary top-level targets.
 """,
+        "non_target_linker_inputs": """\
+A value returned from `linker_input_files.collect`, for targets that aren't
+generating Xcode targets.
+""",
+        "non_target_swift_info_modules": """\
+A value returned from `swift_common.create_swift_info`, for targets that aren't
+generating Xcode targets.
+""",
         "outputs": """\
 A value returned from `output_files.collect`, that contains information about
 the output files for this target and its transitive dependencies.
@@ -106,6 +114,9 @@ any target that depends on this target.
         "target": """\
 A `struct` that contains information about the current target that is
 potentially needed by the dependent targets.
+""",
+        "target_libraries": """\
+A `depset` of library `File`s for targets that generate an Xcode target.
 """,
         "target_type": """\
 A string that categorizes the type of the current target. This will be one of


### PR DESCRIPTION
This enables a sort of automatic Focused Project Build with Xcode mode, where it builds part of the build tree with Bazel that we can't translate properly into an Xcode target.

This isn't perfect yet though, as some of the dependencies of those targets might get made into Xcode targets from different branches in the build graph. Xcode based indexing also doesn't run for those targets, so the need for importing Bazel's index is higher. But since this unblocks some builds, it's worth getting in now and iterating on it.