### PR TITLE
Support `codesignopts`

### DIFF
--- a/examples/command_line/tool/BUILD
+++ b/examples/command_line/tool/BUILD
@@ -4,14 +4,14 @@ load("@rules_cc//cc:defs.bzl", "objc_library")
 macos_command_line_application(
     name = "tool",
     bundle_id = "io.buildbuddy.example",
+    codesignopts = [
+        "--digest-algorithm=sha1",
+        "--digest-algorithm=sha384",
+    ],
     infoplists = ["Info.plist"],
     minimum_os_version = "11.0",
     visibility = ["//visibility:public"],
     deps = [":tool.library"],
-    codesignopts = [
-        "--digest-algorithm=sha1",
-        "--digest-algorithm=sha384",
-    ]
 )
 
 objc_library(

--- a/examples/command_line/tool/BUILD
+++ b/examples/command_line/tool/BUILD
@@ -8,6 +8,10 @@ macos_command_line_application(
     minimum_os_version = "11.0",
     visibility = ["//visibility:public"],
     deps = [":tool.library"],
+    codesignopts = [
+        "--digest-algorithm=sha1",
+        "--digest-algorithm=sha384",
+    ]
 )
 
 objc_library(

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -1031,6 +1031,10 @@
 					"-fstack-protector-all",
 					"-g",
 				);
+				OTHER_CODE_SIGN_FLAGS = (
+					"--digest-algorithm=sha1",
+					"--digest-algorithm=sha384",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
 					"-Wall",

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -593,6 +593,10 @@
             "build_settings": {
                 "GCC_OPTIMIZATION_LEVEL": "0",
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CODE_SIGN_FLAGS": [
+                    "--digest-algorithm=sha1",
+                    "--digest-algorithm=sha384"
+                ],
                 "OTHER_LDFLAGS": [
                     "-ObjC"
                 ],

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -1028,6 +1028,10 @@
 					"-fstack-protector-all",
 					"-g",
 				);
+				OTHER_CODE_SIGN_FLAGS = (
+					"--digest-algorithm=sha1",
+					"--digest-algorithm=sha384",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"-fstack-protector",
 					"-Wall",

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -554,6 +554,10 @@
             "build_settings": {
                 "GCC_OPTIMIZATION_LEVEL": "0",
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "OTHER_CODE_SIGN_FLAGS": [
+                    "--digest-algorithm=sha1",
+                    "--digest-algorithm=sha384"
+                ],
                 "OTHER_LDFLAGS": [
                     "-ObjC"
                 ],

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -53,10 +53,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
 
     non_arc_srcs = ()
     pch = None
-    bundle_id = None
     provisioning_profile = None
-    infoplists = ()
-    entitlements = None
 
     attrs = dir(ctx.rule.attr)
 
@@ -85,6 +82,10 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
         infoplists = ("infoplists")
         should_generate_target = False
     elif AppleBundleInfo in target:
+        codesignopts = "codesignopts"
+        entitlements = "entitlements"
+        infoplists = ("infoplists")
+        provisioning_profile = "provisioning_profile"
         xcode_targets = {
             "deps": [target_type.compile],
         }
@@ -97,9 +98,10 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
         if "entitlements" in attrs:
             entitlements = "entitlements"
     elif AppleBinaryInfo in target:
-        xcode_targets = {"deps": [target_type.compile]}
+        codesignopts = "codesignopts"
         if "infoplists" in attrs:
             infoplists = ("infoplists")
+        xcode_targets = {"deps": [target_type.compile]}
     elif AppleFrameworkImportInfo in target:
         xcode_targets = {"deps": [target_type.compile]}
         should_generate_target = False
@@ -112,7 +114,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
 
     return [
         XcodeProjAutomaticTargetProcessingInfo(
-            codesignopts = "codesignopts",
+            codesignopts = codesignopts,
             should_generate_target = should_generate_target,
             target_type = this_target_type,
             xcode_targets = xcode_targets,

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -51,6 +51,10 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
     else:
         srcs = ()
 
+    bundle_id = None
+    codesignopts = None
+    entitlements = None
+    infoplists = ()
     non_arc_srcs = ()
     pch = None
     provisioning_profile = None
@@ -96,7 +100,8 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
         if "entitlements" in attrs:
             entitlements = "entitlements"
     elif AppleBinaryInfo in target:
-        codesignopts = "codesignopts"
+        if "codesignopts" in attrs:
+            codesignopts = "codesignopts"
         if "infoplists" in attrs:
             infoplists = ("infoplists")
         xcode_targets = {"deps": [target_type.compile]}

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -82,15 +82,13 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
         infoplists = ("infoplists")
         should_generate_target = False
     elif AppleBundleInfo in target:
-        codesignopts = "codesignopts"
-        entitlements = "entitlements"
-        infoplists = ("infoplists")
-        provisioning_profile = "provisioning_profile"
         xcode_targets = {
             "deps": [target_type.compile],
         }
         if _is_test_target(target):
             xcode_targets["test_host"] = [target_type.compile]
+        if "codesignopts" in attrs:
+            codesignopts = "codesignopts"
         if "provisioning_profile" in attrs:
             provisioning_profile = "provisioning_profile"
         if "infoplists" in attrs:

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -112,6 +112,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
 
     return [
         XcodeProjAutomaticTargetProcessingInfo(
+            codesignopts = "codesignopts",
             should_generate_target = should_generate_target,
             target_type = this_target_type,
             xcode_targets = xcode_targets,

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -20,6 +20,9 @@ return a `XcodeProjInfo` provider instance instead.
         "bundle_id": """\
 An attribute name (or `None`) to collect the bundle id string from.
 """,
+        "codesignopts": """\
+A `list` of code sign options.
+""",
         "entitlements": """\
 An attribute name (or `None`) to collect `File`s from for the
 `entitlements`-like attribute.

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -21,7 +21,7 @@ return a `XcodeProjInfo` provider instance instead.
 An attribute name (or `None`) to collect the bundle id string from.
 """,
         "codesignopts": """\
-A `list` of code sign options.
+An attribute name (or `None`) to collect the `codesignopts` `list` from.
 """,
         "entitlements": """\
 An attribute name (or `None`) to collect `File`s from for the

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -102,6 +102,19 @@ def process_modulemaps(*, swift_info):
         files = uniq(modulemap_files),
     )
 
+def process_codesignopts(*, codesignopts, build_settings):
+    """Logic for processing code signing flags.
+
+    Args:
+        codesignopts: A `list` of code sign options
+        build_settings: A mutable `dict` that will be updated with code signing
+            flag build settings that are processed.
+    Return:
+        The modified build settings object
+    """
+    if codesignopts and build_settings != None:
+        set_if_true(build_settings, "OTHER_CODE_SIGN_FLAGS", codesignopts)
+
 def process_defines(*, cc_info, swift_info, build_settings):
     """ Logic for processing defines of a module
 

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -21,6 +21,7 @@ load(":search_paths.bzl", "process_search_paths")
 load(":target_id.bzl", "get_id")
 load(
     ":target_properties.bzl",
+    "process_codesignopts",
     "process_defines",
     "process_dependencies",
     "process_modulemaps",
@@ -314,6 +315,11 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
 
     cc_info = target[CcInfo] if CcInfo in target else None
     objc = target[apple_common.Objc] if apple_common.Objc in target else None
+    codesignopts = getattr(ctx.rule.attr, "codesignopts", None)
+    process_codesignopts(
+        codesignopts = codesignopts,
+        build_settings = build_settings,
+    )
     process_defines(
         cc_info = cc_info,
         swift_info = swift_info,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -316,15 +316,17 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
     cc_info = target[CcInfo] if CcInfo in target else None
     objc = target[apple_common.Objc] if apple_common.Objc in target else None
 
-    codesignopts = getattr(
-        ctx.rule.attr,
-        automatic_target_info.codesignopts,
-        None,
-    )
-    process_codesignopts(
-        codesignopts = codesignopts,
-        build_settings = build_settings,
-    )
+    codesignopts_attr_name = automatic_target_info.codesignopts
+    if codesignopts_attr_name:
+        codesignopts = getattr(
+            ctx.rule.attr,
+            automatic_target_info.codesignopts,
+            None,
+        )
+        process_codesignopts(
+            codesignopts = codesignopts,
+            build_settings = build_settings,
+        )
     process_defines(
         cc_info = cc_info,
         swift_info = swift_info,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -315,7 +315,12 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
 
     cc_info = target[CcInfo] if CcInfo in target else None
     objc = target[apple_common.Objc] if apple_common.Objc in target else None
-    codesignopts = getattr(ctx.rule.attr, "codesignopts", None)
+
+    codesignopts = getattr(
+        ctx.rule.attr,
+        automatic_target_info.codesignopts,
+        None,
+    )
     process_codesignopts(
         codesignopts = codesignopts,
         build_settings = build_settings,


### PR DESCRIPTION
Adds logic to support the `codesignopts` property on rules
as part of Support `macos_command_line_application` #99