### PR TITLE
Add `.messagesApplication` to `hasCompilePhase` and `shouldCreateScheme`

### DIFF
--- a/tools/generator/src/Extensions/PBXProductType+Extensions.swift
+++ b/tools/generator/src/Extensions/PBXProductType+Extensions.swift
@@ -172,6 +172,7 @@ extension PBXProductType {
     var hasCompilePhase: Bool {
         switch self {
         case .bundle,
+             .messagesApplication,
              .watchApp,
              .watch2App,
              .watch2AppContainer,
@@ -275,7 +276,8 @@ extension PBXProductType {
 
     var shouldCreateScheme: Bool {
         switch self {
-        case .watchExtension,
+        case .messagesApplication,
+             .watchExtension,
              .watch2AppContainer,
              .watch2Extension:
             return false


### PR DESCRIPTION
Part of #104.

This represents a stub app bundle that doesn't have a compile phase, and shouldn't have its own scheme.