### PR TITLE
Update `bazel_labels.normalize` to use shorthand notation

### DIFF
--- a/test/internal/bazel_labels/normalize_tests.bzl
+++ b/test/internal/bazel_labels/normalize_tests.bzl
@@ -26,7 +26,7 @@ def _relative_label_test(ctx):
 
     value = ":chicken"
     actual = bazel_labels.normalize(value)
-    expected = "@//Sources/Foo:chicken"
+    expected = "//Sources/Foo:chicken"
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)
@@ -50,7 +50,7 @@ def _absolute_label_without_repo_name_test(ctx):
 
     value = "//Sources/Foo:chicken"
     actual = bazel_labels.normalize(value)
-    expected = "@//Sources/Foo:chicken"
+    expected = "//Sources/Foo:chicken"
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)

--- a/test/internal/xcode_schemes/collect_top_level_targets_tests.bzl
+++ b/test/internal/xcode_schemes/collect_top_level_targets_tests.bzl
@@ -65,9 +65,9 @@ def _single_scheme_test(ctx):
     ]
     actual = xcode_schemes.collect_top_level_targets(schemes)
     expected = sets.make([
-        "@//Sources/App:App",
-        "@//Tests/BarTests:BarTests",
-        "@//Tests/FooTests:FooTests",
+        "//Sources/App:App",
+        "//Tests/BarTests:BarTests",
+        "//Tests/FooTests:FooTests",
     ])
     asserts.true(env, sets.is_equal(expected, actual))
 
@@ -99,10 +99,10 @@ def _list_of_schemes_test(ctx):
     ]
     actual = xcode_schemes.collect_top_level_targets(schemes)
     expected = sets.make([
-        "@//Sources/App:App",
-        "@//Tests/BarTests:BarTests",
-        "@//Tests/FooTests:FooTests",
-        "@//Tests/HelloTests:HelloTests",
+        "//Sources/App:App",
+        "//Tests/BarTests:BarTests",
+        "//Tests/FooTests:FooTests",
+        "//Tests/HelloTests:HelloTests",
     ])
     asserts.true(env, sets.is_equal(expected, actual))
 

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -88,8 +88,16 @@ def make_bazel_labels(workspace_name_resolvers = workspace_name_resolvers):
 
     def _normalize(value):
         parts = _parse(value)
+
+        # If the label is for the default/current repository, use the shorthand
+        # label expression and not include the repository name.
+        if parts.repository_name == "@":
+            repo_name = ""
+        else:
+            repo_name = parts.repository_name
+
         return "{repo_name}//{package}:{name}".format(
-            repo_name = parts.repository_name,
+            repo_name = repo_name,
             package = parts.package,
             name = parts.name,
         )


### PR DESCRIPTION
Related to #573.

If the label is for the default repository, omit the repository name.