### PR TITLE
Add support for `launchdplists`

### DIFF
--- a/examples/command_line/tool/BUILD
+++ b/examples/command_line/tool/BUILD
@@ -12,6 +12,7 @@ macos_command_line_application(
         "export_symbol_list.exp",
     ],
     infoplists = ["Info.plist"],
+    launchdplists = ["Launchd.plist"],
     minimum_os_version = "11.0",
     visibility = ["//visibility:public"],
     deps = [":tool.library"],

--- a/examples/command_line/tool/Launchd.plist
+++ b/examples/command_line/tool/Launchd.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.example.tool</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>arg1</string>
+        <string>arg2</string>
+    </array>
+    <key>KeepAlive</key>
+    <true/>
+</dict>
+</plist>

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 
 /* Begin PBXFileReference section */
 		02C5A30086BED77944B9B2DA /* lib_swift.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = lib_swift.swift.modulemap; sourceTree = "<group>"; };
+		0477978206709B50F3C4A328 /* Launchd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Launchd.plist; sourceTree = "<group>"; };
 		061F2388C98C7C8A40A50744 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
 		12C3BFE593A8E590FD298519 /* LibSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LibSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CE87466AFFDC6606F8518F8 /* SwiftGreetingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftGreetingsTests.swift; sourceTree = "<group>"; };
@@ -126,6 +127,7 @@
 		CBE528880485D0994B3CC1FC /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		DBF917653F9E4EBBEDB863FD /* Library.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Library.h; sourceTree = "<group>"; };
 		E3938AB43AEB959A432DB9EF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		E5C95BEC19004126C5F267A8 /* Launchd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Launchd.plist; sourceTree = "<group>"; };
 		E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _BazelForcedCompile_.swift; sourceTree = DERIVED_FILE_DIR; };
 		F5B8CDF37038F1DAA6B0A624 /* private_lib.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = private_lib.swift.modulemap; sourceTree = "<group>"; };
 		F93835BAA75A671D6D3361A9 /* liblib_swift.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_swift.a; path = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_swift.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -217,6 +219,14 @@
 			path = fixtures;
 			sourceTree = "<group>";
 		};
+		41A8BFC84E25E93767A7B621 /* tool */ = {
+			isa = PBXGroup;
+			children = (
+				5EC76696A9306345EC2B2A95 /* tool.merged_launchdplists-intermediates */,
+			);
+			path = tool;
+			sourceTree = "<group>";
+		};
 		4EED761FD2246722F245DFA0 /* command_line */ = {
 			isa = PBXGroup;
 			children = (
@@ -253,6 +263,14 @@
 			path = examples;
 			sourceTree = "<group>";
 		};
+		5EC76696A9306345EC2B2A95 /* tool.merged_launchdplists-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				E5C95BEC19004126C5F267A8 /* Launchd.plist */,
+			);
+			path = "tool.merged_launchdplists-intermediates";
+			sourceTree = "<group>";
+		};
 		68A1D737225E7A97337523DE /* test */ = {
 			isa = PBXGroup;
 			children = (
@@ -274,6 +292,7 @@
 			isa = PBXGroup;
 			children = (
 				936244BBF22D78803D3F9055 /* lib */,
+				41A8BFC84E25E93767A7B621 /* tool */,
 			);
 			path = command_line;
 			sourceTree = "<group>";
@@ -337,6 +356,7 @@
 				537B806ECAA55F19DAFDF318 /* BUILD */,
 				A87E0D1B629CCF579B579DA6 /* export_symbol_list.exp */,
 				E3938AB43AEB959A432DB9EF /* Info.plist */,
+				0477978206709B50F3C4A328 /* Launchd.plist */,
 				C06A565663AED0899589F574 /* main.m */,
 			);
 			path = tool;
@@ -1052,6 +1072,7 @@
 					"-L/usr/lib/swift",
 					"-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
 					"-Wl,-rpath,/usr/lib/swift",
+					"-Wl,-sectcreate,__TEXT,__launchd_plist,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/tool/tool.merged_launchdplists-intermediates/Launchd.plist",
 					"-framework",
 					Foundation,
 					"-weak_framework",

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -2,4 +2,5 @@ $(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_impl.swift.modulemap
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_swift.swift.modulemap
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/private_lib.swift.modulemap
+$(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/tool/tool.merged_launchdplists-intermediates/Launchd.plist
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/external/examples_command_line_external/Library.swift.modulemap

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -37,6 +37,11 @@
         "examples/command_line/lib/dir with space/lib.h",
         "examples/command_line/tool/BUILD",
         "examples/command_line/tool/Info.plist",
+        "examples/command_line/tool/Launchd.plist",
+        {
+            "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/tool/tool.merged_launchdplists-intermediates/Launchd.plist",
+            "t": "g"
+        },
         "examples/command_line/Tests/BUILD",
         {
             "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_swift.swift.modulemap",
@@ -640,6 +645,7 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-Wl,-sectcreate,__TEXT,__launchd_plist,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/tool/tool.merged_launchdplists-intermediates/Launchd.plist",
                     "-framework",
                     "Foundation",
                     "-weak_framework",

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -116,11 +116,13 @@
 		7EA31D6C8ED425D3BB693543 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		7F5E4ABAACB85A529597A95E /* lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = lib.swift; sourceTree = "<group>"; };
 		85AA47D00BD6B0AF833B0617 /* export_symbol_list.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = export_symbol_list.exp; sourceTree = "<group>"; };
+		8B03B3D734122C32E07042B6 /* Launchd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Launchd.plist; sourceTree = "<group>"; };
 		9D46BEBDD407F679ED938408 /* ExternalFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExternalFramework.framework; sourceTree = "<group>"; };
 		B093EB1BAB8D20D1457C10D2 /* libImportableLibrary.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libImportableLibrary.a; sourceTree = "<group>"; };
 		B457072C62E4282C472889FB /* lib_swift.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = lib_swift.swift.modulemap; sourceTree = "<group>"; };
 		B45E624D6CB9A25AD05AA3EB /* lib.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = lib.m; sourceTree = "<group>"; };
 		BE5F89CF78F0E7C26F1539FC /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
+		BE8FEDF37273346A16A57EFB /* Launchd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Launchd.plist; sourceTree = "<group>"; };
 		CA049D9915CC7DA47818EB6A /* Library.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = Library.swift.modulemap; sourceTree = "<group>"; };
 		D04DA2A609AD72919E00E6F6 /* libprivate_lib.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libprivate_lib.a; path = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/libprivate_lib.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4E23788130BC4E7FCB9DB99 /* LibSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LibSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -237,10 +239,19 @@
 			path = lib;
 			sourceTree = "<group>";
 		};
+		64D2B5C0BE051C0CF3653C77 /* tool */ = {
+			isa = PBXGroup;
+			children = (
+				BDF82AAB3F607DFA7969DA86 /* tool.merged_launchdplists-intermediates */,
+			);
+			path = tool;
+			sourceTree = "<group>";
+		};
 		65C3F8240235013331E64FFD /* command_line */ = {
 			isa = PBXGroup;
 			children = (
 				502410081D92A547EC3F3479 /* lib */,
+				64D2B5C0BE051C0CF3653C77 /* tool */,
 			);
 			path = command_line;
 			sourceTree = "<group>";
@@ -357,6 +368,7 @@
 				7EA31D6C8ED425D3BB693543 /* BUILD */,
 				85AA47D00BD6B0AF833B0617 /* export_symbol_list.exp */,
 				2E8FDF5B64B5BB961DFACC26 /* Info.plist */,
+				BE8FEDF37273346A16A57EFB /* Launchd.plist */,
 				0C0B86F4542BE9E526167481 /* main.m */,
 			);
 			path = tool;
@@ -376,6 +388,14 @@
 				75220B3D4824CC076232744F /* command_line */,
 			);
 			path = examples;
+			sourceTree = "<group>";
+		};
+		BDF82AAB3F607DFA7969DA86 /* tool.merged_launchdplists-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				8B03B3D734122C32E07042B6 /* Launchd.plist */,
+			);
+			path = "tool.merged_launchdplists-intermediates";
 			sourceTree = "<group>";
 		};
 		C5CA9947DC4EB509CCBABCA5 /* command_line */ = {
@@ -1049,6 +1069,7 @@
 					"-L/usr/lib/swift",
 					"-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
 					"-Wl,-rpath,/usr/lib/swift",
+					"-Wl,-sectcreate,__TEXT,__launchd_plist,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool/tool.merged_launchdplists-intermediates/Launchd.plist",
 					"-framework",
 					Foundation,
 					"-weak_framework",

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/generated.copied.xcfilelist
@@ -2,4 +2,5 @@ $(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_impl.swift.modulemap
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_swift.swift.modulemap
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/private_lib.swift.modulemap
+$(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool/tool.merged_launchdplists-intermediates/Launchd.plist
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/external/examples_command_line_external/Library.swift.modulemap

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -37,6 +37,11 @@
         "examples/command_line/lib/dir with space/lib.h",
         "examples/command_line/tool/BUILD",
         "examples/command_line/tool/Info.plist",
+        "examples/command_line/tool/Launchd.plist",
+        {
+            "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool/tool.merged_launchdplists-intermediates/Launchd.plist",
+            "t": "g"
+        },
         "examples/command_line/Tests/BUILD",
         {
             "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_swift.swift.modulemap",
@@ -601,6 +606,7 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-Wl,-sectcreate,__TEXT,__launchd_plist,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool/tool.merged_launchdplists-intermediates/Launchd.plist",
                     "-framework",
                     "Foundation",
                     "-weak_framework",

--- a/test/internal/launchd_plists/BUILD
+++ b/test/internal/launchd_plists/BUILD
@@ -1,0 +1,6 @@
+load(
+    ":get_file_from_objc_provider_tests.bzl",
+    "get_file_from_objc_provider_test_suite",
+)
+
+get_file_from_objc_provider_test_suite(name = "get_file_from_objc_provider")

--- a/test/internal/launchd_plists/get_file_from_objc_provider_tests.bzl
+++ b/test/internal/launchd_plists/get_file_from_objc_provider_tests.bzl
@@ -1,0 +1,40 @@
+"""Tests for `launchd_plists.get_file_from_objc_provider`."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+
+# buildifier: disable=bzl-visibility
+load("//xcodeproj/internal:launchd_plists.bzl", "launchd_plists")
+
+def _get_file_from_objc_provider_test(ctx):
+    env = unittest.begin(ctx)
+
+    launchd_plist_file = ctx.actions.declare_file("Launchd.plist")
+    ctx.actions.write(launchd_plist_file, content = "")
+    launchd_plist_path = launchd_plist_file.path
+
+    linkopt_list = [
+        "-Wl,-sectcreate,__TEXT,__launchd_plist,{}".format(launchd_plist_path),
+    ]
+    link_inputs_list = [launchd_plist_file]
+    linkopt_depset = depset(linkopt_list)
+    link_inputs_depset = depset(link_inputs_list)
+
+    objc_prov = apple_common.new_objc_provider(
+        linkopt = linkopt_depset,
+        link_inputs = link_inputs_depset,
+    )
+
+    actual = launchd_plists.get_file_from_objc_provider(objc_prov)
+    asserts.equals(env, launchd_plist_file, actual)
+
+    return unittest.end(env)
+
+get_file_from_objc_provider_test = unittest.make(
+    _get_file_from_objc_provider_test,
+)
+
+def get_file_from_objc_provider_test_suite(name):
+    return unittest.suite(
+        name,
+        get_file_from_objc_provider_test,
+    )

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -63,6 +63,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
     entitlements = None
     exported_symbols_lists = []
     infoplists = []
+    launchdplists = []
     bazel_build_mode_error = None
     non_arc_srcs = []
     pch = None
@@ -117,6 +118,8 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
             exported_symbols_lists = ["exported_symbols_lists"]
         if "infoplists" in attrs:
             infoplists = ["infoplists"]
+        if "launchdplists" in attrs:
+            launchdplists = ["launchdplists"]
         xcode_targets = {"deps": [target_type.compile]}
     elif AppleFrameworkImportInfo in target:
         xcode_targets = {"deps": [target_type.compile]}
@@ -157,6 +160,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
             bundle_id = bundle_id,
             provisioning_profile = provisioning_profile,
             infoplists = infoplists,
+            launchdplists = launchdplists,
             entitlements = entitlements,
             bazel_build_mode_error = bazel_build_mode_error,
         ),

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -64,6 +64,8 @@ def _is_categorized_attr(attr, *, automatic_target_info):
         return True
     elif attr in automatic_target_info.exported_symbols_lists:
         return True
+    elif attr in automatic_target_info.launchdplists:
+        return True
     else:
         return False
 
@@ -173,6 +175,11 @@ def _collect(
             # assigning to the existing variable
             pch.append(file)
         elif attr in automatic_target_info.infoplists:
+            if file.is_source:
+                # We don't need to include a generated one, as we already use
+                # the Bazel generated one, which is one step further generated
+                extra_files.append(file_path(file))
+        elif attr in automatic_target_info.launchdplists:
             if file.is_source:
                 # We don't need to include a generated one, as we already use
                 # the Bazel generated one, which is one step further generated
@@ -353,6 +360,7 @@ def _from_resource_bundle(bundle):
         resource_bundles = depset(),
         resource_bundle_dependencies = bundle.dependencies,
         infoplists = depset(),
+        launchdplists = depset(),
         entitlements = None,
         exported_symbols_lists = depset(),
         xccurrentversions = depset(),

--- a/xcodeproj/internal/launchd_plists.bzl
+++ b/xcodeproj/internal/launchd_plists.bzl
@@ -1,0 +1,33 @@
+"""API to retrieve a launchd plist file from a `Target`."""
+
+load(":link_opts.bzl", "link_opts")
+
+def _get_file_from_objc_provider(objc_provider):
+    """
+    Retrieves the launchd plist from the TEXT section provided by the ObjcProvider.
+    """
+
+    launchd_plist_section = link_opts.get_section(
+        objc_provider.linkopt.to_list(),
+        "__TEXT",
+        "__launchd_plist",
+    )
+
+    if launchd_plist_section == None:
+        return None
+
+    # Retrieve the launchd plist file from the link inputs
+    for file in objc_provider.link_inputs.to_list():
+        if file.path == launchd_plist_section.file:
+            return file
+    return None
+
+def _get_file(target):
+    if apple_common.AppleExecutableBinary in target:
+        return _get_file_from_objc_provider(target[apple_common.AppleExecutableBinary].objc)
+    return None
+
+launchd_plists = struct(
+    get_file = _get_file,
+    get_file_from_objc_provider = _get_file_from_objc_provider,
+)

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -39,6 +39,10 @@ A sequence of attribute names to collect `File`s from for the
 A sequence of attribute names to collect `File`s from for the `infoplists`-like
 attributes.
 """,
+        "launchdplists": """\
+A sequence of attribute names to collect `File`s from for the `launchdplists`-like
+attributes.
+""",
         "non_arc_srcs": """\
 A sequence of attribute names to collect `File`s from for `non_arc_srcs`-like
 attributes.

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -8,6 +8,7 @@ load(":collections.bzl", "set_if_true")
 load(":configuration.bzl", "get_configuration")
 load(":files.bzl", "file_path", "join_paths_ignoring_empty")
 load(":info_plists.bzl", "info_plists")
+load(":launchd_plists.bzl", "launchd_plists")
 load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
 load(":opts.bzl", "process_opts")
@@ -193,6 +194,10 @@ def process_top_level_target(
     if info_plist_file:
         info_plist = file_path(info_plist_file)
         additional_files.append(info_plist_file)
+
+    launchd_plist_file = launchd_plists.get_file(target)
+    if launchd_plist_file:
+        additional_files.append(launchd_plist_file)
 
     provisioning_profiles.process_attr(
         ctx = ctx,


### PR DESCRIPTION
## Summary

Add support for both BwB and BwX for the `launchdplists` rules_apple attribute.

The `launchdplists` property takes a list of `.plist` labels which are then merged by rules_apple into a single `.plist`. This `.plist` is then embedded into the `macos_command_line_application` binary.

rules_apple embeds the launchd plist into the `__TEXT` section of the binary under the section `__launchd_plist` ([see here](https://github.com/bazelbuild/rules_apple/blob/56c54f25253b616bdd852b569023a437a4f95768/apple/internal/macos_binary_support.bzl#L188-L194))

Closes #99 

## Tasks

- [x] Add tests
- [x] Update documentation