### PR TITLE
Default `avoid_deps`

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -94,7 +94,7 @@ def _collect(
         automatic_target_info,
         additional_files = [],
         transitive_infos,
-        avoid_deps):
+        avoid_deps = []):
     """Collects all of the inputs of a target.
 
     Args:
@@ -113,7 +113,7 @@ def _collect(
             (e.g. modulemaps or BUILD files).
         transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
             dependencies of `target`.
-        avoid_deps: A `list` pf the targets that already consumed resources, and
+        avoid_deps: A `list` of the targets that already consumed resources, and
             their resources shouldn't be bundled with `target`.
 
     Returns:

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -131,7 +131,6 @@ def process_library_target(
         automatic_target_info = automatic_target_info,
         additional_files = modulemaps.files,
         transitive_infos = transitive_infos,
-        avoid_deps = [],
     )
     outputs = output_files.collect(
         target_files = [],

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -99,7 +99,6 @@ rules_xcodeproj requires {} to have `{}` set.
             linker_inputs = linker_inputs,
             automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
-            avoid_deps = [],
         ),
         outputs = output_files.merge(
             automatic_target_info = automatic_target_info,


### PR DESCRIPTION
It's only used in the top-level target case.