### PR TITLE
Stop extracting top level values for unfocused libraries

### DIFF
--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -33,11 +33,11 @@
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework",
+            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework",
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework",
+            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework",
             "t": "e"
         },
         "examples/multiplatform/WidgetExtension/BUILD",
@@ -94,11 +94,11 @@
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework",
+            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework",
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework",
+            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework",
             "t": "e"
         },
         {

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -31,11 +31,11 @@
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework",
+            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework",
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework",
+            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework",
             "t": "e"
         },
         "examples/multiplatform/WidgetExtension/BUILD",
@@ -79,11 +79,11 @@
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework",
+            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework",
             "t": "e"
         },
         {
-            "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework",
+            "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework",
             "t": "e"
         },
         {

--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -22,6 +22,7 @@ def _collect(*, cc_info, objc, swift_info, is_xcode_target):
         _cc_info = cc_info,
         _objc = objc,
         _swift_info = swift_info,
+        _is_top_level = False,
         _is_xcode_library_target = is_xcode_library_target,
     )
 
@@ -76,6 +77,7 @@ def _merge(
 
     return struct(
         _cc_info = cc_info,
+        _is_top_level = True,
         _is_xcode_library_target = False,
         _objc = objc,
         _swift_info = swift_info,

--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -35,18 +35,21 @@ def _collect(*, ctx, compilation_providers, avoid_compilation_providers = None):
         The `struct` should be passed to functions on `linker_input_files` to
         retrieve its contents.
     """
-    if compilation_providers._is_xcode_library_target:
-        primary_static_library = _compute_primary_static_library(
-            compilation_providers = compilation_providers,
-        )
-        top_level_values = None
-    else:
+    if compilation_providers._is_top_level:
         primary_static_library = None
         top_level_values = _extract_top_level_values(
             ctx = ctx,
             compilation_providers = compilation_providers,
             avoid_compilation_providers = avoid_compilation_providers,
         )
+    elif compilation_providers._is_xcode_library_target:
+        primary_static_library = _compute_primary_static_library(
+            compilation_providers = compilation_providers,
+        )
+        top_level_values = None
+    else:
+        primary_static_library = None
+        top_level_values = None
 
     return struct(
         _compilation_providers = compilation_providers,


### PR DESCRIPTION
Unfocused libraries were going down the "top level" path accidentally.