### PR TITLE
Fix project generation for simple projects

### DIFF
--- a/tools/generator/src/Generator/WriteXcodeProj.swift
+++ b/tools/generator/src/Generator/WriteXcodeProj.swift
@@ -29,6 +29,7 @@ extension Generator {
         }
 
         let dest = internalOutputPath + "bazel"
+        try internalOutputPath.mkpath()
         try bazelIntegrationDirectory.copy(dest)
     }
 }


### PR DESCRIPTION
Fixes #648.

If a project doesn't have generated, external, or compile stub files, we didn't create the proper internal directory before trying to copy over the compiler stubs. We now create the requires parent directories.