### PR TITLE
WIP: Support `exported_symbols_lists`

### DIFF
--- a/examples/command_line/tool/BUILD
+++ b/examples/command_line/tool/BUILD
@@ -8,6 +8,9 @@ macos_command_line_application(
         "--digest-algorithm=sha1",
         "--digest-algorithm=sha384",
     ],
+    exported_symbols_lists = [
+        "export_symbol_list.exp"
+    ],
     infoplists = ["Info.plist"],
     minimum_os_version = "11.0",
     visibility = ["//visibility:public"],

--- a/examples/command_line/tool/export_symbol_list.exp
+++ b/examples/command_line/tool/export_symbol_list.exp
@@ -1,0 +1,1 @@
+_greeting

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -54,6 +54,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
     bundle_id = None
     codesignopts = None
     entitlements = None
+    exported_symbols_lists = None
     infoplists = ()
     bazel_build_mode_error = None
     non_arc_srcs = ()
@@ -103,6 +104,8 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
     elif AppleBinaryInfo in target:
         if "codesignopts" in attrs:
             codesignopts = "codesignopts"
+        if "exported_symbols_lists" in attrs:
+            exported_symbols_lists = "exported_symbols_lists"
         if "infoplists" in attrs:
             infoplists = ("infoplists")
         xcode_targets = {"deps": [target_type.compile]}
@@ -124,6 +127,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
     return [
         XcodeProjAutomaticTargetProcessingInfo(
             codesignopts = codesignopts,
+            exported_symbols_lists = exported_symbols_lists,
             should_generate_target = should_generate_target,
             target_type = this_target_type,
             xcode_targets = xcode_targets,

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -80,6 +80,8 @@ def _is_categorized_attr(attr, *, automatic_target_info):
         return True
     elif attr == automatic_target_info.entitlements:
         return True
+    elif attr == automatic_target_info.exported_symbols_lists
+        return True
     else:
         return False
 
@@ -154,13 +156,14 @@ def _collect(
     """
     output_files = target.files.to_list()
 
-    srcs = []
-    non_arc_srcs = []
-    hdrs = []
-    pch = []
     entitlements = []
-    generated = []
+    exported_symbols_lists = []
     extra_files = []
+    generated = []
+    hdrs = []
+    non_arc_srcs = []
+    pch = []
+    srcs = []
     uncategorized = []
 
     # Include BUILD files for the project but not for external repos
@@ -192,6 +195,8 @@ def _collect(
             # assigning to `entitlements` creates a new local variable instead
             # of assigning to the existing variable
             entitlements.append(file)
+        elif attr == automatic_target_info.exported_symbols_lists:
+            exported_symbols_lists.append(file)
         else:
             categorized = False
 
@@ -307,6 +312,7 @@ def _collect(
             resource_bundle_dependencies,
         ),
         entitlements = entitlements[0] if entitlements else None,
+        exported_symbols_lists = depset(exported_symbols_lists),
         xccurrentversions = depset(
             xccurrentversions,
             transitive = [
@@ -356,6 +362,7 @@ def _from_resource_bundle(bundle):
         resource_bundle_dependencies = bundle.dependencies,
         infoplists = depset(),
         entitlements = None,
+        exported_symbols_lists = depset(),
         xccurrentversions = depset(),
         generated = depset(),
         extra_files = depset(),
@@ -388,6 +395,12 @@ def _merge(*, transitive_infos, extra_generated = None):
             ],
         ),
         entitlements = None,
+        exported_symbols_lists = depset(
+            transitive = [
+                info.inputs.exported_symbols_lists
+                for _, info in transitive_infos
+            ],
+        ),
         xccurrentversions = depset(
             transitive = [
                 info.inputs.xccurrentversions

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -31,6 +31,10 @@ An attribute name (or `None`) to collect the `codesignopts` `list` from.
 An attribute name (or `None`) to collect `File`s from for the
 `entitlements`-like attribute.
 """,
+        "exported_symbols_lists": """\
+An attribute name (or `None`) to collect `File`s from for the
+`exported_symbols_lists` attribute.
+""",
         "infoplists": """\
 A sequence of attribute names to collect `File`s from for the `infoplists`-like
 attributes.


### PR DESCRIPTION
Adds support for `exported_symbols_lists` as part of
Support `macos_command_line_application` #99

Looking for gudiance on if this is the right approach to use for these
flags