### PR TITLE
Make file sorting more deterministic

### DIFF
--- a/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
@@ -1363,8 +1363,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				7BADA8103BB4E09B7735582D /* Assets.xcassets in Resources */,
-				7FBA65F5399D7FAEB6BDA26D /* GoogleMaps.bundle in Resources */,
 				171DACB244D0CE6D2880DE13 /* GoogleMaps.bundle in Resources */,
+				7FBA65F5399D7FAEB6BDA26D /* GoogleMaps.bundle in Resources */,
 				3DA2238D1AE0C4DE3F8700B6 /* Preview Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/tools/generator/src/Extensions/Sorting.swift
+++ b/tools/generator/src/Extensions/Sorting.swift
@@ -22,7 +22,10 @@ private extension PBXFileElement {
     }
 
     var namePathSortString: String {
-        "\(name ?? path ?? "")\t\(name ?? "")\t\(path ?? "")"
+        let parentNamePathSortString = parent?.namePathSortString ?? ""
+        return """
+\(name ?? path ?? "")\t\(name ?? "")\t\(path ?? "")\t\(parentNamePathSortString)
+"""
     }
 }
 
@@ -96,9 +99,7 @@ private struct PBXFileReferenceByTargetKey {
         file = element.value
     }
 
-    var sortString: String {
-        return "\(file.namePathSortString)\t\(targetKey)"
-    }
+    var sortString: String { "\(file.namePathSortString)\t\(targetKey)" }
 }
 
 extension Dictionary


### PR DESCRIPTION
Use parent sort key as well, since multiple resources can be named the same thing in consolidated targets.