### PR TITLE
Fix simple BwB projects

### DIFF
--- a/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
+++ b/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
@@ -21,6 +21,7 @@ env -i \
         consolidatedTargets: ConsolidatedTargets
     ) throws -> PBXAggregateTarget? {
         guard
+            buildMode.usesBazelModeBuildScripts ||
             files.containsExternalFiles || files.containsGeneratedFiles
         else {
             return nil


### PR DESCRIPTION
Fixes #651.

We need to always add the `BazelDependencies` target when building with Bazel.