### PR TITLE
Add `linker_input_files.get_library_static_libraries`

### DIFF
--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -368,7 +368,9 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
 
     non_mergable_targets = [
         library
-        for library in linker_input_files.get_static_libraries(linker_inputs)
+        for library in linker_input_files.get_top_level_static_libraries(
+            linker_inputs,
+        )
         if mergeable_label and library.owner != mergeable_label
     ]
 

--- a/xcodeproj/internal/xcodeproj.bzl
+++ b/xcodeproj/internal/xcodeproj.bzl
@@ -371,7 +371,7 @@ def _xcodeproj_impl(ctx):
             ).to_list(),
         )
         non_xcode_libraries = sets.make(
-            linker_input_files.get_static_libraries(
+            linker_input_files.get_top_level_static_libraries(
                 linker_input_files.merge(
                     compilation_providers = comp_providers.merge(
                         transitive_compilation_providers = [


### PR DESCRIPTION
This will be used in a future change for better forced-unfocused target detection.