### PR TITLE
Add `Project.targetHosts` to the DTO

### DIFF
--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -130,6 +130,7 @@
     "label": "//test/fixtures:fixture_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [
         "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217",
         [

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -76,6 +76,7 @@
     "label": "//test/fixtures:fixture_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [
         "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
         [

--- a/test/fixtures/cc/bwb_spec.json
+++ b/test/fixtures/cc/bwb_spec.json
@@ -26,6 +26,7 @@
     "label": "//test/fixtures/cc:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [],
     "targets": [
         "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-5534cb307cb8",

--- a/test/fixtures/cc/bwx_spec.json
+++ b/test/fixtures/cc/bwx_spec.json
@@ -26,6 +26,7 @@
     "label": "//test/fixtures/cc:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [],
     "targets": [
         "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-ccd9595da841",

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -60,6 +60,7 @@
     "label": "//test/fixtures/command_line:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [
         "//examples/command_line/Tests:LibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630",
         [

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -60,6 +60,7 @@
     "label": "//test/fixtures/command_line:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [
         "//examples/command_line/Tests:LibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60",
         [

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -36,6 +36,7 @@
     "label": "//test/fixtures/generator:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [
         "//tools/generator/test:tests.library darwin_x86_64-dbg-ST-5534cb307cb8",
         [

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -36,6 +36,7 @@
     "label": "//test/fixtures/generator:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [
         "//tools/generator/test:tests.library darwin_x86_64-dbg-ST-ccd9595da841",
         [

--- a/test/fixtures/macos_app/bwb_spec.json
+++ b/test/fixtures/macos_app/bwb_spec.json
@@ -28,6 +28,7 @@
     "label": "//test/fixtures/macos_app:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [
         "//examples/macos_app/Example:Example.library macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68",
         [

--- a/test/fixtures/macos_app/bwx_spec.json
+++ b/test/fixtures/macos_app/bwx_spec.json
@@ -26,6 +26,7 @@
     "label": "//test/fixtures/macos_app:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [
         "//examples/macos_app/Example:Example.library macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd",
         [

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -132,6 +132,24 @@
     "label": "//test/fixtures/multiplatform:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [
+        "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc",
+        [
+            "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf"
+        ],
+        "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a",
+        [
+            "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db"
+        ],
+        "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc",
+        [
+            "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc"
+        ],
+        "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a",
+        [
+            "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a"
+        ]
+    ],
     "target_merges": [
         "//examples/multiplatform/Tool:Tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630",
         [

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -113,6 +113,24 @@
     "label": "//test/fixtures/multiplatform:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [
+        "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3",
+        [
+            "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_arm64-dbg-ST-787a8770ecb8"
+        ],
+        "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba",
+        [
+            "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01"
+        ],
+        "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3",
+        [
+            "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3"
+        ],
+        "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba",
+        [
+            "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba"
+        ]
+    ],
     "target_merges": [
         "//examples/multiplatform/Tool:Tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60",
         [

--- a/test/fixtures/simple/bwb_spec.json
+++ b/test/fixtures/simple/bwb_spec.json
@@ -19,6 +19,7 @@
     "label": "//test/fixtures/simple:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [],
     "targets": [
         "//examples/simple:SwiftBin darwin_x86_64-dbg-ST-f7d2792bf9e4",

--- a/test/fixtures/simple/bwx_spec.json
+++ b/test/fixtures/simple/bwx_spec.json
@@ -19,6 +19,7 @@
     "label": "//test/fixtures/simple:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [],
     "targets": [
         "//examples/simple:SwiftBin darwin_x86_64-dbg-ST-ccd9595da841",

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -38,6 +38,7 @@
     "label": "//test/fixtures/tvos_app:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [
         "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1",
         [

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -38,6 +38,7 @@
     "label": "//test/fixtures/tvos_app:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",
+    "target_hosts": [],
     "target_merges": [
         "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de",
         [

--- a/tools/generator/src/DTO/Project.swift
+++ b/tools/generator/src/DTO/Project.swift
@@ -6,6 +6,7 @@ struct Project: Equatable, Decodable {
     let buildSettings: [String: BuildSetting]
     var targets: [TargetID: Target]
     let targetMerges: [TargetID: Set<TargetID>]
+    let targetHosts: [TargetID: Set<TargetID>]
     let extraFiles: Set<FilePath>
     let schemeAutogenerationMode: SchemeAutogenerationMode
     let customXcodeSchemes: [XcodeScheme]

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -17,6 +17,10 @@ enum Fixtures {
         ],
         targets: targets,
         targetMerges: [:],
+        targetHosts: [
+            "W": ["I"],
+            "WKE": ["W"],
+        ],
         extraFiles: [
             .generated("a1b2c/bin/t.c"),
             .generated("a/b/module.modulemap"),

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -17,6 +17,7 @@ final class GeneratorTests: XCTestCase {
             buildSettings: [:],
             targets: Fixtures.targets,
             targetMerges: [:],
+            targetHosts: [:],
             extraFiles: [],
             schemeAutogenerationMode: .auto,
             customXcodeSchemes: []

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -13,6 +13,7 @@ def processed_target(
         automatic_target_info,
         dependencies,
         extension_infoplists = None,
+        hosted_targets = None,
         inputs,
         linker_inputs,
         non_mergable_targets = None,
@@ -31,6 +32,8 @@ def processed_target(
             target.
         extension_infoplists: A `list` of `File` for the Info.plist's of an
             application extension target, or `None`.
+        hosted_targets: An optional `list` of `struct`s as used in
+            `XcodeProjInfo.hosted_targets`.
         inputs: A value as returned from `input_files.collect` that will
             provide values for the `XcodeProjInfo.inputs` field.
         linker_inputs: A value returned from `linker_input_files.collect`
@@ -56,6 +59,7 @@ def processed_target(
         automatic_target_info = automatic_target_info,
         extension_infoplists = extension_infoplists,
         dependencies = dependencies,
+        hosted_targets = hosted_targets,
         inputs = inputs,
         linker_inputs = linker_inputs,
         non_mergable_targets = non_mergable_targets,

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -85,13 +85,18 @@ A `list` of target ids (see the `target` `struct`) that this target directly
 depends on.
 """,
         "extension_infoplists": """\
-A `depset` of `struct`s with 'id' and 'infoplist' fields. The 'id' field is
-the target id of the application extension target. The 'infoplist' field is a
-`File` for the Info.plist for the target.
+A `depset` of `struct`s with 'id' and 'infoplist' fields. The 'id' field is the
+target id of the application extension target. The 'infoplist' field is a `File`
+for the Info.plist for the target.
+""",
+        "hosted_targets": """\
+A `depset` of `struct`s with 'host' and 'hosted' fields. The 'host' field is the
+target id of the hosting target. The 'hosted' field is the target id of the
+hosted target.
 """,
         "inputs": """\
-A value returned from `input_files.collect`, that contains the input files
-for this target. It also includes the two extra fields that collect all of the
+A value returned from `input_files.collect`, that contains the input files for
+this target. It also includes the two extra fields that collect all of the
 generated `Files` and all of the `Files` that should be added to the Xcode
 project, but are not associated with any targets.
 """,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -178,17 +178,32 @@ def process_top_level_target(
     avoid_deps = [test_host_target] if test_host_target else []
 
     watch_app_target = getattr(ctx.rule.attr, "watch_application", None)
+    watch_app_target_info = (
+        watch_app_target[XcodeProjInfo] if watch_app_target else None
+    )
     watch_application = (
-        watch_app_target[XcodeProjInfo].target.id if watch_app_target else None
+        watch_app_target_info.target.id if watch_app_target_info else None
     )
 
     extension_targets = getattr(ctx.rule.attr, "extensions", [])
     extension_target = getattr(ctx.rule.attr, "extension", None)
     if extension_target:
         extension_targets.append(extension_target)
-    extensions = [
-        extension[XcodeProjInfo].target.id
-        for extension in extension_targets
+    extension_target_infos = [
+        extension_target[XcodeProjInfo]
+        for extension_target in extension_targets
+    ]
+    extensions = [info.target.id for info in extension_target_infos]
+
+    hosted_target_infos = extension_target_infos
+    if watch_app_target_info:
+        hosted_target_infos.append(watch_app_target_info)
+    hosted_targets = [
+        struct(
+            host = id,
+            hosted = info.target.id,
+        )
+        for info in hosted_target_infos
     ]
 
     additional_files = []
@@ -382,6 +397,7 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
         automatic_target_info = automatic_target_info,
         dependencies = dependencies,
         extension_infoplists = extension_infoplists,
+        hosted_targets = hosted_targets,
         inputs = inputs,
         linker_inputs = linker_inputs,
         non_mergable_targets = non_mergable_targets,

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -65,6 +65,16 @@ def _write_json_spec(*, ctx, project_name, configuration, inputs, infos):
         flattened_key_values.to_list(target_merges),
     )
 
+    hosted_targets = depset(
+        transitive = [info.hosted_targets for info in infos],
+    )
+    target_hosts = {}
+    for s in hosted_targets.to_list():
+        target_hosts.setdefault(s.hosted, []).append(s.host)
+    target_hosts_json = json.encode(
+        flattened_key_values.to_list(target_hosts),
+    )
+
     extra_files = [
         file_path_to_dto(file)
         for file in extra_files.to_list()
@@ -96,20 +106,22 @@ def _write_json_spec(*, ctx, project_name, configuration, inputs, infos):
 "label":"{label}",\
 "name":"{name}",\
 "scheme_autogeneration_mode":"{scheme_autogeneration_mode}",\
+"target_hosts":{target_hosts},\
 "target_merges":{target_merges},\
 "targets":{targets}\
 }}
 """.format(
         bazel_path = ctx.attr.bazel_path,
+        bazel_workspace_name = ctx.workspace_name,
         configuration = configuration,
         custom_xcode_schemes = custom_xcode_schemes_json,
         extra_files = json.encode(extra_files),
         label = ctx.label,
-        target_merges = target_merges_json,
         name = project_name,
-        bazel_workspace_name = ctx.workspace_name,
-        targets = targets_json,
         scheme_autogeneration_mode = ctx.attr.scheme_autogeneration_mode,
+        target_hosts = target_hosts_json,
+        target_merges = target_merges_json,
+        targets = targets_json,
     )
 
     output = ctx.actions.declare_file("{}_spec.json".format(ctx.attr.name))

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -53,6 +53,7 @@ def _target_info_fields(
         *,
         dependencies,
         extension_infoplists,
+        hosted_targets,
         inputs,
         linker_inputs,
         non_mergable_targets,
@@ -74,6 +75,7 @@ def _target_info_fields(
         dependencies: Maps to the `XcodeProjInfo.dependencies` field.
         extension_infoplists: Maps to the `XcodeProjInfo.extension_infoplists`
             field.
+        hosted_targets: Maps to the `XcodeProjInfo.hosted_targets` field.
         inputs: Maps to the `XcodeProjInfo.inputs` field.
         linker_inputs: Maps to the `XcodeProjInfo.linker_inputs` field.
         non_mergable_targets: Maps to the `XcodeProjInfo.non_mergable_targets`
@@ -99,6 +101,7 @@ def _target_info_fields(
         *   `dependencies`
         *   `extension_infoplists`
         *   `generated_inputs`
+        *   `hosted_targets`
         *   `inputs`
         *   `linker_inputs`
         *   `non_mergable_targets`
@@ -116,6 +119,7 @@ def _target_info_fields(
     return {
         "dependencies": dependencies,
         "extension_infoplists": extension_infoplists,
+        "hosted_targets": hosted_targets,
         "inputs": inputs,
         "linker_inputs": linker_inputs,
         "non_mergable_targets": non_mergable_targets,
@@ -154,6 +158,12 @@ def _skip_target(*, deps, transitive_infos):
         extension_infoplists = depset(
             transitive = [
                 info.extension_infoplists
+                for _, info in transitive_infos
+            ],
+        ),
+        hosted_targets = depset(
+            transitive = [
+                info.hosted_targets
                 for _, info in transitive_infos
             ],
         ),
@@ -318,6 +328,18 @@ def _create_xcodeprojinfo(*, ctx, target, transitive_infos):
             processed_target.extension_infoplists,
             transitive = [
                 info.extension_infoplists
+                for attr, info in transitive_infos
+                if (info.target_type in
+                    processed_target.automatic_target_info.xcode_targets.get(
+                        attr,
+                        [None],
+                    ))
+            ],
+        ),
+        hosted_targets = depset(
+            processed_target.hosted_targets,
+            transitive = [
+                info.hosted_targets
                 for attr, info in transitive_infos
                 if (info.target_type in
                     processed_target.automatic_target_info.xcode_targets.get(


### PR DESCRIPTION
This will allow us to properly create schemes for hosted targets, such as Watch Apps or Application Extensions.