### PR TITLE
Introduce `BazelLabel` type

### DIFF
--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -147,6 +147,7 @@
 		804848AF97DCD0402E5B8587 /* BuildSettingsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD828AC8336C5A1F0C951071 /* BuildSettingsProvider.swift */; };
 		80DB1DEE41E0521C535EF842 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF420FAF127AC6B393E4678 /* PBXResourcesBuildPhase.swift */; };
 		81538A9DF3EE3B84C20E7C11 /* PBXObjectReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA5F81BF5F85E9032BC2014 /* PBXObjectReference.swift */; };
+		819D6A8B6B245F427CEEC1E5 /* BazelLabel+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8169934D430D8F6CC14E5E40 /* BazelLabel+TestExtensions.swift */; };
 		81D03FFE4CE12D33C7982F23 /* OrderedDictionary+Invariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A11A26366495E4A9EFBEC0B /* OrderedDictionary+Invariants.swift */; };
 		83401B70003CB4C9642FF821 /* LinkerInputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B53AF9EB4EE0D76B72A641 /* LinkerInputs.swift */; };
 		835FBBDCA423CB2040EB1F24 /* OrderedSet+CustomDebugStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E577B87CB8E962E6110B1A0 /* OrderedSet+CustomDebugStringConvertible.swift */; };
@@ -548,6 +549,7 @@
 		7DD377ABEF6A8CECEE71C6A3 /* _HashTable+BucketIterator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+BucketIterator.swift"; sourceTree = "<group>"; };
 		7E6551A5EEE9CC51C5A05BD3 /* CreateXCSharedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateXCSharedData.swift; sourceTree = "<group>"; };
 		7EFA193BCD097396D150AF96 /* Document.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
+		8169934D430D8F6CC14E5E40 /* BazelLabel+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BazelLabel+TestExtensions.swift"; sourceTree = "<group>"; };
 		817B04CE0868E15EFE7D8C44 /* OrderedDictionary+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Hashable.swift"; sourceTree = "<group>"; };
 		8645BE71A723C3736CCE7131 /* OrderedSet+Initializers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Initializers.swift"; sourceTree = "<group>"; };
 		86549ABD234E1583AA0655DE /* XCCurrentVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCCurrentVersion.swift; sourceTree = "<group>"; };
@@ -1103,6 +1105,7 @@
 			isa = PBXGroup;
 			children = (
 				DACBE49740AB347EFAE8EC00 /* AddTargetsTests.swift */,
+				8169934D430D8F6CC14E5E40 /* BazelLabel+TestExtensions.swift */,
 				E37E1D8F0FD9F2FEEC62C2B3 /* BazelLabelTests.swift */,
 				35445591FE5C7D2FCEF9533F /* BUILD */,
 				08416B4EDA557D797F63BB4F /* BuildSettingConditionalTests.swift */,
@@ -1941,6 +1944,7 @@
 			files = (
 				F9312E0C5F409E17F509CC96 /* _BazelForcedCompile_.swift in Sources */,
 				75B34A42A3528868C8D25993 /* AddTargetsTests.swift in Sources */,
+				819D6A8B6B245F427CEEC1E5 /* BazelLabel+TestExtensions.swift in Sources */,
 				C963F445C29D4475EB4F7780 /* BazelLabelTests.swift in Sources */,
 				0A22A35B5C2350A27CA5A895 /* BuildSettingConditionalTests.swift in Sources */,
 				73237287CCC966570F78F438 /* ConsolidateTargetsTest.swift in Sources */,

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -210,8 +210,10 @@
 		C0C01A34E3B73713C8A5AD93 /* UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D663E878398F3764B9C1A8 /* UIKit.swift */; };
 		C28A10245E6237BB03708CF9 /* XCScheme+RemoteRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053AD1C0C7003B91D7B9EB16 /* XCScheme+RemoteRunnable.swift */; };
 		C3C078F384218F905E374FEF /* XCScheme+PathRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9993D3F386DFC594BC0967A /* XCScheme+PathRunnable.swift */; };
+		C41E28F5D880E1B3B3CE23A6 /* BazelLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4642D1BB48B4523F92FBC3 /* BazelLabel.swift */; };
 		C4A4BDEEBC4DEA94A9C38B98 /* XCScheme+ProfileAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01004934C429F4A4F09C0C85 /* XCScheme+ProfileAction.swift */; };
 		C7FE7B26776F35CE278DA25A /* OrderedDictionary+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4142BB8EF88F4DD2D5440E4 /* OrderedDictionary+CustomStringConvertible.swift */; };
+		C963F445C29D4475EB4F7780 /* BazelLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E37E1D8F0FD9F2FEEC62C2B3 /* BazelLabelTests.swift */; };
 		CB02C36925CC30F4843D2DD1 /* OrderedDictionary+Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C1FEAE6FD7E8D74F258FD4B /* OrderedDictionary+Initializers.swift */; };
 		CC4D1146CF72525D99E9036C /* OrderedSet+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBB4BB99570B6487A866E782 /* OrderedSet+Equatable.swift */; };
 		CD168B5A573CE3A79098C630 /* PBXProjEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC11446A42A073B91FFC6262 /* PBXProjEncoder.swift */; };
@@ -632,6 +634,7 @@
 		D69926E3303EC6DCEFF83DE3 /* PopulateMainGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopulateMainGroup.swift; sourceTree = "<group>"; };
 		D9993D3F386DFC594BC0967A /* XCScheme+PathRunnable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+PathRunnable.swift"; sourceTree = "<group>"; };
 		DACBE49740AB347EFAE8EC00 /* AddTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTargetsTests.swift; sourceTree = "<group>"; };
+		DD4642D1BB48B4523F92FBC3 /* BazelLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BazelLabel.swift; sourceTree = "<group>"; };
 		DD828AC8336C5A1F0C951071 /* BuildSettingsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettingsProvider.swift; sourceTree = "<group>"; };
 		DDCE836ACE8D0A6B4577C665 /* _HashTable+UnsafeHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+UnsafeHandle.swift"; sourceTree = "<group>"; };
 		DDF5D934175EDDA9EF296101 /* NSRecursiveLock+Sync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRecursiveLock+Sync.swift"; sourceTree = "<group>"; };
@@ -640,6 +643,7 @@
 		DFB50D8D42412EB98A465DED /* OrderedDictionary+Elements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Elements.swift"; sourceTree = "<group>"; };
 		E0413D918157ADBE8DAEA92D /* Mirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mirror.swift; sourceTree = "<group>"; };
 		E06CA54BB3677E9BBC8A5D94 /* CompileStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CompileStub.m; sourceTree = "<group>"; };
+		E37E1D8F0FD9F2FEEC62C2B3 /* BazelLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BazelLabelTests.swift; sourceTree = "<group>"; };
 		E4142BB8EF88F4DD2D5440E4 /* OrderedDictionary+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+CustomStringConvertible.swift"; sourceTree = "<group>"; };
 		E43EBF1E6F26B25BB157D396 /* PBXBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildPhase.swift; sourceTree = "<group>"; };
 		E4507DAF85285409A7CA226E /* PBXObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXObject.swift; sourceTree = "<group>"; };
@@ -1099,6 +1103,7 @@
 			isa = PBXGroup;
 			children = (
 				DACBE49740AB347EFAE8EC00 /* AddTargetsTests.swift */,
+				E37E1D8F0FD9F2FEEC62C2B3 /* BazelLabelTests.swift */,
 				35445591FE5C7D2FCEF9533F /* BUILD */,
 				08416B4EDA557D797F63BB4F /* BuildSettingConditionalTests.swift */,
 				F9D15BC7ED54D7EBC0111629 /* ConsolidatedTargetExtensionsTests.swift */,
@@ -1277,6 +1282,7 @@
 		E8D8D9144332FC9166A9BA70 /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				DD4642D1BB48B4523F92FBC3 /* BazelLabel.swift */,
 				61886AE6F5D2C1864AFB163E /* BuildMode.swift */,
 				16F8C4C7C2081CE4ED3E6131 /* BuildSetting.swift */,
 				3C1F008B03E81D8D0104DB8C /* ExtensionPointIdentifier.swift */,
@@ -1935,6 +1941,7 @@
 			files = (
 				F9312E0C5F409E17F509CC96 /* _BazelForcedCompile_.swift in Sources */,
 				75B34A42A3528868C8D25993 /* AddTargetsTests.swift in Sources */,
+				C963F445C29D4475EB4F7780 /* BazelLabelTests.swift in Sources */,
 				0A22A35B5C2350A27CA5A895 /* BuildSettingConditionalTests.swift in Sources */,
 				73237287CCC966570F78F438 /* ConsolidateTargetsTest.swift in Sources */,
 				7CB1EBC22647A052E1F33593 /* ConsolidatedTargetExtensionsTests.swift in Sources */,
@@ -1983,6 +1990,7 @@
 			files = (
 				25439613FB7D1BD428EED6A1 /* _BazelForcedCompile_.swift in Sources */,
 				E296F8785FF730A70F61CB6A /* BuildSettingConditional.swift in Sources */,
+				C41E28F5D880E1B3B3CE23A6 /* BazelLabel.swift in Sources */,
 				9DC1B46D96E0EC172CF49086 /* BuildMode.swift in Sources */,
 				A7B2AC8B32D47FDA97CDFB51 /* BuildSetting.swift in Sources */,
 				8FCC7D3937EEC9B1D3C1D237 /* ExtensionPointIdentifier.swift in Sources */,

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -183,6 +183,7 @@
             "inputs": {
                 "srcs": [
                     "tools/generator/test/AddTargetsTests.swift",
+                    "tools/generator/test/BazelLabelTests.swift",
                     "tools/generator/test/BuildSettingConditionalTests.swift",
                     "tools/generator/test/ConsolidateTargetsTest.swift",
                     "tools/generator/test/ConsolidatedTargetExtensionsTests.swift",
@@ -414,6 +415,7 @@
             "inputs": {
                 "srcs": [
                     "tools/generator/src/BuildSettingConditional.swift",
+                    "tools/generator/src/DTO/BazelLabel.swift",
                     "tools/generator/src/DTO/BuildMode.swift",
                     "tools/generator/src/DTO/BuildSetting.swift",
                     "tools/generator/src/DTO/ExtensionPointIdentifier.swift",

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -183,6 +183,7 @@
             "inputs": {
                 "srcs": [
                     "tools/generator/test/AddTargetsTests.swift",
+                    "tools/generator/test/BazelLabel+TestExtensions.swift",
                     "tools/generator/test/BazelLabelTests.swift",
                     "tools/generator/test/BuildSettingConditionalTests.swift",
                     "tools/generator/test/ConsolidateTargetsTest.swift",

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		5E86FF5B228AE32DAB9CE44A /* BuildSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9570F5DB90273906103037E /* BuildSettings.swift */; };
 		5ECED6299B24791AC2FDCE47 /* LinkerInputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C019F3F4CCAA69A6F5565C0D /* LinkerInputs.swift */; };
 		5F50664E006EE645FFC8B076 /* CreateXcodeProjTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC5B799900C53A6F581CF62 /* CreateXcodeProjTests.swift */; };
+		60356CFF6DE55ED0B3BFEB50 /* BazelLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C17B4CCC3DB3DC6D8775CE0 /* BazelLabelTests.swift */; };
 		61F25C0B5AC2A8359DCF19B2 /* _UnsafeBitset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA9BF8DE4218EEF99B853E /* _UnsafeBitset.swift */; };
 		641C7B1D35514491C48E478C /* Path+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0277C77247B53722A111757 /* Path+Extras.swift */; };
 		65267FBDE7D0B453B46A4E36 /* XCConfigurationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5909E222A81AD5E732C7A9 /* XCConfigurationList.swift */; };
@@ -164,6 +165,7 @@
 		94E03F3E14B3B7AAC5E818BE /* XCScheme+ArchiveAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B1B07B1780ED7297DD889B /* XCScheme+ArchiveAction.swift */; };
 		9513603529C8D34C341B74ED /* OrderedSet+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697793A0038D2FB76FD542C4 /* OrderedSet+CustomStringConvertible.swift */; };
 		95D264466C03AFDD8500E4FB /* OrderedSet+Partial SetAlgebra+Basics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A234AB51A97D97EE651298 /* OrderedSet+Partial SetAlgebra+Basics.swift */; };
+		9763B775672AC96E1AA25415 /* BazelLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAB1232C0C94C42545636DB /* BazelLabel.swift */; };
 		97DB9AA49CCEFBBCA98FC229 /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786B15315524DB56CCC1A6E5 /* Bool+Extras.swift */; };
 		9804BBA597E3344B7F9008C4 /* PBXProductTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 354634746D24325319B693F8 /* PBXProductTypeExtensionsTests.swift */; };
 		99CBCF0D4F483E3BC08D99AD /* Dump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4796B5647870377961BBE65A /* Dump.swift */; };
@@ -504,6 +506,7 @@
 		5AA008E08C0FBB48956C0C68 /* XCScheme+CommandLineArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+CommandLineArguments.swift"; sourceTree = "<group>"; };
 		5B3DF1F6D8B6C99E63E3211A /* Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Swift.swift; sourceTree = "<group>"; };
 		5BC9574D73D444A40C0F7116 /* OrderedDictionary+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Codable.swift"; sourceTree = "<group>"; };
+		5C17B4CCC3DB3DC6D8775CE0 /* BazelLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BazelLabelTests.swift; sourceTree = "<group>"; };
 		5D2E8521610664CCE4F18220 /* KeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPath.swift; sourceTree = "<group>"; };
 		5DF925DC93003F74678BEE77 /* PBXProj+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXProj+Testing.swift"; sourceTree = "<group>"; };
 		5E0508567B3931B91F6BFBF4 /* _HashTable+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+CustomStringConvertible.swift"; sourceTree = "<group>"; };
@@ -661,6 +664,7 @@
 		FA83272F166637CFAFC4C79C /* OrderedDictionary+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Hashable.swift"; sourceTree = "<group>"; };
 		FAD042334686EC625458D787 /* XCWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspace.swift; sourceTree = "<group>"; };
 		FB78F15F8AFA4FD268CBC7BD /* KeyedDecodingContainer+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Additions.swift"; sourceTree = "<group>"; };
+		FCAB1232C0C94C42545636DB /* BazelLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BazelLabel.swift; sourceTree = "<group>"; };
 		FD37ED60DF0F25AB4A7DCE63 /* ConsolidateTargetsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsolidateTargetsTest.swift; sourceTree = "<group>"; };
 		FD68E5A7AC6AF524F6B2E4D3 /* WorkspaceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSettings.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -799,6 +803,7 @@
 			isa = PBXGroup;
 			children = (
 				37060CBDC54D48ADDEEA0274 /* AddTargetsTests.swift */,
+				5C17B4CCC3DB3DC6D8775CE0 /* BazelLabelTests.swift */,
 				A8C917E9D54ACB73DF3F6EAA /* BUILD */,
 				F4E71029096D6AC34B84A74A /* BuildSettingConditionalTests.swift */,
 				53506B77928F8228012289D3 /* ConsolidatedTargetExtensionsTests.swift */,
@@ -888,6 +893,7 @@
 		4109211F3DD18CAE886E009A /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				FCAB1232C0C94C42545636DB /* BazelLabel.swift */,
 				A5D3AD9C0FCEA5D8F2712060 /* BuildMode.swift */,
 				6291A9D4888F94F5597DDA02 /* BuildSetting.swift */,
 				D0BCE3D30558882AC418F0B4 /* ExtensionPointIdentifier.swift */,
@@ -1707,6 +1713,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D1FF2A2A272865879D4B94D2 /* AddTargetsTests.swift in Sources */,
+				60356CFF6DE55ED0B3BFEB50 /* BazelLabelTests.swift in Sources */,
 				130CE1601B9654CC0320CD9C /* BuildSettingConditionalTests.swift in Sources */,
 				02DCA9635FB629EFFEB10F73 /* ConsolidateTargetsTest.swift in Sources */,
 				557BF7507A3798A7DB119838 /* ConsolidatedTargetExtensionsTests.swift in Sources */,
@@ -1761,6 +1768,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FC8F414E5E27000A18EA2767 /* BuildSettingConditional.swift in Sources */,
+				9763B775672AC96E1AA25415 /* BazelLabel.swift in Sources */,
 				56B79FA316DC4D17D7633323 /* BuildMode.swift in Sources */,
 				D5FEDDFFB0D73117CB8A413E /* BuildSetting.swift in Sources */,
 				5106D7C8071619FD00716C9C /* ExtensionPointIdentifier.swift in Sources */,

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		7707F8E8F006A7AC6E1BC2BB /* PBXVariantGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F59053C0267E06F04377233 /* PBXVariantGroup.swift */; };
 		79F53950A8310BF2A491669C /* XCTAssertNoDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246DA27DDBB9DDC350093B5E /* XCTAssertNoDifference.swift */; };
 		7B645D49A5AC42B87FA526EF /* XCTFail.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB715BB44E25F5C1330F19A /* XCTFail.swift */; };
+		7BBFD440672C1CBE317C9204 /* BazelLabel+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4DFC45C9538AD37FAE2610 /* BazelLabel+TestExtensions.swift */; };
 		7C9193A9C51ECD915E3D66D4 /* Decoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D850DED77E2FF12781EB199 /* Decoders.swift */; };
 		81082AE9BDF69B75F8F66FFF /* AnyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABAB6A2BBE4B5DB7A7C46B9 /* AnyType.swift */; };
 		8163DAA88E903FCED5EA958C /* Photos.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9501520C482194DB21C3F7C /* Photos.swift */; };
@@ -607,6 +608,7 @@
 		B9570F5DB90273906103037E /* BuildSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettings.swift; sourceTree = "<group>"; };
 		B9CC2D5E3BD42DA1195EE7D9 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		BCB6D4C1A760E0F5039DCA16 /* OrderedSet+CustomDebugStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+CustomDebugStringConvertible.swift"; sourceTree = "<group>"; };
+		BD4DFC45C9538AD37FAE2610 /* BazelLabel+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BazelLabel+TestExtensions.swift"; sourceTree = "<group>"; };
 		BDB74D3730A6741F0EBA95CF /* PBXGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXGroup.swift; sourceTree = "<group>"; };
 		BEFE87E1BA432999CAE565E4 /* Writable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Writable.swift; sourceTree = "<group>"; };
 		C019F3F4CCAA69A6F5565C0D /* LinkerInputs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkerInputs.swift; sourceTree = "<group>"; };
@@ -803,6 +805,7 @@
 			isa = PBXGroup;
 			children = (
 				37060CBDC54D48ADDEEA0274 /* AddTargetsTests.swift */,
+				BD4DFC45C9538AD37FAE2610 /* BazelLabel+TestExtensions.swift */,
 				5C17B4CCC3DB3DC6D8775CE0 /* BazelLabelTests.swift */,
 				A8C917E9D54ACB73DF3F6EAA /* BUILD */,
 				F4E71029096D6AC34B84A74A /* BuildSettingConditionalTests.swift */,
@@ -1713,6 +1716,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D1FF2A2A272865879D4B94D2 /* AddTargetsTests.swift in Sources */,
+				7BBFD440672C1CBE317C9204 /* BazelLabel+TestExtensions.swift in Sources */,
 				60356CFF6DE55ED0B3BFEB50 /* BazelLabelTests.swift in Sources */,
 				130CE1601B9654CC0320CD9C /* BuildSettingConditionalTests.swift in Sources */,
 				02DCA9635FB629EFFEB10F73 /* ConsolidateTargetsTest.swift in Sources */,

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -178,6 +178,7 @@
             "inputs": {
                 "srcs": [
                     "tools/generator/test/AddTargetsTests.swift",
+                    "tools/generator/test/BazelLabelTests.swift",
                     "tools/generator/test/BuildSettingConditionalTests.swift",
                     "tools/generator/test/ConsolidateTargetsTest.swift",
                     "tools/generator/test/ConsolidatedTargetExtensionsTests.swift",
@@ -389,6 +390,7 @@
             "inputs": {
                 "srcs": [
                     "tools/generator/src/BuildSettingConditional.swift",
+                    "tools/generator/src/DTO/BazelLabel.swift",
                     "tools/generator/src/DTO/BuildMode.swift",
                     "tools/generator/src/DTO/BuildSetting.swift",
                     "tools/generator/src/DTO/ExtensionPointIdentifier.swift",

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -178,6 +178,7 @@
             "inputs": {
                 "srcs": [
                     "tools/generator/test/AddTargetsTests.swift",
+                    "tools/generator/test/BazelLabel+TestExtensions.swift",
                     "tools/generator/test/BazelLabelTests.swift",
                     "tools/generator/test/BuildSettingConditionalTests.swift",
                     "tools/generator/test/ConsolidateTargetsTest.swift",

--- a/tools/generator/src/DTO/BazelLabel.swift
+++ b/tools/generator/src/DTO/BazelLabel.swift
@@ -1,0 +1,63 @@
+struct BazelLabel: Equatable, Hashable, Decodable {
+    let repository: String
+    let package: String
+    let name: String
+}
+
+// extension BazelLabel {
+//     static func parse(_: String) -> BazelLabel? {
+//         // TODO: IMPLEMENT ME!
+//         return BazelLabel(
+//             repository: "",
+//             package: "",
+//             name: ""
+//         )
+//     }
+// }
+
+extension BazelLabel {
+    init?(_: String) {
+        // TODO: IMPLEMENT ME!
+        self.init(
+            repository: "",
+            package: "",
+            name: ""
+        )
+    }
+}
+
+extension BazelLabel: CustomStringConvertible {
+    var description: String {
+        return "\(repository)//\(package):\(name)"
+    }
+}
+
+extension BazelLabel: RawRepresentable {
+    init?(rawValue: String) {
+        self.init(rawValue)
+    }
+
+    var rawValue: String { "\(self)" }
+}
+
+extension BazelLabel: ExpressibleByStringLiteral {
+    init(stringLiteral value: String) {
+        self.init(value)!
+        // guard let label = self.init(value) else {
+        //     fatalError("Invalid Bazel label: \(value)")
+        // }
+        // self = label
+    }
+}
+
+// struct BazelLabel: Equatble, Hashable, Decodable {
+//     let rawValue: String
+
+//     init(_ labelStr: String) {
+//         self.rawValue = labelStr
+//     }
+// }
+
+// extension BazelLabel: RawRepresentable {
+//     init?
+// }

--- a/tools/generator/src/DTO/BazelLabel.swift
+++ b/tools/generator/src/DTO/BazelLabel.swift
@@ -53,12 +53,6 @@ extension BazelLabel: CustomStringConvertible {
     }
 }
 
-extension BazelLabel: ExpressibleByStringLiteral {
-    init(stringLiteral value: String) {
-        self.init(value)!
-    }
-}
-
 extension BazelLabel: Encodable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()

--- a/tools/generator/src/DTO/BazelLabel.swift
+++ b/tools/generator/src/DTO/BazelLabel.swift
@@ -53,14 +53,6 @@ extension BazelLabel: CustomStringConvertible {
     }
 }
 
-extension BazelLabel: RawRepresentable {
-    init?(rawValue: String) {
-        self.init(rawValue)
-    }
-
-    var rawValue: String { "\(self)" }
-}
-
 extension BazelLabel: ExpressibleByStringLiteral {
     init(stringLiteral value: String) {
         self.init(value)!
@@ -70,7 +62,7 @@ extension BazelLabel: ExpressibleByStringLiteral {
 extension BazelLabel: Encodable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode(rawValue)
+        try container.encode("\(self)")
     }
 }
 

--- a/tools/generator/src/DTO/BazelLabel.swift
+++ b/tools/generator/src/DTO/BazelLabel.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct BazelLabel: Equatable, Hashable, Decodable {
+struct BazelLabel: Equatable, Hashable {
     let repository: String
     let package: String
     let name: String
@@ -63,6 +63,21 @@ extension BazelLabel: RawRepresentable {
 
 extension BazelLabel: ExpressibleByStringLiteral {
     init(stringLiteral value: String) {
+        self.init(value)!
+    }
+}
+
+extension BazelLabel: Encodable {
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+extension BazelLabel: Decodable {
+    init(from decoder: Decoder) throws {
+        let value = try decoder.singleValueContainer().decode(String.self)
+        // TODO: Switch to throwing an error
         self.init(value)!
     }
 }

--- a/tools/generator/src/DTO/BazelLabel.swift
+++ b/tools/generator/src/DTO/BazelLabel.swift
@@ -1,27 +1,48 @@
+import Foundation
+
 struct BazelLabel: Equatable, Hashable, Decodable {
     let repository: String
     let package: String
     let name: String
 }
 
-// extension BazelLabel {
-//     static func parse(_: String) -> BazelLabel? {
-//         // TODO: IMPLEMENT ME!
-//         return BazelLabel(
-//             repository: "",
-//             package: "",
-//             name: ""
-//         )
-//     }
-// }
-
 extension BazelLabel {
-    init?(_: String) {
-        // TODO: IMPLEMENT ME!
+    static let rootSeparator = "//"
+    static let nameSeparator = ":"
+    static let packageSeparator = "/"
+
+    init?(_ value: String) {
+        let rootParts = value.components(separatedBy: Self.rootSeparator)
+        guard rootParts.count == 2 else {
+            return nil
+        }
+
+        let repository = rootParts[0]
+        let packageAndNameParts = rootParts[1].components(separatedBy: Self.nameSeparator)
+
+        let package: String
+        let name: String
+        if packageAndNameParts.count == 2 {
+            package = packageAndNameParts[0]
+            name = packageAndNameParts[1]
+        } else if packageAndNameParts.count == 1 {
+            package = packageAndNameParts[0]
+            guard package != "" else {
+              return nil
+            }
+            let packageParts = package.components(separatedBy: Self.packageSeparator)
+            guard let lastPart = packageParts.last else {
+              return nil
+            }
+            name = lastPart
+        } else {
+            return nil
+        }
+
         self.init(
-            repository: "",
-            package: "",
-            name: ""
+            repository: repository,
+            package: package,
+            name: name
         )
     }
 }
@@ -43,21 +64,5 @@ extension BazelLabel: RawRepresentable {
 extension BazelLabel: ExpressibleByStringLiteral {
     init(stringLiteral value: String) {
         self.init(value)!
-        // guard let label = self.init(value) else {
-        //     fatalError("Invalid Bazel label: \(value)")
-        // }
-        // self = label
     }
 }
-
-// struct BazelLabel: Equatble, Hashable, Decodable {
-//     let rawValue: String
-
-//     init(_ labelStr: String) {
-//         self.rawValue = labelStr
-//     }
-// }
-
-// extension BazelLabel: RawRepresentable {
-//     init?
-// }

--- a/tools/generator/test/BazelLabel+TestExtensions.swift
+++ b/tools/generator/test/BazelLabel+TestExtensions.swift
@@ -1,0 +1,7 @@
+@testable import generator
+
+extension BazelLabel: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self.init(value)!
+    }
+}

--- a/tools/generator/test/BazelLabelTests.swift
+++ b/tools/generator/test/BazelLabelTests.swift
@@ -42,15 +42,6 @@ class BazelLabelTests: XCTestCase {
         XCTAssertEqual("//foo/bar:bar", actual)
     }
 
-    func test_rawRepresentable() throws {
-        let rawValue = "//foo/bar:hello"
-        guard let label = BazelLabel(rawValue: rawValue) else {
-            XCTFail("Expected a label")
-            return
-        }
-        XCTAssertEqual(rawValue, label.rawValue)
-    }
-
     func test_encodingAndDecoding() throws {
         let label: BazelLabel = "//foo/bar:hello"
 

--- a/tools/generator/test/BazelLabelTests.swift
+++ b/tools/generator/test/BazelLabelTests.swift
@@ -50,4 +50,17 @@ class BazelLabelTests: XCTestCase {
         }
         XCTAssertEqual(rawValue, label.rawValue)
     }
+
+    func test_encodingAndDecoding() throws {
+        let label: BazelLabel = "//foo/bar:hello"
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(label)
+        let dataStr = String(data: data, encoding: .utf8)!
+        XCTAssertEqual(dataStr, "\"\\/\\/foo\\/bar:hello\"")
+
+        let decoder = JSONDecoder()
+        let result = try decoder.decode(BazelLabel.self, from: data)
+        XCTAssertEqual(label, result)
+    }
 }

--- a/tools/generator/test/BazelLabelTests.swift
+++ b/tools/generator/test/BazelLabelTests.swift
@@ -1,0 +1,9 @@
+import XCTest
+
+@testable import generator
+
+class BazelLabelTests: XCTestCase {
+  func testSomething() {
+      XCTFail("IMPLEMENT ME!")
+  }
+}

--- a/tools/generator/test/BazelLabelTests.swift
+++ b/tools/generator/test/BazelLabelTests.swift
@@ -3,7 +3,51 @@ import XCTest
 @testable import generator
 
 class BazelLabelTests: XCTestCase {
-  func testSomething() {
-      XCTFail("IMPLEMENT ME!")
-  }
+    func test_init_withStringLiteral_noRepository() throws {
+        let label: BazelLabel = "//foo/bar:hello"
+        XCTAssertEqual(label.repository, "")
+        XCTAssertEqual(label.package, "foo/bar")
+        XCTAssertEqual(label.name, "hello")
+    }
+
+    func test_init_withStringLiteral_withRepository() throws {
+        let label: BazelLabel = "@awesome_repo//foo/bar:hello"
+        XCTAssertEqual(label.repository, "@awesome_repo")
+        XCTAssertEqual(label.package, "foo/bar")
+        XCTAssertEqual(label.name, "hello")
+    }
+
+    func test_init_withStringLiteral_noName() throws {
+        let label: BazelLabel = "//foo/bar"
+        XCTAssertEqual(label.repository, "")
+        XCTAssertEqual(label.package, "foo/bar")
+        XCTAssertEqual(label.name, "bar")
+    }
+
+    func test_customString_withRepository() throws {
+        let label: BazelLabel = "@awesome_repo//foo/bar:hello"
+        let actual = "\(label)"
+        XCTAssertEqual("@awesome_repo//foo/bar:hello", actual)
+    }
+
+    func test_customString_noRepository() throws {
+        let label: BazelLabel = "//foo/bar:hello"
+        let actual = "\(label)"
+        XCTAssertEqual("//foo/bar:hello", actual)
+    }
+
+    func test_customString_noName() throws {
+        let label: BazelLabel = "//foo/bar"
+        let actual = "\(label)"
+        XCTAssertEqual("//foo/bar:bar", actual)
+    }
+
+    func test_rawRepresentable() throws {
+        let rawValue = "//foo/bar:hello"
+        guard let label = BazelLabel(rawValue: rawValue) else {
+            XCTFail("Expected a label")
+            return
+        }
+        XCTAssertEqual(rawValue, label.rawValue)
+    }
 }


### PR DESCRIPTION
I implemented the type such that it parses early. If I implemented exactly like `TargetID`, the client of the type would not know if they had a valid value or not. In other words, I wanted to ensure that a `label.name` would not fail.

Once this is merged, I can update the rest of the code to use it.