### PR TITLE
Fix simple BwX projects with unfocused targets

### DIFF
--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -128,6 +128,7 @@
         },
         "test/fixtures/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures:fixture_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -73,6 +73,7 @@
         },
         "test/fixtures/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures:fixture_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/cc/bwb_spec.json
+++ b/test/fixtures/cc/bwb_spec.json
@@ -23,6 +23,7 @@
         "examples/cc/tool/BUILD",
         "test/fixtures/cc/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/cc:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/cc/bwx_spec.json
+++ b/test/fixtures/cc/bwx_spec.json
@@ -23,6 +23,7 @@
         "examples/cc/tool/BUILD",
         "test/fixtures/cc/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/cc:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -59,6 +59,7 @@
         },
         "test/fixtures/command_line/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/command_line:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -59,6 +59,7 @@
         },
         "test/fixtures/command_line/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/command_line:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -33,6 +33,7 @@
         "tools/generator/test/BUILD",
         "test/fixtures/generator/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/generator:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -33,6 +33,7 @@
         "tools/generator/test/BUILD",
         "test/fixtures/generator/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/generator:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/macos_app/bwb_spec.json
+++ b/test/fixtures/macos_app/bwb_spec.json
@@ -25,6 +25,7 @@
         "examples/macos_app/Example/Assets.xcassets",
         "test/fixtures/macos_app/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/macos_app:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/macos_app/bwx_spec.json
+++ b/test/fixtures/macos_app/bwx_spec.json
@@ -23,6 +23,7 @@
         },
         "test/fixtures/macos_app/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/macos_app:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -173,6 +173,7 @@
         "examples/multiplatform/Tool/Info.plist",
         "test/fixtures/multiplatform/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/multiplatform:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -147,6 +147,7 @@
         "examples/multiplatform/Tool/Info.plist",
         "test/fixtures/multiplatform/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/multiplatform:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/simple/bwb_spec.json
+++ b/test/fixtures/simple/bwb_spec.json
@@ -16,6 +16,7 @@
         "examples/simple/BUILD",
         "test/fixtures/simple/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/simple:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/simple/bwx_spec.json
+++ b/test/fixtures/simple/bwx_spec.json
@@ -16,6 +16,7 @@
         "examples/simple/BUILD",
         "test/fixtures/simple/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/simple:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -35,6 +35,7 @@
         },
         "test/fixtures/tvos_app/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/tvos_app:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -35,6 +35,7 @@
         },
         "test/fixtures/tvos_app/BUILD"
     ],
+    "force_bazel_dependencies": false,
     "label": "//test/fixtures/tvos_app:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/tools/generator/src/DTO/Project.swift
+++ b/tools/generator/src/DTO/Project.swift
@@ -10,4 +10,5 @@ struct Project: Equatable, Decodable {
     let extraFiles: Set<FilePath>
     let schemeAutogenerationMode: SchemeAutogenerationMode
     let customXcodeSchemes: [XcodeScheme]
+    let forceBazelDependencies: Bool
 }

--- a/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
+++ b/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
@@ -14,6 +14,7 @@ env -i \
     static func addBazelDependenciesTarget(
         in pbxProj: PBXProj,
         buildMode: BuildMode,
+        forceBazelDependencies: Bool,
         files: [FilePath: File],
         filePathResolver: FilePathResolver,
         xcodeprojBazelLabel: BazelLabel,
@@ -21,6 +22,7 @@ env -i \
         consolidatedTargets: ConsolidatedTargets
     ) throws -> PBXAggregateTarget? {
         guard
+            forceBazelDependencies ||
             buildMode.usesBazelModeBuildScripts ||
             files.containsExternalFiles || files.containsGeneratedFiles
         else {

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -55,6 +55,7 @@ struct Environment {
     let addBazelDependenciesTarget: (
         _ pbxProj: PBXProj,
         _ buildMode: BuildMode,
+        _ addBazelDependenciesTarget: Bool,
         _ files: [FilePath: File],
         _ filePathResolver: FilePathResolver,
         _ xcodeprojBazelLabel: BazelLabel,

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -100,6 +100,7 @@ class Generator {
         let bazelDependencies = try environment.addBazelDependenciesTarget(
             pbxProj,
             buildMode,
+            project.forceBazelDependencies,
             files,
             filePathResolver,
             project.label,

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -32,7 +32,8 @@ enum Fixtures {
             .generated("v/a.txt", includeInNavigator: false),
         ],
         schemeAutogenerationMode: .auto,
-        customXcodeSchemes: []
+        customXcodeSchemes: [],
+        forceBazelDependencies: false
     )
 
     static let extensionPointIdentifiers: [TargetID: ExtensionPointIdentifier] = [

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -22,7 +22,8 @@ final class GeneratorTests: XCTestCase {
             ],
             extraFiles: [],
             schemeAutogenerationMode: .auto,
-            customXcodeSchemes: []
+            customXcodeSchemes: [],
+            forceBazelDependencies: false
         )
         let xccurrentversions: [XCCurrentVersion] = [
             .init(container: "Ex/M.xcdatamodeld", version: "M2.xcdatamodel"),
@@ -309,6 +310,7 @@ final class GeneratorTests: XCTestCase {
         struct AddBazelDependenciesTargetCalled: Equatable {
             let pbxProj: PBXProj
             let buildMode: BuildMode
+            let forceBazelDependencies: Bool
             let files: [FilePath: File]
             let filePathResolver: FilePathResolver
             let xcodeprojBazelLabel: BazelLabel
@@ -321,6 +323,7 @@ final class GeneratorTests: XCTestCase {
         func addBazelDependenciesTarget(
             in pbxProj: PBXProj,
             buildMode: BuildMode,
+            forceBazelDependencies: Bool,
             files: [FilePath: File],
             filePathResolver: FilePathResolver,
             xcodeprojBazelLabel: BazelLabel,
@@ -330,6 +333,7 @@ final class GeneratorTests: XCTestCase {
             addBazelDependenciesTargetCalled.append(.init(
                 pbxProj: pbxProj,
                 buildMode: buildMode,
+                forceBazelDependencies: forceBazelDependencies,
                 files: files,
                 filePathResolver: filePathResolver,
                 xcodeprojBazelLabel: xcodeprojBazelLabel,
@@ -343,6 +347,7 @@ final class GeneratorTests: XCTestCase {
             AddBazelDependenciesTargetCalled(
                 pbxProj: pbxProj,
                 buildMode: buildMode,
+                forceBazelDependencies: project.forceBazelDependencies,
                 files: files,
                 filePathResolver: filePathResolver,
                 xcodeprojBazelLabel: project.label,

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -25,7 +25,14 @@ load(":xcodeproj_aspect.bzl", "xcodeproj_aspect")
 
 # Actions
 
-def _write_json_spec(*, ctx, project_name, configuration, inputs, infos):
+def _write_json_spec(
+        *,
+        ctx,
+        project_name,
+        configuration,
+        inputs,
+        force_bazel_dependencies,
+        infos):
     resource_bundle_informations = depset(
         transitive = [info.resource_bundle_informations for info in infos],
     ).to_list()
@@ -104,6 +111,7 @@ def _write_json_spec(*, ctx, project_name, configuration, inputs, infos):
 "configuration":"{configuration}",\
 "custom_xcode_schemes":{custom_xcode_schemes},\
 "extra_files":{extra_files},\
+"force_bazel_dependencies":{force_bazel_dependencies},\
 "label":"{label}",\
 "name":"{name}",\
 "scheme_autogeneration_mode":"{scheme_autogeneration_mode}",\
@@ -117,6 +125,7 @@ def _write_json_spec(*, ctx, project_name, configuration, inputs, infos):
         configuration = configuration,
         custom_xcode_schemes = custom_xcode_schemes_json,
         extra_files = json.encode(extra_files),
+        force_bazel_dependencies = json.encode(force_bazel_dependencies),
         label = ctx.label,
         name = project_name,
         scheme_autogeneration_mode = ctx.attr.scheme_autogeneration_mode,
@@ -401,6 +410,7 @@ def _xcodeproj_impl(ctx):
         project_name = project_name,
         configuration = configuration,
         inputs = inputs,
+        force_bazel_dependencies = bool(extra_generated),
         infos = infos,
     )
     xccurrentversions_file = _write_xccurrentversions(


### PR DESCRIPTION
Fixes #705.

We now correctly include the `BazelDependencies` target.

This isn't perfect, there is still situations which we should include `BazelDependencies` but we aren't, but they can be addressed with further Focused Projects work.