### PR TITLE
Add framework files to `extra_files`

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -11,6 +11,7 @@ load(
     "file_path_to_dto",
     "parsed_file_path",
 )
+load(":linker_input_files.bzl", "linker_input_files")
 load(":output_group_map.bzl", "output_group_map")
 load(":providers.bzl", "XcodeProjInfo")
 load(":resources.bzl", "collect_resources")
@@ -104,6 +105,7 @@ def _collect(
         platform,
         bundle_resources,
         is_bundle,
+        linker_inputs,
         automatic_target_info,
         additional_files = [],
         transitive_infos,
@@ -118,6 +120,8 @@ def _collect(
             project. If this is `False` then all resources will get added to
             `extra_files` instead of `resources`.
         is_bundle: Whether `target` is a bundle.
+        linker_inputs: A value returned from
+            `linker_file_inputs.collect_for_top_level`, or a similar function.
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
         additional_files: A `list` of `File`s to add to the inputs. This can
@@ -234,6 +238,11 @@ def _collect(
             for dep in dep:
                 if type(dep) == "Target":
                     _handle_dep(dep, attr = attr)
+
+    # TODO: Ensure this continues to work once we support framework targets
+    additional_files = additional_files + linker_input_files.to_framework_files(
+        linker_inputs,
+    )
 
     generated.extend([file for file in additional_files if not file.is_source])
     for file in additional_files:

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -123,6 +123,7 @@ def process_library_target(
         platform = platform,
         bundle_resources = bundle_resources,
         is_bundle = False,
+        linker_inputs = linker_inputs,
         automatic_target_info = automatic_target_info,
         additional_files = modulemaps.files,
         transitive_infos = transitive_infos,

--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -433,6 +433,16 @@ def _to_dto(linker_inputs):
 
     return ret
 
+def _to_framework_files(linker_inputs):
+    top_level_values = linker_inputs._top_level_values
+    if not top_level_values:
+        return []
+
+    return (
+        top_level_values.dynamic_frameworks +
+        top_level_values.static_frameworks
+    )
+
 def _get_primary_static_library(linker_inputs):
     """Returns the "primary" static library for this target.
 
@@ -451,4 +461,5 @@ linker_input_files = struct(
     get_static_libraries = _get_static_libraries,
     merge = _merge,
     to_dto = _to_dto,
+    to_framework_files = _to_framework_files,
 )

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -69,6 +69,12 @@ rules_xcodeproj requires {} to have `{}` set.
     else:
         resource_bundle_informations = None
 
+    linker_inputs = linker_input_files.collect_for_non_top_level(
+        cc_info = cc_info,
+        objc = objc,
+        is_xcode_target = False,
+    )
+
     return processed_target(
         automatic_target_info = automatic_target_info,
         dependencies = process_dependencies(
@@ -81,15 +87,12 @@ rules_xcodeproj requires {} to have `{}` set.
             platform = None,
             bundle_resources = False,
             is_bundle = False,
+            linker_inputs = linker_inputs,
             automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
             avoid_deps = [],
         ),
-        linker_inputs = linker_input_files.collect_for_non_top_level(
-            cc_info = cc_info,
-            objc = objc,
-            is_xcode_target = False,
-        ),
+        linker_inputs = linker_inputs,
         outputs = output_files.merge(
             automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -218,27 +218,6 @@ def process_top_level_target(
         minimum_deployment_os_version = props.minimum_deployment_os_version,
     )
 
-    inputs = input_files.collect(
-        ctx = ctx,
-        target = target,
-        platform = platform,
-        is_bundle = is_bundle,
-        bundle_resources = bundle_resources,
-        automatic_target_info = automatic_target_info,
-        additional_files = additional_files,
-        transitive_infos = transitive_infos,
-        avoid_deps = avoid_deps,
-    )
-    outputs = output_files.collect(
-        target_files = target_files,
-        bundle_info = bundle_info,
-        default_info = target[DefaultInfo],
-        swift_info = swift_info,
-        id = id,
-        transitive_infos = transitive_infos,
-        should_produce_dto = should_include_outputs(ctx = ctx),
-    )
-
     package_bin_dir = join_paths_ignoring_empty(
         ctx.bin_dir.path,
         label.workspace_root,
@@ -266,8 +245,30 @@ def process_top_level_target(
         ],
         avoid_linker_inputs = avoid_linker_inputs,
     )
-    xcode_library_targets = linker_inputs.xcode_library_targets
 
+    inputs = input_files.collect(
+        ctx = ctx,
+        target = target,
+        platform = platform,
+        is_bundle = is_bundle,
+        linker_inputs = linker_inputs,
+        bundle_resources = bundle_resources,
+        automatic_target_info = automatic_target_info,
+        additional_files = additional_files,
+        transitive_infos = transitive_infos,
+        avoid_deps = avoid_deps,
+    )
+    outputs = output_files.collect(
+        target_files = target_files,
+        bundle_info = bundle_info,
+        default_info = target[DefaultInfo],
+        swift_info = swift_info,
+        id = id,
+        transitive_infos = transitive_infos,
+        should_produce_dto = should_include_outputs(ctx = ctx),
+    )
+
+    xcode_library_targets = linker_inputs.xcode_library_targets
     if len(xcode_library_targets) == 1 and not inputs.srcs:
         mergeable_target = xcode_library_targets[0]
         mergeable_label = mergeable_target.label


### PR DESCRIPTION
This ensures that header-less `apple_static_framework_import` etc. work.

The method for collecting these files probably won't work as-is when we add support for `ios_framework` etc. We will need to filter out files that will be produced by Xcode targets.