### PR TITLE
Move link files into `link.params`

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/Example/Example.LinkFileList
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/Example/Example.LinkFileList
@@ -1,2 +1,0 @@
-test/fixtures/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/libUtils.a
-test/fixtures/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/libCoreUtilsObjC.a

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/Example/Example.link.params
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/Example/Example.link.params
@@ -9,5 +9,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/Example/Example.LinkFileList
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/libUtils.a
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/libCoreUtilsObjC.a

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/libTestingUtils.a

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.link.params
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.link.params
@@ -9,5 +9,4 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/libTestingUtils.a

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleTests/ExampleTests.__internal__.__test_bundle.LinkFileList
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleTests/ExampleTests.__internal__.__test_bundle.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/libTestingUtils.a

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleTests/ExampleTests.__internal__.__test_bundle.link.params
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleTests/ExampleTests.__internal__.__test_bundle.link.params
@@ -10,5 +10,4 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleTests/ExampleTests.__internal__.__test_bundle.LinkFileList
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/libTestingUtils.a

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/Example/Example.LinkFileList
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/Example/Example.LinkFileList
@@ -1,2 +1,0 @@
-test/fixtures/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Utils/libUtils.a
-test/fixtures/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/CoreUtilsObjC/libCoreUtilsObjC.a

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/Example/Example.link.params
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/Example/Example.link.params
@@ -9,5 +9,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/Example/Example.LinkFileList
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Utils/libUtils.a
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/CoreUtilsObjC/libCoreUtilsObjC.a

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils/libTestingUtils.a

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.link.params
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.link.params
@@ -9,5 +9,4 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.LinkFileList
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils/libTestingUtils.a

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/ExampleTests/ExampleTests.__internal__.__test_bundle.LinkFileList
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/ExampleTests/ExampleTests.__internal__.__test_bundle.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils/libTestingUtils.a

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/ExampleTests/ExampleTests.__internal__.__test_bundle.link.params
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/ExampleTests/ExampleTests.__internal__.__test_bundle.link.params
@@ -10,5 +10,4 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/ExampleTests/ExampleTests.__internal__.__test_bundle.LinkFileList
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils/libTestingUtils.a

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/examples/cc/tool/tool.LinkFileList
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/examples/cc/tool/tool.LinkFileList
@@ -1,2 +1,0 @@
-test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib2/liblib_impl.a
-test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/examples_cc_external/liblib_impl.a

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/examples/cc/tool/tool.link.params
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/examples/cc/tool/tool.link.params
@@ -1,7 +1,7 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-5534cb307cb8/examples/cc/tool/tool.LinkFileList
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib2/liblib_impl.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/examples_cc_external/liblib_impl.a
 -force_load
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib/liblib_impl.lo

--- a/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/examples/cc/tool/tool.LinkFileList
+++ b/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/examples/cc/tool/tool.LinkFileList
@@ -1,2 +1,0 @@
-test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/examples/cc/lib2/liblib_impl.a
-test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/examples_cc_external/liblib_impl.a

--- a/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/examples/cc/tool/tool.link.params
+++ b/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/examples/cc/tool/tool.link.params
@@ -1,7 +1,7 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-ccd9595da841/examples/cc/tool/tool.LinkFileList
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/examples/cc/lib2/liblib_impl.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/examples_cc_external/liblib_impl.a
 -force_load
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/examples/cc/lib/liblib_impl.lo

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.LinkFileList
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.LinkFileList
@@ -1,5 +1,0 @@
-test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_swift.a
-test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/swift_c_module/libc_lib.a
-test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/libprivate_lib.a
-test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_impl.a
-test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/links/external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.link.params
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.link.params
@@ -13,7 +13,10 @@ SwiftUI
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.LinkFileList
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_swift.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/swift_c_module/libc_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/libprivate_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_impl.a
+$(BAZEL_EXTERNAL)/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
 -force_load
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/tool/tool.LinkFileList
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/tool/tool.LinkFileList
@@ -1,5 +1,0 @@
-test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_swift.a
-test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/swift_c_module/libc_lib.a
-test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/libprivate_lib.a
-test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_impl.a
-test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/links/external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/tool/tool.link.params
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/tool/tool.link.params
@@ -13,8 +13,11 @@ SwiftUI
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/tool/tool.LinkFileList
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_swift.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/swift_c_module/libc_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/libprivate_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_impl.a
+$(BAZEL_EXTERNAL)/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
 -force_load
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -exported_symbols_list

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.LinkFileList
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.LinkFileList
@@ -1,5 +1,0 @@
-test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/liblib_swift.a
-test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/swift_c_module/libc_lib.a
-test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/libprivate_lib.a
-test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/liblib_impl.a
-test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/links/external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.link.params
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.link.params
@@ -13,7 +13,10 @@ SwiftUI
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.LinkFileList
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/liblib_swift.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/swift_c_module/libc_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/libprivate_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/liblib_impl.a
+$(BAZEL_EXTERNAL)/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
 -force_load
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/tool/tool.LinkFileList
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/tool/tool.LinkFileList
@@ -1,5 +1,0 @@
-test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/liblib_swift.a
-test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/swift_c_module/libc_lib.a
-test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/libprivate_lib.a
-test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/liblib_impl.a
-test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/links/external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/tool/tool.link.params
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/tool/tool.link.params
@@ -13,8 +13,11 @@ SwiftUI
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/tool/tool.LinkFileList
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/liblib_swift.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/swift_c_module/libc_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/libprivate_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/liblib_impl.a
+$(BAZEL_EXTERNAL)/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
 -force_load
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -exported_symbols_list

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/generator.LinkFileList
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/generator.LinkFileList
@@ -1,5 +1,0 @@
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/libgenerator.library.a
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/libAEXML.a
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/libPathKit.a

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/generator.link.params
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/generator.link.params
@@ -11,5 +11,8 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/generator.LinkFileList
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/libgenerator.library.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/libAEXML.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/libPathKit.a

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/test/tests.LinkFileList
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/test/tests.LinkFileList
@@ -1,7 +1,0 @@
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/libgenerator.library.a
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/libAEXML.a
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/libPathKit.a
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
-test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/test/tests.link.params
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/test/tests.link.params
@@ -14,5 +14,10 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/test/tests.LinkFileList
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/libgenerator.library.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/libAEXML.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/libPathKit.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/tools/generator/generator.LinkFileList
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/tools/generator/generator.LinkFileList
@@ -1,5 +1,0 @@
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/libgenerator.library.a
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tadija_aexml/libAEXML.a
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_kylef_pathkit/libPathKit.a

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/tools/generator/generator.link.params
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/tools/generator/generator.link.params
@@ -11,5 +11,8 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-ccd9595da841/tools/generator/generator.LinkFileList
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/libgenerator.library.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tadija_aexml/libAEXML.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_kylef_pathkit/libPathKit.a

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/tools/generator/test/tests.LinkFileList
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/tools/generator/test/tests.LinkFileList
@@ -1,7 +1,0 @@
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/libgenerator.library.a
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tadija_aexml/libAEXML.a
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_kylef_pathkit/libPathKit.a
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
-test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/tools/generator/test/tests.link.params
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-ccd9595da841/tools/generator/test/tests.link.params
@@ -14,5 +14,10 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-ccd9595da841/tools/generator/test/tests.LinkFileList
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/libgenerator.library.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tadija_aexml/libAEXML.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_kylef_pathkit/libPathKit.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/AppClip/AppClip.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/AppClip/AppClip.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/AppClip/AppClip.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/AppClip/AppClip.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/AppClip/AppClip.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iOSApp/iOSApp.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iOSApp/iOSApp.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iOSApp/iOSApp.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iOSApp/iOSApp.link.params
@@ -16,7 +16,5 @@ CoreTelephony
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iOSApp/iOSApp.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/AppClip/AppClip.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/AppClip/AppClip.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/AppClip/AppClip.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/AppClip/AppClip.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/AppClip/AppClip.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iOSApp/iOSApp.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iOSApp/iOSApp.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iOSApp/iOSApp.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iOSApp/iOSApp.link.params
@@ -16,7 +16,5 @@ CoreTelephony
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iOSApp/iOSApp.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/examples/multiplatform/tvOSApp/tvOSApp.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/examples/multiplatform/tvOSApp/tvOSApp.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/examples/multiplatform/tvOSApp/tvOSApp.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/examples/multiplatform/tvOSApp/tvOSApp.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/links/gen_dir/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/AppClip/AppClip.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/AppClip/AppClip.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/AppClip/AppClip.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/AppClip/AppClip.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/AppClip/AppClip.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/iOSApp/iOSApp.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/iOSApp/iOSApp.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/iOSApp/iOSApp.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/iOSApp/iOSApp.link.params
@@ -16,7 +16,5 @@ CoreTelephony
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/examples/multiplatform/iOSApp/iOSApp.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/AppClip/AppClip.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/AppClip/AppClip.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/AppClip/AppClip.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/AppClip/AppClip.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/AppClip/AppClip.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/WidgetExtension/WidgetExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/iMessageApp/iMessageAppExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/iOSApp/iOSApp.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/iOSApp/iOSApp.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/iOSApp/iOSApp.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/iOSApp/iOSApp.link.params
@@ -16,7 +16,5 @@ CoreTelephony
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/examples/multiplatform/iOSApp/iOSApp.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/examples/multiplatform/tvOSApp/tvOSApp.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/examples/multiplatform/tvOSApp/tvOSApp.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/examples/multiplatform/tvOSApp/tvOSApp.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/examples/multiplatform/tvOSApp/tvOSApp.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/examples/multiplatform/tvOSApp/tvOSApp.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
@@ -1,1 +1,0 @@
-test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/links/gen_dir/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
@@ -8,7 +8,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--filelist
-$(INTERNAL_DIR)/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.LinkFileList
 -force_load
 $(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/Lib/libLib.a

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -542,18 +542,6 @@ extension Generator {
         }
 
         for target in targets.values {
-            let linkFiles = try target.linkerInputs.staticLibraries
-                .map { filePath in
-                    return """
-\(try filePathResolver.resolve(filePath, useGenDir: true, mode: .srcRoot))
-
-"""
-                }
-            if !linkFiles.isEmpty {
-                files[try target.linkFileListFilePath()] =
-                    .nonReferencedContent(linkFiles.joined())
-            }
-
             let linkopts = try target
                 .allLinkerFlags(
                     xcodeGeneratedFiles: xcodeGeneratedFiles,

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -562,10 +562,6 @@ extension Target {
         return Path(components: components)
     }
 
-    func linkFileListFilePath() throws -> FilePath {
-        return try .internal(internalTargetFilesPath() + "\(name).LinkFileList")
-    }
-
     func linkParamsFilePath() throws -> FilePath {
         return try .internal(internalTargetFilesPath() + "\(name).link.params")
     }

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1029,35 +1029,19 @@ $(GEN_DIR)/v/a.txt
 
 """)
 
-        // LinkFileLists
-
-        files[.internal("targets/a1b2c/A 2/A.LinkFileList")] =
-            .nonReferencedContent("""
-\(srcRootGenDir)/a/c.a
-\(srcRootGenDir)/z/A.a
-a/imported.a
-
-""")
-
-        files[.internal("targets/a1b2c/C 2/d.LinkFileList")] =
-            .nonReferencedContent("""
-\(srcRootGenDir)/a/c.a
-
-""")
-
         // link.params
 
         files[.internal("targets/a1b2c/A 2/A.link.params")] =
             .nonReferencedContent("""
--filelist
-"$(INTERNAL_DIR)/targets/a1b2c/A 2/A.LinkFileList"
+$(BUILD_DIR)/bazel-out/a/c.a
+$(BUILD_DIR)/bazel-out/z/A.a
+a/imported.a
 
 """)
 
         files[.internal("targets/a1b2c/C 2/d.link.params")] =
             .nonReferencedContent("""
--filelist
-"$(INTERNAL_DIR)/targets/a1b2c/C 2/d.LinkFileList"
+$(BUILD_DIR)/bazel-out/a/c.a
 
 """)
 


### PR DESCRIPTION
Now that we are using `link.params`, we no longer need to also use `-fileList`. This allows us to set the paths freely, and later we will use this capability to point to Bazel generated files to prevent unnecessary copying.