### PR TITLE
Update `xcodeproj` macro to process Xcode schemes

### DIFF
--- a/test/fixtures/generator/BUILD
+++ b/test/fixtures/generator/BUILD
@@ -1,6 +1,6 @@
-load("//tools/generator:xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
+load("//tools/generator:xcodeproj_targets.bzl", "get_xcodeproj_targets")
 load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
 
 xcodeproj_fixture(
-    targets = XCODEPROJ_TARGETS,
+    targets = get_xcodeproj_targets(),
 )

--- a/test/internal/bazel_labels/BUILD.bazel
+++ b/test/internal/bazel_labels/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":absolute_tests.bzl", "absolute_test_suite")
+
+absolute_test_suite(name = "absolute_tests")

--- a/test/internal/bazel_labels/BUILD.bazel
+++ b/test/internal/bazel_labels/BUILD.bazel
@@ -1,3 +1,3 @@
-load(":absolute_tests.bzl", "absolute_test_suite")
+load(":parse_tests.bzl", "parse_test_suite")
 
-absolute_test_suite(name = "absolute_tests")
+parse_test_suite(name = "parse_tests")

--- a/test/internal/bazel_labels/absolute_tests.bzl
+++ b/test/internal/bazel_labels/absolute_tests.bzl
@@ -1,11 +1,17 @@
 """Tests for `bazel_labels.absolute`"""
 
-load("@bazel_skylib//lib:unittest.bzl", "unittest")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
+load("//xcodeproj/internal:bazel_labels.bzl", "bazel_labels")
 
 def _absolute_label_without_repo_name_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
+    # TODO: FIX ME
+    actual = bazel_labels.absolute("//Sources/Foo")
+    expected = ""
+    asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 

--- a/test/internal/bazel_labels/absolute_tests.bzl
+++ b/test/internal/bazel_labels/absolute_tests.bzl
@@ -1,0 +1,48 @@
+"""Tests for `bazel_labels.absolute`"""
+
+load("@bazel_skylib//lib:unittest.bzl", "unittest")
+
+def _absolute_label_without_repo_name_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+absolute_label_without_repo_name_test = unittest.make(_absolute_label_without_repo_name_test)
+
+def _absolute_label_with_repo_name_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+absolute_label_with_repo_name_test = unittest.make(_absolute_label_with_repo_name_test)
+
+def _relative_label_with_colon_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+relative_label_with_colon_test = unittest.make(_relative_label_with_colon_test)
+
+def _relative_label_without_colon_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    return unittest.end(env)
+
+relative_label_without_colon_test = unittest.make(_relative_label_without_colon_test)
+
+def absolute_test_suite(name):
+    return unittest.suite(
+        name,
+        absolute_label_without_repo_name_test,
+        absolute_label_with_repo_name_test,
+        relative_label_with_colon_test,
+        relative_label_without_colon_test,
+    )

--- a/test/internal/bazel_labels/parse_tests.bzl
+++ b/test/internal/bazel_labels/parse_tests.bzl
@@ -8,9 +8,15 @@ load("//xcodeproj/internal:bazel_labels.bzl", "bazel_labels")
 def _absolute_label_without_repo_name_test(ctx):
     env = unittest.begin(ctx)
 
+    value = "//Sources/Foo:chicken"
+
     # TODO: FIX ME
-    actual = bazel_labels.absolute("//Sources/Foo")
-    expected = ""
+    actual = bazel_labels.parse(value, loading_phase = False)
+    expected = bazel_labels.create(
+        repository_name = "@",
+        package = "Sources/Foo",
+        name = "chicken",
+    )
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)
@@ -22,14 +28,29 @@ def _absolute_label_with_repo_name_test(ctx):
 
     unittest.fail(env, "IMPLEMENT ME!")
 
+    value = "@my_dep//Sources/Foo:chicken"
+
     return unittest.end(env)
 
 absolute_label_with_repo_name_test = unittest.make(_absolute_label_with_repo_name_test)
+
+def _absolute_label_without_explicit_name_test(ctx):
+    env = unittest.begin(ctx)
+
+    unittest.fail(env, "IMPLEMENT ME!")
+
+    value = "//Sources/Foo"
+
+    return unittest.end(env)
+
+absolute_label_without_explicit_name_test = unittest.make(_absolute_label_without_explicit_name_test)
 
 def _relative_label_with_colon_test(ctx):
     env = unittest.begin(ctx)
 
     unittest.fail(env, "IMPLEMENT ME!")
+
+    value = ":chicken"
 
     return unittest.end(env)
 
@@ -40,15 +61,18 @@ def _relative_label_without_colon_test(ctx):
 
     unittest.fail(env, "IMPLEMENT ME!")
 
+    value = "chicken"
+
     return unittest.end(env)
 
 relative_label_without_colon_test = unittest.make(_relative_label_without_colon_test)
 
-def absolute_test_suite(name):
+def parse_test_suite(name):
     return unittest.suite(
         name,
         absolute_label_without_repo_name_test,
         absolute_label_with_repo_name_test,
+        absolute_label_without_explicit_name_test,
         relative_label_with_colon_test,
         relative_label_without_colon_test,
     )

--- a/test/internal/bazel_labels/parse_tests.bzl
+++ b/test/internal/bazel_labels/parse_tests.bzl
@@ -6,11 +6,16 @@ load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load(
     "//xcodeproj/internal:bazel_labels.bzl",
     "make_bazel_labels",
-    "make_stub_name_resolver",
+)
+
+# buildifier: disable=bzl-visibility
+load(
+    "//xcodeproj/internal:workspace_name_resolvers.bzl",
+    "make_stub_workspace_name_resolvers",
 )
 
 bazel_labels = make_bazel_labels(
-    name_resolver = make_stub_name_resolver(
+    workspace_name_resolvers = make_stub_workspace_name_resolvers(
         repo_name = "@",
         pkg_name = "Sources/Foo",
     ),

--- a/test/internal/bazel_labels/parse_tests.bzl
+++ b/test/internal/bazel_labels/parse_tests.bzl
@@ -20,7 +20,6 @@ def _absolute_label_without_repo_name_test(ctx):
     env = unittest.begin(ctx)
 
     value = "//Sources/Foo:chicken"
-
     actual = bazel_labels.parse(value)
     expected = bazel_labels.create(
         repository_name = "@",
@@ -36,9 +35,14 @@ absolute_label_without_repo_name_test = unittest.make(_absolute_label_without_re
 def _absolute_label_with_repo_name_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
-
     value = "@my_dep//Sources/Foo:chicken"
+    actual = bazel_labels.parse(value)
+    expected = bazel_labels.create(
+        repository_name = "@my_dep",
+        package = "Sources/Foo",
+        name = "chicken",
+    )
+    asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 
@@ -47,9 +51,14 @@ absolute_label_with_repo_name_test = unittest.make(_absolute_label_with_repo_nam
 def _absolute_label_without_explicit_name_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
-
     value = "//Sources/Foo"
+    actual = bazel_labels.parse(value)
+    expected = bazel_labels.create(
+        repository_name = "@",
+        package = "Sources/Foo",
+        name = "Foo",
+    )
+    asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 
@@ -58,9 +67,14 @@ absolute_label_without_explicit_name_test = unittest.make(_absolute_label_withou
 def _relative_label_with_colon_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
-
     value = ":chicken"
+    actual = bazel_labels.parse(value)
+    expected = bazel_labels.create(
+        repository_name = "@",
+        package = "Sources/Foo",
+        name = "chicken",
+    )
+    asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 
@@ -69,9 +83,14 @@ relative_label_with_colon_test = unittest.make(_relative_label_with_colon_test)
 def _relative_label_without_colon_test(ctx):
     env = unittest.begin(ctx)
 
-    unittest.fail(env, "IMPLEMENT ME!")
-
     value = "chicken"
+    actual = bazel_labels.parse(value)
+    expected = bazel_labels.create(
+        repository_name = "@",
+        package = "Sources/Foo",
+        name = "chicken",
+    )
+    asserts.equals(env, expected, actual)
 
     return unittest.end(env)
 

--- a/test/internal/bazel_labels/parse_tests.bzl
+++ b/test/internal/bazel_labels/parse_tests.bzl
@@ -3,15 +3,16 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 # buildifier: disable=bzl-visibility
-load("//xcodeproj/internal:bazel_labels.bzl", "bazel_labels")
+load("//xcodeproj/internal:bazel_labels.bzl", "make_bazel_labels")
+
+bazel_labels = make_bazel_labels(loading_phase = False)
 
 def _absolute_label_without_repo_name_test(ctx):
     env = unittest.begin(ctx)
 
     value = "//Sources/Foo:chicken"
 
-    # TODO: FIX ME
-    actual = bazel_labels.parse(value, loading_phase = False)
+    actual = bazel_labels.parse(value)
     expected = bazel_labels.create(
         repository_name = "@",
         package = "Sources/Foo",

--- a/test/internal/bazel_labels/parse_tests.bzl
+++ b/test/internal/bazel_labels/parse_tests.bzl
@@ -3,9 +3,18 @@
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 # buildifier: disable=bzl-visibility
-load("//xcodeproj/internal:bazel_labels.bzl", "make_bazel_labels")
+load(
+    "//xcodeproj/internal:bazel_labels.bzl",
+    "make_bazel_labels",
+    "make_stub_name_resolver",
+)
 
-bazel_labels = make_bazel_labels(loading_phase = False)
+bazel_labels = make_bazel_labels(
+    name_resolver = make_stub_name_resolver(
+        repo_name = "@",
+        pkg_name = "Sources/Foo",
+    ),
+)
 
 def _absolute_label_without_repo_name_test(ctx):
     env = unittest.begin(ctx)

--- a/test/internal/xcode_schemes/collect_top_level_targets_tests.bzl
+++ b/test/internal/xcode_schemes/collect_top_level_targets_tests.bzl
@@ -40,19 +40,28 @@ def _single_scheme_test(ctx):
     schemes = [
         xcode_schemes.scheme(
             name = "App",
-            build_action = xcode_schemes.build_action(["//Do/Not/Find/Me"]),
-            test_action = xcode_schemes.test_action([
-                "//Tests/FooTests",
-                "//Tests/BarTests",
-            ]),
-            launch_action = xcode_schemes.launch_action("//Sources/App"),
+            build_action = xcode_schemes.build_action(
+                targets = ["//Do/Not/Find/Me"],
+                loading_phase = False,
+            ),
+            test_action = xcode_schemes.test_action(
+                targets = [
+                    "//Tests/FooTests",
+                    "//Tests/BarTests",
+                ],
+                loading_phase = False,
+            ),
+            launch_action = xcode_schemes.launch_action(
+                "//Sources/App",
+                loading_phase = False,
+            ),
         ),
     ]
     actual = xcode_schemes.collect_top_level_targets(schemes)
     expected = sets.make([
-        "//Sources/App",
-        "//Tests/BarTests",
-        "//Tests/FooTests",
+        "@//Sources/App:App",
+        "@//Tests/BarTests:BarTests",
+        "@//Tests/FooTests:FooTests",
     ])
     asserts.true(env, sets.is_equal(expected, actual))
 
@@ -66,28 +75,43 @@ def _list_of_schemes_test(ctx):
     schemes = [
         xcode_schemes.scheme(
             name = "App",
-            build_action = xcode_schemes.build_action(["//Do/Not/Find/Me"]),
-            test_action = xcode_schemes.test_action([
-                "//Tests/FooTests",
-                "//Tests/BarTests",
-            ]),
-            launch_action = xcode_schemes.launch_action("//Sources/App"),
+            build_action = xcode_schemes.build_action(
+                targets = ["//Do/Not/Find/Me"],
+                loading_phase = False,
+            ),
+            test_action = xcode_schemes.test_action(
+                targets = [
+                    "//Tests/FooTests",
+                    "//Tests/BarTests",
+                ],
+                loading_phase = False,
+            ),
+            launch_action = xcode_schemes.launch_action(
+                "//Sources/App",
+                loading_phase = False,
+            ),
         ),
         xcode_schemes.scheme(
             name = "Foo",
-            build_action = xcode_schemes.build_action(["//Sources/Foo"]),
-            test_action = xcode_schemes.test_action([
-                "//Tests/FooTests",
-                "//Tests/HelloTests",
-            ]),
+            build_action = xcode_schemes.build_action(
+                targets = ["//Sources/Foo"],
+                loading_phase = False,
+            ),
+            test_action = xcode_schemes.test_action(
+                targets = [
+                    "//Tests/FooTests",
+                    "//Tests/HelloTests",
+                ],
+                loading_phase = False,
+            ),
         ),
     ]
     actual = xcode_schemes.collect_top_level_targets(schemes)
     expected = sets.make([
-        "//Sources/App",
-        "//Tests/BarTests",
-        "//Tests/FooTests",
-        "//Tests/HelloTests",
+        "@//Sources/App:App",
+        "@//Tests/BarTests:BarTests",
+        "@//Tests/FooTests:FooTests",
+        "@//Tests/HelloTests:HelloTests",
     ])
     asserts.true(env, sets.is_equal(expected, actual))
 

--- a/test/internal/xcode_schemes/collect_top_level_targets_tests.bzl
+++ b/test/internal/xcode_schemes/collect_top_level_targets_tests.bzl
@@ -4,7 +4,12 @@ load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 # buildifier: disable=bzl-visibility
-load("//xcodeproj/internal:xcode_schemes.bzl", "xcode_schemes")
+load("//xcodeproj/internal:bazel_labels.bzl", "make_stub_name_resolver")
+load("//xcodeproj/internal:xcode_schemes.bzl", "make_xcode_schemes")
+
+xcode_schemes = make_xcode_schemes(
+    name_resolver = make_stub_name_resolver(),
+)
 
 def _empty_schemes_list_test(ctx):
     env = unittest.begin(ctx)
@@ -40,21 +45,12 @@ def _single_scheme_test(ctx):
     schemes = [
         xcode_schemes.scheme(
             name = "App",
-            build_action = xcode_schemes.build_action(
-                targets = ["//Do/Not/Find/Me"],
-                loading_phase = False,
-            ),
-            test_action = xcode_schemes.test_action(
-                targets = [
-                    "//Tests/FooTests",
-                    "//Tests/BarTests",
-                ],
-                loading_phase = False,
-            ),
-            launch_action = xcode_schemes.launch_action(
-                "//Sources/App",
-                loading_phase = False,
-            ),
+            build_action = xcode_schemes.build_action(["//Do/Not/Find/Me"]),
+            test_action = xcode_schemes.test_action([
+                "//Tests/FooTests",
+                "//Tests/BarTests",
+            ]),
+            launch_action = xcode_schemes.launch_action("//Sources/App"),
         ),
     ]
     actual = xcode_schemes.collect_top_level_targets(schemes)
@@ -75,35 +71,20 @@ def _list_of_schemes_test(ctx):
     schemes = [
         xcode_schemes.scheme(
             name = "App",
-            build_action = xcode_schemes.build_action(
-                targets = ["//Do/Not/Find/Me"],
-                loading_phase = False,
-            ),
-            test_action = xcode_schemes.test_action(
-                targets = [
-                    "//Tests/FooTests",
-                    "//Tests/BarTests",
-                ],
-                loading_phase = False,
-            ),
-            launch_action = xcode_schemes.launch_action(
-                "//Sources/App",
-                loading_phase = False,
-            ),
+            build_action = xcode_schemes.build_action(["//Do/Not/Find/Me"]),
+            test_action = xcode_schemes.test_action([
+                "//Tests/FooTests",
+                "//Tests/BarTests",
+            ]),
+            launch_action = xcode_schemes.launch_action("//Sources/App"),
         ),
         xcode_schemes.scheme(
             name = "Foo",
-            build_action = xcode_schemes.build_action(
-                targets = ["//Sources/Foo"],
-                loading_phase = False,
-            ),
-            test_action = xcode_schemes.test_action(
-                targets = [
-                    "//Tests/FooTests",
-                    "//Tests/HelloTests",
-                ],
-                loading_phase = False,
-            ),
+            build_action = xcode_schemes.build_action(["//Sources/Foo"]),
+            test_action = xcode_schemes.test_action([
+                "//Tests/FooTests",
+                "//Tests/HelloTests",
+            ]),
         ),
     ]
     actual = xcode_schemes.collect_top_level_targets(schemes)

--- a/test/internal/xcode_schemes/collect_top_level_targets_tests.bzl
+++ b/test/internal/xcode_schemes/collect_top_level_targets_tests.bzl
@@ -4,12 +4,22 @@ load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
 # buildifier: disable=bzl-visibility
-load("//xcodeproj/internal:bazel_labels.bzl", "make_stub_name_resolver")
+load("//xcodeproj/internal:bazel_labels.bzl", "make_bazel_labels")
+
+# buildifier: disable=bzl-visibility
+load(
+    "//xcodeproj/internal:workspace_name_resolvers.bzl",
+    "make_stub_workspace_name_resolvers",
+)
+
+# buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:xcode_schemes.bzl", "make_xcode_schemes")
 
-xcode_schemes = make_xcode_schemes(
-    name_resolver = make_stub_name_resolver(),
+bazel_labels = make_bazel_labels(
+    workspace_name_resolvers = make_stub_workspace_name_resolvers(),
 )
+
+xcode_schemes = make_xcode_schemes(bazel_labels = bazel_labels)
 
 def _empty_schemes_list_test(ctx):
     env = unittest.begin(ctx)

--- a/test/internal/xcode_schemes/model_tests.bzl
+++ b/test/internal/xcode_schemes/model_tests.bzl
@@ -9,9 +9,9 @@ def _scheme_test(ctx):
     env = unittest.begin(ctx)
 
     name = "Foo"
-    build_action = xcode_schemes.build_action(["//Sources/Foo"])
-    test_action = xcode_schemes.test_action(["//Tests/FooTests"])
-    launch_action = xcode_schemes.launch_action("//Sources/App")
+    build_action = xcode_schemes.build_action(["//Sources/Foo"], loading_phase = False)
+    test_action = xcode_schemes.test_action(["//Tests/FooTests"], loading_phase = False)
+    launch_action = xcode_schemes.launch_action("//Sources/App", loading_phase = False)
 
     actual = xcode_schemes.scheme(
         name = name,
@@ -36,7 +36,7 @@ def _build_action_test(ctx):
 
     targets = ["//Sources/Foo"]
 
-    actual = xcode_schemes.build_action(targets)
+    actual = xcode_schemes.build_action(targets, loading_phase = False)
     expected = struct(
         targets = targets,
     )
@@ -51,7 +51,7 @@ def _test_action_test(ctx):
 
     targets = ["//Tests/FooTests"]
 
-    actual = xcode_schemes.test_action(targets)
+    actual = xcode_schemes.test_action(targets, loading_phase = False)
     expected = struct(
         targets = targets,
     )
@@ -74,6 +74,7 @@ def _launch_action_test(ctx):
         args = args,
         env = env,
         working_directory = working_directory,
+        loading_phase = False,
     )
     expected = struct(
         target = target,

--- a/test/internal/xcode_schemes/model_tests.bzl
+++ b/test/internal/xcode_schemes/model_tests.bzl
@@ -6,20 +6,25 @@ load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 load(
     "//xcodeproj/internal:bazel_labels.bzl",
     "make_bazel_labels",
-    "make_stub_name_resolver",
+)
+
+# buildifier: disable=bzl-visibility
+load(
+    "//xcodeproj/internal:workspace_name_resolvers.bzl",
+    "make_stub_workspace_name_resolvers",
 )
 
 # buildifier: disable=bzl-visibility
 load("//xcodeproj/internal:xcode_schemes.bzl", "make_xcode_schemes")
 
-name_resolver = make_stub_name_resolver()
+workspace_name_resolvers = make_stub_workspace_name_resolvers()
 
 bazel_labels = make_bazel_labels(
-    name_resolver = name_resolver,
+    workspace_name_resolvers = workspace_name_resolvers,
 )
 
 xcode_schemes = make_xcode_schemes(
-    name_resolver = name_resolver,
+    bazel_labels = bazel_labels,
 )
 
 def _scheme_test(ctx):

--- a/tools/generator/BUILD
+++ b/tools/generator/BUILD
@@ -30,7 +30,8 @@ _SCHEMES = [
     xcode_schemes.scheme(
         name = "Generator",
         launch_action = xcode_schemes.launch_action(
-            "//tools/generator:generator",
+            # "//tools/generator:generator",
+            ":generator",
         ),
         test_action = xcode_schemes.test_action([
             "//tools/generator/test:tests",

--- a/tools/generator/BUILD
+++ b/tools/generator/BUILD
@@ -29,10 +29,7 @@ swift_binary(
 _SCHEMES = [
     xcode_schemes.scheme(
         name = "Generator",
-        launch_action = xcode_schemes.launch_action(
-            # "//tools/generator:generator",
-            ":generator",
-        ),
+        launch_action = xcode_schemes.launch_action(":generator"),
         test_action = xcode_schemes.test_action([
             "//tools/generator/test:tests",
         ]),

--- a/tools/generator/BUILD
+++ b/tools/generator/BUILD
@@ -3,7 +3,7 @@ load(
     "swift_binary",
     "swift_library",
 )
-load("//xcodeproj:xcodeproj.bzl", "xcodeproj")
+load("//xcodeproj:xcodeproj.bzl", "xcode_schemes", "xcodeproj")
 load(":xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
 
 swift_library(
@@ -26,10 +26,25 @@ swift_binary(
     ],
 )
 
+_SCHEMES = [
+    xcode_schemes.scheme(
+        name = "Generator",
+        launch_action = xcode_schemes.launch_action(
+            "//tools/generator:generator",
+        ),
+        test_action = xcode_schemes.test_action([
+            "//tools/generator/test:tests",
+        ]),
+    ),
+]
+
 xcodeproj(
     name = "xcodeproj",
     build_mode = "bazel",
     project_name = "generator",
+    # GH573: Revert to `auto` once custom schemes are implemented.
+    scheme_autogeneration_mode = "all",
+    schemes = _SCHEMES,
     tags = ["manual"],
     targets = XCODEPROJ_TARGETS,
 )

--- a/tools/generator/BUILD
+++ b/tools/generator/BUILD
@@ -3,8 +3,8 @@ load(
     "swift_binary",
     "swift_library",
 )
-load("//xcodeproj:xcodeproj.bzl", "xcode_schemes", "xcodeproj")
-load(":xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
+load("//xcodeproj:xcodeproj.bzl", "xcodeproj")
+load(":xcodeproj_targets.bzl", "get_xcode_schemes")
 
 swift_library(
     name = "generator.library",
@@ -26,25 +26,14 @@ swift_binary(
     ],
 )
 
-_SCHEMES = [
-    xcode_schemes.scheme(
-        name = "Generator",
-        launch_action = xcode_schemes.launch_action(":generator"),
-        test_action = xcode_schemes.test_action([
-            "//tools/generator/test:tests",
-        ]),
-    ),
-]
-
 xcodeproj(
     name = "xcodeproj",
     build_mode = "bazel",
     project_name = "generator",
     # GH573: Revert to `auto` once custom schemes are implemented.
     scheme_autogeneration_mode = "all",
-    schemes = _SCHEMES,
+    schemes = get_xcode_schemes(),
     tags = ["manual"],
-    targets = XCODEPROJ_TARGETS,
 )
 
 # Integration test related targets

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -1,6 +1,24 @@
 """Exposes targets used by `xcodeproj` to allow use in fixture tests."""
 
-XCODEPROJ_TARGETS = [
-    "//tools/generator:generator",
-    "//tools/generator/test:tests",
-]
+load("@bazel_skylib//lib:sets.bzl", "sets")
+load("//xcodeproj:xcodeproj.bzl", "xcode_schemes")
+
+def get_xcode_schemes():
+    return [
+        xcode_schemes.scheme(
+            name = "Generator",
+            launch_action = xcode_schemes.launch_action(
+                "//tools/generator:generator",
+            ),
+            test_action = xcode_schemes.test_action([
+                "//tools/generator/test:tests",
+            ]),
+        ),
+    ]
+
+def get_xcodeproj_targets():
+    return sets.to_list(
+        xcode_schemes.collect_top_level_targets(
+            get_xcode_schemes(),
+        ),
+    )

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -68,7 +68,7 @@ def make_bazel_labels(name_resolver = native_name_resolver):
     """Creates a `bazel_labels` module using the specified name resolver.
 
     Args:
-        name_resolver: Optional. A name resolver `struct`.
+        name_resolver: Optional. A `name_resolver` module.
 
     Returns:
         A `struct` that can be used as a Bazel labels module.

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -1,22 +1,104 @@
 """API for resolving and managing Bazel labels"""
 
-def _absolute(label):
-    if label.startswith("@") or label.startswith("//"):
-        return label
-    repo_name = native.repository_name()
-    if repo_name == "@":
-        repo_name = ""
-    pkg_name = native.package_name()
-    name = label[1:] if label.startswith(":") else label
-    return "{repo_name}//{pkg_name}:{name}".format(
-        repo_name = repo_name,
-        pkg_name = pkg_name,
+_ROOT_SEPARATOR = "//"
+_ROOT_SEPARATOR_LEN = len(_ROOT_SEPARATOR)
+_NAME_SEPARATOR = ":"
+_NAME_SEPARATOR_LEN = len(_NAME_SEPARATOR)
+_PKG_SEPARATOR = "/"
+_PKG_SEPARATOR_LEN = len(_PKG_SEPARATOR)
+
+def _create(repository_name, package, name):
+    return struct(
+        repository_name = repository_name,
+        package = package,
         name = name,
     )
 
-# TODO: Handle label without explicit name (//Sources/Foo)
-# TODO: Should I normalize in absolute or create a separate function?
+def _parse(value, loading_phase = True):
+    """Parse a string as a Bazel label returning its parts.
+
+    Args:
+        value: A `string` value to parse.
+        load_phase: Optional. A `bool` that indicates whether the function is
+            being called from Bazel's loading phase. Some native functionality
+            is only available during the loading phase.
+
+    Returns:
+        A `struct` as returned from `bazel_labels.create`.
+    """
+    root_sep_pos = value.find(_ROOT_SEPARATOR)
+
+    # The package starts after the root separator
+    if root_sep_pos > -1:
+        pkg_start_pos = root_sep_pos + _ROOT_SEPARATOR_LEN
+    else:
+        pkg_start_pos = -1
+
+    # Extract the repo name
+    if root_sep_pos > 0:
+        repo_name = value[:root_sep_pos]
+    elif loading_phase:
+        repo_name = native.repository_name()
+    else:
+        repo_name = "@"
+
+    colon_pos = value.find(_NAME_SEPARATOR)
+
+    # Extract the name
+    if colon_pos > -1:
+        # Found a colon, the name follows it
+        name_start_pos = colon_pos + _NAME_SEPARATOR_LEN
+        pkg_end_pos = colon_pos
+    elif pkg_start_pos > -1:
+        # No colon and have a package, so the name is the last part of the
+        # package
+        pkg_end_pos = len(value)
+        last_sep_pos = value.rfind(_PKG_SEPARATOR, pkg_start_pos)
+        if last_sep_pos > -1:
+            name_start_pos = last_sep_pos + _PKG_SEPARATOR_LEN
+        else:
+            name_start_pos = pkg_start_pos
+    else:
+        # No colon and no package, the value is the name
+        name = value
+        pkg_end_pos = -1
+    name = value[name_start_pos:]
+
+    if pkg_start_pos > -1:
+        package = value[pkg_start_pos:pkg_end_pos]
+    elif loading_phase:
+        package = native.package_name()
+    else:
+        package = ""
+
+    return _create(
+        repository_name = repo_name,
+        package = package,
+        name = name,
+    )
+
+    # if value.startswith("@") or value.startswith("//"):
+    #     return value
+    # repo_name = native.repository_name()
+    # if repo_name == "@":
+    #     repo_name = ""
+    # pkg_name = native.package_name()
+    # name = value[1:] if value.startswith(":") else value
+
+def _normalize(value, loading_phase = True):
+    parts = _parse(value, loading_phase = loading_phase)
+    return "{repo_name}//{package}:{name}".format(
+        repo_name = parts.repository_name,
+        package = parts.package,
+        name = parts.name,
+    )
+
+# TODO: Handle value without explicit name (//Sources/Foo)
+# TODO: Perhaps do normalze (convert string to a format that is
+# explicit label with all parts), and validate (
 
 bazel_labels = struct(
-    absolute = _absolute,
+    create = _create,
+    parse = _parse,
+    normalize = _normalize,
 )

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -1,0 +1,19 @@
+"""API for resolving and managing Bazel labels"""
+
+def _absolute(label):
+    if label.startswith("@") or label.startswith("//"):
+        return label
+    repo_name = native.repository_name()
+    if repo_name == "@":
+        repo_name = ""
+    pkg_name = native.package_name()
+    name = label[1:] if label.startswith(":") else label
+    return "{repo_name}//{pkg_name}:{name}".format(
+        repo_name = repo_name,
+        pkg_name = pkg_name,
+        name = name,
+    )
+
+bazel_labels = struct(
+    absolute = _absolute,
+)

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -1,5 +1,51 @@
 """API for resolving and managing Bazel labels"""
 
+# MARK: - name_resolver Module Factory
+
+def _create_name_resolver(repository_name, package_name):
+    """Create a name resolver module.
+
+    Args:
+        repository_name: A `function` that returns the current repository name.
+        package_name: A `function` that returns the current package name.
+
+    Returns:
+        A `struct` that can be used as a name resolver module.
+    """
+    return struct(
+        repository_name = repository_name,
+        package_name = package_name,
+    )
+
+native_name_resolver = _create_name_resolver(
+    repository_name = native.repository_name,
+    package_name = native.package_name,
+)
+
+def make_stub_name_resolver(repo_name = "@", pkg_name = ""):
+    """Create a name resolver module that returns the provided values.
+
+    Args:
+        repo_name: A `string` value returned as the repository name.
+        pkg_name: A `string` value returned as the package name.
+
+    Returns:
+        A `struct` that can nbe used as a name resolver module.
+    """
+
+    def _stub_repository_name():
+        return repo_name
+
+    def _stub_package_name():
+        return pkg_name
+
+    return _create_name_resolver(
+        repository_name = _stub_repository_name,
+        package_name = _stub_package_name,
+    )
+
+# MARK: - bazel_labels Module Factory
+
 _ROOT_SEPARATOR = "//"
 _ROOT_SEPARATOR_LEN = len(_ROOT_SEPARATOR)
 _NAME_SEPARATOR = ":"
@@ -7,14 +53,14 @@ _NAME_SEPARATOR_LEN = len(_NAME_SEPARATOR)
 _PKG_SEPARATOR = "/"
 _PKG_SEPARATOR_LEN = len(_PKG_SEPARATOR)
 
-def _create(repository_name, package, name):
+def _create_label_parts(repository_name, package, name):
     return struct(
         repository_name = repository_name,
         package = package,
         name = name,
     )
 
-def make_bazel_labels(loading_phase = True):
+def make_bazel_labels(name_resolver = native_name_resolver):
     def _parse(value):
         """Parse a string as a Bazel label returning its parts.
 
@@ -35,10 +81,8 @@ def make_bazel_labels(loading_phase = True):
         # Extract the repo name
         if root_sep_pos > 0:
             repo_name = value[:root_sep_pos]
-        elif loading_phase:
-            repo_name = native.repository_name()
         else:
-            repo_name = "@"
+            repo_name = name_resolver.repository_name()
 
         colon_pos = value.find(_NAME_SEPARATOR)
 
@@ -64,12 +108,10 @@ def make_bazel_labels(loading_phase = True):
 
         if pkg_start_pos > -1:
             package = value[pkg_start_pos:pkg_end_pos]
-        elif loading_phase:
-            package = native.package_name()
         else:
-            package = ""
+            package = name_resolver.package_name()
 
-        return _create(
+        return _create_label_parts(
             repository_name = repo_name,
             package = package,
             name = name,
@@ -84,7 +126,7 @@ def make_bazel_labels(loading_phase = True):
         # name = value[1:] if value.startswith(":") else value
 
     def _normalize(value):
-        parts = _parse(value, loading_phase = loading_phase)
+        parts = _parse(value)
         return "{repo_name}//{package}:{name}".format(
             repo_name = parts.repository_name,
             package = parts.package,
@@ -96,7 +138,7 @@ def make_bazel_labels(loading_phase = True):
     # explicit label with all parts), and validate (
 
     return struct(
-        create = _create,
+        create = _create_label_parts,
         parse = _parse,
         normalize = _normalize,
     )

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -61,6 +61,15 @@ def _create_label_parts(repository_name, package, name):
     )
 
 def make_bazel_labels(name_resolver = native_name_resolver):
+    """Creates a `bazel_labels` module using the specified name resolver.
+
+    Args:
+        name_resolver: Optional. A name resolver `struct`.
+
+    Returns:
+        A `struct` that can be used as a Bazel labels module.
+    """
+
     def _parse(value):
         """Parse a string as a Bazel label returning its parts.
 
@@ -102,7 +111,7 @@ def make_bazel_labels(name_resolver = native_name_resolver):
                 name_start_pos = pkg_start_pos
         else:
             # No colon and no package, the value is the name
-            name = value
+            name_start_pos = 0
             pkg_end_pos = -1
         name = value[name_start_pos:]
 

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -14,91 +14,91 @@ def _create(repository_name, package, name):
         name = name,
     )
 
-def _parse(value, loading_phase = True):
-    """Parse a string as a Bazel label returning its parts.
+def make_bazel_labels(loading_phase = True):
+    def _parse(value):
+        """Parse a string as a Bazel label returning its parts.
 
-    Args:
-        value: A `string` value to parse.
-        load_phase: Optional. A `bool` that indicates whether the function is
-            being called from Bazel's loading phase. Some native functionality
-            is only available during the loading phase.
+        Args:
+            value: A `string` value to parse.
 
-    Returns:
-        A `struct` as returned from `bazel_labels.create`.
-    """
-    root_sep_pos = value.find(_ROOT_SEPARATOR)
+        Returns:
+            A `struct` as returned from `bazel_labels.create`.
+        """
+        root_sep_pos = value.find(_ROOT_SEPARATOR)
 
-    # The package starts after the root separator
-    if root_sep_pos > -1:
-        pkg_start_pos = root_sep_pos + _ROOT_SEPARATOR_LEN
-    else:
-        pkg_start_pos = -1
-
-    # Extract the repo name
-    if root_sep_pos > 0:
-        repo_name = value[:root_sep_pos]
-    elif loading_phase:
-        repo_name = native.repository_name()
-    else:
-        repo_name = "@"
-
-    colon_pos = value.find(_NAME_SEPARATOR)
-
-    # Extract the name
-    if colon_pos > -1:
-        # Found a colon, the name follows it
-        name_start_pos = colon_pos + _NAME_SEPARATOR_LEN
-        pkg_end_pos = colon_pos
-    elif pkg_start_pos > -1:
-        # No colon and have a package, so the name is the last part of the
-        # package
-        pkg_end_pos = len(value)
-        last_sep_pos = value.rfind(_PKG_SEPARATOR, pkg_start_pos)
-        if last_sep_pos > -1:
-            name_start_pos = last_sep_pos + _PKG_SEPARATOR_LEN
+        # The package starts after the root separator
+        if root_sep_pos > -1:
+            pkg_start_pos = root_sep_pos + _ROOT_SEPARATOR_LEN
         else:
-            name_start_pos = pkg_start_pos
-    else:
-        # No colon and no package, the value is the name
-        name = value
-        pkg_end_pos = -1
-    name = value[name_start_pos:]
+            pkg_start_pos = -1
 
-    if pkg_start_pos > -1:
-        package = value[pkg_start_pos:pkg_end_pos]
-    elif loading_phase:
-        package = native.package_name()
-    else:
-        package = ""
+        # Extract the repo name
+        if root_sep_pos > 0:
+            repo_name = value[:root_sep_pos]
+        elif loading_phase:
+            repo_name = native.repository_name()
+        else:
+            repo_name = "@"
 
-    return _create(
-        repository_name = repo_name,
-        package = package,
-        name = name,
+        colon_pos = value.find(_NAME_SEPARATOR)
+
+        # Extract the name
+        if colon_pos > -1:
+            # Found a colon, the name follows it
+            name_start_pos = colon_pos + _NAME_SEPARATOR_LEN
+            pkg_end_pos = colon_pos
+        elif pkg_start_pos > -1:
+            # No colon and have a package, so the name is the last part of the
+            # package
+            pkg_end_pos = len(value)
+            last_sep_pos = value.rfind(_PKG_SEPARATOR, pkg_start_pos)
+            if last_sep_pos > -1:
+                name_start_pos = last_sep_pos + _PKG_SEPARATOR_LEN
+            else:
+                name_start_pos = pkg_start_pos
+        else:
+            # No colon and no package, the value is the name
+            name = value
+            pkg_end_pos = -1
+        name = value[name_start_pos:]
+
+        if pkg_start_pos > -1:
+            package = value[pkg_start_pos:pkg_end_pos]
+        elif loading_phase:
+            package = native.package_name()
+        else:
+            package = ""
+
+        return _create(
+            repository_name = repo_name,
+            package = package,
+            name = name,
+        )
+
+        # if value.startswith("@") or value.startswith("//"):
+        #     return value
+        # repo_name = native.repository_name()
+        # if repo_name == "@":
+        #     repo_name = ""
+        # pkg_name = native.package_name()
+        # name = value[1:] if value.startswith(":") else value
+
+    def _normalize(value):
+        parts = _parse(value, loading_phase = loading_phase)
+        return "{repo_name}//{package}:{name}".format(
+            repo_name = parts.repository_name,
+            package = parts.package,
+            name = parts.name,
+        )
+
+    # TODO: Handle value without explicit name (//Sources/Foo)
+    # TODO: Perhaps do normalze (convert string to a format that is
+    # explicit label with all parts), and validate (
+
+    return struct(
+        create = _create,
+        parse = _parse,
+        normalize = _normalize,
     )
 
-    # if value.startswith("@") or value.startswith("//"):
-    #     return value
-    # repo_name = native.repository_name()
-    # if repo_name == "@":
-    #     repo_name = ""
-    # pkg_name = native.package_name()
-    # name = value[1:] if value.startswith(":") else value
-
-def _normalize(value, loading_phase = True):
-    parts = _parse(value, loading_phase = loading_phase)
-    return "{repo_name}//{package}:{name}".format(
-        repo_name = parts.repository_name,
-        package = parts.package,
-        name = parts.name,
-    )
-
-# TODO: Handle value without explicit name (//Sources/Foo)
-# TODO: Perhaps do normalze (convert string to a format that is
-# explicit label with all parts), and validate (
-
-bazel_labels = struct(
-    create = _create,
-    parse = _parse,
-    normalize = _normalize,
-)
+bazel_labels = make_bazel_labels()

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -54,6 +54,10 @@ _PKG_SEPARATOR = "/"
 _PKG_SEPARATOR_LEN = len(_PKG_SEPARATOR)
 
 def _create_label_parts(repository_name, package, name):
+    if not repository_name.startswith("@"):
+        fail("Repository names must start with an '@'. {repo_name}".format(
+            repo_name = repository_name,
+        ))
     return struct(
         repository_name = repository_name,
         package = package,
@@ -125,14 +129,6 @@ def make_bazel_labels(name_resolver = native_name_resolver):
             package = package,
             name = name,
         )
-
-        # if value.startswith("@") or value.startswith("//"):
-        #     return value
-        # repo_name = native.repository_name()
-        # if repo_name == "@":
-        #     repo_name = ""
-        # pkg_name = native.package_name()
-        # name = value[1:] if value.startswith(":") else value
 
     def _normalize(value):
         parts = _parse(value)

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -14,6 +14,9 @@ def _absolute(label):
         name = name,
     )
 
+# TODO: Handle label without explicit name (//Sources/Foo)
+# TODO: Should I normalize in absolute or create a separate function?
+
 bazel_labels = struct(
     absolute = _absolute,
 )

--- a/xcodeproj/internal/workspace_name_resolvers.bzl
+++ b/xcodeproj/internal/workspace_name_resolvers.bzl
@@ -1,0 +1,43 @@
+"""API for resolving workspace names"""
+
+def _make_workspace_name_resolvers(repository_name, package_name):
+    """Create a name resolver module.
+
+    Args:
+        repository_name: A `function` that returns the current repository name.
+        package_name: A `function` that returns the current package name.
+
+    Returns:
+        A `struct` that can be used as a name resolver module.
+    """
+    return struct(
+        repository_name = repository_name,
+        package_name = package_name,
+    )
+
+workspace_name_resolvers = _make_workspace_name_resolvers(
+    repository_name = native.repository_name,
+    package_name = native.package_name,
+)
+
+def make_stub_workspace_name_resolvers(repo_name = "@", pkg_name = ""):
+    """Create a `workspace_name_resolvers` module that returns the provided values.
+
+    Args:
+        repo_name: A `string` value returned as the repository name.
+        pkg_name: A `string` value returned as the package name.
+
+    Returns:
+        A `struct` that can nbe used as a name resolver module.
+    """
+
+    def _stub_repository_name():
+        return repo_name
+
+    def _stub_package_name():
+        return pkg_name
+
+    return _make_workspace_name_resolvers(
+        repository_name = _stub_repository_name,
+        package_name = _stub_package_name,
+    )

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -1,6 +1,7 @@
 """API for defining custom Xcode schemes"""
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
+load(":bazel_labels.bzl", "bazel_labels")
 
 def _scheme(
         name,
@@ -38,7 +39,7 @@ def _build_action(targets):
         A `struct` representing a build action.
     """
     return struct(
-        targets = targets,
+        targets = [bazel_labels.absolute(t) for t in targets],
     )
 
 def _test_action(targets):
@@ -51,7 +52,7 @@ def _test_action(targets):
         A `struct` representing a test action.
     """
     return struct(
-        targets = targets,
+        targets = [bazel_labels.absolute(t) for t in targets],
     )
 
 def _launch_action(target, args = None, env = None, working_directory = None):
@@ -70,7 +71,7 @@ def _launch_action(target, args = None, env = None, working_directory = None):
         A `struct` representing a launch action.
     """
     return struct(
-        target = target,
+        target = bazel_labels.absolute(target),
         args = args,
         env = env,
         working_directory = working_directory,

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -3,6 +3,9 @@
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load(":bazel_labels.bzl", "bazel_labels")
 
+# TODO: Consider switching loading_phase to injecting the module to use for
+# bazel_labels.
+
 def _scheme(
         name,
         build_action = None,
@@ -29,33 +32,50 @@ def _scheme(
         launch_action = launch_action,
     )
 
-def _build_action(targets):
+def _build_action(targets, loading_phase = True):
     """Constructs a build action for an Xcode scheme.
 
     Args:
         targets: A `sequence` of target labels as `string` values.
+        load_phase: Optional. A `bool` that indicates whether the function is
+            being called from Bazel's loading phase. Some native functionality
+            is only available during the loading phase.
 
     Return:
         A `struct` representing a build action.
     """
     return struct(
-        targets = [bazel_labels.absolute(t) for t in targets],
+        targets = [
+            bazel_labels.normalize(t, loading_phase = loading_phase)
+            for t in targets
+        ],
     )
 
-def _test_action(targets):
+def _test_action(targets, loading_phase = True):
     """Constructs a test action for an Xcode scheme.
 
     Args:
         targets: A `sequence` of target labels as `string` values.
+        load_phase: Optional. A `bool` that indicates whether the function is
+            being called from Bazel's loading phase. Some native functionality
+            is only available during the loading phase.
 
     Return:
         A `struct` representing a test action.
     """
     return struct(
-        targets = [bazel_labels.absolute(t) for t in targets],
+        targets = [
+            bazel_labels.normalize(t, loading_phase = loading_phase)
+            for t in targets
+        ],
     )
 
-def _launch_action(target, args = None, env = None, working_directory = None):
+def _launch_action(
+        target,
+        args = None,
+        env = None,
+        working_directory = None,
+        loading_phase = True):
     """Constructs a launch action for an Xcode scheme.
 
     Args:
@@ -66,12 +86,15 @@ def _launch_action(target, args = None, env = None, working_directory = None):
             environment variables when the target is executed.
         working_directory: Optional. A `string` that will be set as the custom
             working directory in the Xcode scheme's launch action.
+        load_phase: Optional. A `bool` that indicates whether the function is
+            being called from Bazel's loading phase. Some native functionality
+            is only available during the loading phase.
 
     Return:
         A `struct` representing a launch action.
     """
     return struct(
-        target = bazel_labels.absolute(target),
+        target = bazel_labels.normalize(target, loading_phase = loading_phase),
         args = args,
         env = env,
         working_directory = working_directory,

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -1,7 +1,7 @@
 """API for defining custom Xcode schemes"""
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
-load(":bazel_labels.bzl", "make_bazel_labels", "native_name_resolver")
+load(":bazel_labels.bzl", _bazel_labels = "bazel_labels")
 
 def _scheme(
         name,
@@ -57,17 +57,15 @@ def _collect_top_level_targets(schemes):
         )
     return results
 
-def make_xcode_schemes(name_resolver = native_name_resolver):
+def make_xcode_schemes(bazel_labels):
     """Create an `xcode_schemes` module.
 
     Args:
-        name_resolver: Optional. A `name_resolver` module.
+        bazel_labels: A `bazel_labels` module.
 
     Returns:
         A `struct` that can be used as a `bazel_labels` module.
     """
-
-    bazel_labels = make_bazel_labels(name_resolver = name_resolver)
 
     def _build_action(targets):
         """Constructs a build action for an Xcode scheme.
@@ -135,4 +133,6 @@ def make_xcode_schemes(name_resolver = native_name_resolver):
         collect_top_level_targets = _collect_top_level_targets,
     )
 
-xcode_schemes = make_xcode_schemes()
+xcode_schemes = make_xcode_schemes(
+    bazel_labels = _bazel_labels,
+)

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -1,10 +1,7 @@
 """API for defining custom Xcode schemes"""
 
 load("@bazel_skylib//lib:sets.bzl", "sets")
-load(":bazel_labels.bzl", "bazel_labels")
-
-# TODO: Consider switching loading_phase to injecting the module to use for
-# bazel_labels.
+load(":bazel_labels.bzl", "make_bazel_labels", "native_name_resolver")
 
 def _scheme(
         name,
@@ -30,74 +27,6 @@ def _scheme(
         build_action = build_action,
         test_action = test_action,
         launch_action = launch_action,
-    )
-
-def _build_action(targets, loading_phase = True):
-    """Constructs a build action for an Xcode scheme.
-
-    Args:
-        targets: A `sequence` of target labels as `string` values.
-        load_phase: Optional. A `bool` that indicates whether the function is
-            being called from Bazel's loading phase. Some native functionality
-            is only available during the loading phase.
-
-    Return:
-        A `struct` representing a build action.
-    """
-    return struct(
-        targets = [
-            bazel_labels.normalize(t, loading_phase = loading_phase)
-            for t in targets
-        ],
-    )
-
-def _test_action(targets, loading_phase = True):
-    """Constructs a test action for an Xcode scheme.
-
-    Args:
-        targets: A `sequence` of target labels as `string` values.
-        load_phase: Optional. A `bool` that indicates whether the function is
-            being called from Bazel's loading phase. Some native functionality
-            is only available during the loading phase.
-
-    Return:
-        A `struct` representing a test action.
-    """
-    return struct(
-        targets = [
-            bazel_labels.normalize(t, loading_phase = loading_phase)
-            for t in targets
-        ],
-    )
-
-def _launch_action(
-        target,
-        args = None,
-        env = None,
-        working_directory = None,
-        loading_phase = True):
-    """Constructs a launch action for an Xcode scheme.
-
-    Args:
-        target: A target label as a `string` value.
-        args: Optional. A `list` of `string` arguments that should be passed to
-            the target when executed.
-        env: Optional. A `dict` of `string` values that will be set as
-            environment variables when the target is executed.
-        working_directory: Optional. A `string` that will be set as the custom
-            working directory in the Xcode scheme's launch action.
-        load_phase: Optional. A `bool` that indicates whether the function is
-            being called from Bazel's loading phase. Some native functionality
-            is only available during the loading phase.
-
-    Return:
-        A `struct` representing a launch action.
-    """
-    return struct(
-        target = bazel_labels.normalize(target, loading_phase = loading_phase),
-        args = args,
-        env = env,
-        working_directory = working_directory,
     )
 
 def _collect_top_level_targets_from_a_scheme(scheme):
@@ -128,10 +57,82 @@ def _collect_top_level_targets(schemes):
         )
     return results
 
-xcode_schemes = struct(
-    scheme = _scheme,
-    build_action = _build_action,
-    test_action = _test_action,
-    launch_action = _launch_action,
-    collect_top_level_targets = _collect_top_level_targets,
-)
+def make_xcode_schemes(name_resolver = native_name_resolver):
+    """Create an `xcode_schemes` module.
+
+    Args:
+        name_resolver: Optional. A `name_resolver` module.
+
+    Returns:
+        A `struct` that can be used as a `bazel_labels` module.
+    """
+
+    bazel_labels = make_bazel_labels(name_resolver = name_resolver)
+
+    def _build_action(targets):
+        """Constructs a build action for an Xcode scheme.
+
+        Args:
+            targets: A `sequence` of target labels as `string` values.
+
+        Return:
+            A `struct` representing a build action.
+        """
+        return struct(
+            targets = [
+                bazel_labels.normalize(t)
+                for t in targets
+            ],
+        )
+
+    def _test_action(targets):
+        """Constructs a test action for an Xcode scheme.
+
+        Args:
+            targets: A `sequence` of target labels as `string` values.
+
+        Return:
+            A `struct` representing a test action.
+        """
+        return struct(
+            targets = [
+                bazel_labels.normalize(t)
+                for t in targets
+            ],
+        )
+
+    def _launch_action(
+            target,
+            args = None,
+            env = None,
+            working_directory = None):
+        """Constructs a launch action for an Xcode scheme.
+
+        Args:
+            target: A target label as a `string` value.
+            args: Optional. A `list` of `string` arguments that should be passed to
+                the target when executed.
+            env: Optional. A `dict` of `string` values that will be set as
+                environment variables when the target is executed.
+            working_directory: Optional. A `string` that will be set as the custom
+                working directory in the Xcode scheme's launch action.
+
+        Return:
+            A `struct` representing a launch action.
+        """
+        return struct(
+            target = bazel_labels.normalize(target),
+            args = args,
+            env = env,
+            working_directory = working_directory,
+        )
+
+    return struct(
+        scheme = _scheme,
+        build_action = _build_action,
+        test_action = _test_action,
+        launch_action = _launch_action,
+        collect_top_level_targets = _collect_top_level_targets,
+    )
+
+xcode_schemes = make_xcode_schemes()

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -482,18 +482,26 @@ A JSON string representing a list of Xcode schemes to create.\
 
 _xcodeproj = make_xcodeproj_rule()
 
-def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, **kwargs):
+def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, schemes = None, **kwargs):
     """Creates an .xcodeproj file in the workspace when run.
 
     Args:
         name: The name of the target.
         xcodeproj_rule: The actual `xcodeproj` rule. This is overridden during
             fixture testing. You shouldn't need to set it yourself.
+        schemes: Optional. A `list` of `struct` values as returned by
+            `xcode_schemes.scheme`.
         **kwargs: Additional arguments to pass to `xcodeproj_rule`.
     """
     testonly = kwargs.pop("testonly", True)
 
     project = kwargs.get("project_name", name)
+
+    targets = kwargs.pop("targets", [])
+    schemes_json = ""
+    if schemes != None:
+        targets_from_schemes = xcode_schemes.collect_top_level_targets(schemes)
+        targets = targets_module.merge(targets, targets_from_schemes)
 
     if kwargs.get("toplevel_cache_buster"):
         fail("`toplevel_cache_buster` is for internal use only")
@@ -515,5 +523,7 @@ def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, **kwargs):
         name = name,
         testonly = testonly,
         toplevel_cache_buster = toplevel_cache_buster,
+        schemes_json = schemes_json,
+        targets = targets,
         **kwargs
     )

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -501,6 +501,7 @@ def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, schemes = None, **kwargs):
     targets = kwargs.pop("targets", [])
     schemes_json = None
     if schemes != None:
+        # TODO: Try to support relative labels?
         schemes_json = json.encode(schemes)
         targets_from_schemes = xcode_schemes.collect_top_level_targets(schemes)
         targets_set = sets.make(targets)

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -443,10 +443,6 @@ A JSON string representing a list of Xcode schemes to create.\
             allow_files = True,
             default = Label("//xcodeproj/internal/bazel_integration_files"),
         ),
-        "_create_lldbinit_script": attr.label(
-            allow_single_file = True,
-            default = Label("//xcodeproj/internal/bazel_integration_files:create_lldbinit.sh"),
-        ),
         "_external_file_marker": attr.label(
             allow_single_file = True,
             # This just has to point to a source file in an external repo. It is
@@ -467,6 +463,10 @@ A JSON string representing a list of Xcode schemes to create.\
         "_installer_template": attr.label(
             allow_single_file = True,
             default = Label("//xcodeproj/internal:installer.template.sh"),
+        ),
+        "_create_lldbinit_script": attr.label(
+            allow_single_file = True,
+            default = Label("//xcodeproj/internal/bazel_integration_files:create_lldbinit.sh"),
         ),
         "_xccurrentversions_parser": attr.label(
             cfg = "exec",
@@ -499,6 +499,7 @@ def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, schemes = None, **kwargs):
 
     project = kwargs.get("project_name", name)
 
+    # Combine targets that are specified directly and implicitly via the schemes
     targets = [bazel_labels.normalize(t) for t in kwargs.pop("targets", [])]
     schemes_json = None
     if schemes != None:

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -417,6 +417,11 @@ def make_xcodeproj_rule(
             doc = "Specifies how Xcode schemes are automatically generated.",
             values = ["auto", "none", "all"],
         ),
+        "schemes_json": attr.string(
+            doc = """\
+A JSON string representing a list of Xcode schemes to create.\
+""",
+        ),
         "targets": attr.label_list(
             cfg = target_transition,
             mandatory = True,
@@ -435,6 +440,10 @@ def make_xcodeproj_rule(
         "_bazel_integration_files": attr.label(
             allow_files = True,
             default = Label("//xcodeproj/internal/bazel_integration_files"),
+        ),
+        "_create_lldbinit_script": attr.label(
+            allow_single_file = True,
+            default = Label("//xcodeproj/internal/bazel_integration_files:create_lldbinit.sh"),
         ),
         "_external_file_marker": attr.label(
             allow_single_file = True,
@@ -456,10 +465,6 @@ def make_xcodeproj_rule(
         "_installer_template": attr.label(
             allow_single_file = True,
             default = Label("//xcodeproj/internal:installer.template.sh"),
-        ),
-        "_create_lldbinit_script": attr.label(
-            allow_single_file = True,
-            default = Label("//xcodeproj/internal/bazel_integration_files:create_lldbinit.sh"),
         ),
         "_xccurrentversions_parser": attr.label(
             cfg = "exec",

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -18,6 +18,7 @@ load(
 )
 load(":providers.bzl", "XcodeProjInfo", "XcodeProjOutputInfo")
 load(":resource_target.bzl", "process_resource_bundles")
+load(":xcode_schemes.bzl", "xcode_schemes")
 load(":xcodeproj_aspect.bzl", "xcodeproj_aspect")
 
 # Actions
@@ -498,10 +499,13 @@ def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, schemes = None, **kwargs):
     project = kwargs.get("project_name", name)
 
     targets = kwargs.pop("targets", [])
-    schemes_json = ""
+    schemes_json = None
     if schemes != None:
+        schemes_json = json.encode(schemes)
         targets_from_schemes = xcode_schemes.collect_top_level_targets(schemes)
-        targets = targets_module.merge(targets, targets_from_schemes)
+        targets_set = sets.make(targets)
+        targets_set = sets.union(targets_set, targets_from_schemes)
+        targets = sorted(sets.to_list(targets_set))
 
     if kwargs.get("toplevel_cache_buster"):
         fail("`toplevel_cache_buster` is for internal use only")

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -508,13 +508,6 @@ def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, schemes = None, **kwargs):
         targets_set = sets.union(targets_set, targets_from_schemes)
         targets = sorted(sets.to_list(targets_set))
 
-        # DEBUG BEGIN
-        print("*** CHUCK targets: ")
-        for idx, item in enumerate(targets):
-            print("*** CHUCK", idx, ":", item)
-
-        # DEBUG END
-
     if kwargs.get("toplevel_cache_buster"):
         fail("`toplevel_cache_buster` is for internal use only")
 

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -4,6 +4,7 @@ load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load(":bazel_labels.bzl", "bazel_labels")
 load(":collections.bzl", "uniq")
 load(":configuration.bzl", "get_configuration")
 load(":files.bzl", "file_path", "file_path_to_dto", "parsed_file_path")
@@ -498,7 +499,7 @@ def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, schemes = None, **kwargs):
 
     project = kwargs.get("project_name", name)
 
-    targets = kwargs.pop("targets", [])
+    targets = [bazel_labels.normalize(t) for t in kwargs.pop("targets", [])]
     schemes_json = None
     if schemes != None:
         # TODO: Try to support relative labels?

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -508,6 +508,13 @@ def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, schemes = None, **kwargs):
         targets_set = sets.union(targets_set, targets_from_schemes)
         targets = sorted(sets.to_list(targets_set))
 
+        # DEBUG BEGIN
+        print("*** CHUCK targets: ")
+        for idx, item in enumerate(targets):
+            print("*** CHUCK", idx, ":", item)
+
+        # DEBUG END
+
     if kwargs.get("toplevel_cache_buster"):
         fail("`toplevel_cache_buster` is for internal use only")
 

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -502,7 +502,6 @@ def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, schemes = None, **kwargs):
     targets = [bazel_labels.normalize(t) for t in kwargs.pop("targets", [])]
     schemes_json = None
     if schemes != None:
-        # TODO: Try to support relative labels?
         schemes_json = json.encode(schemes)
         targets_from_schemes = xcode_schemes.collect_top_level_targets(schemes)
         targets_set = sets.make(targets)

--- a/xcodeproj/xcodeproj.bzl
+++ b/xcodeproj/xcodeproj.bzl
@@ -4,6 +4,7 @@ load(
     "//xcodeproj/internal:providers.bzl",
     _XcodeProjAutomaticTargetProcessingInfo = "XcodeProjAutomaticTargetProcessingInfo",
 )
+load("//xcodeproj/internal:xcode_schemes.bzl", _xcode_schemes = "xcode_schemes")
 load("//xcodeproj/internal:xcodeproj.bzl", _xcodeproj = "xcodeproj")
 
 # Re-exporting providers
@@ -11,3 +12,6 @@ XcodeProjAutomaticTargetProcessingInfo = _XcodeProjAutomaticTargetProcessingInfo
 
 # Re-exporting rules
 xcodeproj = _xcodeproj
+
+# Re-exporting APIs
+xcode_schemes = _xcode_schemes


### PR DESCRIPTION
Related to #573.

- Add `workspace_name_resolvers` module to expose `repository_name()` and `package_name()`. 
  - This was added so that a different implementation could be injected into unit tests.
- Add `bazel_labels` module to normalize label values provided to `xcodeproj` and `xcode_schemes`. 
  - The `make_bazel_labels` function allows for the injection of a custom `workspace_name_resolvers` module. 
  - In a later PR, we will add code to validate that the provided labels exist.
- Update `xcode_schemes` module to include `make_xcode_schemes`. 
  - This allows a custom `bazel_labels` module to be injected.
- Update `xcodeproj` macro to accept and process `schemes`. 
  - This logic combines any targets provided directly to the macro and any top-level targets specified in the schemes.
- Add `schemes_json` attribute to `_xcodeproj` rule. 
  - Note: This is a little different from the proposal. In this PR, I opted to make it a single JSON string instead of a list of string values. It makes it easier to encode the JSON and to decode once we implement that logic.
- Update `//tools/generator:xcodeproj` to accept custom schemes, but still generate the automatic schemes. 
  - To share the xcodeproj target list between the `xcodeproj` declaration and the `xcodeproj_fixtures` declaration, I reworked `//tools/generator:xcodeproj_targets.bzl` to include the schemes definition and provide functions to retrieve them. 
    - This is necessary so that name resolution APIs (`native.repository_name` and `native.package_name`) can be executed without failure. These APIs are only available during the loading phase and must be called from a build file thread.
  - NOTE: These gymnastics are only necessary because we are sharing the target list between two different packages. For regular clients, the syntax as shown in the proposal works.