### PR TITLE
Stop copying unfocused swiftmodules

### DIFF
--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -116,10 +116,6 @@ besides their primary top-level targets.
 A value returned from `compilation_providers.collect`, for targets that aren't
 generating Xcode targets.
 """,
-        "non_target_swift_info_modules": """\
-A value returned from `swift_common.create_swift_info`, for targets that aren't
-generating Xcode targets.
-""",
         "outputs": """\
 A value returned from `output_files.collect`, that contains information about
 the output files for this target and its transitive dependencies.


### PR DESCRIPTION
With recent changed we no longer need to copy swiftmodules for compilation or linking.