### PR TITLE
Fix search paths for non-merged top-level targets

### DIFF
--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -363,7 +363,26 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -539,7 +558,26 @@
                 "type": "com.apple.product-type.bundle.unit-test"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217",
             "watch_application": null
@@ -754,7 +792,26 @@
                 "type": "com.apple.product-type.bundle.unit-test"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217",
             "watch_application": null
@@ -939,7 +996,15 @@
                 "type": "com.apple.product-type.bundle.ui-testing"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217",
             "watch_application": null

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -328,7 +328,26 @@
                 "//ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
                 "//ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54"
             ],
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -551,7 +570,26 @@
             "resource_bundle_dependencies": [
                 "//OnlyStructuredResources:OnlyStructuredResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54"
             ],
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
             "watch_application": null
@@ -830,7 +868,26 @@
             "resource_bundle_dependencies": [
                 "//ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54"
             ],
-            "search_paths": {},
+            "search_paths": {
+                "includes": [
+                    "CoreUtilsObjC",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/CoreUtilsObjC",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
             "watch_application": null
@@ -997,7 +1054,15 @@
             "resource_bundle_dependencies": [
                 "@examples_ios_app_external//:ExternalResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54"
             ],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//Example:Example applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
             "watch_application": null

--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -685,8 +685,6 @@
 					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin",
 					"$(BAZEL_EXTERNAL)/examples_cc_external",
 					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/examples_cc_external",
-					"$(BAZEL_EXTERNAL)/bazel_tools",
-					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/bazel_tools",
 				);
 			};
 			name = Debug;

--- a/test/fixtures/cc/bwb_spec.json
+++ b/test/fixtures/cc/bwb_spec.json
@@ -334,14 +334,6 @@
                     {
                         "_": "darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/examples_cc_external",
                         "t": "g"
-                    },
-                    {
-                        "_": "bazel_tools",
-                        "t": "e"
-                    },
-                    {
-                        "_": "darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/bazel_tools",
-                        "t": "g"
                     }
                 ],
                 "system_includes": [

--- a/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
@@ -702,8 +702,6 @@
 					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin",
 					"$(BAZEL_EXTERNAL)/examples_cc_external",
 					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/examples_cc_external",
-					"$(BAZEL_EXTERNAL)/bazel_tools",
-					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/bazel_tools",
 				);
 			};
 			name = Debug;

--- a/test/fixtures/cc/bwx_spec.json
+++ b/test/fixtures/cc/bwx_spec.json
@@ -329,14 +329,6 @@
                     {
                         "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/examples_cc_external",
                         "t": "g"
-                    },
-                    {
-                        "_": "bazel_tools",
-                        "t": "e"
-                    },
-                    {
-                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/bazel_tools",
-                        "t": "g"
                     }
                 ],
                 "system_includes": [

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -180,7 +180,33 @@
                 "type": "com.apple.product-type.bundle.unit-test"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "examples_command_line_external",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "examples_command_line_external",
+                        "t": "e"
+                    },
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/external/examples_command_line_external",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -806,7 +832,45 @@
                 "type": "com.apple.product-type.tool"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "examples_command_line_external",
+                        "t": "e"
+                    }
+                ],
+                "includes": [
+                    "examples/command_line/lib/dir with space",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/dir with space",
+                        "t": "g"
+                    },
+                    "examples/command_line/lib/private",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/private",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "examples_command_line_external",
+                        "t": "e"
+                    },
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/external/examples_command_line_external",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -175,7 +175,33 @@
                 "type": "com.apple.product-type.bundle.unit-test"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "examples_command_line_external",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "examples_command_line_external",
+                        "t": "e"
+                    },
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/external/examples_command_line_external",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -762,7 +788,45 @@
                 "type": "com.apple.product-type.tool"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "examples_command_line_external",
+                        "t": "e"
+                    }
+                ],
+                "includes": [
+                    "examples/command_line/lib/dir with space",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/dir with space",
+                        "t": "g"
+                    },
+                    "examples/command_line/lib/private",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/private",
+                        "t": "g"
+                    }
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "examples_command_line_external",
+                        "t": "e"
+                    },
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/external/examples_command_line_external",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -2535,6 +2535,10 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGET_NAME = generator;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin",
+				);
 			};
 			name = Debug;
 		};

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -142,7 +142,15 @@
                 "type": "com.apple.product-type.bundle.unit-test"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "darwin_x86_64-dbg-ST-5534cb307cb8/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -363,7 +371,15 @@
                 "type": "com.apple.product-type.tool"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "darwin_x86_64-dbg-ST-5534cb307cb8/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -2158,6 +2158,10 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGET_NAME = generator;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin",
+				);
 			};
 			name = Debug;
 		};

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -137,7 +137,15 @@
                 "type": "com.apple.product-type.bundle.unit-test"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -338,7 +346,15 @@
                 "type": "com.apple.product-type.tool"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null

--- a/test/fixtures/macos_app/bwb_spec.json
+++ b/test/fixtures/macos_app/bwb_spec.json
@@ -107,7 +107,22 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    "examples/macos_app/third_party"
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null

--- a/test/fixtures/macos_app/bwx_spec.json
+++ b/test/fixtures/macos_app/bwx_spec.json
@@ -105,7 +105,22 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    "examples/macos_app/third_party"
+                ],
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin",
+                        "t": "g"
+                    },
+                    {
+                        "_": "applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -2716,6 +2716,14 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGET_NAME = watchOSApp;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin",
+				);
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};
 			name = Debug;

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -24,11 +24,11 @@
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework",
+            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework",
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework",
+            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework",
             "t": "e"
         },
         "examples/multiplatform/WidgetExtension/BUILD",
@@ -81,11 +81,11 @@
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework",
+            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework",
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework",
+            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework",
             "t": "e"
         },
         {
@@ -959,7 +959,29 @@
                 "type": "com.apple.product-type.tool"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/macos-arm64_x86_64",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -1145,7 +1167,29 @@
                 "type": "com.apple.product-type.app-extension"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -1231,7 +1275,29 @@
                 "type": "com.apple.product-type.app-extension"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -1552,7 +1618,49 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    {
+                        "_": "com_google_google_maps",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_google_google_maps",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc"
@@ -1664,7 +1772,49 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    {
+                        "_": "com_google_google_maps",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_google_google_maps",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a"
@@ -2016,7 +2166,29 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -2101,7 +2273,29 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -2368,7 +2562,15 @@
                 "type": "com.apple.product-type.application.watchapp2"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -2432,7 +2634,15 @@
                 "type": "com.apple.product-type.application.watchapp2"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -2517,7 +2727,29 @@
                 "type": "com.apple.product-type.watchkit2-extension"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -2602,7 +2834,29 @@
                 "type": "com.apple.product-type.watchkit2-extension"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null

--- a/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
@@ -1997,6 +1997,14 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGET_NAME = watchOSApp;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin",
+				);
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};
 			name = Debug;

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -24,11 +24,11 @@
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework",
+            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework",
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework",
+            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework",
             "t": "e"
         },
         "examples/multiplatform/WidgetExtension/BUILD",
@@ -68,11 +68,11 @@
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework",
+            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework",
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework",
+            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework",
             "t": "e"
         },
         {
@@ -828,7 +828,29 @@
                 "type": "com.apple.product-type.tool"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/macos-arm64_x86_64",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -998,7 +1020,29 @@
                 "type": "com.apple.product-type.app-extension"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -1083,7 +1127,29 @@
                 "type": "com.apple.product-type.app-extension"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -1381,7 +1447,49 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    {
+                        "_": "com_google_google_maps",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/external/com_google_google_maps",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3"
@@ -1500,7 +1608,49 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    {
+                        "_": "com_google_google_maps",
+                        "t": "e"
+                    },
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/external/com_google_google_maps",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba"
@@ -1822,7 +1972,29 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -1907,7 +2079,29 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -2143,7 +2337,15 @@
                 "type": "com.apple.product-type.application.watchapp2"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -2206,7 +2408,15 @@
                 "type": "com.apple.product-type.application.watchapp2"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -2291,7 +2501,29 @@
                 "type": "com.apple.product-type.watchkit2-extension"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -2376,7 +2608,29 @@
                 "type": "com.apple.product-type.watchkit2-extension"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "framework_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "quote_includes": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift",
+                        "t": "e"
+                    },
+                    {
+                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/external/com_github_krzyzanowskim_cryptoswift",
+                        "t": "g"
+                    },
+                    ".",
+                    {
+                        "_": "applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null

--- a/test/fixtures/simple/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/simple/bwb.xcodeproj/project.pbxproj
@@ -251,6 +251,10 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGET_NAME = SwiftBin;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-f7d2792bf9e4/bin",
+				);
 			};
 			name = Debug;
 		};

--- a/test/fixtures/simple/bwb_spec.json
+++ b/test/fixtures/simple/bwb_spec.json
@@ -76,7 +76,15 @@
                 "type": "com.apple.product-type.tool"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "darwin_x86_64-dbg-ST-f7d2792bf9e4/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null

--- a/test/fixtures/simple/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/simple/bwx.xcodeproj/project.pbxproj
@@ -175,6 +175,10 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGET_NAME = SwiftBin;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)",
+					"$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin",
+				);
 			};
 			name = Debug;
 		};

--- a/test/fixtures/simple/bwx_spec.json
+++ b/test/fixtures/simple/bwx_spec.json
@@ -71,7 +71,15 @@
                 "type": "com.apple.product-type.tool"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -128,7 +128,15 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -280,7 +288,15 @@
                 "type": "com.apple.product-type.bundle.unit-test"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1",
             "watch_application": null
@@ -438,7 +454,15 @@
                 "type": "com.apple.product-type.bundle.ui-testing"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1",
             "watch_application": null

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -123,7 +123,15 @@
                 "type": "com.apple.product-type.application"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": null,
             "watch_application": null
@@ -255,7 +263,15 @@
                 "type": "com.apple.product-type.bundle.unit-test"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de",
             "watch_application": null
@@ -393,7 +409,15 @@
                 "type": "com.apple.product-type.bundle.ui-testing"
             },
             "resource_bundle_dependencies": [],
-            "search_paths": {},
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin",
+                        "t": "g"
+                    }
+                ]
+            },
             "swiftmodules": [],
             "test_host": "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de",
             "watch_application": null

--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -1,0 +1,83 @@
+"""Module for propagating compilation providers."""
+
+def _collect(*, cc_info, objc, is_xcode_target):
+    """Collects compilation providers for a non top-level target.
+
+    Args:
+        cc_info: The `CcInfo` of the target, or `None`.
+        objc: The `ObjcProvider` of the target, or `None`.
+        is_xcode_target: Whether the target is an Xcode target.
+
+    Returns:
+        An opaque `struct` containing the linker input files for a target. The
+        `struct` should be passed to functions in the `collect_providers` module
+        to retrieve its contents.
+    """
+    is_xcode_library_target = cc_info and is_xcode_target
+
+    return struct(
+        _cc_info = cc_info,
+        _objc = objc,
+        _is_xcode_library_target = is_xcode_library_target,
+    )
+
+def _merge(*, transitive_compilation_providers):
+    """Merges compilation providers from the deps of a target.
+
+    Args:
+        transitive_compilation_providers: A `list` of
+            `(target(), XcodeProjInfo)` tuples of transitive dependencies that
+            should have compilation providers merged.
+
+    Returns:
+        A value similar to the one returned from
+        `compilation_providers.collect`.
+    """
+    cc_info = cc_common.merge_cc_infos(
+        cc_infos = [
+            providers._cc_info
+            for _, providers in transitive_compilation_providers
+            if providers._cc_info
+        ],
+    )
+
+    objc_providers = [
+        providers._objc
+        for _, providers in transitive_compilation_providers
+        if providers._objc
+    ]
+    if objc_providers:
+        objc = apple_common.new_objc_provider(providers = objc_providers)
+    else:
+        objc = None
+
+    return struct(
+        _cc_info = cc_info,
+        _is_xcode_library_target = False,
+        _objc = objc,
+        _transitive_compilation_providers = transitive_compilation_providers,
+    )
+
+def _get_xcode_library_targets(*, compilation_providers):
+    """Returns the Xcode library target dependencies for this target.
+
+    Args:
+        compilation_providers: A value returned from
+            `compilation_providers.merge`.
+
+    Returns:
+        A list of targets `struct`s that are Xcode library targets.
+    """
+    return [
+        target
+        for target, providers in (
+            compilation_providers._transitive_compilation_providers
+        )
+        if providers._is_xcode_library_target
+    ]
+
+compilation_providers = struct(
+    collect = _collect,
+    get_xcode_library_targets = _get_xcode_library_targets,
+    merge = _merge,
+)

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -105,8 +105,7 @@ def _collect(
             project. If this is `False` then all resources will get added to
             `extra_files` instead of `resources`.
         is_bundle: Whether `target` is a bundle.
-        linker_inputs: A value returned from
-            `linker_file_inputs.collect_for_top_level`, or a similar function.
+        linker_inputs: A value returned from `linker_file_inputs.collect`.
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
         additional_files: A `list` of `File`s to add to the inputs. This can

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -5,6 +5,7 @@ load(
     "AppleResourceBundleInfo",
     "AppleResourceInfo",
 )
+load(":compilation_providers.bzl", comp_providers = "compilation_providers")
 load(":configuration.bzl", "get_configuration")
 load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
@@ -69,14 +70,19 @@ rules_xcodeproj requires {} to have `{}` set.
     else:
         resource_bundle_informations = None
 
-    linker_inputs = linker_input_files.collect_for_non_top_level(
+    compilation_providers = comp_providers.collect(
         cc_info = cc_info,
         objc = objc,
         is_xcode_target = False,
     )
+    linker_inputs = linker_input_files.collect(
+        ctx = ctx,
+        compilation_providers = compilation_providers,
+    )
 
     return processed_target(
         automatic_target_info = automatic_target_info,
+        compilation_providers = compilation_providers,
         dependencies = process_dependencies(
             automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
@@ -92,15 +98,13 @@ rules_xcodeproj requires {} to have `{}` set.
             transitive_infos = transitive_infos,
             avoid_deps = [],
         ),
-        linker_inputs = linker_inputs,
         outputs = output_files.merge(
             automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
         ),
         resource_bundle_informations = resource_bundle_informations,
         search_paths = process_search_paths(
-            cc_info = cc_info,
-            objc = objc,
+            compilation_providers = compilation_providers,
             bin_dir_path = ctx.bin_dir.path,
             opts_search_paths = create_opts_search_paths(
                 quote_includes = [],

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -11,11 +11,12 @@ load(":providers.bzl", "target_type")
 def processed_target(
         *,
         automatic_target_info,
+        compilation_providers,
         dependencies,
         extension_infoplists = None,
         hosted_targets = None,
         inputs,
-        linker_inputs,
+        library = None,
         non_mergable_targets = None,
         outputs,
         potential_target_merges = None,
@@ -28,6 +29,8 @@ def processed_target(
     Args:
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             the target.
+        compilation_providers: A value returned from
+            `compilation_providers.collect`.
         dependencies: A `list` of target ids of direct dependencies of this
             target.
         extension_infoplists: A `list` of `File` for the Info.plist's of an
@@ -36,9 +39,8 @@ def processed_target(
             `XcodeProjInfo.hosted_targets`.
         inputs: A value as returned from `input_files.collect` that will
             provide values for the `XcodeProjInfo.inputs` field.
-        linker_inputs: A value returned from `linker_input_files.collect`
-            that will provide values for the `XcodeProjInfo.linker_inputs`
-            field.
+        library: A `File` for the static library produced by this target, or
+            `None`.
         non_mergable_targets: An optional `list` of strings that will be in the
             `XcodeProjInfo.non_mergable_targets` `depset`.
         outputs: A value as returned from `output_files.collect` that will
@@ -57,11 +59,12 @@ def processed_target(
     """
     return struct(
         automatic_target_info = automatic_target_info,
+        compilation_providers = compilation_providers,
         extension_infoplists = extension_infoplists,
         dependencies = dependencies,
         hosted_targets = hosted_targets,
         inputs = inputs,
-        linker_inputs = linker_inputs,
+        library = library,
         non_mergable_targets = non_mergable_targets,
         outputs = outputs,
         potential_target_merges = potential_target_merges,
@@ -117,7 +120,8 @@ def xcode_target(
         modulemaps: The value returned from `_process_modulemaps`.
         swiftmodules: The value returned from `_process_swiftmodules`.
         inputs: The value returned from `input_files.collect`.
-        linker_inputs: A value returned from `linker_input_files.collect`.
+        linker_inputs: A value returned from `linker_input_files.collect` or
+            `None`.
         info_plist: A value as returned by `files.file_path` or `None`.
         watch_application: The `id` of the watch application target that should
             be embedded in this target, or `None`.

--- a/xcodeproj/internal/product.bzl
+++ b/xcodeproj/internal/product.bzl
@@ -34,7 +34,7 @@ def process_product(
         fp = bundle_file_path
     elif target[DefaultInfo].files_to_run.executable:
         fp = file_path(target[DefaultInfo].files_to_run.executable)
-    elif CcInfo in target:
+    elif CcInfo in target and linker_inputs:
         library = linker_input_files.get_primary_static_library(linker_inputs)
         fp = file_path(library) if library else None
     else:

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -80,6 +80,9 @@ target_type = struct(
 XcodeProjInfo = provider(
     "Provides information needed to generate an Xcode project.",
     fields = {
+        "compilation_providers": """\
+A value returned from `compilation_providers.collect_for_{non_,}top_level`.
+""",
         "dependencies": """\
 A `list` of target ids (see the `target` `struct`) that this target directly
 depends on.
@@ -100,9 +103,6 @@ this target. It also includes the two extra fields that collect all of the
 generated `Files` and all of the `Files` that should be added to the Xcode
 project, but are not associated with any targets.
 """,
-        "linker_inputs": """\
-A value returned from `linker_input_files.collect`.
-""",
         "potential_target_merges": """\
 A `depset` of `struct`s with 'src' and 'dest' fields. The 'src' field is the id
 of the target that can be merged into the target with the id of the 'dest'
@@ -112,8 +112,8 @@ field.
 A `depset` of all static library files that are linked into top-level targets
 besides their primary top-level targets.
 """,
-        "non_target_linker_inputs": """\
-A value returned from `linker_input_files.collect`, for targets that aren't
+        "non_target_compilation_providers": """\
+A value returned from `compilation_providers.collect`, for targets that aren't
 generating Xcode targets.
 """,
         "non_target_swift_info_modules": """\

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -4,7 +4,6 @@ load("@bazel_skylib//lib:paths.bzl", "paths")
 load(":collections.bzl", "set_if_true")
 load(":files.bzl", "parsed_file_path")
 load(":input_files.bzl", "input_files")
-load(":linker_input_files.bzl", "linker_input_files")
 load(":output_files.bzl", "output_files")
 load(":processed_target.bzl", "xcode_target")
 load(":product.bzl", "process_product")
@@ -32,18 +31,12 @@ def _process_resource_bundle(bundle, *, information):
         "{}.bundle".format(name),
     ))
 
-    linker_inputs = linker_input_files.collect_for_non_top_level(
-        cc_info = None,
-        objc = None,
-        is_xcode_target = True,
-    )
-
     product = process_product(
         target = None,
         product_name = name,
         product_type = "com.apple.product-type.bundle",
         bundle_file_path = bundle_file_path,
-        linker_inputs = linker_inputs,
+        linker_inputs = None,
     )
 
     outputs = output_files.collect(
@@ -70,7 +63,7 @@ def _process_resource_bundle(bundle, *, information):
         modulemaps = process_modulemaps(swift_info = None),
         swiftmodules = process_swiftmodules(swift_info = None),
         inputs = input_files.from_resource_bundle(bundle),
-        linker_inputs = linker_inputs,
+        linker_inputs = None,
         info_plist = None,
         dependencies = bundle.dependencies,
         outputs = outputs,

--- a/xcodeproj/internal/search_paths.bzl
+++ b/xcodeproj/internal/search_paths.bzl
@@ -7,18 +7,28 @@ load(
     "parsed_file_path",
 )
 
-def process_search_paths(*, cc_info, objc, bin_dir_path, opts_search_paths):
+def process_search_paths(
+        *,
+        compilation_providers,
+        bin_dir_path,
+        opts_search_paths):
     """Processes search paths.
 
     Args:
-        cc_info: The `CcInfo` provider for the target.
-        objc: The `ObjcProvider` provider for the target.
+        compilation_providers: A value returned from
+            `compilation_providers.collect`.
         bin_dir_path: `ctx.bin_dir.path`.
         opts_search_paths: A value returned from `create_opts_search_paths`.
 
     Returns:
         A DTO `dict`.
     """
+    if not compilation_providers:
+        return {}
+
+    cc_info = compilation_providers._cc_info
+    objc = compilation_providers._objc
+
     search_paths = {}
     if cc_info:
         compilation_context = cc_info.compilation_context

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -9,6 +9,7 @@ load(
     "get_targeted_device_family",
 )
 load(":collections.bzl", "set_if_true")
+load(":compilation_providers.bzl", comp_providers = "compilation_providers")
 load(":configuration.bzl", "get_configuration")
 load(":files.bzl", "file_path", "join_paths_ignoring_empty")
 load(":info_plists.bzl", "info_plists")
@@ -276,18 +277,26 @@ def process_top_level_target(
 
     if (test_host_target_info and
         props.product_type == "com.apple.product-type.bundle.unit-test"):
-        avoid_linker_inputs = test_host_target_info.linker_inputs
+        avoid_compilation_providers = (
+            test_host_target_info.compilation_providers
+        )
     else:
-        avoid_linker_inputs = None
+        avoid_compilation_providers = None
 
-    linker_inputs = linker_input_files.collect_for_top_level(
-        ctx = ctx,
-        transitive_linker_inputs = [
-            (dep[XcodeProjInfo].target, dep[XcodeProjInfo].linker_inputs)
+    compilation_providers = comp_providers.merge(
+        transitive_compilation_providers = [
+            (
+                dep[XcodeProjInfo].target,
+                dep[XcodeProjInfo].compilation_providers,
+            )
             # TODO: Get attr name from `XcodeProjAutomaticTargetProcessingInfo`
             for dep in getattr(ctx.rule.attr, "deps", [])
         ],
-        avoid_linker_inputs = avoid_linker_inputs,
+    )
+    linker_inputs = linker_input_files.collect(
+        ctx = ctx,
+        compilation_providers = compilation_providers,
+        avoid_compilation_providers = avoid_compilation_providers,
     )
 
     inputs = input_files.collect(
@@ -312,7 +321,9 @@ def process_top_level_target(
         should_produce_dto = should_include_outputs(ctx = ctx),
     )
 
-    xcode_library_targets = linker_inputs.xcode_library_targets
+    xcode_library_targets = comp_providers.get_xcode_library_targets(
+        compilation_providers = compilation_providers,
+    )
     if len(xcode_library_targets) == 1 and not inputs.srcs:
         mergeable_target = xcode_library_targets[0]
         mergeable_label = mergeable_target.label
@@ -374,7 +385,6 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
     )
 
     cc_info = target[CcInfo] if CcInfo in target else None
-    objc = target[apple_common.Objc] if apple_common.Objc in target else None
 
     codesignopts_attr_name = automatic_target_info.codesignopts
     if codesignopts_attr_name:
@@ -393,19 +403,18 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
         build_settings = build_settings,
     )
     search_paths = process_search_paths(
-        cc_info = cc_info,
-        objc = objc,
+        compilation_providers = compilation_providers,
         bin_dir_path = ctx.bin_dir.path,
         opts_search_paths = opts_search_paths,
     )
 
     return processed_target(
         automatic_target_info = automatic_target_info,
+        compilation_providers = compilation_providers,
         dependencies = dependencies,
         extension_infoplists = extension_infoplists,
         hosted_targets = hosted_targets,
         inputs = inputs,
-        linker_inputs = linker_inputs,
         non_mergable_targets = non_mergable_targets,
         outputs = outputs,
         potential_target_merges = potential_target_merges,

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -6,6 +6,7 @@ load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":bazel_labels.bzl", "bazel_labels")
 load(":collections.bzl", "uniq")
+load(":compilation_providers.bzl", comp_providers = "compilation_providers")
 load(":configuration.bzl", "get_configuration")
 load(":files.bzl", "file_path", "file_path_to_dto", "parsed_file_path")
 load(":flattened_key_values.bzl", "flattened_key_values")
@@ -371,10 +372,12 @@ def _xcodeproj_impl(ctx):
         non_xcode_libraries = sets.make(
             linker_input_files.get_static_libraries(
                 linker_input_files.merge(
-                    transitive_linker_inputs = [
-                        (info.target, info.non_target_linker_inputs)
-                        for info in infos
-                    ],
+                    compilation_providers = comp_providers.merge(
+                        transitive_compilation_providers = [
+                            (info.target, info.compilation_providers)
+                            for info in infos
+                        ],
+                    ),
                 ),
             ),
         )


### PR DESCRIPTION
Collecting and merging of `CcInfo` and `ObjcProvider` providers was extracted out of `linker_input_files` to all for its use in `process_search_paths`. `process_search_paths` now uses these providers to get the search paths, allowing top-level targets to have correct search paths, which matters when they aren't merged with a library target.