### PR TITLE
Fix linking of some Apple binaries

### DIFF
--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -295,8 +295,6 @@ def process_top_level_target(
 
     if apple_common.Objc in target:
         objc = target[apple_common.Objc]
-    elif apple_common.AppleExecutableBinary in target:
-        objc = target[apple_common.AppleExecutableBinary].objc
     else:
         objc = None
 


### PR DESCRIPTION
`AppleExecutableBinary.objc` doesn't have the linking information I thought it did.