### PR TITLE
Keep unique set of TargetInfo values in XCSchemeInfo structs

### DIFF
--- a/tools/generator/src/Extensions/XCScheme+Extensions.swift
+++ b/tools/generator/src/Extensions/XCScheme+Extensions.swift
@@ -212,3 +212,17 @@ extension XCScheme.ArchiveAction {
         )
     }
 }
+
+extension XCScheme.BuildableReference: Hashable {
+    public func hash(into hasher: inout Hasher) {
+        // This should match the Equatable conformance for XCScheme.BuildableReference.
+        // NOTE: The equality check in XCScheme.BuildableReference checks the `blueprint` property
+        // in addition to the `blueprintName`. The `blueprint` property is private. The
+        // `blueprintName` and `blueprintIdentifier` should be sufficient to include in the hashable
+        // calculation.
+        hasher.combine(referencedContainer)
+        hasher.combine(blueprintIdentifier)
+        hasher.combine(buildableName)
+        hasher.combine(blueprintName)
+    }
+}

--- a/tools/generator/src/Generator/XCSchemeInfo+BuildActionInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+BuildActionInfo.swift
@@ -2,12 +2,12 @@ import XcodeProj
 
 extension XCSchemeInfo {
     struct BuildActionInfo {
-        let targetInfos: [XCSchemeInfo.TargetInfo]
+        let targetInfos: Set<XCSchemeInfo.TargetInfo>
 
         init<TargetInfos: Sequence>(
             targetInfos: TargetInfos
         ) throws where TargetInfos.Element == XCSchemeInfo.TargetInfo {
-            self.targetInfos = Array(targetInfos)
+            self.targetInfos = Set(targetInfos)
 
             guard !self.targetInfos.isEmpty else {
                 throw PreconditionError(message: """

--- a/tools/generator/src/Generator/XCSchemeInfo+HostInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+HostInfo.swift
@@ -1,7 +1,7 @@
 import XcodeProj
 
 extension XCSchemeInfo {
-    struct HostInfo: Equatable {
+    struct HostInfo: Equatable, Hashable {
         let pbxTarget: PBXTarget
         let buildableReference: XCScheme.BuildableReference
         let index: Int

--- a/tools/generator/src/Generator/XCSchemeInfo+TargetInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+TargetInfo.swift
@@ -1,7 +1,7 @@
 import XcodeProj
 
 extension XCSchemeInfo {
-    enum HostResolution: Equatable {
+    enum HostResolution: Equatable, Hashable {
         /// Host resolution has not occurred.
         case unresolved
         /// Host resoultion has occurred. No host was selected.
@@ -10,7 +10,7 @@ extension XCSchemeInfo {
         case selected(HostInfo)
     }
 
-    struct TargetInfo: Equatable {
+    struct TargetInfo: Equatable, Hashable {
         let pbxTarget: PBXTarget
         let buildableReference: XCScheme.BuildableReference
         let hostInfos: [HostInfo]

--- a/tools/generator/src/Generator/XCSchemeInfo+TestActionInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+TestActionInfo.swift
@@ -3,7 +3,7 @@ import XcodeProj
 extension XCSchemeInfo {
     struct TestActionInfo {
         let buildConfigurationName: String
-        let targetInfos: [XCSchemeInfo.TargetInfo]
+        let targetInfos: Set<XCSchemeInfo.TargetInfo>
 
         /// The primary initializer.
         init<TargetInfos: Sequence>(
@@ -11,7 +11,7 @@ extension XCSchemeInfo {
             targetInfos: TargetInfos
         ) throws where TargetInfos.Element == XCSchemeInfo.TargetInfo {
             self.buildConfigurationName = buildConfigurationName
-            self.targetInfos = Array(targetInfos)
+            self.targetInfos = Set(targetInfos)
 
             guard !self.targetInfos.isEmpty else {
                 throw PreconditionError(message: """


### PR DESCRIPTION
Related to #573.

- Implement `Hashable` for `XCScheme.BuildableReference`, `XCSchemeInfo.HostInfo`, and `XCSchemeInfo.TargetInfo`.
- Update `XCSchemeInfo.BuildActionInfo` and `XCSchemeInfo.TestActionInfo` to store their `targetInfos` as `Set<XCSchemeInfo.TargetInfo>`.