### PR TITLE
Simplify `ConsolidatedTarget.resourceBundleDependencies` calculation

### DIFF
--- a/tools/generator/src/Generator/ConsolidateTargets.swift
+++ b/tools/generator/src/Generator/ConsolidateTargets.swift
@@ -342,12 +342,7 @@ extension ConsolidatedTarget {
         }
         self.uniqueFiles = uniqueFiles
 
-        var resourceBundleDependencies: Set<TargetID> = []
-        targets.values.forEach {
-            resourceBundleDependencies.formUnion($0.resourceBundleDependencies)
-        }
-        self.resourceBundleDependencies = resourceBundleDependencies
-
+        resourceBundleDependencies = aTarget.resourceBundleDependencies
         watchApplication = aTarget.watchApplication
         extensions = aTarget.extensions
 


### PR DESCRIPTION
There is no need to merge these, as the consolidation logic will reject targets with different resource bundle targets, since they also show up in `dependencies`.