### PR TITLE
Adjust `hdrs` collection to exclusively use `compilation_context`

### DIFF
--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -1168,8 +1168,8 @@
             "info_plist": null,
             "inputs": {
                 "hdrs": [
-                    "Utils/Foo.h",
-                    "Utils/Utils.h"
+                    "Utils/Utils.h",
+                    "Utils/Foo.h"
                 ],
                 "srcs": [
                     "Utils/Foo.m"

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -1183,8 +1183,8 @@
             "info_plist": null,
             "inputs": {
                 "hdrs": [
-                    "Utils/Foo.h",
-                    "Utils/Utils.h"
+                    "Utils/Utils.h",
+                    "Utils/Foo.h"
                 ],
                 "srcs": [
                     "Utils/Foo.m"

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -14,16 +14,16 @@
     "extra_files": [
         "examples/command_line/lib/BUILD",
         {
+            "_": "examples_command_line_external/ExternalFramework.framework",
+            "t": "e"
+        },
+        {
             "_": "examples_command_line_external/ImportableLibrary/Library.h",
             "t": "e"
         },
         {
             "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_impl.swift.modulemap",
             "t": "g"
-        },
-        {
-            "_": "examples_command_line_external/ExternalFramework.framework",
-            "t": "e"
         },
         {
             "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/external/examples_command_line_external/Library.swift.modulemap",
@@ -35,6 +35,7 @@
         },
         "examples/command_line/lib/dir with space/lib.h",
         "examples/command_line/third_party/BUILD",
+        "examples/command_line/third_party/ExampleFramework.framework",
         "examples/command_line/tool/BUILD",
         "examples/command_line/tool/Info.plist",
         "examples/command_line/Tests/BUILD",

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -14,16 +14,16 @@
     "extra_files": [
         "examples/command_line/lib/BUILD",
         {
+            "_": "examples_command_line_external/ExternalFramework.framework",
+            "t": "e"
+        },
+        {
             "_": "examples_command_line_external/ImportableLibrary/Library.h",
             "t": "e"
         },
         {
             "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_impl.swift.modulemap",
             "t": "g"
-        },
-        {
-            "_": "examples_command_line_external/ExternalFramework.framework",
-            "t": "e"
         },
         {
             "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/external/examples_command_line_external/Library.swift.modulemap",
@@ -35,6 +35,7 @@
         },
         "examples/command_line/lib/dir with space/lib.h",
         "examples/command_line/third_party/BUILD",
+        "examples/command_line/third_party/ExampleFramework.framework",
         "examples/command_line/tool/BUILD",
         "examples/command_line/tool/Info.plist",
         "examples/command_line/Tests/BUILD",

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -52,7 +52,6 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
         srcs = ()
 
     non_arc_srcs = ()
-    hdrs = ()
     pch = None
     bundle_id = None
     provisioning_profile = None
@@ -66,14 +65,12 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
             "deps": [target_type.compile],
             "interface_deps": [target_type.compile],
         }
-        hdrs = ("hdrs", "textual_hdrs")
     elif ctx.rule.kind == "objc_library":
         xcode_targets = {
             "deps": [target_type.compile],
             "runtime_deps": [target_type.compile],
         }
         non_arc_srcs = ("non_arc_srcs")
-        hdrs = ("hdrs", "textual_hdrs")
         pch = "pch"
     elif ctx.rule.kind == "swift_library":
         xcode_targets = {
@@ -120,7 +117,6 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
             xcode_targets = xcode_targets,
             non_arc_srcs = non_arc_srcs,
             srcs = srcs,
-            hdrs = hdrs,
             pch = pch,
             bundle_id = bundle_id,
             provisioning_profile = provisioning_profile,

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -74,8 +74,6 @@ def _is_categorized_attr(attr, *, automatic_target_info):
         return True
     elif attr in automatic_target_info.non_arc_srcs:
         return True
-    elif attr in automatic_target_info.hdrs:
-        return True
     elif attr == automatic_target_info.pch:
         return True
     elif attr in automatic_target_info.infoplists:
@@ -85,13 +83,15 @@ def _is_categorized_attr(attr, *, automatic_target_info):
     else:
         return False
 
-def _process_cc_info_headers(headers, *, pch):
+def _process_cc_info_headers(headers, *, output_files, pch, generated):
+    def _process_header(header):
+        if not header.is_source:
+            generated.append(header)
+        return header
     return [
-        header
+        _process_header(header)
         for header in headers
-        if (header.is_source and
-            ".framework" not in header.path and
-            header not in pch)
+        if header not in pch and header not in output_files
     ]
 
 # API
@@ -176,8 +176,6 @@ def _collect(
             srcs.append(file)
         elif attr in automatic_target_info.non_arc_srcs:
             non_arc_srcs.append(file)
-        elif attr in automatic_target_info.hdrs:
-            hdrs.append(file)
         elif attr == automatic_target_info.pch:
             # We use `append` instead of setting a single value because
             # assigning to `pch` creates a new local variable instead of
@@ -275,19 +273,19 @@ def _collect(
     # headers from `objc_import` and the like.
     if CcInfo in target:
         compilation_context = target[CcInfo].compilation_context
-        srcs.extend(
-            _process_cc_info_headers(
-                compilation_context.direct_private_headers,
-                pch = pch,
-            ),
-        )
-        hdrs.extend(
-            _process_cc_info_headers(
-                (compilation_context.direct_public_headers +
-                 compilation_context.direct_textual_headers),
-                pch = pch,
-            ),
-        )
+        srcs.extend(_process_cc_info_headers(
+            compilation_context.direct_private_headers,
+            output_files = output_files,
+            pch = pch,
+            generated = generated,
+        ))
+        hdrs.extend(_process_cc_info_headers(
+            (compilation_context.direct_public_headers +
+                compilation_context.direct_textual_headers),
+            output_files = output_files,
+            pch = pch,
+            generated = generated,
+        ))
 
     return struct(
         srcs = depset(srcs),

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -28,10 +28,6 @@ An attribute name (or `None`) to collect `File`s from for the
 A sequence of attribute names to collect `File`s from for the `infoplists`-like
 attributes.
 """,
-        "hdrs": """\
-A sequence of attribute names to collect `File`s from for the `hdrs`-like
-attributes.
-""",
         "non_arc_srcs": """\
 A sequence of attribute names to collect `File`s from for `non_arc_srcs`-like
 attributes.


### PR DESCRIPTION
Fixes #451.

This fixes issues where generated files were used with rules like `apple_static_framework_import`.

If a `apple_static_framework_import` doesn't have any headers, but the archive is generated, we will still run into an issue. To resolve that we need to adjust `linker_input_files` to add `static_framework_file`, `library`, and the like to inputs. That's for a later change (probably merging the `input_files` and `linker_inputs` into one module`). 