### PR TITLE
Improve `force_bazel_dependencies` check

### DIFF
--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -128,7 +128,7 @@
         },
         "test/fixtures/BUILD"
     ],
-    "force_bazel_dependencies": false,
+    "force_bazel_dependencies": true,
     "label": "//test/fixtures:fixture_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -73,7 +73,7 @@
         },
         "test/fixtures/BUILD"
     ],
-    "force_bazel_dependencies": false,
+    "force_bazel_dependencies": true,
     "label": "//test/fixtures:fixture_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -59,7 +59,7 @@
         },
         "test/fixtures/command_line/BUILD"
     ],
-    "force_bazel_dependencies": false,
+    "force_bazel_dependencies": true,
     "label": "//test/fixtures/command_line:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -59,7 +59,7 @@
         },
         "test/fixtures/command_line/BUILD"
     ],
-    "force_bazel_dependencies": false,
+    "force_bazel_dependencies": true,
     "label": "//test/fixtures/command_line:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/macos_app/bwb_spec.json
+++ b/test/fixtures/macos_app/bwb_spec.json
@@ -25,7 +25,7 @@
         "examples/macos_app/Example/Assets.xcassets",
         "test/fixtures/macos_app/BUILD"
     ],
-    "force_bazel_dependencies": false,
+    "force_bazel_dependencies": true,
     "label": "//test/fixtures/macos_app:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/macos_app/bwx_spec.json
+++ b/test/fixtures/macos_app/bwx_spec.json
@@ -23,7 +23,7 @@
         },
         "test/fixtures/macos_app/BUILD"
     ],
-    "force_bazel_dependencies": false,
+    "force_bazel_dependencies": true,
     "label": "//test/fixtures/macos_app:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -173,7 +173,7 @@
         "examples/multiplatform/Tool/Info.plist",
         "test/fixtures/multiplatform/BUILD"
     ],
-    "force_bazel_dependencies": false,
+    "force_bazel_dependencies": true,
     "label": "//test/fixtures/multiplatform:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -147,7 +147,7 @@
         "examples/multiplatform/Tool/Info.plist",
         "test/fixtures/multiplatform/BUILD"
     ],
-    "force_bazel_dependencies": false,
+    "force_bazel_dependencies": true,
     "label": "//test/fixtures/multiplatform:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -35,7 +35,7 @@
         },
         "test/fixtures/tvos_app/BUILD"
     ],
-    "force_bazel_dependencies": false,
+    "force_bazel_dependencies": true,
     "label": "//test/fixtures/tvos_app:xcodeproj_bwb",
     "name": "bwb",
     "scheme_autogeneration_mode": "auto",

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -35,7 +35,7 @@
         },
         "test/fixtures/tvos_app/BUILD"
     ],
-    "force_bazel_dependencies": false,
+    "force_bazel_dependencies": true,
     "label": "//test/fixtures/tvos_app:xcodeproj_bwx",
     "name": "bwx",
     "scheme_autogeneration_mode": "auto",

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -329,6 +329,13 @@ def _collect(
                     automatic_target_info.xcode_targets.get(attr, [None]))
             ],
         ),
+        has_generated_files = bool(generated) or bool([
+            True
+            for attr, info in transitive_infos
+            if (info.inputs.has_generated_files and
+                (info.target_type in
+                 automatic_target_info.xcode_targets.get(attr, [None])))
+        ]),
         extra_files = depset(
             extra_files,
             transitive = [
@@ -408,6 +415,11 @@ def _merge(*, transitive_infos, extra_generated = None):
                 for _, info in transitive_infos
             ],
         ),
+        has_generated_files = bool([
+            True
+            for _, info in transitive_infos
+            if info.inputs.has_generated_files
+        ]),
         extra_files = depset(
             transitive = [
                 info.inputs.extra_files

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -29,7 +29,6 @@ def _write_json_spec(
         project_name,
         configuration,
         inputs,
-        force_bazel_dependencies,
         infos):
     resource_bundle_informations = depset(
         transitive = [info.resource_bundle_informations for info in infos],
@@ -123,7 +122,7 @@ def _write_json_spec(
         configuration = configuration,
         custom_xcode_schemes = custom_xcode_schemes_json,
         extra_files = json.encode(extra_files),
-        force_bazel_dependencies = json.encode(force_bazel_dependencies),
+        force_bazel_dependencies = json.encode(inputs.has_generated_files),
         label = ctx.label,
         name = project_name,
         scheme_autogeneration_mode = ctx.attr.scheme_autogeneration_mode,
@@ -387,7 +386,6 @@ def _xcodeproj_impl(ctx):
         project_name = project_name,
         configuration = configuration,
         inputs = inputs,
-        force_bazel_dependencies = bool(extra_generated),
         infos = infos,
     )
     xccurrentversions_file = _write_xccurrentversions(


### PR DESCRIPTION
We how force the `BazelDependencies` target if there are any Bazel generated files, which better matches what we were trying to do with the flag.