### PR TITLE
Use `$BAZEL_OUT` for Bazel generated swift modules

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1767,7 +1767,7 @@
 				SUPPORTED_PLATFORMS = iphonesimulator;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG AWESOME";
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -311,7 +311,12 @@
             },
             "modulemaps": [],
             "name": "Example",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Example/Example.app",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Example",
             "platform": {
                 "arch": "x86_64",
@@ -398,7 +403,22 @@
                 }
             ],
             "name": "Example.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Example/Example.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Example/Example.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Example/Example.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Example",
             "platform": {
                 "arch": "x86_64",
@@ -561,7 +581,12 @@
             },
             "modulemaps": [],
             "name": "ExampleObjcTests.__internal__.__test_bundle",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleObjcTests/ExampleObjcTests.xctest",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleObjcTests",
             "platform": {
                 "arch": "x86_64",
@@ -863,7 +888,12 @@
             },
             "modulemaps": [],
             "name": "ExampleTests.__internal__.__test_bundle",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleTests/ExampleTests.xctest",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleTests",
             "platform": {
                 "arch": "x86_64",
@@ -955,7 +985,22 @@
                 }
             ],
             "name": "ExampleTests.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleTests/ExampleTests.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleTests/ExampleTests.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleTests/ExampleTests.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleTests",
             "platform": {
                 "arch": "x86_64",
@@ -1052,7 +1097,12 @@
             },
             "modulemaps": [],
             "name": "ExampleUITests.__internal__.__test_bundle",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleUITests/ExampleUITests.xctest",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
@@ -1117,7 +1167,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "ExampleUITests.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleUITests/ExampleUITests.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleUITests/ExampleUITests.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleUITests/ExampleUITests.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
@@ -1230,7 +1295,26 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "TestingUtils",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils/TestingUtils.swiftdoc",
+                        "t": "g"
+                    },
+                    "h": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils/SwiftAPI/TestingUtils-Swift.h",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils/TestingUtils.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils/TestingUtils.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils",
             "platform": {
                 "arch": "x86_64",

--- a/test/fixtures/cc/bwx_spec.json
+++ b/test/fixtures/cc/bwx_spec.json
@@ -302,7 +302,12 @@
             },
             "modulemaps": [],
             "name": "tool",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/examples/cc/tool/tool",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/examples/cc/tool",
             "platform": {
                 "arch": "x86_64",

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -1210,7 +1210,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -161,7 +161,12 @@
             },
             "modulemaps": [],
             "name": "LibSwiftTests.__internal__.__test_bundle",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/Tests",
             "platform": {
                 "arch": "x86_64",
@@ -259,7 +264,22 @@
                 }
             ],
             "name": "LibSwiftTestsLib",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/Tests/LibSwiftTestsLib.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/Tests/LibSwiftTestsLib.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/Tests/LibSwiftTestsLib.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/Tests",
             "platform": {
                 "arch": "x86_64",
@@ -472,7 +492,26 @@
                 }
             ],
             "name": "lib_swift",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/LibSwift.swiftdoc",
+                        "t": "g"
+                    },
+                    "h": {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/private/LibSwift-Swift.h",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/LibSwift.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/LibSwift.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
@@ -783,7 +822,12 @@
             },
             "modulemaps": [],
             "name": "tool",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool/tool",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool",
             "platform": {
                 "arch": "x86_64",

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -2331,7 +2331,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml $(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -2464,7 +2464,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -2501,7 +2501,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections $(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit $(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml $(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj $(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator $(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay $(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -2592,7 +2592,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections $(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit $(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml $(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -122,7 +122,12 @@
             },
             "modulemaps": [],
             "name": "tests",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/test/tests.xctest",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/test",
             "platform": {
                 "arch": "x86_64",
@@ -216,7 +221,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "tests.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/test/tests.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/test/tests.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/test/tests.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/test",
             "platform": {
                 "arch": "x86_64",
@@ -337,7 +357,12 @@
             },
             "modulemaps": [],
             "name": "generator",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/generator",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator",
             "platform": {
                 "arch": "x86_64",
@@ -447,7 +472,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "generator.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/generator.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/generator.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/generator.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator",
             "platform": {
                 "arch": "x86_64",
@@ -723,7 +763,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "OrderedCollections",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_apple_swift_collections",
             "platform": {
                 "arch": "x86_64",
@@ -786,7 +841,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "PathKit",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_kylef_pathkit/PathKit.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_kylef_pathkit/PathKit.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_kylef_pathkit",
             "platform": {
                 "arch": "x86_64",
@@ -947,7 +1017,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "CustomDump",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_swift_custom_dump",
             "platform": {
                 "arch": "x86_64",
@@ -1015,7 +1100,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "XCTestDynamicOverlay",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_xctest_dynamic_overlay",
             "platform": {
                 "arch": "x86_64",
@@ -1094,7 +1194,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "AEXML",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tadija_aexml/AEXML.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tadija_aexml/AEXML.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tadija_aexml",
             "platform": {
                 "arch": "x86_64",
@@ -1536,7 +1651,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "XcodeProj",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tuist_xcodeproj",
             "platform": {
                 "arch": "x86_64",

--- a/test/fixtures/macos_app/bwx_spec.json
+++ b/test/fixtures/macos_app/bwx_spec.json
@@ -91,7 +91,12 @@
             },
             "modulemaps": [],
             "name": "Example",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin/examples/macos_app/Example/Example.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin/examples/macos_app/Example",
             "platform": {
                 "arch": "x86_64",
@@ -161,7 +166,22 @@
                 "examples/macos_app/third_party/ExampleFramework.framework/Modules/module.modulemap"
             ],
             "name": "Example.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin/examples/macos_app/Example/iOSApp.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin/examples/macos_app/Example/iOSApp.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin/examples/macos_app/Example/iOSApp.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin/examples/macos_app/Example",
             "platform": {
                 "arch": "x86_64",

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -2607,8 +2607,8 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -2734,8 +2734,8 @@
 				SDKROOT = watchos;
 				SUPPORTED_PLATFORMS = "watchsimulator watchos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib";
-				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -2807,8 +2807,8 @@
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib";
-				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -2894,8 +2894,8 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -3085,8 +3085,8 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -3251,8 +3251,8 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib";
-				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -316,7 +316,12 @@
             },
             "modulemaps": [],
             "name": "AppClip",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/AppClip/AppClip.ipa",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "arm64",
@@ -435,7 +440,12 @@
             },
             "modulemaps": [],
             "name": "AppClip",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/AppClip/AppClip.ipa",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "x86_64",
@@ -518,7 +528,22 @@
                 }
             ],
             "name": "AppClip.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/AppClip/AppClip.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/AppClip/AppClip.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/AppClip/AppClip.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "arm64",
@@ -605,7 +630,22 @@
                 }
             ],
             "name": "AppClip.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/AppClip/AppClip.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/AppClip/AppClip.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/AppClip/AppClip.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "x86_64",
@@ -693,7 +733,22 @@
                 }
             ],
             "name": "Lib",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib/Lib.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64",
@@ -775,7 +830,22 @@
                 }
             ],
             "name": "Lib",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib/Lib.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
@@ -858,7 +928,22 @@
                 }
             ],
             "name": "Lib",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/Lib/Lib.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64",
@@ -940,7 +1025,22 @@
                 }
             ],
             "name": "Lib",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/Lib/Lib.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
@@ -1023,7 +1123,22 @@
                 }
             ],
             "name": "Lib",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/Lib/Lib.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64_32",
@@ -1105,7 +1220,22 @@
                 }
             ],
             "name": "Lib",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/Lib/Lib.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
@@ -1192,7 +1322,12 @@
             },
             "modulemaps": [],
             "name": "Tool",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool/Tool",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool",
             "platform": {
                 "arch": "x86_64",
@@ -1252,7 +1387,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "Tool.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool/Tool.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool/Tool.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool/Tool.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool",
             "platform": {
                 "arch": "x86_64",
@@ -1353,7 +1503,12 @@
             },
             "modulemaps": [],
             "name": "WidgetExtension",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/WidgetExtension/WidgetExtension.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "arm64",
@@ -1467,7 +1622,12 @@
             },
             "modulemaps": [],
             "name": "WidgetExtension",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/WidgetExtension/WidgetExtension.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "x86_64",
@@ -1553,7 +1713,22 @@
                 }
             ],
             "name": "WidgetExtension.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "arm64",
@@ -1643,7 +1818,22 @@
                 }
             ],
             "name": "WidgetExtension.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "x86_64",
@@ -1737,7 +1927,12 @@
             },
             "modulemaps": [],
             "name": "iMessageApp",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp/iMessageApp.ipa",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
@@ -1810,7 +2005,12 @@
             },
             "modulemaps": [],
             "name": "iMessageApp",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp/iMessageApp.ipa",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
@@ -1913,7 +2113,12 @@
             },
             "modulemaps": [],
             "name": "iMessageAppExtension",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
@@ -2028,7 +2233,12 @@
             },
             "modulemaps": [],
             "name": "iMessageAppExtension",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
@@ -2110,7 +2320,22 @@
                 }
             ],
             "name": "iMessageAppExtension.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
@@ -2196,7 +2421,22 @@
                 }
             ],
             "name": "iMessageAppExtension.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
@@ -2354,7 +2594,12 @@
             },
             "modulemaps": [],
             "name": "iOSApp",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iOSApp/iOSApp.ipa",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "arm64",
@@ -2525,7 +2770,12 @@
             },
             "modulemaps": [],
             "name": "iOSApp",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iOSApp/iOSApp.ipa",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "x86_64",
@@ -2640,7 +2890,22 @@
                 }
             ],
             "name": "iOSApp.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iOSApp/iOSApp.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iOSApp/iOSApp.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iOSApp/iOSApp.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "arm64",
@@ -2759,7 +3024,22 @@
                 }
             ],
             "name": "iOSApp.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iOSApp/iOSApp.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iOSApp/iOSApp.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iOSApp/iOSApp.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "x86_64",
@@ -2900,7 +3180,12 @@
             },
             "modulemaps": [],
             "name": "tvOSApp",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp/tvOSApp.ipa",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "arm64",
@@ -3014,7 +3299,12 @@
             },
             "modulemaps": [],
             "name": "tvOSApp",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/tvOSApp/tvOSApp.ipa",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "x86_64",
@@ -3097,7 +3387,22 @@
                 }
             ],
             "name": "tvOSApp.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp/iOSApp.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp/iOSApp.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp/iOSApp.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "arm64",
@@ -3184,7 +3489,22 @@
                 }
             ],
             "name": "tvOSApp.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/tvOSApp/iOSApp.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/tvOSApp/iOSApp.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/tvOSApp/iOSApp.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "x86_64",
@@ -3277,7 +3597,12 @@
             },
             "modulemaps": [],
             "name": "watchOSApp",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSApp/watchOSApp.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSApp",
             "platform": {
                 "arch": "arm64_32",
@@ -3349,7 +3674,12 @@
             },
             "modulemaps": [],
             "name": "watchOSApp",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSApp/watchOSApp.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSApp",
             "platform": {
                 "arch": "x86_64",
@@ -3451,7 +3781,12 @@
             },
             "modulemaps": [],
             "name": "watchOSAppExtension",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "arm64_32",
@@ -3565,7 +3900,12 @@
             },
             "modulemaps": [],
             "name": "watchOSAppExtension",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "x86_64",
@@ -3648,7 +3988,22 @@
                 }
             ],
             "name": "watchOSAppExtension.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "arm64_32",
@@ -3735,7 +4090,22 @@
                 }
             ],
             "name": "watchOSAppExtension.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "x86_64",

--- a/test/fixtures/simple/bwx_spec.json
+++ b/test/fixtures/simple/bwx_spec.json
@@ -59,7 +59,12 @@
             },
             "modulemaps": [],
             "name": "SwiftBin",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "darwin_x86_64-dbg-ST-ccd9595da841/bin/examples/simple/SwiftBin",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/examples/simple",
             "platform": {
                 "arch": "x86_64",

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -822,7 +822,7 @@
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = appletvsimulator;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -108,7 +108,12 @@
             },
             "modulemaps": [],
             "name": "Example",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/Example/Example.ipa",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/Example",
             "platform": {
                 "arch": "x86_64",
@@ -170,7 +175,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "Example.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/Example/Example.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/Example/Example.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/Example/Example.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/Example",
             "platform": {
                 "arch": "x86_64",
@@ -251,7 +271,12 @@
             },
             "modulemaps": [],
             "name": "ExampleTests.__internal__.__test_bundle",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleTests",
             "platform": {
                 "arch": "x86_64",
@@ -315,7 +340,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "ExampleTests.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleTests",
             "platform": {
                 "arch": "x86_64",
@@ -400,7 +440,12 @@
             },
             "modulemaps": [],
             "name": "ExampleUITests.__internal__.__test_bundle",
-            "outputs": {},
+            "outputs": {
+                "p": {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle.zip",
+                    "t": "g"
+                }
+            },
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
@@ -463,7 +508,22 @@
             "linker_inputs": {},
             "modulemaps": [],
             "name": "ExampleUITests.library",
-            "outputs": {},
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleUITests",
             "platform": {
                 "arch": "x86_64",

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -75,7 +75,8 @@ extension Generator {
         logger: Logger
     ) throws -> (
         files: [FilePath: File],
-        rootElements: [PBXFileElement]
+        rootElements: [PBXFileElement],
+        xcodeGeneratedFiles: Set<FilePath>
     ) {
         var fileReferences: [FilePath: PBXFileReference] = [:]
         var groups: [FilePath: PBXGroup] = [:]
@@ -573,7 +574,19 @@ extension Generator {
         knownRegions.remove("Base")
         pbxProj.rootObject!.knownRegions = knownRegions.sorted() + ["Base"]
 
-        return (files, rootElements)
+        var xcodeGeneratedFiles: Set<FilePath> = []
+        switch buildMode {
+        case .xcode:
+            for (_, target) in targets {
+                if let filePath = target.outputs.swift?.module {
+                    xcodeGeneratedFiles.insert(filePath)
+                }
+            }
+        default:
+            break
+        }
+
+        return (files, rootElements, xcodeGeneratedFiles)
     }
 
     private static func setXCCurrentVersions(

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -33,7 +33,8 @@ struct Environment {
         _ logger: Logger
     ) throws -> (
         files: [FilePath: File],
-        rootElements: [PBXFileElement]
+        rootElements: [PBXFileElement],
+        xcodeGeneratedFiles: Set<FilePath>
     )
 
     let createProducts: (
@@ -79,6 +80,7 @@ struct Environment {
         _ buildMode: BuildMode,
         _ pbxTargets: [ConsolidatedTarget.Key: PBXTarget],
         _ hostIDs: [TargetID: [TargetID]],
+        _ xcodeGeneratedFiles: Set<FilePath>,
         _ filePathResolver: FilePathResolver
     ) throws -> Void
 

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -74,7 +74,11 @@ class Generator {
             logger
         )
 
-        let (files, rootElements) = try environment.createFilesAndGroups(
+        let (
+            files,
+            rootElements,
+            xcodeGeneratedFiles
+        ) = try environment.createFilesAndGroups(
             pbxProj,
             buildMode,
             targets,
@@ -122,6 +126,7 @@ class Generator {
             buildMode,
             pbxTargets,
             project.targetHosts,
+            xcodeGeneratedFiles,
             filePathResolver
         )
         try environment.setTargetDependencies(

--- a/tools/generator/test/AddTargetsTests.swift
+++ b/tools/generator/test/AddTargetsTests.swift
@@ -25,8 +25,8 @@ final class AddTargetsTests: XCTestCase {
             workspaceOutputPath: workspaceOutputPath
         )
 
-        let (files, _) = Fixtures.files(in: pbxProj, parentGroup: mainGroup)
-        let (expectedFiles, _) = Fixtures.files(
+        let (files, _, _) = Fixtures.files(in: pbxProj, parentGroup: mainGroup)
+        let (expectedFiles, _, _) = Fixtures.files(
             in: expectedPBXProj,
             parentGroup: expectedMainGroup
         )

--- a/tools/generator/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generator/test/CreateFilesAndGroupsTests.swift
@@ -50,7 +50,8 @@ final class CreateFilesAndGroupsTests: XCTestCase {
 
         let (
             createdFiles,
-            createdRootElements
+            createdRootElements,
+            _
         ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             buildMode: .xcode,
@@ -95,7 +96,11 @@ final class CreateFilesAndGroupsTests: XCTestCase {
             workspaceOutputPath: workspaceOutputPath
         )
 
-        let (expectedFiles, expectedElements) = Fixtures.files(
+        let (
+            expectedFiles,
+            expectedElements,
+            expectedXcodeGeneratedFiles
+        ) = Fixtures.files(
             in: expectedPBXProj,
             internalDirectoryName: internalDirectoryName,
             workspaceOutputPath: workspaceOutputPath
@@ -133,7 +138,8 @@ final class CreateFilesAndGroupsTests: XCTestCase {
 
         let (
             createdFiles,
-            createdRootElements
+            createdRootElements,
+            xcodeGeneratedFiles
         ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             buildMode: .xcode,
@@ -158,6 +164,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
             createdFiles.map(KeyAndValue.init).sorted(),
             expectedFiles.map(KeyAndValue.init).sorted()
         )
+        XCTAssertNoDifference(xcodeGeneratedFiles, expectedXcodeGeneratedFiles)
 
         XCTAssertNoDifference(pbxProj, expectedPBXProj)
     }

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -86,7 +86,7 @@ final class GeneratorTests: XCTestCase {
                 ),
             ]
         )
-        let (files, filesAndGroups) = Fixtures.files(
+        let (files, filesAndGroups, xcodeGeneratedFiles) = Fixtures.files(
             in: pbxProj,
             internalDirectoryName: internalDirectoryName,
             workspaceOutputPath: workspaceOutputPath
@@ -208,7 +208,8 @@ final class GeneratorTests: XCTestCase {
             logger _: Logger
         ) -> (
             files: [FilePath: File],
-            rootElements: [PBXFileElement]
+            rootElements: [PBXFileElement],
+            xcodeGeneratedFiles: Set<FilePath>
         ) {
             createFilesAndGroupsCalled.append(.init(
                 pbxProj: pbxProj,
@@ -218,7 +219,7 @@ final class GeneratorTests: XCTestCase {
                 xccurrentversions: xccurrentversions,
                 filePathResolver: filePathResolver
             ))
-            return (files, rootElements)
+            return (files, rootElements, xcodeGeneratedFiles)
         }
 
         let expectedCreateFilesAndGroupsCalled = [CreateFilesAndGroupsCalled(
@@ -408,6 +409,7 @@ final class GeneratorTests: XCTestCase {
             let buildMode: BuildMode
             let pbxTargets: [ConsolidatedTarget.Key: PBXTarget]
             let hostIDs: [TargetID: [TargetID]]
+            let xcodeGeneratedFiles: Set<FilePath>
             let filePathResolver: FilePathResolver
         }
 
@@ -418,6 +420,7 @@ final class GeneratorTests: XCTestCase {
             buildMode: BuildMode,
             pbxTargets: [ConsolidatedTarget.Key: PBXTarget],
             hostIDs: [TargetID: [TargetID]],
+            xcodeGeneratedFiles: Set<FilePath>,
             filePathResolver: FilePathResolver
         ) {
             setTargetConfigurationsCalled.append(.init(
@@ -426,6 +429,7 @@ final class GeneratorTests: XCTestCase {
                 buildMode: buildMode,
                 pbxTargets: pbxTargets,
                 hostIDs: hostIDs,
+                xcodeGeneratedFiles: xcodeGeneratedFiles,
                 filePathResolver: filePathResolver
             ))
         }
@@ -437,6 +441,7 @@ final class GeneratorTests: XCTestCase {
                 buildMode: buildMode,
                 pbxTargets: pbxTargets,
                 hostIDs: project.targetHosts,
+                xcodeGeneratedFiles: xcodeGeneratedFiles,
                 filePathResolver: filePathResolver
             ),
         ]

--- a/tools/generator/test/SetTargetConfigurationsTests.swift
+++ b/tools/generator/test/SetTargetConfigurationsTests.swift
@@ -19,7 +19,11 @@ final class SetTargetConfigurationsTests: XCTestCase {
 
         let consolidatedTargets = Fixtures.consolidatedTargets
 
-        let (pbxTargets, disambiguatedTargets) = Fixtures.pbxTargets(
+        let (
+            pbxTargets,
+            disambiguatedTargets,
+            xcodeGeneratedFiles
+        ) = Fixtures.pbxTargets(
             in: pbxProj,
             consolidatedTargets: consolidatedTargets
         )
@@ -36,6 +40,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .xcode,
             pbxTargets: pbxTargets,
             hostIDs: Fixtures.project.targetHosts,
+            xcodeGeneratedFiles: xcodeGeneratedFiles,
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -171,6 +176,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .xcode,
             pbxTargets: pbxTargets,
             hostIDs: [:],
+            xcodeGeneratedFiles: [],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -221,6 +227,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .xcode,
             pbxTargets: pbxTargets,
             hostIDs: [:],
+            xcodeGeneratedFiles: [],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -273,6 +280,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .xcode,
             pbxTargets: pbxTargets,
             hostIDs: [:],
+            xcodeGeneratedFiles: [],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -360,6 +368,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .xcode,
             pbxTargets: pbxTargets,
             hostIDs: [:],
+            xcodeGeneratedFiles: [],
             filePathResolver: Self.filePathResolverFixture
         )
 

--- a/tools/generator/test/SetTargetDependenciesTests.swift
+++ b/tools/generator/test/SetTargetDependenciesTests.swift
@@ -12,7 +12,7 @@ final class SetTargetDependenciesTests: XCTestCase {
 
         let consolidatedTargets = Fixtures.consolidatedTargets
 
-        let (pbxTargets, disambiguatedTargets) = Fixtures.pbxTargets(
+        let (pbxTargets, disambiguatedTargets, _) = Fixtures.pbxTargets(
             in: pbxProj,
             consolidatedTargets: consolidatedTargets
         )

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -29,7 +29,7 @@ def should_include_outputs(ctx):
         `True` for Build with Bazel projects and portions of the build that
         need to build with Bazel (i.e. Focused Projects).
     """
-    return ctx.attr._build_mode[BuildSettingInfo].value != "xcode"
+    return ctx.attr._build_mode[BuildSettingInfo].value != "bazel_via_proxy"
 
 def process_dependencies(*, automatic_target_info, transitive_infos):
     """ Logic for processing target dependencies


### PR DESCRIPTION
Part of #633.

This fixes some compilation error for BwX Focused Projects (e.g. rules_spm). It also unlocks the ability to no longer have to copy swiftmodules into Derived Data, which will be a followup change.