### PR TITLE
Generate entitlements as part of project generation

### DIFF
--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -434,7 +434,10 @@ def _xcodeproj_impl(ctx):
     return [
         DefaultInfo(
             executable = installer,
-            files = depset([xcodeproj]),
+            files = depset(
+                [xcodeproj],
+                transitive = [inputs.important_generated],
+            ),
             runfiles = ctx.runfiles(files = [xcodeproj]),
         ),
         OutputGroupInfo(


### PR DESCRIPTION
Xcode won't attempt to build if entitlements are missing. So if entitlements are Bazel generated, we now generate them as part of the project generation itself. This will ensure that a version of the entitlements exist.