### PR TITLE
Link to Bazel generated archives via `$BAZEL_OUT`

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/Example/Example.link.params
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/Example/Example.link.params
@@ -9,5 +9,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/libUtils.a
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/libCoreUtilsObjC.a
+$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/libUtils.a
+$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/libCoreUtilsObjC.a

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.link.params
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleObjcTests/ExampleObjcTests.__internal__.__test_bundle.link.params
@@ -9,4 +9,4 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/libTestingUtils.a
+$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/libTestingUtils.a

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleTests/ExampleTests.__internal__.__test_bundle.link.params
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/ExampleTests/ExampleTests.__internal__.__test_bundle.link.params
@@ -10,4 +10,4 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/libTestingUtils.a
+$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/libTestingUtils.a

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/examples/cc/tool/tool.link.params
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/examples/cc/tool/tool.link.params
@@ -1,7 +1,7 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib2/liblib_impl.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/examples_cc_external/liblib_impl.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib2/liblib_impl.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/examples_cc_external/liblib_impl.a
 -force_load
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib/liblib_impl.lo
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib/liblib_impl.lo

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.link.params
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.link.params
@@ -13,10 +13,10 @@ SwiftUI
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_swift.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/swift_c_module/libc_lib.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/libprivate_lib.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_impl.a
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_swift.a
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/swift_c_module/libc_lib.a
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/libprivate_lib.a
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_impl.a
 $(BAZEL_EXTERNAL)/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
 -force_load
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/tool/tool.link.params
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/tool/tool.link.params
@@ -13,10 +13,10 @@ SwiftUI
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_swift.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/swift_c_module/libc_lib.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/libprivate_lib.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_impl.a
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_swift.a
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/swift_c_module/libc_lib.a
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/libprivate_lib.a
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/liblib_impl.a
 $(BAZEL_EXTERNAL)/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
 -force_load
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/generator.link.params
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/generator.link.params
@@ -11,8 +11,8 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/libgenerator.library.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/libAEXML.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/libPathKit.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/libgenerator.library.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/libAEXML.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/libPathKit.a

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/test/tests.link.params
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-5534cb307cb8/tools/generator/test/tests.link.params
@@ -14,10 +14,10 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/libgenerator.library.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/libAEXML.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/libPathKit.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/libgenerator.library.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/libAEXML.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/libPathKit.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/AppClip/AppClip.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/AppClip/AppClip.link.params
@@ -9,4 +9,4 @@
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
@@ -9,4 +9,4 @@
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
@@ -9,4 +9,4 @@
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iOSApp/iOSApp.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/examples/multiplatform/iOSApp/iOSApp.link.params
@@ -17,4 +17,4 @@ CoreTelephony
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/AppClip/AppClip.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/AppClip/AppClip.link.params
@@ -9,4 +9,4 @@
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/WidgetExtension/WidgetExtension.link.params
@@ -9,4 +9,4 @@
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iMessageApp/iMessageAppExtension.link.params
@@ -9,4 +9,4 @@
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iOSApp/iOSApp.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/examples/multiplatform/iOSApp/iOSApp.link.params
@@ -17,4 +17,4 @@ CoreTelephony
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/examples/multiplatform/tvOSApp/tvOSApp.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/examples/multiplatform/tvOSApp/tvOSApp.link.params
@@ -9,4 +9,4 @@
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/examples/multiplatform/tvOSApp/tvOSApp.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/examples/multiplatform/tvOSApp/tvOSApp.link.params
@@ -9,4 +9,4 @@
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
@@ -9,4 +9,4 @@
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib/libLib.a

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/targets/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.link.params
@@ -9,4 +9,4 @@
 -no-canonical-prefixes
 -lc++
 -force_load
-$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib/libLib.a
+$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib/libLib.a

--- a/tools/generator/src/DTO/Target+LinkerFlags.swift
+++ b/tools/generator/src/DTO/Target+LinkerFlags.swift
@@ -25,7 +25,13 @@ extension Target {
                 guard !forceLoad.contains(filePath) else {
                     return nil
                 }
-                return try filePathResolver.resolve(filePath).string.quoted
+                return try filePathResolver
+                    .resolve(
+                        filePath,
+                        useOriginalGeneratedFiles:
+                            !xcodeGeneratedFiles.contains(filePath)
+                    )
+                    .string.quoted
             }
         )
 
@@ -33,7 +39,13 @@ extension Target {
             .flatMap { filePath in
                 return [
                     "-force_load",
-                    try filePathResolver.resolve(filePath).string.quoted,
+                    try filePathResolver
+                        .resolve(
+                            filePath,
+                            useOriginalGeneratedFiles:
+                                !xcodeGeneratedFiles.contains(filePath)
+                        )
+                        .string.quoted,
                 ]
             }
         )

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -533,6 +533,7 @@ extension Generator {
         switch buildMode {
         case .xcode:
             for (_, target) in targets {
+                xcodeGeneratedFiles.insert(target.product.path)
                 if let filePath = target.outputs.swift?.module {
                     xcodeGeneratedFiles.insert(filePath)
                 }

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1045,7 +1045,31 @@ $(BUILD_DIR)/bazel-out/a/c.a
 
 """)
 
-        return (files, elements, [.generated("x/y.swiftmodule")])
+        // `xcodegeneratedfiles`
+
+        let xcodeGeneratedFiles: Set<FilePath> = [
+            .generated("z/A.a"),
+            .generated("x/y.swiftmodule"),
+            .generated("z/A.app"),
+            .generated("z/AC.app"),
+            .generated("a/b.framework"),
+            .generated("B.xctest"),
+            .generated("B3.xctest"),
+            .generated("a/c.a"),
+            .generated("d"),
+            .generated("e1/E.a"),
+            .generated("e2/E.a"),
+            .generated("z/I.app"),
+            .generated("r1/R1.bundle"),
+            .generated("T/T 1/T.a"),
+            .generated("T/T 2/T.a"),
+            .generated("T/T 3/T.a"),
+            .generated("z/W.app"),
+            .generated("z/WDK.appex"),
+            .generated("z/WK.appex"),
+        ]
+
+        return (files, elements, xcodeGeneratedFiles)
     }
 
     static func products(


### PR DESCRIPTION
This will allow us to stop copying over unfocused archives in BwX mode.