### PR TITLE
Stop copying swiftmodules in BwB mode

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -772,7 +772,6 @@
 			buildPhases = (
 				74D44EF0C730EDEC6D46E69E /* Copy Bazel Outputs */,
 				58F5AB439EA84217B9B89516 /* Sources */,
-				3D4CFD8FC03BCBC4496FF968 /* Copy Swift Generated Header */,
 			);
 			buildRules = (
 			);
@@ -906,23 +905,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "perl -pe 's/^([^\"].*\\$\\(.*\\).*)/\"$1\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		3D4CFD8FC03BCBC4496FF968 /* Copy Swift Generated Header */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(DERIVED_FILE_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
-			);
-			name = "Copy Swift Generated Header";
-			outputPaths = (
-				"$(CONFIGURATION_BUILD_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [[ -z \"${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}\" ]]; then\n  exit 0\nfi\n\ncp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		74D44EF0C730EDEC6D46E69E /* Copy Bazel Outputs */ = {
@@ -1356,8 +1338,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/TestingUtils.swiftmodule\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/TestingUtils.swiftdoc\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/TestingUtils.swiftsourceinfo";
-				BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/SwiftAPI/TestingUtils-Swift.h";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils";
 				BAZEL_TARGET_ID = "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1389,7 +1369,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleUITests/ExampleUITests.xctest";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleUITests/ExampleUITests.swiftmodule\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleUITests/ExampleUITests.swiftdoc\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleUITests/ExampleUITests.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleUITests";
 				BAZEL_TARGET_ID = "//ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
@@ -1667,7 +1646,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example/Example.app";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example/Example.swiftmodule\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example/Example.swiftdoc\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example/Example.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example";
 				BAZEL_TARGET_ID = "//Example:Example applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
@@ -1717,7 +1695,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleTests/ExampleTests.xctest";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleTests/ExampleTests.swiftmodule\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleTests/ExampleTests.swiftdoc\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleTests/ExampleTests.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleTests";
 				BAZEL_TARGET_ID = "//ExampleTests:ExampleTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -59,35 +59,7 @@ else
   fi
 fi
 
-mkdir -p "$OBJECT_FILE_DIR-normal/$ARCHS"
-
-# Copy swiftmodule
-if [[ -n ${BAZEL_OUTPUTS_SWIFTMODULE:-} ]]; then
-  SAVEIFS=$IFS; IFS=$'\n'
-  # shellcheck disable=2206 # `read` doesn't work correctly for this case
-  swiftmodule=($BAZEL_OUTPUTS_SWIFTMODULE)
-  IFS=$SAVEIFS
-
-  log="$(mktemp)"
-  rsync \
-    "${swiftmodule[@]}" \
-    --copy-links \
-    --times \
-    --chmod=u+w \
-    --out-format="%n%L" \
-    "$OBJECT_FILE_DIR-normal/$ARCHS" \
-    | tee -i "$log"
-  if [[ -s "$log" ]]; then
-    touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"
-  fi
-fi
-
-# Copy swift generated header
-if [[ -n ${BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER:-} ]]; then
-  header="$OBJECT_FILE_DIR-normal/$ARCHS/$SWIFT_OBJC_INTERFACE_HEADER_NAME"
-  mkdir -p "${header%/*}"
-  cp \
-    "$BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER" \
-    "$header"
-  chmod u+w "$header"
-fi
+# TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
+# Copy diagnostics, and on a change
+# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# See git blame for this comment for an example

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -59,35 +59,7 @@ else
   fi
 fi
 
-mkdir -p "$OBJECT_FILE_DIR-normal/$ARCHS"
-
-# Copy swiftmodule
-if [[ -n ${BAZEL_OUTPUTS_SWIFTMODULE:-} ]]; then
-  SAVEIFS=$IFS; IFS=$'\n'
-  # shellcheck disable=2206 # `read` doesn't work correctly for this case
-  swiftmodule=($BAZEL_OUTPUTS_SWIFTMODULE)
-  IFS=$SAVEIFS
-
-  log="$(mktemp)"
-  rsync \
-    "${swiftmodule[@]}" \
-    --copy-links \
-    --times \
-    --chmod=u+w \
-    --out-format="%n%L" \
-    "$OBJECT_FILE_DIR-normal/$ARCHS" \
-    | tee -i "$log"
-  if [[ -s "$log" ]]; then
-    touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"
-  fi
-fi
-
-# Copy swift generated header
-if [[ -n ${BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER:-} ]]; then
-  header="$OBJECT_FILE_DIR-normal/$ARCHS/$SWIFT_OBJC_INTERFACE_HEADER_NAME"
-  mkdir -p "${header%/*}"
-  cp \
-    "$BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER" \
-    "$header"
-  chmod u+w "$header"
-fi
+# TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
+# Copy diagnostics, and on a change
+# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# See git blame for this comment for an example

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -549,7 +549,6 @@
 			buildPhases = (
 				CF5964970607E7A9795E2A66 /* Copy Bazel Outputs */,
 				18F25BCCAD587CF0E7BE2E95 /* Sources */,
-				7D1C1AFB1B1C40174C24CF23 /* Copy Swift Generated Header */,
 			);
 			buildRules = (
 			);
@@ -727,23 +726,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"LibSwiftTests.xctest\" \\\n  \"\"\n";
-			showEnvVarsInLog = 0;
-		};
-		7D1C1AFB1B1C40174C24CF23 /* Copy Swift Generated Header */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(DERIVED_FILE_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
-			);
-			name = "Copy Swift Generated Header";
-			outputPaths = (
-				"$(CONFIGURATION_BUILD_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [[ -z \"${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}\" ]]; then\n  exit 0\nfi\n\ncp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9A630CF63C380FAE522825A9 /* Bazel Build */ = {
@@ -928,8 +910,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/LibSwift.swiftmodule\n$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/LibSwift.swiftdoc\n$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/LibSwift.swiftsourceinfo";
-				BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/private/LibSwift-Swift.h";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib";
 				BAZEL_TARGET_ID = "//examples/command_line/lib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1148,7 +1128,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.zip";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/Tests/LibSwiftTestsLib.swiftmodule\n$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/Tests/LibSwiftTestsLib.swiftdoc\n$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/Tests/LibSwiftTestsLib.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/Tests";
 				BAZEL_TARGET_ID = "//examples/command_line/Tests:LibSwiftTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-ST-0139d977e630";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -59,35 +59,7 @@ else
   fi
 fi
 
-mkdir -p "$OBJECT_FILE_DIR-normal/$ARCHS"
-
-# Copy swiftmodule
-if [[ -n ${BAZEL_OUTPUTS_SWIFTMODULE:-} ]]; then
-  SAVEIFS=$IFS; IFS=$'\n'
-  # shellcheck disable=2206 # `read` doesn't work correctly for this case
-  swiftmodule=($BAZEL_OUTPUTS_SWIFTMODULE)
-  IFS=$SAVEIFS
-
-  log="$(mktemp)"
-  rsync \
-    "${swiftmodule[@]}" \
-    --copy-links \
-    --times \
-    --chmod=u+w \
-    --out-format="%n%L" \
-    "$OBJECT_FILE_DIR-normal/$ARCHS" \
-    | tee -i "$log"
-  if [[ -s "$log" ]]; then
-    touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"
-  fi
-fi
-
-# Copy swift generated header
-if [[ -n ${BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER:-} ]]; then
-  header="$OBJECT_FILE_DIR-normal/$ARCHS/$SWIFT_OBJC_INTERFACE_HEADER_NAME"
-  mkdir -p "${header%/*}"
-  cp \
-    "$BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER" \
-    "$header"
-  chmod u+w "$header"
-fi
+# TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
+# Copy diagnostics, and on a change
+# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# See git blame for this comment for an example

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -2279,7 +2279,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/PathKit.swiftdoc\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit/PathKit.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit";
 				BAZEL_TARGET_ID = "@com_github_kylef_pathkit//:PathKit darwin_x86_64-dbg-ST-5534cb307cb8";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -2319,7 +2318,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftdoc\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj";
 				BAZEL_TARGET_ID = "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-dbg-ST-5534cb307cb8";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -2349,7 +2347,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/AEXML.swiftmodule\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/AEXML.swiftdoc\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml/AEXML.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml";
 				BAZEL_TARGET_ID = "@com_github_tadija_aexml//:AEXML darwin_x86_64-dbg-ST-5534cb307cb8";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -2420,7 +2417,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftdoc\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay";
 				BAZEL_TARGET_ID = "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay darwin_x86_64-dbg-ST-5534cb307cb8";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -2449,7 +2445,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftdoc\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump";
 				BAZEL_TARGET_ID = "@com_github_pointfreeco_swift_custom_dump//:CustomDump darwin_x86_64-dbg-ST-5534cb307cb8";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -2480,7 +2475,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/test/tests.xctest";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/test/tests.swiftmodule\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/test/tests.swiftdoc\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/test/tests.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/test";
 				BAZEL_TARGET_ID = "//tools/generator/test:tests darwin_x86_64-dbg-ST-5534cb307cb8";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
@@ -2515,7 +2509,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftdoc\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections";
 				BAZEL_TARGET_ID = "@com_github_apple_swift_collections//:OrderedCollections darwin_x86_64-dbg-ST-5534cb307cb8";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -2574,7 +2567,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/generator.swiftmodule\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/generator.swiftdoc\n$(BAZEL_OUT)/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/generator.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator";
 				BAZEL_TARGET_ID = "//tools/generator:generator.library darwin_x86_64-dbg-ST-5534cb307cb8";
 				DEBUG_INFORMATION_FORMAT = dwarf;

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -59,35 +59,7 @@ else
   fi
 fi
 
-mkdir -p "$OBJECT_FILE_DIR-normal/$ARCHS"
-
-# Copy swiftmodule
-if [[ -n ${BAZEL_OUTPUTS_SWIFTMODULE:-} ]]; then
-  SAVEIFS=$IFS; IFS=$'\n'
-  # shellcheck disable=2206 # `read` doesn't work correctly for this case
-  swiftmodule=($BAZEL_OUTPUTS_SWIFTMODULE)
-  IFS=$SAVEIFS
-
-  log="$(mktemp)"
-  rsync \
-    "${swiftmodule[@]}" \
-    --copy-links \
-    --times \
-    --chmod=u+w \
-    --out-format="%n%L" \
-    "$OBJECT_FILE_DIR-normal/$ARCHS" \
-    | tee -i "$log"
-  if [[ -s "$log" ]]; then
-    touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"
-  fi
-fi
-
-# Copy swift generated header
-if [[ -n ${BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER:-} ]]; then
-  header="$OBJECT_FILE_DIR-normal/$ARCHS/$SWIFT_OBJC_INTERFACE_HEADER_NAME"
-  mkdir -p "${header%/*}"
-  cp \
-    "$BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER" \
-    "$header"
-  chmod u+w "$header"
-fi
+# TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
+# Copy diagnostics, and on a change
+# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# See git blame for this comment for an example

--- a/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
@@ -434,7 +434,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin/examples/macos_app/Example/Example.zip";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin/examples/macos_app/Example/iOSApp.swiftmodule\n$(BAZEL_OUT)/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin/examples/macos_app/Example/iOSApp.swiftdoc\n$(BAZEL_OUT)/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin/examples/macos_app/Example/iOSApp.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin/examples/macos_app/Example";
 				BAZEL_TARGET_ID = "//examples/macos_app/Example:Example applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";

--- a/test/fixtures/macos_app/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/macos_app/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -59,35 +59,7 @@ else
   fi
 fi
 
-mkdir -p "$OBJECT_FILE_DIR-normal/$ARCHS"
-
-# Copy swiftmodule
-if [[ -n ${BAZEL_OUTPUTS_SWIFTMODULE:-} ]]; then
-  SAVEIFS=$IFS; IFS=$'\n'
-  # shellcheck disable=2206 # `read` doesn't work correctly for this case
-  swiftmodule=($BAZEL_OUTPUTS_SWIFTMODULE)
-  IFS=$SAVEIFS
-
-  log="$(mktemp)"
-  rsync \
-    "${swiftmodule[@]}" \
-    --copy-links \
-    --times \
-    --chmod=u+w \
-    --out-format="%n%L" \
-    "$OBJECT_FILE_DIR-normal/$ARCHS" \
-    | tee -i "$log"
-  if [[ -s "$log" ]]; then
-    touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"
-  fi
-fi
-
-# Copy swift generated header
-if [[ -n ${BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER:-} ]]; then
-  header="$OBJECT_FILE_DIR-normal/$ARCHS/$SWIFT_OBJC_INTERFACE_HEADER_NAME"
-  mkdir -p "${header%/*}"
-  cp \
-    "$BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER" \
-    "$header"
-  chmod u+w "$header"
-fi
+# TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
+# Copy diagnostics, and on a change
+# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# See git blame for this comment for an example

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -2643,8 +2643,6 @@
 				"ARCHS[sdk=iphoneos*]" = arm64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/iOSApp.ipa";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOSApp.ipa";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/iOSApp.swiftmodule\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/iOSApp.swiftdoc\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/iOSApp.swiftsourceinfo";
-				"BAZEL_OUTPUTS_SWIFTMODULE[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOSApp.swiftmodule\n$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOSApp.swiftdoc\n$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp/iOSApp.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db";
@@ -2726,8 +2724,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=watchos*]" = arm64_32;
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib/Lib.swiftmodule\n$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib/Lib.swiftdoc\n$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo";
-				"BAZEL_OUTPUTS_SWIFTMODULE[sdk=watchos*]" = "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib/Lib.swiftmodule\n$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib/Lib.swiftdoc\n$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib";
 				BAZEL_TARGET_ID = "//examples/multiplatform/Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a";
@@ -2780,8 +2776,6 @@
 				"BAZEL_HOST_TARGET_ID_0[sdk=watchos*]" = "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftmodule\n$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftdoc\n$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftsourceinfo";
-				"BAZEL_OUTPUTS_SWIFTMODULE[sdk=watchos*]" = "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftmodule\n$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftdoc\n$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSAppExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension";
 				BAZEL_TARGET_ID = "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a";
@@ -2852,8 +2846,6 @@
 				"ARCHS[sdk=appletvos*]" = arm64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/tvOSApp.ipa";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/tvOSApp.ipa";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/iOSApp.swiftmodule\n$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/iOSApp.swiftdoc\n$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/iOSApp.swiftsourceinfo";
-				"BAZEL_OUTPUTS_SWIFTMODULE[sdk=appletvos*]" = "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/iOSApp.swiftmodule\n$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/iOSApp.swiftdoc\n$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/iOSApp.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/tvOSApp:tvOSApp applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67";
@@ -2930,8 +2922,6 @@
 				"ARCHS[sdk=iphoneos*]" = arm64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/AppClip/AppClip.ipa";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/AppClip/AppClip.ipa";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/AppClip/AppClip.swiftmodule\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/AppClip/AppClip.swiftdoc\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/AppClip/AppClip.swiftsourceinfo";
-				"BAZEL_OUTPUTS_SWIFTMODULE[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/AppClip/AppClip.swiftmodule\n$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/AppClip/AppClip.swiftdoc\n$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/AppClip/AppClip.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/AppClip";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/AppClip";
 				BAZEL_TARGET_ID = "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db";
@@ -3002,7 +2992,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Tool/Tool";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Tool/Tool.swiftmodule\n$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Tool/Tool.swiftdoc\n$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Tool/Tool.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Tool";
 				BAZEL_TARGET_ID = "//examples/multiplatform/Tool:Tool applebin_macos-darwin_x86_64-dbg-ST-0139d977e630";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
@@ -3040,10 +3029,6 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=appletvos*]" = arm64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/Lib.swiftmodule\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/Lib.swiftdoc\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo";
-				"BAZEL_OUTPUTS_SWIFTMODULE[sdk=appletvos*]" = "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib/Lib.swiftmodule\n$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib/Lib.swiftdoc\n$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo";
-				"BAZEL_OUTPUTS_SWIFTMODULE[sdk=appletvsimulator*]" = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib/Lib.swiftmodule\n$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib/Lib.swiftdoc\n$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo";
-				"BAZEL_OUTPUTS_SWIFTMODULE[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/Lib.swiftmodule\n$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/Lib.swiftdoc\n$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/Lib.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvsimulator*]" = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib";
@@ -3120,8 +3105,6 @@
 				"BAZEL_HOST_TARGET_ID_0[sdk=iphoneos*]" = "//examples/multiplatform/iMessageApp:iMessageApp applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.zip";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.zip";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftmodule\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftdoc\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftsourceinfo";
-				"BAZEL_OUTPUTS_SWIFTMODULE[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftmodule\n$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftdoc\n$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db";
@@ -3282,8 +3265,6 @@
 				"BAZEL_HOST_TARGET_ID_0[sdk=iphoneos*]" = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/WidgetExtension/WidgetExtension.zip";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/WidgetExtension/WidgetExtension.zip";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftmodule\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftdoc\n$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftsourceinfo";
-				"BAZEL_OUTPUTS_SWIFTMODULE[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftmodule\n$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftdoc\n$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/WidgetExtension/WidgetExtension.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/WidgetExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/WidgetExtension";
 				BAZEL_TARGET_ID = "//examples/multiplatform/WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db";

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -59,35 +59,7 @@ else
   fi
 fi
 
-mkdir -p "$OBJECT_FILE_DIR-normal/$ARCHS"
-
-# Copy swiftmodule
-if [[ -n ${BAZEL_OUTPUTS_SWIFTMODULE:-} ]]; then
-  SAVEIFS=$IFS; IFS=$'\n'
-  # shellcheck disable=2206 # `read` doesn't work correctly for this case
-  swiftmodule=($BAZEL_OUTPUTS_SWIFTMODULE)
-  IFS=$SAVEIFS
-
-  log="$(mktemp)"
-  rsync \
-    "${swiftmodule[@]}" \
-    --copy-links \
-    --times \
-    --chmod=u+w \
-    --out-format="%n%L" \
-    "$OBJECT_FILE_DIR-normal/$ARCHS" \
-    | tee -i "$log"
-  if [[ -s "$log" ]]; then
-    touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"
-  fi
-fi
-
-# Copy swift generated header
-if [[ -n ${BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER:-} ]]; then
-  header="$OBJECT_FILE_DIR-normal/$ARCHS/$SWIFT_OBJC_INTERFACE_HEADER_NAME"
-  mkdir -p "${header%/*}"
-  cp \
-    "$BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER" \
-    "$header"
-  chmod u+w "$header"
-fi
+# TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
+# Copy diagnostics, and on a change
+# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# See git blame for this comment for an example

--- a/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -59,35 +59,7 @@ else
   fi
 fi
 
-mkdir -p "$OBJECT_FILE_DIR-normal/$ARCHS"
-
-# Copy swiftmodule
-if [[ -n ${BAZEL_OUTPUTS_SWIFTMODULE:-} ]]; then
-  SAVEIFS=$IFS; IFS=$'\n'
-  # shellcheck disable=2206 # `read` doesn't work correctly for this case
-  swiftmodule=($BAZEL_OUTPUTS_SWIFTMODULE)
-  IFS=$SAVEIFS
-
-  log="$(mktemp)"
-  rsync \
-    "${swiftmodule[@]}" \
-    --copy-links \
-    --times \
-    --chmod=u+w \
-    --out-format="%n%L" \
-    "$OBJECT_FILE_DIR-normal/$ARCHS" \
-    | tee -i "$log"
-  if [[ -s "$log" ]]; then
-    touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"
-  fi
-fi
-
-# Copy swift generated header
-if [[ -n ${BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER:-} ]]; then
-  header="$OBJECT_FILE_DIR-normal/$ARCHS/$SWIFT_OBJC_INTERFACE_HEADER_NAME"
-  mkdir -p "${header%/*}"
-  cp \
-    "$BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER" \
-    "$header"
-  chmod u+w "$header"
-fi
+# TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
+# Copy diagnostics, and on a change
+# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# See git blame for this comment for an example

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -660,7 +660,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle.zip";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftmodule\n$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftdoc\n$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleUITests/ExampleUITests.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleUITests";
 				BAZEL_TARGET_ID = "//examples/tvos_app/ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
@@ -753,7 +752,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example/Example.ipa";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example/Example.swiftmodule\n$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example/Example.swiftdoc\n$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example/Example.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example";
 				BAZEL_TARGET_ID = "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
@@ -796,7 +794,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle.zip";
-				BAZEL_OUTPUTS_SWIFTMODULE = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftmodule\n$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftdoc\n$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleTests/ExampleTests.swiftsourceinfo";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleTests";
 				BAZEL_TARGET_ID = "//examples/tvos_app/ExampleTests:ExampleTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -59,35 +59,7 @@ else
   fi
 fi
 
-mkdir -p "$OBJECT_FILE_DIR-normal/$ARCHS"
-
-# Copy swiftmodule
-if [[ -n ${BAZEL_OUTPUTS_SWIFTMODULE:-} ]]; then
-  SAVEIFS=$IFS; IFS=$'\n'
-  # shellcheck disable=2206 # `read` doesn't work correctly for this case
-  swiftmodule=($BAZEL_OUTPUTS_SWIFTMODULE)
-  IFS=$SAVEIFS
-
-  log="$(mktemp)"
-  rsync \
-    "${swiftmodule[@]}" \
-    --copy-links \
-    --times \
-    --chmod=u+w \
-    --out-format="%n%L" \
-    "$OBJECT_FILE_DIR-normal/$ARCHS" \
-    | tee -i "$log"
-  if [[ -s "$log" ]]; then
-    touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"
-  fi
-fi
-
-# Copy swift generated header
-if [[ -n ${BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER:-} ]]; then
-  header="$OBJECT_FILE_DIR-normal/$ARCHS/$SWIFT_OBJC_INTERFACE_HEADER_NAME"
-  mkdir -p "${header%/*}"
-  cp \
-    "$BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER" \
-    "$header"
-  chmod u+w "$header"
-fi
+# TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
+# Copy diagnostics, and on a change
+# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# See git blame for this comment for an example

--- a/tools/generator/src/Generator/AddTargets.swift
+++ b/tools/generator/src/Generator/AddTargets.swift
@@ -59,6 +59,7 @@ Product for target "\(key)" not found in `products`
                 ),
                 try createCopyGeneratedHeaderScript(
                     in: pbxProj,
+                    buildMode: buildMode,
                     generatesSwiftHeader: target.generatesSwiftHeader
                 ),
                 try createFrameworksPhase(
@@ -296,9 +297,10 @@ File "\(sourceFile.filePath)" not found in `files`
 
     private static func createCopyGeneratedHeaderScript(
         in pbxProj: PBXProj,
+        buildMode: BuildMode,
         generatesSwiftHeader: Bool
     ) throws -> PBXShellScriptBuildPhase? {
-        guard generatesSwiftHeader else {
+        guard buildMode == .xcode && generatesSwiftHeader else {
             return nil
         }
 

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -322,30 +322,6 @@ $(CONFIGURATION_BUILD_DIR)
             buildSettings.set("SWIFT_INCLUDE_PATHS", to: includePaths)
         }
 
-        if let swiftOutputs = target.outputs.swift,
-           buildMode.usesBazelModeBuildScripts
-        {
-            let swiftmoduleOutputPaths = try swiftOutputs.paths(
-                filePathResolver: filePathResolver
-            )
-            if !swiftmoduleOutputPaths.isEmpty {
-                buildSettings.set(
-                    "BAZEL_OUTPUTS_SWIFTMODULE",
-                    to: swiftmoduleOutputPaths.joined(separator: "\n")
-                )
-            }
-
-            if let generatedHeader = swiftOutputs.generatedHeader {
-                buildSettings.set(
-                    "BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER",
-                    to: try filePathResolver.resolve(
-                        generatedHeader,
-                        useOriginalGeneratedFiles: true
-                    )
-                )
-            }
-        }
-
         if let productOutput = target.outputs.product,
            buildMode.usesBazelModeBuildScripts
         {

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -73,7 +73,7 @@ enum Fixtures {
                 swift: .init(
                     module: .generated("x/y.swiftmodule"),
                     doc: .generated("x/y.swiftdoc"),
-                    sourceInfo: .generated("x/y.sourceinfo")
+                    sourceInfo: .generated("x/y.swiftsourceinfo")
                 )
             )
         ),

--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -59,35 +59,7 @@ else
   fi
 fi
 
-mkdir -p "$OBJECT_FILE_DIR-normal/$ARCHS"
-
-# Copy swiftmodule
-if [[ -n ${BAZEL_OUTPUTS_SWIFTMODULE:-} ]]; then
-  SAVEIFS=$IFS; IFS=$'\n'
-  # shellcheck disable=2206 # `read` doesn't work correctly for this case
-  swiftmodule=($BAZEL_OUTPUTS_SWIFTMODULE)
-  IFS=$SAVEIFS
-
-  log="$(mktemp)"
-  rsync \
-    "${swiftmodule[@]}" \
-    --copy-links \
-    --times \
-    --chmod=u+w \
-    --out-format="%n%L" \
-    "$OBJECT_FILE_DIR-normal/$ARCHS" \
-    | tee -i "$log"
-  if [[ -s "$log" ]]; then
-    touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"
-  fi
-fi
-
-# Copy swift generated header
-if [[ -n ${BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER:-} ]]; then
-  header="$OBJECT_FILE_DIR-normal/$ARCHS/$SWIFT_OBJC_INTERFACE_HEADER_NAME"
-  mkdir -p "${header%/*}"
-  cp \
-    "$BAZEL_OUTPUTS_SWIFT_GENERATED_HEADER" \
-    "$header"
-  chmod u+w "$header"
-fi
+# TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
+# Copy diagnostics, and on a change
+# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# See git blame for this comment for an example


### PR DESCRIPTION
Search paths (for Indexing) and linker flags (for Debugging) now point into `$BAZEL_OUT`.

The `Copy Bazel Outputs` script hasn't been removed, as it will be used later for diagnostics replay.