### PR TITLE
Only set `CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION` in BwB

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1649,7 +1649,6 @@
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example";
 				BAZEL_TARGET_ID = "//Example:Example applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = Example/app.entitlements;
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -2985,7 +2985,6 @@
 				BAZEL_TARGET_ID = "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db";
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "$(GEN_DIR)/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/AppClip/Entitlements.withbundleid.plist";
 				"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = "$(GEN_DIR)/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/AppClip/Entitlements.withbundleid.plist";
 				CODE_SIGN_STYLE = Manual;

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -755,7 +755,6 @@
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example";
 				BAZEL_TARGET_ID = "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "$(GEN_DIR)/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example/app.entitlements";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -292,9 +292,17 @@ $(CONFIGURATION_BUILD_DIR)
                 to: entitlementsPath.string.quoted
             )
 
-            // This is required because otherwise Xcode fails the build due
-            // the entitlements file being modified by the Bazel build script.
-            buildSettings["CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION"] = true
+            if !buildMode.usesBazelModeBuildScripts {
+                // This is required because otherwise Xcode can fails the build
+                // due to a generated entitlements file being modified by the
+                // Bazel build script.
+                // We only set this for BwB mode though, because when this is
+                // set, Xcode uses the entitlements as provided instead of
+                // modifying them, which is needed in BwX mode.
+                buildSettings[
+                    "CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION"
+                ] = true
+            }
         }
 
         if let pch = target.inputs.pch {


### PR DESCRIPTION
This is because when this is set, Xcode uses the entitlements as provided instead of modifying them, which is needed in BwX mode.