### PR TITLE
Properly set `Info.list` for command line tools

### DIFF
--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		61606C8E4C3C583C1DE87CAE /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		70E39C0BDE73FBB3E0447A9C /* lib_impl.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = lib_impl.swift.modulemap; sourceTree = "<group>"; };
 		7FC818A23F6CAC131654773F /* c_lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = c_lib.h; sourceTree = "<group>"; };
+		8A16089ADBC24C0D8A2EEB42 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		8EA0A841B76E8C631203A851 /* c_lib.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = c_lib.modulemap; sourceTree = "<group>"; };
 		8EEF31F83F9AF990435CC135 /* tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tool; sourceTree = BUILT_PRODUCTS_DIR; };
 		94BEEB36D3E48677861539C1 /* ExternalFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExternalFramework.framework; sourceTree = "<group>"; };
@@ -205,6 +206,14 @@
 			path = command_line;
 			sourceTree = "<group>";
 		};
+		13F95FFBB2BC6694EAF8EA5B /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				656E9280CC745A8B42324D0A /* tool */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
 		1CBB95DBE8A44BC1D878A3AE /* macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630 */ = {
 			isa = PBXGroup;
 			children = (
@@ -269,6 +278,7 @@
 			isa = PBXGroup;
 			children = (
 				A26D921EF2C79FCEAD39BBD7 /* Tests */,
+				703A1AAF8C78699E42633430 /* tool */,
 			);
 			path = command_line;
 			sourceTree = "<group>";
@@ -310,6 +320,14 @@
 			path = "tool.merged_launchdplists-intermediates";
 			sourceTree = "<group>";
 		};
+		656E9280CC745A8B42324D0A /* tool */ = {
+			isa = PBXGroup;
+			children = (
+				8A16089ADBC24C0D8A2EEB42 /* Info.plist */,
+			);
+			path = tool;
+			sourceTree = "<group>";
+		};
 		68A1D737225E7A97337523DE /* test */ = {
 			isa = PBXGroup;
 			children = (
@@ -325,6 +343,14 @@
 				DBF917653F9E4EBBEDB863FD /* Library.h */,
 			);
 			path = ImportableLibrary;
+			sourceTree = "<group>";
+		};
+		703A1AAF8C78699E42633430 /* tool */ = {
+			isa = PBXGroup;
+			children = (
+				13F95FFBB2BC6694EAF8EA5B /* rules_xcodeproj */,
+			);
+			path = tool;
 			sourceTree = "<group>";
 		};
 		7F39486CE984F082D17A7720 /* command_line */ = {
@@ -1057,6 +1083,7 @@
 					examples/command_line/lib/private,
 					"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/private",
 				);
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/tool/rules_xcodeproj/tool/Info.plist";
 				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/command_line/tool/tool.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,4 +1,5 @@
 $(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/Tests/rules_xcodeproj/LibSwiftTests.__internal__.__test_bundle/Info.plist
+$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/tool/rules_xcodeproj/tool/Info.plist
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_impl.swift.modulemap
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/lib_swift.swift.modulemap
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib/private_lib.swift.modulemap

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -41,6 +41,10 @@
         "examples/command_line/tool/Info.plist",
         "examples/command_line/tool/Launchd.plist",
         {
+            "_": "applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/tool/rules_xcodeproj/tool/Info.plist",
+            "t": "g"
+        },
+        {
             "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/tool/tool.merged_launchdplists-intermediates/Launchd.plist",
             "t": "g"
         },
@@ -760,7 +764,10 @@
                 "//examples/command_line/tool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630"
             ],
             "extensions": [],
-            "info_plist": null,
+            "info_plist": {
+                "_": "applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/tool/rules_xcodeproj/tool/Info.plist",
+                "t": "g"
+            },
             "inputs": {
                 "exported_symbols_lists": [
                     "examples/command_line/tool/export_symbol_list.exp"

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		85AA47D00BD6B0AF833B0617 /* export_symbol_list.exp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.exports; path = export_symbol_list.exp; sourceTree = "<group>"; };
 		8B03B3D734122C32E07042B6 /* Launchd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Launchd.plist; sourceTree = "<group>"; };
 		9D46BEBDD407F679ED938408 /* ExternalFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExternalFramework.framework; sourceTree = "<group>"; };
+		A7FDE84F8E9D5D2A2BF00855 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B093EB1BAB8D20D1457C10D2 /* libImportableLibrary.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libImportableLibrary.a; sourceTree = "<group>"; };
 		B457072C62E4282C472889FB /* lib_swift.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = lib_swift.swift.modulemap; sourceTree = "<group>"; };
 		B45E624D6CB9A25AD05AA3EB /* lib.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = lib.m; sourceTree = "<group>"; };
@@ -240,6 +241,14 @@
 			path = bin;
 			sourceTree = "<group>";
 		};
+		4AB0060AF327BE4ECCD99EB5 /* tool */ = {
+			isa = PBXGroup;
+			children = (
+				FE8D74D2FF9BA823B0DF150F /* rules_xcodeproj */,
+			);
+			path = tool;
+			sourceTree = "<group>";
+		};
 		502410081D92A547EC3F3479 /* lib */ = {
 			isa = PBXGroup;
 			children = (
@@ -306,6 +315,7 @@
 			isa = PBXGroup;
 			children = (
 				65FF3E31EBF72509F7704AED /* Tests */,
+				4AB0060AF327BE4ECCD99EB5 /* tool */,
 			);
 			path = command_line;
 			sourceTree = "<group>";
@@ -481,6 +491,14 @@
 			path = examples_command_line_external;
 			sourceTree = "<group>";
 		};
+		F85A57A59E90820D732B0FD4 /* tool */ = {
+			isa = PBXGroup;
+			children = (
+				A7FDE84F8E9D5D2A2BF00855 /* Info.plist */,
+			);
+			path = tool;
+			sourceTree = "<group>";
+		};
 		FE5F8DA1EDE79F202DF698DA /* command_line */ = {
 			isa = PBXGroup;
 			children = (
@@ -490,6 +508,14 @@
 				AEA469E9B752E999F07AF5BE /* tool */,
 			);
 			path = command_line;
+			sourceTree = "<group>";
+		};
+		FE8D74D2FF9BA823B0DF150F /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				F85A57A59E90820D732B0FD4 /* tool */,
+			);
+			path = rules_xcodeproj;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1111,13 +1137,13 @@
 					"SECRET_3=\\\"Hello\\\"",
 					"SECRET_2=\\\"World!\\\"",
 				);
-				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
 					"\"examples/command_line/lib/dir with space\"",
 					"\"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/dir with space\"",
 					examples/command_line/lib/private,
 					"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/private",
 				);
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool/rules_xcodeproj/tool/Info.plist";
 				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/command_line/tool/tool.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,4 +1,5 @@
 $(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/Tests/rules_xcodeproj/LibSwiftTests.__internal__.__test_bundle/Info.plist
+$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool/rules_xcodeproj/tool/Info.plist
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_impl.swift.modulemap
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/lib_swift.swift.modulemap
 $(GEN_DIR)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib/private_lib.swift.modulemap

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -41,6 +41,10 @@
         "examples/command_line/tool/Info.plist",
         "examples/command_line/tool/Launchd.plist",
         {
+            "_": "applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool/rules_xcodeproj/tool/Info.plist",
+            "t": "g"
+        },
+        {
             "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool/tool.merged_launchdplists-intermediates/Launchd.plist",
             "t": "g"
         },
@@ -760,7 +764,10 @@
                 "//examples/command_line/tool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60"
             ],
             "extensions": [],
-            "info_plist": null,
+            "info_plist": {
+                "_": "applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool/rules_xcodeproj/tool/Info.plist",
+                "t": "g"
+            },
             "inputs": {
                 "exported_symbols_lists": [
                     "examples/command_line/tool/export_symbol_list.exp"

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -302,6 +302,7 @@
 		17C68CB3AB068C4D32CB53C7 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		19C8F7CCC5F4C0A75BC6D6B8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1B5A0430B943510A260B7A6F /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		1EC071053D0E26A8E400248C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		21B075DF13D48A7176B9FD50 /* AppClip.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppClip.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		228FA03886D4CED2E8B87937 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		22D3E7618EB2EFFE6AA88608 /* Intents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Intents.swift; sourceTree = "<group>"; };
@@ -460,6 +461,14 @@
 				6F5F4D4F3C3E4B363E9F52FD /* examples */,
 			);
 			path = bin;
+			sourceTree = "<group>";
+		};
+		0476B5B1CFE2912BECD8336B /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				C9A36802C7909D75F9DC3124 /* multiplatform */,
+			);
+			path = examples;
 			sourceTree = "<group>";
 		};
 		0787F0AF3FBE63BCA8C3178F /* rules_xcodeproj */ = {
@@ -978,6 +987,14 @@
 			path = test;
 			sourceTree = "<group>";
 		};
+		693B23F3194D94F6AF341D6C /* Tool */ = {
+			isa = PBXGroup;
+			children = (
+				1EC071053D0E26A8E400248C /* Info.plist */,
+			);
+			path = Tool;
+			sourceTree = "<group>";
+		};
 		6AA5D58B14D472F1B080BB80 /* iMessageAppExtension */ = {
 			isa = PBXGroup;
 			children = (
@@ -1104,6 +1121,14 @@
 			path = watchOSAppExtension;
 			sourceTree = "<group>";
 		};
+		8730AFEA4D9B2B2D7AD19BF6 /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				0476B5B1CFE2912BECD8336B /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
 		887DB9E1AAF0059110BE927D /* examples */ = {
 			isa = PBXGroup;
 			children = (
@@ -1198,6 +1223,14 @@
 				43C315EC01E609F1EE3230C2 /* bin */,
 			);
 			path = "applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a";
+			sourceTree = "<group>";
+		};
+		9DD9CFFE2CD76BCD5FC81487 /* applebin_macos-darwin_x86_64-dbg-ST-0139d977e630 */ = {
+			isa = PBXGroup;
+			children = (
+				8730AFEA4D9B2B2D7AD19BF6 /* bin */,
+			);
+			path = "applebin_macos-darwin_x86_64-dbg-ST-0139d977e630";
 			sourceTree = "<group>";
 		};
 		9EA22BD8EA5DD4B8B1653D1B /* multiplatform */ = {
@@ -1427,6 +1460,7 @@
 			children = (
 				44FBC146205D75E8D96B4679 /* applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf */,
 				DC8FFF2F01AC842CF5E234B4 /* applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db */,
+				9DD9CFFE2CD76BCD5FC81487 /* applebin_macos-darwin_x86_64-dbg-ST-0139d977e630 */,
 				4CA7FB73CD1E886EFC382786 /* applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2 */,
 				CF799A70EE04F3764346BCDC /* applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67 */,
 				22599C40BE6FD70E12668DA9 /* applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc */,
@@ -1490,6 +1524,22 @@
 				3705666C022FE1D4313AB4C0 /* WidgetExtension */,
 			);
 			path = multiplatform;
+			sourceTree = "<group>";
+		};
+		C9A36802C7909D75F9DC3124 /* multiplatform */ = {
+			isa = PBXGroup;
+			children = (
+				CD7FB64235C7EC9F4113B98A /* Tool */,
+			);
+			path = multiplatform;
+			sourceTree = "<group>";
+		};
+		CD7FB64235C7EC9F4113B98A /* Tool */ = {
+			isa = PBXGroup;
+			children = (
+				F9EF9C71490F4D9BBCEF5ED4 /* rules_xcodeproj */,
+			);
+			path = Tool;
 			sourceTree = "<group>";
 		};
 		CF799A70EE04F3764346BCDC /* applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67 */ = {
@@ -1686,6 +1736,14 @@
 				3F4E1CAC6C1DF2A5384D1223 /* Info.plist */,
 			);
 			path = iOSApp;
+			sourceTree = "<group>";
+		};
+		F9EF9C71490F4D9BBCEF5ED4 /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				693B23F3194D94F6AF341D6C /* Tool */,
+			);
+			path = rules_xcodeproj;
 			sourceTree = "<group>";
 		};
 		FC05C2D18658EB768ABA1EC1 /* watchOSAppExtension */ = {
@@ -3001,6 +3059,7 @@
 				ENABLE_TESTABILITY = YES;
 				EXECUTABLE_EXTENSION = "";
 				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Tool/rules_xcodeproj/Tool/Info.plist";
 				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/examples/multiplatform/Tool/Tool.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -10,6 +10,7 @@ $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatfor
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp/rules_xcodeproj/iMessageAppExtension/Info.plist
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/rules_xcodeproj/iOSApp/Info.plist
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist
+$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Tool/rules_xcodeproj/Tool/Info.plist
 $(GEN_DIR)/applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/rules_xcodeproj/tvOSApp/Info.plist
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/rules_xcodeproj/tvOSApp/Info.plist
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -171,6 +171,10 @@
         },
         "examples/multiplatform/Tool/BUILD",
         "examples/multiplatform/Tool/Info.plist",
+        {
+            "_": "applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Tool/rules_xcodeproj/Tool/Info.plist",
+            "t": "g"
+        },
         "test/fixtures/multiplatform/BUILD"
     ],
     "force_bazel_dependencies": true,
@@ -1323,7 +1327,10 @@
                 "//examples/multiplatform/Tool:Tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630"
             ],
             "extensions": [],
-            "info_plist": null,
+            "info_plist": {
+                "_": "applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Tool/rules_xcodeproj/Tool/Info.plist",
+                "t": "g"
+            },
             "inputs": {},
             "is_swift": false,
             "label": "//examples/multiplatform/Tool:Tool",

--- a/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
@@ -443,6 +443,7 @@
 		A55936D0B572746D0704E8FF /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		A58905D8A9A73FF271B31642 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		A64E82DCF9CD209DC5E8DA47 /* iMessageAppExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = iMessageAppExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		B0C8F9603EF8C19386894362 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		B458BF83189E16639F54CF22 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		B4945564FB57B2AAF142EFC4 /* GoogleMaps.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = GoogleMaps.framework; sourceTree = "<group>"; };
 		B71472125A1D13A0A543BA64 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -656,6 +657,14 @@
 			path = AppClip;
 			sourceTree = "<group>";
 		};
+		1AB1E4E232A817F49D9F61FD /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				B83E6EAD02AEB025D0739BE2 /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
 		1BA749CEF41796114E05A0B8 /* ios-arm64_x86_64-simulator */ = {
 			isa = PBXGroup;
 			children = (
@@ -850,12 +859,28 @@
 			path = "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53";
 			sourceTree = "<group>";
 		};
+		3727EA93E714DBE0E8BF3000 /* multiplatform */ = {
+			isa = PBXGroup;
+			children = (
+				3B6FBFFC08D8E8E3D8FD9F8A /* Tool */,
+			);
+			path = multiplatform;
+			sourceTree = "<group>";
+		};
 		39C890447E3E6E12316E2550 /* examples */ = {
 			isa = PBXGroup;
 			children = (
 				E3322E4253D29158CCC8A9ED /* multiplatform */,
 			);
 			path = examples;
+			sourceTree = "<group>";
+		};
+		3B6FBFFC08D8E8E3D8FD9F8A /* Tool */ = {
+			isa = PBXGroup;
+			children = (
+				6E00826A9EE820289D1D0CFA /* rules_xcodeproj */,
+			);
+			path = Tool;
 			sourceTree = "<group>";
 		};
 		3D3090CCDD6D0F40C3D54040 /* iOSApp */ = {
@@ -1101,6 +1126,22 @@
 			path = examples;
 			sourceTree = "<group>";
 		};
+		6C8B65D449ABE04C9AA23244 /* Tool */ = {
+			isa = PBXGroup;
+			children = (
+				B0C8F9603EF8C19386894362 /* Info.plist */,
+			);
+			path = Tool;
+			sourceTree = "<group>";
+		};
+		6E00826A9EE820289D1D0CFA /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				6C8B65D449ABE04C9AA23244 /* Tool */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
 		6F57F63611A7208E1E2EE279 /* multiplatform */ = {
 			isa = PBXGroup;
 			children = (
@@ -1115,6 +1156,14 @@
 				F5B9D2578B2D8BD01CD08A7D /* Info.plist */,
 			);
 			path = iMessageAppExtension;
+			sourceTree = "<group>";
+		};
+		721113869ECDCCA0C80232BF /* applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60 */ = {
+			isa = PBXGroup;
+			children = (
+				1AB1E4E232A817F49D9F61FD /* bin */,
+			);
+			path = "applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60";
 			sourceTree = "<group>";
 		};
 		721E3236AADE7DA8A1E0A8A6 /* ios-arm64_x86_64-simulator */ = {
@@ -1327,6 +1376,7 @@
 			children = (
 				42B7CA7F67B202FE3CFA469E /* applebin_ios-ios_arm64-dbg-ST-787a8770ecb8 */,
 				F8A631DFD0B3688960A53DEA /* applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01 */,
+				721113869ECDCCA0C80232BF /* applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60 */,
 				FA7079F90AC441AAF2F02EF7 /* applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef */,
 				FC8F0974C2FEA3036E0C16A0 /* applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53 */,
 				2F5F6DE57B19DEE2DD56F416 /* applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3 */,
@@ -1423,6 +1473,14 @@
 				A8903A303B7E16C27E50E99E /* watchOSApp */,
 			);
 			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
+		B83E6EAD02AEB025D0739BE2 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				3727EA93E714DBE0E8BF3000 /* multiplatform */,
+			);
+			path = examples;
 			sourceTree = "<group>";
 		};
 		B8EA354216899CDA48953ABE /* rules_xcodeproj */ = {
@@ -3096,7 +3154,7 @@
 				ENABLE_TESTABILITY = YES;
 				EXECUTABLE_EXTENSION = "";
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool/rules_xcodeproj/Tool/Info.plist";
 				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/examples/multiplatform/Tool/Tool.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -10,6 +10,7 @@ $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatfor
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp/rules_xcodeproj/iMessageAppExtension/Info.plist
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iOSApp/rules_xcodeproj/iOSApp/Info.plist
 $(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist
+$(GEN_DIR)/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool/rules_xcodeproj/Tool/Info.plist
 $(GEN_DIR)/applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp/rules_xcodeproj/tvOSApp/Info.plist
 $(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/tvOSApp/rules_xcodeproj/tvOSApp/Info.plist
 $(GEN_DIR)/applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -145,6 +145,10 @@
         },
         "examples/multiplatform/Tool/BUILD",
         "examples/multiplatform/Tool/Info.plist",
+        {
+            "_": "applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool/rules_xcodeproj/Tool/Info.plist",
+            "t": "g"
+        },
         "test/fixtures/multiplatform/BUILD"
     ],
     "force_bazel_dependencies": true,
@@ -1305,7 +1309,10 @@
                 "//examples/multiplatform/Tool:Tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60"
             ],
             "extensions": [],
-            "info_plist": null,
+            "info_plist": {
+                "_": "applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool/rules_xcodeproj/Tool/Info.plist",
+                "t": "g"
+            },
             "inputs": {},
             "is_swift": false,
             "label": "//examples/multiplatform/Tool:Tool",

--- a/xcodeproj/internal/info_plists.bzl
+++ b/xcodeproj/internal/info_plists.bzl
@@ -23,6 +23,10 @@ def _get_file(target):
         return target[AppleBundleInfo].infoplist
     elif apple_common.Objc in target:
         return _get_file_from_objc_provider(target[apple_common.Objc])
+    elif apple_common.AppleExecutableBinary in target:
+        return _get_file_from_objc_provider(
+            target[apple_common.AppleExecutableBinary].objc,
+        )
     return None
 
 def _adjust_for_xcode(file, *, ctx):

--- a/xcodeproj/internal/launchd_plists.bzl
+++ b/xcodeproj/internal/launchd_plists.bzl
@@ -23,8 +23,12 @@ def _get_file_from_objc_provider(objc_provider):
     return None
 
 def _get_file(target):
-    if apple_common.AppleExecutableBinary in target:
-        return _get_file_from_objc_provider(target[apple_common.AppleExecutableBinary].objc)
+    if apple_common.Objc in target:
+        return _get_file_from_objc_provider(target[apple_common.Objc])
+    elif apple_common.AppleExecutableBinary in target:
+        return _get_file_from_objc_provider(
+            target[apple_common.AppleExecutableBinary].objc,
+        )
     return None
 
 launchd_plists = struct(

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -234,7 +234,7 @@ def process_top_level_target(
     if info_plist_file:
         info_plist = file_path(info_plist_file)
         additional_files.append(info_plist_file)
-        if bundle_info.bundle_extension == ".appex":
+        if bundle_info and bundle_info.bundle_extension == ".appex":
             extension_infoplists = [
                 struct(
                     id = id,


### PR DESCRIPTION
The `ObjcProvider` can be found under `AppleExecutableBinary.objc`.