### PR TITLE
Rename `default_input_file_attributes_aspect`

### DIFF
--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -1,4 +1,4 @@
-"""Implementation of the `default_input_file_attributes_aspect` aspect."""
+"""Implementation of the `default_automatic_target_processing_aspect` aspect."""
 
 load(
     "@build_bazel_rules_apple//apple:providers.bzl",
@@ -37,7 +37,7 @@ def _is_test_target(target):
 
 # Aspects
 
-def _default_input_file_attributes_aspect_impl(target, ctx):
+def _default_automatic_target_processing_aspect_impl(target, ctx):
     if XcodeProjAutomaticTargetProcessingInfo in target:
         return []
 
@@ -123,7 +123,7 @@ def _default_input_file_attributes_aspect_impl(target, ctx):
         ),
     ]
 
-default_input_file_attributes_aspect = aspect(
-    implementation = _default_input_file_attributes_aspect_impl,
+default_automatic_target_processing_aspect = aspect(
+    implementation = _default_automatic_target_processing_aspect_impl,
     attr_aspects = ["*"],
 )

--- a/xcodeproj/internal/xcodeproj_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_aspect.bzl
@@ -2,8 +2,8 @@
 
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
-    ":default_input_file_attributes_aspect.bzl",
-    "default_input_file_attributes_aspect",
+    ":default_automatic_target_processing_aspect.bzl",
+    "default_automatic_target_processing_aspect",
 )
 load(":providers.bzl", "XcodeProjInfo", "XcodeProjProvisioningProfileInfo")
 load(":provisioning_profiles.bzl", "provisioning_profiles")
@@ -83,5 +83,5 @@ xcodeproj_aspect = aspect(
         ),
     },
     fragments = ["apple", "cpp", "objc"],
-    requires = [default_input_file_attributes_aspect],
+    requires = [default_automatic_target_processing_aspect],
 )


### PR DESCRIPTION
The old name doesn't make sense anymore. It's now named `default_automatic_target_processing_aspect` to reflect that it creates the `XcodeProjAutomaticTargetProcessingInfo` provider.