### PR TITLE
Convert `process_search_paths` to a Starlark module

### DIFF
--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -13,7 +13,7 @@ load(":output_files.bzl", "output_files")
 load(":platform.bzl", "platform_info")
 load(":processed_target.bzl", "processed_target", "xcode_target")
 load(":product.bzl", "process_product")
-load(":search_paths.bzl", "process_search_paths")
+load(":target_search_paths.bzl", "target_search_paths")
 load(":target_id.bzl", "get_id")
 load(
     ":target_properties.bzl",
@@ -150,7 +150,7 @@ def process_library_target(
         compilation_providers = compilation_providers,
         build_settings = build_settings,
     )
-    search_paths = process_search_paths(
+    search_paths = target_search_paths.make(
         compilation_providers = compilation_providers,
         bin_dir_path = ctx.bin_dir.path,
         opts_search_paths = opts_search_paths,

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -10,16 +10,15 @@ load(":compilation_providers.bzl", comp_providers = "compilation_providers")
 load(":configuration.bzl", "get_configuration")
 load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
-load(":opts.bzl", "create_opts_search_paths")
 load(":output_files.bzl", "output_files")
 load(":processed_target.bzl", "processed_target")
-load(":search_paths.bzl", "process_search_paths")
 load(":target_id.bzl", "get_id")
 load(
     ":target_properties.bzl",
     "process_dependencies",
     "should_bundle_resources",
 )
+load(":target_search_paths.bzl", "target_search_paths")
 
 def process_non_xcode_target(
         *,
@@ -107,14 +106,9 @@ rules_xcodeproj requires {} to have `{}` set.
             transitive_infos = transitive_infos,
         ),
         resource_bundle_informations = resource_bundle_informations,
-        search_paths = process_search_paths(
+        search_paths = target_search_paths.make(
             compilation_providers = compilation_providers,
             bin_dir_path = ctx.bin_dir.path,
-            opts_search_paths = create_opts_search_paths(
-                quote_includes = [],
-                includes = [],
-                system_includes = [],
-            ),
         ),
         target = None,
         xcode_target = None,

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -32,7 +32,7 @@ def _create(
             with Bazel.
 
     Returns:
-        A `struct` representing the internal data structure of the
+        An opaque `struct` representing the internal data structure of the
         `output_files` module.
     """
     direct_build = []

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -8,6 +8,7 @@ load(":output_files.bzl", "output_files")
 load(":platform.bzl", "platform_info")
 load(":product.bzl", "product_to_dto")
 load(":providers.bzl", "target_type")
+load(":target_search_paths.bzl", "target_search_paths")
 
 def processed_target(
         *,
@@ -50,7 +51,7 @@ def processed_target(
             the `XcodeProjInfo.potential_target_merges` `depset`.
         resource_bundle_informations: An optional `list` of `struct`s that will
             be in the `XcodeProjInfo.resource_bundle_informations` `depset`.
-        search_paths: The value returned from `_process_search_paths`.
+        search_paths: A value as returned from `target_search_paths.make`.
         target: An optional `XcodeProjInfo.target` `struct`.
         xcode_target: An optional string that will be in the
             `XcodeProjInfo.xcode_targets` `depset`.
@@ -88,7 +89,7 @@ def xcode_target(
         is_swift,
         test_host = None,
         build_settings,
-        search_paths,
+        search_paths = None,
         modulemaps,
         swiftmodules,
         inputs,
@@ -118,7 +119,8 @@ def xcode_target(
         test_host: The `id` of the target that is the test host for this
             target, or `None` if this target does not have a test host.
         build_settings: A `dict` of Xcode build settings for the target.
-        search_paths: The value returned from `_process_search_paths`.
+        search_paths: The value returned from `target_search_paths.make`,
+            or `None`.
         modulemaps: The value returned from `_process_modulemaps`.
         swiftmodules: The value returned from `_process_swiftmodules`.
         inputs: The value returned from `input_files.collect`.
@@ -159,7 +161,11 @@ def xcode_target(
 
     set_if_true(target_json, "test_host", test_host)
     set_if_true(target_json, "build_settings", build_settings)
-    set_if_true(target_json, "search_paths", search_paths)
+    set_if_true(
+        target_json,
+        "search_paths",
+        target_search_paths.to_dto(search_paths),
+    )
     set_if_true(
         target_json,
         "modulemaps",

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -60,7 +60,6 @@ def _process_resource_bundle(bundle, *, information):
         product = product,
         is_swift = False,
         build_settings = build_settings,
-        search_paths = {},
         modulemaps = process_modulemaps(swift_info = None),
         swiftmodules = process_swiftmodules(swift_info = None),
         inputs = input_files.from_resource_bundle(bundle),

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -22,7 +22,7 @@ load(":providers.bzl", "XcodeProjInfo")
 load(":processed_target.bzl", "processed_target", "xcode_target")
 load(":product.bzl", "process_product")
 load(":provisioning_profiles.bzl", "provisioning_profiles")
-load(":search_paths.bzl", "process_search_paths")
+load(":target_search_paths.bzl", "target_search_paths")
 load(":target_id.bzl", "get_id")
 load(
     ":target_properties.bzl",
@@ -431,7 +431,7 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
         compilation_providers = compilation_providers,
         build_settings = build_settings,
     )
-    search_paths = process_search_paths(
+    search_paths = target_search_paths.make(
         compilation_providers = compilation_providers,
         bin_dir_path = ctx.bin_dir.path,
         opts_search_paths = opts_search_paths,

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -8,7 +8,6 @@ load(":compilation_providers.bzl", comp_providers = "compilation_providers")
 load(":input_files.bzl", "input_files")
 load(":library_targets.bzl", "process_library_target")
 load(":non_xcode_targets.bzl", "process_non_xcode_target")
-load(":opts.bzl", "create_opts_search_paths")
 load(":output_files.bzl", "output_files")
 load(
     ":providers.bzl",
@@ -17,7 +16,7 @@ load(
     "target_type",
 )
 load(":processed_target.bzl", "processed_target")
-load(":search_paths.bzl", "process_search_paths")
+load(":target_search_paths.bzl", "target_search_paths")
 load(":targets.bzl", "targets")
 load(
     ":target_properties.bzl",
@@ -193,14 +192,9 @@ def _skip_target(*, deps, transitive_infos):
                 for _, info in transitive_infos
             ],
         ),
-        search_paths = process_search_paths(
+        search_paths = target_search_paths.make(
             compilation_providers = None,
             bin_dir_path = None,
-            opts_search_paths = create_opts_search_paths(
-                quote_includes = [],
-                includes = [],
-                system_includes = [],
-            ),
         ),
         target = None,
         target_libraries = depset(


### PR DESCRIPTION
This will allow for the eventual de-stringification of `xcode_target`.