### PR TITLE
Still declare unfocused outputs as generated inputs

### DIFF
--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -275,9 +275,6 @@ def _to_dto(outputs):
 
     return dto
 
-def _to_swift_list(outputs):
-    return outputs._transitive_swift.to_list()
-
 def _to_output_groups_fields(*, ctx, outputs, toplevel_cache_buster):
     """Generates a dictionary to be splatted into `OutputGroupInfo`.
 
@@ -364,5 +361,4 @@ output_files = struct(
     merge = _merge,
     to_dto = _to_dto,
     to_output_groups_fields = _to_output_groups_fields,
-    to_swift_list = _to_swift_list,
 )

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -112,6 +112,14 @@ field.
 A `depset` of all static library files that are linked into top-level targets
 besides their primary top-level targets.
 """,
+        "non_target_compilation_providers": """\
+A value returned from `compilation_providers.collect`, for targets that aren't
+generating Xcode targets.
+""",
+        "non_target_swift_info_modules": """\
+A value returned from `swift_common.create_swift_info`, for targets that aren't
+generating Xcode targets.
+""",
         "outputs": """\
 A value returned from `output_files.collect`, that contains information about
 the output files for this target and its transitive dependencies.
@@ -128,6 +136,9 @@ any target that depends on this target.
         "target": """\
 A `struct` that contains information about the current target that is
 potentially needed by the dependent targets.
+""",
+        "target_libraries": """\
+A `depset` of library `File`s for targets that generate an Xcode target.
 """,
         "target_type": """\
 A string that categorizes the type of the current target. This will be one of

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -6,13 +6,17 @@ load("@bazel_skylib//lib:sets.bzl", "sets")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":bazel_labels.bzl", "bazel_labels")
 load(":collections.bzl", "uniq")
+load(":compilation_providers.bzl", comp_providers = "compilation_providers")
 load(":configuration.bzl", "get_configuration")
 load(":files.bzl", "file_path", "file_path_to_dto", "parsed_file_path")
 load(":flattened_key_values.bzl", "flattened_key_values")
 load(":input_files.bzl", "input_files")
+load(":linker_input_files.bzl", "linker_input_files")
 load(
     ":output_files.bzl",
     "output_files",
+    "parse_swift_info_module",
+    "swift_to_list",
 )
 load(":providers.bzl", "XcodeProjInfo", "XcodeProjOutputInfo")
 load(":resource_target.bzl", "process_resource_bundles")
@@ -347,11 +351,54 @@ def _xcodeproj_impl(ctx):
     )
 
     bazel_integration_files = [ctx.file._create_lldbinit_script]
-    if ctx.attr.build_mode != "xcode":
+    if ctx.attr.build_mode == "xcode":
+        non_target_swift_info_modules = depset(
+            transitive = [
+                info.non_target_swift_info_modules
+                for info in infos
+            ],
+        )
+        non_xcode_swiftmodules = sets.union(
+            *[
+                sets.make(swift_to_list(parse_swift_info_module(module)))
+                for module in non_target_swift_info_modules.to_list()
+            ]
+        )
+
+        xcode_libraries = sets.make(
+            depset(
+                transitive = [info.target_libraries for info in infos],
+            ).to_list(),
+        )
+        non_xcode_libraries = sets.make(
+            linker_input_files.get_static_libraries(
+                linker_input_files.merge(
+                    compilation_providers = comp_providers.merge(
+                        transitive_compilation_providers = [
+                            (info.target, info.compilation_providers)
+                            for info in infos
+                        ],
+                    ),
+                ),
+            ),
+        )
+
+        xcode_outputs = xcode_libraries
+        non_xcode_outputs = sets.union(
+            non_xcode_swiftmodules,
+            non_xcode_libraries,
+        )
+
+        extra_generated = sets.to_list(
+            sets.difference(non_xcode_outputs, xcode_outputs),
+        )
+    else:
         bazel_integration_files.extend(ctx.files._bazel_integration_files)
+        extra_generated = []
 
     inputs = input_files.merge(
         transitive_infos = [(None, info) for info in infos],
+        extra_generated = extra_generated,
     )
 
     spec_file = _write_json_spec(

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -4,6 +4,7 @@ load(
     "@build_bazel_rules_apple//apple:providers.bzl",
     "AppleBundleInfo",
 )
+load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(":compilation_providers.bzl", comp_providers = "compilation_providers")
 load(":input_files.bzl", "input_files")
 load(":library_targets.bzl", "process_library_target")
@@ -56,11 +57,14 @@ def _target_info_fields(
         hosted_targets,
         inputs,
         non_mergable_targets,
+        non_target_compilation_providers,
+        non_target_swift_info_modules,
         outputs,
         potential_target_merges,
         resource_bundle_informations,
         search_paths,
         target,
+        target_libraries,
         target_type,
         xcode_targets):
     """Generates target specific fields for the `XcodeProjInfo`.
@@ -77,6 +81,10 @@ def _target_info_fields(
         inputs: Maps to the `XcodeProjInfo.inputs` field.
         non_mergable_targets: Maps to the `XcodeProjInfo.non_mergable_targets`
             field.
+        non_target_compilation_providers: Maps to the
+            `XcodeProjInfo.non_target_compilation_providers` field.
+        non_target_swift_info_modules: Maps to the
+            `XcodeProjInfo.non_target_swift_info_modules` field.
         outputs: Maps to the `XcodeProjInfo.outputs` field.
         potential_target_merges: Maps to the
             `XcodeProjInfo.potential_target_merges` field.
@@ -84,6 +92,7 @@ def _target_info_fields(
             `XcodeProjInfo.resource_bundle_informations` field.
         search_paths: Maps to the `XcodeProjInfo.search_paths` field.
         target: Maps to the `XcodeProjInfo.target` field.
+        target_libraries: Maps to the `XcodeProjInfo.target_libraries` field.
         target_type: Maps to the `XcodeProjInfo.target_type` field.
         xcode_targets: Maps to the `XcodeProjInfo.xcode_targets` field.
 
@@ -97,11 +106,14 @@ def _target_info_fields(
         *   `hosted_targets`
         *   `inputs`
         *   `non_mergable_targets`
+        *   `non_target_compilation_providers`
+        *   `non_target_swift_info_modules`
         *   `outputs`
         *   `potential_target_merges`
         *   `resource_bundle_informations`
         *   `search_paths`
         *   `target`
+        *   `target_libraries`
         *   `target_type`
         *   `xcode_targets`
     """
@@ -112,11 +124,14 @@ def _target_info_fields(
         "hosted_targets": hosted_targets,
         "inputs": inputs,
         "non_mergable_targets": non_mergable_targets,
+        "non_target_compilation_providers": non_target_compilation_providers,
+        "non_target_swift_info_modules": non_target_swift_info_modules,
         "outputs": outputs,
         "potential_target_merges": potential_target_merges,
         "resource_bundle_informations": resource_bundle_informations,
         "search_paths": search_paths,
         "target": target,
+        "target_libraries": target_libraries,
         "target_type": target_type,
         "xcode_targets": xcode_targets,
     }
@@ -173,6 +188,18 @@ def _skip_target(*, deps, transitive_infos):
                 for _, info in transitive_infos
             ],
         ),
+        non_target_compilation_providers = comp_providers.merge(
+            transitive_compilation_providers = [
+                (info.target, info.non_target_compilation_providers)
+                for _, info in transitive_infos
+            ],
+        ),
+        non_target_swift_info_modules = depset(
+            transitive = [
+                info.non_target_swift_info_modules
+                for _, info in transitive_infos
+            ],
+        ),
         outputs = output_files.merge(
             automatic_target_info = None,
             transitive_infos = transitive_infos,
@@ -199,6 +226,12 @@ def _skip_target(*, deps, transitive_infos):
             ),
         ),
         target = None,
+        target_libraries = depset(
+            transitive = [
+                info.target_libraries
+                for _, info in transitive_infos
+            ],
+        ),
         target_type = target_type.compile,
         xcode_targets = depset(
             transitive = [info.xcode_targets for _, info in transitive_infos],
@@ -259,6 +292,37 @@ def _create_xcodeprojinfo(*, ctx, target, transitive_infos):
 
     compilation_providers = processed_target.compilation_providers
 
+    if processed_target.target:
+        non_target_compilation_providers = comp_providers.merge(
+            transitive_compilation_providers = [
+                (info.target, info.non_target_compilation_providers)
+                for attr, info in transitive_infos
+                if (info.target_type in
+                    processed_target.automatic_target_info.xcode_targets.get(
+                        attr,
+                        [None],
+                    ))
+            ],
+        )
+        non_target_swift_info_modules = depset(
+            transitive = [
+                info.non_target_swift_info_modules
+                for attr, info in transitive_infos
+                if (info.target_type in
+                    processed_target.automatic_target_info.xcode_targets.get(
+                        attr,
+                        [None],
+                    ))
+            ],
+        )
+    else:
+        non_target_compilation_providers = compilation_providers
+        swift_info = target[SwiftInfo] if SwiftInfo in target else None
+        if swift_info:
+            non_target_swift_info_modules = swift_info.transitive_modules
+        else:
+            non_target_swift_info_modules = depset()
+
     return _target_info_fields(
         compilation_providers = compilation_providers,
         dependencies = processed_target.dependencies,
@@ -299,6 +363,8 @@ def _create_xcodeprojinfo(*, ctx, target, transitive_infos):
                     ))
             ],
         ),
+        non_target_compilation_providers = non_target_compilation_providers,
+        non_target_swift_info_modules = non_target_swift_info_modules,
         outputs = processed_target.outputs,
         potential_target_merges = depset(
             processed_target.potential_target_merges,
@@ -326,6 +392,18 @@ def _create_xcodeprojinfo(*, ctx, target, transitive_infos):
         ),
         search_paths = processed_target.search_paths,
         target = processed_target.target,
+        target_libraries = depset(
+            [processed_target.library] if processed_target.library else None,
+            transitive = [
+                info.target_libraries
+                for attr, info in transitive_infos
+                if (info.target_type in
+                    processed_target.automatic_target_info.xcode_targets.get(
+                        attr,
+                        [None],
+                    ))
+            ],
+        ),
         target_type = processed_target.automatic_target_info.target_type,
         xcode_targets = depset(
             processed_target.xcode_targets,


### PR DESCRIPTION
This reverts 923861d14d32164766d6f1d2b85445749c79d82e and 3d79475e95d9f50cf61450274debab4375ddb65d.

While we didn't want to copy these, and we no longer copy any generated files, we still need to declare that we need them built.