### PR TITLE
Remove invalid merges warning

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -15,6 +15,7 @@ gh-md-toc --hide-header --hide-footer --start-depth=1
 * [Why aren't Info\.plist details shown when Building with Bazel?](#why-arent-infoplist-details-shown-when-building-with-bazel)
 * [Why do I get an error like "Provisioning profile "PROFILE\_NAME" is Xcode managed, but signing settings require a manually managed profile\. (in target 'TARGET' from project 'PROJECT')"?](#why-do-i-get-an-error-like-provisioning-profile-profile_name-is-xcode-managed-but-signing-settings-require-a-manually-managed-profile-in-target-target-from-project-project)
 * [Why do I get an error like "No profile for team 'TEAM' matching 'PROFILE\_NAME' found: Xcode couldn't find any provisioning profiles matching 'TEAM\_ID/PROFILE\_NAME'\. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the Signing &amp; Capabilities tab of the target editor\."?](#why-do-i-get-an-error-like-no-profile-for-team-team-matching-profile_name-found-xcode-couldnt-find-any-provisioning-profiles-matching-team_idprofile_name-install-the-profile-by-dragging-and-dropping-it-onto-xcodes-dock-item-or-select-a-different-one-in-the-signing--capabilities-tab-of-the-target-editor)
+* [What is CompileStub\.m?](#what-is-compilestubm)
 
 ## My Xcode project seems to be of of sync with my Bazel project. What should I do?
 
@@ -88,3 +89,18 @@ fallback profiles, or if you use specify a profile in the workspace.
 
 Copying the profile to `~/Library/MobileDevice/Provisioning Profiles` will
 resolve the error.
+
+## What is `CompileStub.m`?
+
+If you have a top level target, such as `ios_application`, and it's primary
+library dependency is also directly depended on by another top level target,
+such as `ios_unit_test`, then we can't merge that library into the first top
+level target. When that happens, the first top level target doesn't have any
+source files, so we need to add a stub one to allow Xcode to link to the proper
+library target.
+
+If this setup isn't desired (e.g. wanting to have the target merged to enable
+SwiftUI Previews), there are a couple ways to fix it. For tests, setting the
+first top level target as the `test_host` will allow for the library to merge.
+In other cases, refactor the build graph to have the shared code in it's own
+library separate from the top level target's primary library.

--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -127,7 +127,6 @@
         },
         "test/fixtures/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures:fixture_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -73,7 +73,6 @@
         },
         "test/fixtures/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures:fixture_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/cc/bwb_spec.json
+++ b/test/fixtures/cc/bwb_spec.json
@@ -23,7 +23,6 @@
         "examples/cc/tool/BUILD",
         "test/fixtures/cc/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures/cc:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/cc/bwx_spec.json
+++ b/test/fixtures/cc/bwx_spec.json
@@ -23,7 +23,6 @@
         "examples/cc/tool/BUILD",
         "test/fixtures/cc/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures/cc:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -54,7 +54,6 @@
         },
         "test/fixtures/command_line/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures/command_line:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -54,7 +54,6 @@
         },
         "test/fixtures/command_line/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures/command_line:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -33,12 +33,6 @@
         "tools/generator/test/BUILD",
         "test/fixtures/generator/BUILD"
     ],
-    "invalid_target_merges": [
-        "//tools/generator:generator.library darwin_x86_64-dbg-ST-5534cb307cb8",
-        [
-            "//tools/generator:generator darwin_x86_64-dbg-ST-5534cb307cb8"
-        ]
-    ],
     "label": "//test/fixtures/generator:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -33,12 +33,6 @@
         "tools/generator/test/BUILD",
         "test/fixtures/generator/BUILD"
     ],
-    "invalid_target_merges": [
-        "//tools/generator:generator.library darwin_x86_64-dbg-ST-ccd9595da841",
-        [
-            "//tools/generator:generator darwin_x86_64-dbg-ST-ccd9595da841"
-        ]
-    ],
     "label": "//test/fixtures/generator:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -129,7 +129,6 @@
         "examples/multiplatform/Tool/Info.plist",
         "test/fixtures/multiplatform/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures/multiplatform:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -110,7 +110,6 @@
         "examples/multiplatform/Tool/Info.plist",
         "test/fixtures/multiplatform/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures/multiplatform:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/simple/bwb_spec.json
+++ b/test/fixtures/simple/bwb_spec.json
@@ -16,7 +16,6 @@
         "examples/simple/BUILD",
         "test/fixtures/simple/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures/simple:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/simple/bwx_spec.json
+++ b/test/fixtures/simple/bwx_spec.json
@@ -16,7 +16,6 @@
         "examples/simple/BUILD",
         "test/fixtures/simple/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures/simple:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -35,7 +35,6 @@
         },
         "test/fixtures/tvos_app/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures/tvos_app:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -35,7 +35,6 @@
         },
         "test/fixtures/tvos_app/BUILD"
     ],
-    "invalid_target_merges": [],
     "label": "//test/fixtures/tvos_app:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/tools/generator/src/DTO/Project.swift
+++ b/tools/generator/src/DTO/Project.swift
@@ -6,7 +6,6 @@ struct Project: Equatable, Decodable {
     let buildSettings: [String: BuildSetting]
     var targets: [TargetID: Target]
     let targetMerges: [TargetID: Set<TargetID>]
-    let invalidTargetMerges: [TargetID: Set<TargetID>]
     let extraFiles: Set<FilePath>
     let schemeAutogenerationMode: SchemeAutogenerationMode
     let customXcodeSchemes: [XcodeScheme]

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -68,28 +68,6 @@ class Generator {
         var targets = project.targets
         try environment.processTargetMerges(&targets, project.targetMerges)
 
-        for (src, destinations) in project.invalidTargetMerges {
-            guard let srcTarget = targets[src] else {
-                throw PreconditionError(
-                    message: """
-Source target "\(src)" not found in `targets`
-""")
-            }
-            for destination in destinations {
-                guard let destTarget = targets[destination] else {
-                    throw PreconditionError(message: """
-Destination target "\(destination)" not found in `targets`
-""")
-                }
-                logger.logWarning("""
-Was unable to merge "\(srcTarget.label) \
-(\(srcTarget.configuration))" into \
-"\(destTarget.label) \
-(\(destTarget.configuration))"
-""")
-            }
-        }
-
         let consolidatedTargets = try environment.consolidateTargets(
             targets,
             logger
@@ -166,11 +144,4 @@ Was unable to merge "\(srcTarget.label) \
             outputPath
         )
     }
-}
-
-/// When a potential merge wasn't valid, then the ids of the targets involved
-/// are returned in this `struct`.
-struct InvalidMerge: Equatable {
-    let source: TargetID
-    let destinations: Set<TargetID>
 }

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -17,7 +17,6 @@ enum Fixtures {
         ],
         targets: targets,
         targetMerges: [:],
-        invalidTargetMerges: [:],
         extraFiles: [
             .generated("a1b2c/bin/t.c"),
             .generated("a/b/module.modulemap"),

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -157,9 +157,6 @@ final class GeneratorTests: XCTestCase {
             targets: project.targets,
             targetMerges: project.targetMerges
         )]
-        expectedMessagesLogged.append(StubLogger.MessageLogged(.warning, """
-Was unable to merge "//:Y (a1b2c)" into "//:Z (1a2b3)"
-"""))
 
         // MARK: consolidateTargets()
 

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -17,7 +17,6 @@ final class GeneratorTests: XCTestCase {
             buildSettings: [:],
             targets: Fixtures.targets,
             targetMerges: [:],
-            invalidTargetMerges: ["Y": ["Z"]],
             extraFiles: [],
             schemeAutogenerationMode: .auto,
             customXcodeSchemes: []

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -52,16 +52,9 @@ def _write_json_spec(*, ctx, project_name, configuration, inputs, infos):
     ])
 
     target_merges = {}
-    invalid_target_merges = {}
     for merge in potential_target_merges.to_list():
-        if sets.contains(non_mergable_targets_set, merge.src.product_path):
-            destinations = invalid_target_merges.get(merge.src.id, [])
-            destinations.append(merge.dest)
-            invalid_target_merges[merge.src.id] = destinations
-        else:
-            destinations = target_merges.get(merge.src.id, [])
-            destinations.append(merge.dest)
-            target_merges[merge.src.id] = destinations
+        if not sets.contains(non_mergable_targets_set, merge.src.product_path):
+            target_merges.setdefault(merge.src.id, []).append(merge.dest)
 
     # `xcode_targets` is partial json dictionary strings. It and
     # `potential_target_merges` are dictionaries in alternating key and value
@@ -70,9 +63,6 @@ def _write_json_spec(*, ctx, project_name, configuration, inputs, infos):
     targets_json = "[{}]".format(",".join(sorted_xcode_targets))
     target_merges_json = json.encode(
         flattened_key_values.to_list(target_merges),
-    )
-    invalid_target_merges_json = json.encode(
-        flattened_key_values.to_list(invalid_target_merges),
     )
 
     extra_files = [
@@ -103,7 +93,6 @@ def _write_json_spec(*, ctx, project_name, configuration, inputs, infos):
 "configuration":"{configuration}",\
 "custom_xcode_schemes":{custom_xcode_schemes},\
 "extra_files":{extra_files},\
-"invalid_target_merges":{invalid_target_merges},\
 "label":"{label}",\
 "name":"{name}",\
 "scheme_autogeneration_mode":"{scheme_autogeneration_mode}",\
@@ -115,7 +104,6 @@ def _write_json_spec(*, ctx, project_name, configuration, inputs, infos):
         configuration = configuration,
         custom_xcode_schemes = custom_xcode_schemes_json,
         extra_files = json.encode(extra_files),
-        invalid_target_merges = invalid_target_merges_json,
         label = ctx.label,
         target_merges = target_merges_json,
         name = project_name,


### PR DESCRIPTION
It's a valid setup to have a "stub" top level target, so we shouldn't warn on this. I've added something to the FAQ though, for those expecting a merge that didn't happen.