### PR TITLE
Move `-exported_symbols_list` to be after loads

### DIFF
--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/tool/tool.link.params
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/tool/tool.link.params
@@ -15,7 +15,7 @@ SwiftUI
 -lc++
 -filelist
 $(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/tool/tool.LinkFileList
--exported_symbols_list
-examples/command_line/tool/export_symbol_list.exp
 -force_load
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework
+-exported_symbols_list
+examples/command_line/tool/export_symbol_list.exp

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/tool/tool.link.params
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/tool/tool.link.params
@@ -15,7 +15,7 @@ SwiftUI
 -lc++
 -filelist
 $(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/tool/tool.LinkFileList
--exported_symbols_list
-examples/command_line/tool/export_symbol_list.exp
 -force_load
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework
+-exported_symbols_list
+examples/command_line/tool/export_symbol_list.exp

--- a/tools/generator/src/DTO/Target+LinkerFlags.swift
+++ b/tools/generator/src/DTO/Target+LinkerFlags.swift
@@ -25,29 +25,23 @@ extension Target {
             flags.append(contentsOf: ["-filelist", linkFileList.quoted])
         }
 
-        let exportedSymbolsLists = inputs.exportedSymbolsLists
-        if !exportedSymbolsLists.isEmpty {
-            flags.append(
-                contentsOf: try exportedSymbolsLists.flatMap { filePath in
-                    return [
-                        "-exported_symbols_list",
-                        try filePathResolver.resolve(filePath).string.quoted,
-                    ]
-                }
-            )
-        }
+        flags.append(
+            contentsOf: try linkerInputs.forceLoad.flatMap { filePath in
+                return [
+                    "-force_load",
+                    try filePathResolver.resolve(filePath).string.quoted,
+                ]
+            }
+        )
 
-        let forceLoadLibraries = linkerInputs.forceLoad
-        if !forceLoadLibraries.isEmpty {
-            flags.append(
-                contentsOf: try forceLoadLibraries.flatMap { filePath in
-                    return [
-                        "-force_load",
-                        try filePathResolver.resolve(filePath).string.quoted,
-                    ]
-                }
-            )
-        }
+        flags.append(
+            contentsOf: try inputs.exportedSymbolsLists.flatMap { filePath in
+                return [
+                    "-exported_symbols_list",
+                    try filePathResolver.resolve(filePath).string.quoted,
+                ]
+            }
+        )
 
         return flags
     }


### PR DESCRIPTION
This mimics Bazel better.