### PR TITLE
Apply `wrapMultilineStatementBraces` for `swiftformat`

### DIFF
--- a/tools/generator/src/Generator/ConsolidateTargets.swift
+++ b/tools/generator/src/Generator/ConsolidateTargets.swift
@@ -404,7 +404,8 @@ extension ConsolidatedTarget {
             var consolidatedIdx = 0
             var filesIdx = 0
             while consolidatedIdx < consolidatedFiles.count &&
-                    filesIdx < files.count {
+                    filesIdx < files.count
+            {
                 let file = files[filesIdx]
                 filesIdx += 1
 

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -183,7 +183,8 @@ extension Generator {
                 // are formed is not deterministic, we must change the name and
                 // path here as necessary.
                 if ["xib", "storyboard"].contains(filePath.path.extension),
-                   !group.name!.hasSuffix(fileName) {
+                   !group.name!.hasSuffix(fileName)
+                {
                     group.name = fileName
                     groups[existingGroup.filePath] = nil
                     groups[groupFilePath] = group
@@ -240,7 +241,8 @@ extension Generator {
             // deterministic, we must check for existing groups having the same
             // name as the localized file and any of these extensions.
             if let fileExtension = filePath.path.extension,
-               Self.localizedGroupExtensions.contains(fileExtension) {
+               Self.localizedGroupExtensions.contains(fileExtension)
+            {
                 for groupExtension in Self.localizedGroupExtensions {
                     let groupFilePath = groupBaseFilePath + """
 \(filePath.path.lastComponentWithoutExtension).\(groupExtension)
@@ -332,7 +334,8 @@ extension Generator {
                 target.outputs.forcedBazelCompileFiles(buildMode: buildMode)
             )
             if !target.inputs.containsSources &&
-                target.product.type.hasCompilePhase {
+                target.product.type.hasCompilePhase
+            {
                 allInputPaths.insert(.internal(compileStubPath))
             }
         }
@@ -376,7 +379,8 @@ extension Generator {
                         pathComponent: component,
                         isLeaf: isLeaf,
                         forceGroupCreation: fullFilePath.forceGroupCreation
-                    ) {
+                    )
+                {
                     if isNew {
                         if let group = lastElement as? PBXGroup {
                             // This will be the case for all non-root elements
@@ -488,7 +492,8 @@ extension Generator {
         }
 
         if buildMode.usesBazelModeBuildScripts &&
-            targets.contains(where: { $1.product.type.isApplication }) {
+            targets.contains(where: { $1.product.type.isApplication })
+        {
             files[.internal(appRsyncExcludeFileListPath)] =
                 .nonReferencedContent(#"""
 /*.app/Frameworks/libXCTestBundleInject.dylib

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -111,7 +111,8 @@ Target with id "\(id)" not found in `consolidatedTarget.uniqueFiles`
         // Calculate "EXCLUDED_SOURCE_FILE_NAMES"
         var excludedSourceFileNames: [String] = []
         for (key, fileNames) in conditionalFileNames
-            .sorted(by: { $0.key < $1.key }) {
+            .sorted(by: { $0.key < $1.key })
+        {
             anyBuildSettings[key] = .array(fileNames)
             excludedSourceFileNames.append("$(\(key))")
         }
@@ -662,7 +663,8 @@ where Key == BuildSettingConditional, Value == [String: BuildSetting] {
 
         // Properly set "SDKROOT"
         if let sdkrootBuildSettings = conditionalBuildSettings
-            .removeValue(forKey: "SDKROOT") {
+            .removeValue(forKey: "SDKROOT")
+        {
             conditionalBuildSettings["SDKROOT"] = [
                 .any: sdkrootBuildSettings
                     .sorted { $0.key < $1.key }
@@ -672,7 +674,8 @@ where Key == BuildSettingConditional, Value == [String: BuildSetting] {
 
         // Properly set "SUPPORTED_PLATFORMS"
         if let supportedPlatformsBuildSettings = conditionalBuildSettings
-            .removeValue(forKey: "SUPPORTED_PLATFORMS") {
+            .removeValue(forKey: "SUPPORTED_PLATFORMS")
+        {
             let platforms = Set(
                 try supportedPlatformsBuildSettings.values
                     .map { try $0.toString(key: "SUPPORTED_PLATFORMS") }


### PR DESCRIPTION
`swiftformat --config .swiftformat --rules braces,wrapMultilineStatementBraces --verbose .`

It turns out #677 was not quite right. I only ran `braces` in that PR. I should have run `braces` along with `wrapMultilineStatementBraces` as the `wrapMultilineStatementBraces` takes precedence over `braces`.