### PR TITLE
Fix `.swiftformat` configuration and add first pass for `swiftlint`

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,1 +1,2 @@
---disable indentstrings
+--swiftversion 5.5
+--indentstrings false

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,2 +1,5 @@
 --swiftversion 5.5
---indentstrings false
+
+# If we enable indent, it will indent multiline strings. The code style in this 
+# repository is to allow them to start at position 1 on the line.
+--disable indent

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,7 @@
+disabled_rules:
+  - trailing_comma
+  - todo
+
+excluded:
+  - "**/test/**/*.swift"
+  - "**/*Tests/*.swift"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,5 +3,6 @@ disabled_rules:
   - todo
 
 excluded:
+  # Exclude test files
   - "**/test/**/*.swift"
   - "**/*Tests/*.swift"

--- a/swiftlint
+++ b/swiftlint
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# This file exists to help IDE helpers (e.g., vim+ALE) to execute swiftformat
+# This file exists to help IDE helpers (e.g., vim+ALE) to execute swiftlint
 # using this project's configuration.
 
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 
-swiftformat --config "${script_dir}/.swiftformat" "$@"
+swiftlint lint --config "${script_dir}/.swiftlint.yml" "$@"


### PR DESCRIPTION
- `swiftformat`: Do not perform any indenting as it indents multi-line string values. The `--indentstrings false` only ensures that the string is not indented more than the start line.
- `swiftlint`: First pass at config. It excludes test directories and disables some rules that are not relevant for this repository. There are other warnings and errors. However, they may be legitimate. If we enable a CI check, we will want to address those.