### PR TITLE
Set `*_DEPLOYMENT_TARGET` in `generator`

### DIFF
--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -165,7 +165,6 @@
                     "OS_IOS",
                     "DEBUG=1"
                 ],
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -243,6 +242,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -280,7 +280,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -340,6 +339,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -381,7 +381,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "Example",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -431,6 +430,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -471,7 +471,6 @@
                 "GCC_PREPROCESSOR_DEFINITIONS": [
                     "AWESOME"
                 ],
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.objctests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -525,6 +524,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -576,7 +576,6 @@
                     "DEBUG=1",
                     "AWESOME"
                 ],
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -654,6 +653,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -694,7 +694,6 @@
                 "GCC_PREPROCESSOR_DEFINITIONS": [
                     "AWESOME"
                 ],
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.tests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -749,6 +748,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -792,7 +792,6 @@
                 "ENABLE_TESTABILITY": true,
                 "ENABLE_TESTING_SEARCH_PATHS": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -DAWESOME -static",
                 "PRODUCT_MODULE_NAME": "ExampleTests",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG AWESOME",
@@ -847,6 +846,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -894,7 +894,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.uitests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -942,6 +941,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -974,7 +974,6 @@
                 "ENABLE_TESTABILITY": true,
                 "ENABLE_TESTING_SEARCH_PATHS": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "ExampleUITests",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1011,6 +1010,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1042,7 +1042,6 @@
                 "ENABLE_TESTABILITY": true,
                 "ENABLE_TESTING_SEARCH_PATHS": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -DAWESOME -static",
                 "PRODUCT_MODULE_NAME": "TestingUtils",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG AWESOME",
@@ -1085,6 +1084,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1121,7 +1121,6 @@
                     "OS_IOS",
                     "DEBUG=1"
                 ],
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -1201,6 +1200,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -110,7 +110,6 @@
                     "OS_IOS",
                     "DEBUG=1"
                 ],
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -188,6 +187,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -225,7 +225,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -307,6 +306,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -352,7 +352,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "Example",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -402,6 +401,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -435,7 +435,6 @@
         "//ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
         {
             "build_settings": {
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "com.example.resources.nested"
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
@@ -464,6 +463,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -488,7 +488,6 @@
                 "GCC_PREPROCESSOR_DEFINITIONS": [
                     "AWESOME"
                 ],
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.objctests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -552,6 +551,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -606,7 +606,6 @@
                     "DEBUG=1",
                     "AWESOME"
                 ],
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -684,6 +683,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -717,7 +717,6 @@
         "//ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
         {
             "build_settings": {
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "com.example.resources"
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
@@ -747,6 +746,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -774,7 +774,6 @@
                 "GCC_PREPROCESSOR_DEFINITIONS": [
                     "AWESOME"
                 ],
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.tests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -834,6 +833,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -877,7 +877,6 @@
                 "ENABLE_TESTABILITY": true,
                 "ENABLE_TESTING_SEARCH_PATHS": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -DAWESOME -static",
                 "PRODUCT_MODULE_NAME": "ExampleTests",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG AWESOME",
@@ -932,6 +931,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -979,7 +979,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.uitests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -1027,6 +1026,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1062,7 +1062,6 @@
                 "ENABLE_TESTABILITY": true,
                 "ENABLE_TESTING_SEARCH_PATHS": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "ExampleUITests",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1099,6 +1098,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1125,7 +1125,6 @@
         "//OnlyStructuredResources:OnlyStructuredResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
         {
             "build_settings": {
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "com.example.only_structured_resources"
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
@@ -1145,6 +1144,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1167,7 +1167,6 @@
                 "ENABLE_TESTABILITY": true,
                 "ENABLE_TESTING_SEARCH_PATHS": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -DAWESOME -static",
                 "PRODUCT_MODULE_NAME": "TestingUtils",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG AWESOME",
@@ -1210,6 +1209,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1246,7 +1246,6 @@
                     "OS_IOS",
                     "DEBUG=1"
                 ],
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -1326,6 +1325,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1359,7 +1359,6 @@
         "@examples_ios_app_external//:ExternalResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
         {
             "build_settings": {
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "com.example.resources.external"
             },
             "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54",
@@ -1384,6 +1383,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"

--- a/test/fixtures/cc/bwb_spec.json
+++ b/test/fixtures/cc/bwb_spec.json
@@ -43,7 +43,6 @@
                     "__TIMESTAMP__=\"redacted\"",
                     "__TIME__=\"redacted\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -85,6 +84,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib2",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -129,7 +129,6 @@
                     "__TIME__=\"redacted\"",
                     "SECRET_3=\\\"Hello\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -169,6 +168,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/lib",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -214,7 +214,6 @@
                     "SECRET_2=\\\"World!\\\"",
                     "EXTERNAL_SECRET_2=\\\"World?\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -287,6 +286,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/examples/cc/tool",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -347,7 +347,6 @@
                     "__TIME__=\"redacted\"",
                     "EXTERNAL_SECRET_3=\\\"Goodbye\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -399,6 +398,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/examples_cc_external",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"

--- a/test/fixtures/cc/bwx_spec.json
+++ b/test/fixtures/cc/bwx_spec.json
@@ -43,7 +43,6 @@
                     "__TIMESTAMP__=\"redacted\"",
                     "__TIME__=\"redacted\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -85,6 +84,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/examples/cc/lib2",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -129,7 +129,6 @@
                     "__TIME__=\"redacted\"",
                     "SECRET_3=\\\"Hello\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -169,6 +168,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/examples/cc/lib",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -214,7 +214,6 @@
                     "SECRET_2=\\\"World!\\\"",
                     "EXTERNAL_SECRET_2=\\\"World?\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -287,6 +286,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/examples/cc/tool",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -347,7 +347,6 @@
                     "__TIME__=\"redacted\"",
                     "EXTERNAL_SECRET_3=\\\"Goodbye\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -399,6 +398,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/examples_cc_external",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -94,7 +94,6 @@
                     "SECRET_3=\\\"Hello\\\"",
                     "SECRET_2=\\\"World!\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "com.bazelbuild.rulesapple.Tests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -177,6 +176,7 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/Tests",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -225,7 +225,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -DSECRET_3=\"Hello\" -Xcc -DSECRET_2=\"World!\" -Fexternal/examples_command_line_external -static",
                 "PRODUCT_MODULE_NAME": "LibSwiftTestsLib",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -282,6 +281,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/Tests",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -340,7 +340,6 @@
                     "SECRET_3=\\\"Hello\\\"",
                     "SECRET_2=\\\"World!\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -404,6 +403,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -434,7 +434,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -DSECRET_3=\"Hello\" -Xcc -DSECRET_2=\"World!\" -Fexternal/examples_command_line_external -static",
                 "PRODUCT_MODULE_NAME": "LibSwift",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -497,6 +496,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -547,7 +547,6 @@
                     "__TIMESTAMP__=\"redacted\"",
                     "__TIME__=\"redacted\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -589,6 +588,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -625,7 +625,6 @@
                     "__TIMESTAMP__=\"redacted\"",
                     "__TIME__=\"redacted\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -667,6 +666,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/swift_c_module",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -700,7 +700,6 @@
                     "SECRET_3=\\\"Hello\\\"",
                     "SECRET_2=\\\"World!\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CODE_SIGN_FLAGS": [
                     "-v"
                 ],
@@ -790,6 +789,7 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/tool",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -859,7 +859,6 @@
                     "SECRET_3=\\\"Hello\\\"",
                     "SECRET_2=\\\"World!\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -925,6 +924,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/command_line/tool",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -94,7 +94,6 @@
                     "SECRET_3=\\\"Hello\\\"",
                     "SECRET_2=\\\"World!\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "com.bazelbuild.rulesapple.Tests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -177,6 +176,7 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/Tests",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -225,7 +225,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -DSECRET_3=\"Hello\" -Xcc -DSECRET_2=\"World!\" -Fexternal/examples_command_line_external -static",
                 "PRODUCT_MODULE_NAME": "LibSwiftTestsLib",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -282,6 +281,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/Tests",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -340,7 +340,6 @@
                     "SECRET_3=\\\"Hello\\\"",
                     "SECRET_2=\\\"World!\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -404,6 +403,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -434,7 +434,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Xcc -DSECRET_3=\"Hello\" -Xcc -DSECRET_2=\"World!\" -Fexternal/examples_command_line_external -static",
                 "PRODUCT_MODULE_NAME": "LibSwift",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -497,6 +496,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -547,7 +547,6 @@
                     "__TIMESTAMP__=\"redacted\"",
                     "__TIME__=\"redacted\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -589,6 +588,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -625,7 +625,6 @@
                     "__TIMESTAMP__=\"redacted\"",
                     "__TIME__=\"redacted\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -667,6 +666,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/swift_c_module",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -700,7 +700,6 @@
                     "SECRET_3=\\\"Hello\\\"",
                     "SECRET_2=\\\"World!\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CODE_SIGN_FLAGS": [
                     "-v"
                 ],
@@ -790,6 +789,7 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -859,7 +859,6 @@
                     "SECRET_3=\\\"Hello\\\"",
                     "SECRET_2=\\\"World!\\\""
                 ],
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-fstack-protector",
                     "-Wall",
@@ -925,6 +924,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/command_line/tool",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -53,7 +53,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -128,6 +127,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/test",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -159,7 +159,6 @@
                 "ENABLE_TESTABILITY": true,
                 "ENABLE_TESTING_SEARCH_PATHS": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "tests",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -237,6 +236,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator/test",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -296,7 +296,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -356,6 +355,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -386,7 +386,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "generator",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -486,6 +485,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/tools/generator",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -534,7 +534,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "OrderedCollections",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -768,6 +767,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_apple_swift_collections",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -798,7 +798,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "PathKit",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -836,6 +835,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_kylef_pathkit",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -866,7 +866,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "CustomDump",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1003,6 +1002,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_swift_custom_dump",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -1039,7 +1039,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "XCTestDynamicOverlay",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1077,6 +1076,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -1107,7 +1107,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "AEXML",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1161,6 +1160,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tadija_aexml",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -1191,7 +1191,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "XcodeProj",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1609,6 +1608,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-5534cb307cb8/bin/external/com_github_tuist_xcodeproj",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -53,7 +53,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -128,6 +127,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/test",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -159,7 +159,6 @@
                 "ENABLE_TESTABILITY": true,
                 "ENABLE_TESTING_SEARCH_PATHS": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "tests",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -237,6 +236,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator/test",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -296,7 +296,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -356,6 +355,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -386,7 +386,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "generator",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -486,6 +485,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/tools/generator",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -534,7 +534,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "OrderedCollections",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -768,6 +767,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_apple_swift_collections",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -798,7 +798,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "PathKit",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -836,6 +835,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_kylef_pathkit",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -866,7 +866,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "CustomDump",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1003,6 +1002,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_swift_custom_dump",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -1039,7 +1039,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "XCTestDynamicOverlay",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1077,6 +1076,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_pointfreeco_xctest_dynamic_overlay",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -1107,7 +1107,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "AEXML",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1161,6 +1160,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tadija_aexml",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -1191,7 +1191,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "XcodeProj",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1609,6 +1608,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/external/com_github_tuist_xcodeproj",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"

--- a/test/fixtures/macos_app/bwb_spec.json
+++ b/test/fixtures/macos_app/bwb_spec.json
@@ -44,7 +44,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -92,6 +91,7 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin/examples/macos_app/Example",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "macosx",
                 "os": "macos"
@@ -129,7 +129,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexamples/macos_app/third_party -static",
                 "PRODUCT_MODULE_NAME": "iOSApp",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -168,6 +167,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin/examples/macos_app/Example",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "macosx",
                 "os": "macos"

--- a/test/fixtures/macos_app/bwx_spec.json
+++ b/test/fixtures/macos_app/bwx_spec.json
@@ -42,7 +42,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -96,6 +95,7 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin/examples/macos_app/Example",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "macosx",
                 "os": "macos"
@@ -133,7 +133,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexamples/macos_app/third_party -static",
                 "PRODUCT_MODULE_NAME": "iOSApp",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -172,6 +171,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin/examples/macos_app/Example",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "macosx",
                 "os": "macos"

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -298,7 +298,6 @@
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.app-clip",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -363,6 +362,7 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -407,7 +407,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.app-clip",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -473,6 +472,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -517,7 +517,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static",
                 "PRODUCT_MODULE_NAME": "AppClip",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -562,6 +561,7 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -612,7 +612,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static",
                 "PRODUCT_MODULE_NAME": "AppClip",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -658,6 +657,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -708,7 +708,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static",
                 "PRODUCT_MODULE_NAME": "Lib",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -752,6 +751,7 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -796,7 +796,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static",
                 "PRODUCT_MODULE_NAME": "Lib",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -841,6 +840,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -890,8 +890,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2",
             "inputs": {
@@ -929,6 +928,7 @@
             "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvos",
                 "os": "tvos"
@@ -978,8 +978,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67",
             "inputs": {
@@ -1018,6 +1017,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -1067,8 +1067,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc",
             "inputs": {
@@ -1106,6 +1105,7 @@
             "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64_32",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchos",
                 "os": "watchos"
@@ -1155,8 +1155,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a",
             "inputs": {
@@ -1195,6 +1194,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchsimulator",
                 "os": "watchos"
@@ -1238,7 +1238,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -1282,6 +1281,7 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Tool",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -1312,7 +1312,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "Tool",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1347,6 +1346,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0139d977e630/bin/examples/multiplatform/Tool",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -1378,7 +1378,6 @@
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.widget-extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -1437,6 +1436,7 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -1481,7 +1481,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.widget-extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -1541,6 +1540,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1585,7 +1585,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static",
                 "PRODUCT_MODULE_NAME": "WidgetExtension",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1633,6 +1632,7 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -1683,7 +1683,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static",
                 "PRODUCT_MODULE_NAME": "WidgetExtension",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1732,6 +1731,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1783,7 +1783,6 @@
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.imessage-app",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -1820,6 +1819,7 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -1850,7 +1850,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.imessage-app",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -1888,6 +1887,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1919,7 +1919,6 @@
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.imessage-app.extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -1978,6 +1977,7 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -2022,7 +2022,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.imessage-app.extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -2082,6 +2081,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -2126,7 +2126,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static",
                 "PRODUCT_MODULE_NAME": "iMessageAppExtension",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -2170,6 +2169,7 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -2220,7 +2220,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static",
                 "PRODUCT_MODULE_NAME": "iMessageAppExtension",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -2265,6 +2264,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -2319,7 +2319,6 @@
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -2406,6 +2405,7 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -2474,7 +2474,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -2562,6 +2561,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -2627,7 +2627,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Fexternal/com_google_google_maps/GoogleMaps.xcframework/ios-arm64 -Fexternal/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64 -static",
                 "PRODUCT_MODULE_NAME": "iOSApp",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -2684,6 +2683,7 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -2754,7 +2754,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -Fexternal/com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator -Fexternal/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator -static",
                 "PRODUCT_MODULE_NAME": "iOSApp",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -2812,6 +2811,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -2886,8 +2886,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2",
             "dependencies": [
@@ -2941,6 +2940,7 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvos",
                 "os": "tvos"
@@ -2988,8 +2988,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67",
             "dependencies": [
@@ -3044,6 +3043,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -3093,8 +3093,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2",
             "dependencies": [
@@ -3133,6 +3132,7 @@
             "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvos",
                 "os": "tvos"
@@ -3188,8 +3188,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67",
             "dependencies": [
@@ -3229,6 +3228,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -3283,8 +3283,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc",
             "dependencies": [
@@ -3316,6 +3315,7 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp",
             "platform": {
                 "arch": "arm64_32",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchos",
                 "os": "watchos"
@@ -3349,8 +3349,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a",
             "dependencies": [
@@ -3383,6 +3382,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchsimulator",
                 "os": "watchos"
@@ -3417,8 +3417,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch.extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc",
             "dependencies": [
@@ -3472,6 +3471,7 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "arm64_32",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchos",
                 "os": "watchos"
@@ -3519,8 +3519,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch.extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a",
             "dependencies": [
@@ -3575,6 +3574,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchsimulator",
                 "os": "watchos"
@@ -3624,8 +3624,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc",
             "dependencies": [
@@ -3664,6 +3663,7 @@
             "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "arm64_32",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchos",
                 "os": "watchos"
@@ -3719,8 +3719,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a",
             "dependencies": [
@@ -3760,6 +3759,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchsimulator",
                 "os": "watchos"

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -272,7 +272,6 @@
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.app-clip",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -341,6 +340,7 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -385,7 +385,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.app-clip",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -455,6 +454,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -499,7 +499,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static",
                 "PRODUCT_MODULE_NAME": "AppClip",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -544,6 +543,7 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -594,7 +594,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static",
                 "PRODUCT_MODULE_NAME": "AppClip",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -640,6 +639,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -690,7 +690,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static",
                 "PRODUCT_MODULE_NAME": "Lib",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -734,6 +733,7 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -778,7 +778,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static",
                 "PRODUCT_MODULE_NAME": "Lib",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -823,6 +822,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -872,8 +872,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef",
             "inputs": {
@@ -911,6 +910,7 @@
             "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvos",
                 "os": "tvos"
@@ -960,8 +960,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53",
             "inputs": {
@@ -1000,6 +999,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -1049,8 +1049,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3",
             "inputs": {
@@ -1088,6 +1087,7 @@
             "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64_32",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchos",
                 "os": "watchos"
@@ -1137,8 +1137,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba",
             "inputs": {
@@ -1177,6 +1176,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchsimulator",
                 "os": "watchos"
@@ -1220,7 +1220,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
@@ -1264,6 +1263,7 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -1294,7 +1294,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
                 "PRODUCT_MODULE_NAME": "Tool",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1329,6 +1328,7 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-59a3e2f8ef60/bin/examples/multiplatform/Tool",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"
@@ -1360,7 +1360,6 @@
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.widget-extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -1424,6 +1423,7 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -1468,7 +1468,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.widget-extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -1533,6 +1532,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1577,7 +1577,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static",
                 "PRODUCT_MODULE_NAME": "WidgetExtension",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1625,6 +1624,7 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -1675,7 +1675,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static",
                 "PRODUCT_MODULE_NAME": "WidgetExtension",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -1724,6 +1723,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1775,7 +1775,6 @@
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.imessage-app",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -1817,6 +1816,7 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -1847,7 +1847,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.imessage-app",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -1890,6 +1889,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -1921,7 +1921,6 @@
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.imessage-app.extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -1986,6 +1985,7 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -2030,7 +2030,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.imessage-app.extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -2096,6 +2095,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -2140,7 +2140,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static",
                 "PRODUCT_MODULE_NAME": "iMessageAppExtension",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -2184,6 +2183,7 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -2234,7 +2234,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static",
                 "PRODUCT_MODULE_NAME": "iMessageAppExtension",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -2279,6 +2278,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -2333,7 +2333,6 @@
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -2433,6 +2432,7 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -2501,7 +2501,6 @@
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -2602,6 +2601,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -2667,7 +2667,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Fexternal/com_google_google_maps/GoogleMaps.xcframework/ios-arm64 -Fexternal/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64 -static",
                 "PRODUCT_MODULE_NAME": "iOSApp",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -2724,6 +2723,7 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphoneos",
                 "os": "ios"
@@ -2794,7 +2794,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "IPHONEOS_DEPLOYMENT_TARGET": "15.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -Fexternal/com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator -Fexternal/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator -static",
                 "PRODUCT_MODULE_NAME": "iOSApp",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -2852,6 +2851,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "iphonesimulator",
                 "os": "ios"
@@ -2926,8 +2926,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef",
             "dependencies": [
@@ -2987,6 +2986,7 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvos",
                 "os": "tvos"
@@ -3034,8 +3034,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53",
             "dependencies": [
@@ -3096,6 +3095,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -3145,8 +3145,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef",
             "dependencies": [
@@ -3185,6 +3184,7 @@
             "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "arm64",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvos",
                 "os": "tvos"
@@ -3240,8 +3240,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53",
             "dependencies": [
@@ -3281,6 +3280,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -3335,8 +3335,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3",
             "dependencies": [
@@ -3373,6 +3372,7 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSApp",
             "platform": {
                 "arch": "arm64_32",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchos",
                 "os": "watchos"
@@ -3406,8 +3406,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba",
             "dependencies": [
@@ -3445,6 +3444,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchsimulator",
                 "os": "watchos"
@@ -3479,8 +3479,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch.extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3",
             "dependencies": [
@@ -3540,6 +3539,7 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "arm64_32",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchos",
                 "os": "watchos"
@@ -3587,8 +3587,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch.extension",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba",
             "dependencies": [
@@ -3649,6 +3648,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchsimulator",
                 "os": "watchos"
@@ -3698,8 +3698,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3",
             "dependencies": [
@@ -3738,6 +3737,7 @@
             "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "arm64_32",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchos",
                 "os": "watchos"
@@ -3793,8 +3793,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "WATCHOS_DEPLOYMENT_TARGET": "7.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba",
             "dependencies": [
@@ -3834,6 +3833,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "name": "watchsimulator",
                 "os": "watchos"

--- a/test/fixtures/simple/bwb_spec.json
+++ b/test/fixtures/simple/bwb_spec.json
@@ -30,7 +30,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
                 "PRODUCT_MODULE_NAME": "SwiftBinModuleName",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG HI",
@@ -63,6 +62,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-f7d2792bf9e4/bin/examples/simple",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"

--- a/test/fixtures/simple/bwx_spec.json
+++ b/test/fixtures/simple/bwx_spec.json
@@ -30,7 +30,6 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all",
                 "PRODUCT_MODULE_NAME": "SwiftBinModuleName",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG HI",
@@ -63,6 +62,7 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-ccd9595da841/bin/examples/simple",
             "platform": {
                 "arch": "x86_64",
+                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "name": "macosx",
                 "os": "macos"

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -65,8 +65,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1",
             "dependencies": [
@@ -114,6 +113,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -149,8 +149,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1",
             "inputs": {
@@ -181,6 +180,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -214,8 +214,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.tests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1",
             "dependencies": [
@@ -259,6 +258,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -296,8 +296,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1",
             "dependencies": [
@@ -330,6 +329,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -369,8 +369,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.uitests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1",
             "dependencies": [
@@ -413,6 +412,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -450,8 +450,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1",
             "inputs": {
@@ -482,6 +481,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -65,8 +65,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de",
             "dependencies": [
@@ -114,6 +113,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -149,8 +149,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de",
             "inputs": {
@@ -181,6 +180,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -214,8 +214,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.tests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de",
             "dependencies": [
@@ -259,6 +258,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -296,8 +296,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de",
             "dependencies": [
@@ -330,6 +329,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -369,8 +369,7 @@
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.uitests",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de",
             "dependencies": [
@@ -413,6 +412,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"
@@ -450,8 +450,7 @@
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5",
-                "TVOS_DEPLOYMENT_TARGET": "15.0"
+                "SWIFT_VERSION": "5"
             },
             "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de",
             "inputs": {
@@ -482,6 +481,7 @@
             "platform": {
                 "arch": "x86_64",
                 "environment": "Simulator",
+                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "name": "appletvsimulator",
                 "os": "tvos"

--- a/test/internal/platform/platform_info_to_dto_tests.bzl
+++ b/test/internal/platform/platform_info_to_dto_tests.bzl
@@ -9,28 +9,20 @@ load("//xcodeproj/internal:platform.bzl", "platform_info")
 def _platform_info_to_dto_test_impl(ctx):
     env = unittest.begin(ctx)
 
-    build_settings = {}
     platform = struct(
-        _platform = getattr(apple_common.platform, ctx.attr.platform_key),
         _arch = ctx.attr.arch,
-        _minimum_os_version = ctx.attr.minimum_os_version,
-        _minimum_deployment_os_version = ctx.attr.minimum_deployment_os_version,
+        _deployment_os_version = ctx.attr.minimum_deployment_os_version,
+        _os_version = ctx.attr.minimum_os_version,
+        _platform = getattr(apple_common.platform, ctx.attr.platform_key),
     )
-    dto = platform_info.to_dto(platform, build_settings = build_settings)
+    dto = platform_info.to_dto(platform)
     string_platform = stringify_dict(dto)
-    string_build_settings = stringify_dict(build_settings)
 
     asserts.equals(
         env,
         ctx.attr.expected_platform_dict,
         string_platform,
         "platform",
-    )
-    asserts.equals(
-        env,
-        ctx.attr.expected_build_settings,
-        string_build_settings,
-        "build_settings",
     )
 
     return unittest.end(env)
@@ -39,7 +31,6 @@ platform_info_to_dto_test = unittest.make(
     impl = _platform_info_to_dto_test_impl,
     attrs = {
         "arch": attr.string(mandatory = True),
-        "expected_build_settings": attr.string_dict(mandatory = True),
         "expected_platform_dict": attr.string_dict(mandatory = True),
         "minimum_deployment_os_version": attr.string(mandatory = False),
         "minimum_os_version": attr.string(mandatory = True),
@@ -63,8 +54,7 @@ def platform_info_to_dto_test_suite(name):
             arch,
             minimum_os_version,
             minimum_deployment_os_version,
-            expected_platform_dict,
-            expected_build_settings):
+            expected_platform_dict):
         test_names.append(name)
         platform_info_to_dto_test(
             name = name,
@@ -73,7 +63,6 @@ def platform_info_to_dto_test_suite(name):
             minimum_os_version = minimum_os_version,
             minimum_deployment_os_version = minimum_deployment_os_version,
             expected_platform_dict = expected_platform_dict,
-            expected_build_settings = stringify_dict(expected_build_settings),
             timeout = "short",
         )
 
@@ -88,11 +77,9 @@ def platform_info_to_dto_test_suite(name):
         expected_platform_dict = {
             "arch": "wild",
             "minimum_os_version": "12.0",
+            "minimum_deployment_os_version": "12.0",
             "name": "appletvos",
             "os": "tvos",
-        },
-        expected_build_settings = {
-            "TVOS_DEPLOYMENT_TARGET": "12.0",
         },
     )
 
@@ -107,10 +94,8 @@ def platform_info_to_dto_test_suite(name):
             "environment": "Simulator",
             "name": "iphonesimulator",
             "minimum_os_version": "11.0",
+            "minimum_deployment_os_version": "13.0",
             "os": "ios",
-        },
-        expected_build_settings = {
-            "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
         },
     )
 
@@ -126,10 +111,8 @@ def platform_info_to_dto_test_suite(name):
             "arch": "arm64",
             "name": "macosx",
             "minimum_os_version": "12.1",
+            "minimum_deployment_os_version": "12.1",
             "os": "macos",
-        },
-        expected_build_settings = {
-            "MACOSX_DEPLOYMENT_TARGET": "12.1",
         },
     )
 

--- a/tools/generator/src/DTO/Platform.swift
+++ b/tools/generator/src/DTO/Platform.swift
@@ -10,7 +10,19 @@ struct Platform: Equatable, Hashable, Decodable {
     let os: OS
     let arch: String
     let minimumOsVersion: String
+    let minimumDeploymentOsVersion: String
     let environment: String?
+}
+
+extension Platform.OS {
+    var deploymentTargetBuildSettingKey: String {
+        switch self {
+        case .macOS: return"MACOSX_DEPLOYMENT_TARGET"
+        case .iOS: return "IPHONEOS_DEPLOYMENT_TARGET"
+        case .tvOS: return "TVOS_DEPLOYMENT_TARGET"
+        case .watchOS: return "WATCHOS_DEPLOYMENT_TARGET"
+        }
+    }
 }
 
 // MARK: - Comparable

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -245,6 +245,11 @@ Target with id "\(id)" not found in `consolidatedTarget.uniqueFiles`
         buildSettings.set("SUPPORTED_PLATFORMS", to: target.platform.name)
         buildSettings.set("TARGET_NAME", to: target.name)
 
+        buildSettings.set(
+            target.platform.os.deploymentTargetBuildSettingKey,
+            to: target.platform.minimumDeploymentOsVersion
+        )
+
         let executableExtension = target.product.path.path.extension ?? ""
             if executableExtension != target.product.type.fileExtension {
             buildSettings.set(

--- a/tools/generator/test/BuildSettingConditionalTests.swift
+++ b/tools/generator/test/BuildSettingConditionalTests.swift
@@ -10,6 +10,7 @@ final class BuildSettingConditionalTests: XCTestCase {
             os: .macOS,
             arch: "arm64",
             minimumOsVersion: "11.0",
+            minimumDeploymentOsVersion: "13.0",
             environment: nil
         )),
         "B": .init(platform: .init(
@@ -17,6 +18,7 @@ final class BuildSettingConditionalTests: XCTestCase {
             os: .iOS,
             arch: "arm64",
             minimumOsVersion: "11.0",
+            minimumDeploymentOsVersion: "13.0",
             environment: "Simulator"
         )),
         "C": .init(platform: .init(
@@ -24,6 +26,7 @@ final class BuildSettingConditionalTests: XCTestCase {
             os: .iOS,
             arch: "arm64",
             minimumOsVersion: "11.0",
+            minimumDeploymentOsVersion: "13.0",
             environment: nil
         )),
         "D": .init(platform: .init(
@@ -31,6 +34,7 @@ final class BuildSettingConditionalTests: XCTestCase {
             os: .iOS,
             arch: "arm64",
             minimumOsVersion: "11.0",
+            minimumDeploymentOsVersion: "13.0",
             environment: "Device"
         )),
         "any": .any,

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -194,6 +194,7 @@ enum Fixtures {
                 os: .watchOS,
                 arch: "x86_64",
                 minimumOsVersion: "9.1",
+                minimumDeploymentOsVersion: "9.2",
                 environment: nil
             ),
             product: .init(
@@ -213,6 +214,7 @@ enum Fixtures {
                 os: .tvOS,
                 arch: "arm64",
                 minimumOsVersion: "9.1",
+                minimumDeploymentOsVersion: "9.2",
                 environment: nil
             ),
             product: .init(
@@ -225,7 +227,7 @@ enum Fixtures {
         ),
         "I": Target.mock(
             packageBinDir: "bazel-out/a1b2c/bin/I",
-            platform: .device(os: .iOS),
+            platform: .device(os: .iOS, minimumDeploymentOsVersion: "13.0"),
             product: .init(
                 type: .application,
                 name: "I",
@@ -1997,6 +1999,7 @@ perl -pe 's/^([^"].*\$\(.*\).*)/"$1"/ ; s/\$(\()?([a-zA-Z_]\w*)(?(1)\))/$ENV{$2}
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/A 1",
                 "BAZEL_TARGET_ID": "A 1",
                 "GENERATE_INFOPLIST_FILE": "YES",
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_SWIFT_FLAGS": #"""
 -vfsoverlay $(BUILD_DIR)/gen_dir-overlay.yaml
 """#,
@@ -2022,6 +2025,7 @@ $(INTERNAL_DIR)/targets/a1b2c/A 2/A.link.params
                     "$(inherited)",
                     "@executable_path/../Frameworks",
                 ],
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-ivfsoverlay",
                     "$(BUILD_DIR)/gen_dir-overlay.yaml",
@@ -2044,6 +2048,7 @@ $(INTERNAL_DIR)/targets/a1b2c/A 2/A.link.params
                 "BAZEL_TARGET_ID": "AC",
                 "DEPLOYMENT_LOCATION": "NO",
                 "GENERATE_INFOPLIST_FILE": "YES",
+                "IPHONEOS_DEPLOYMENT_TARGET": "11.0",
                 "LD_RUNPATH_SEARCH_PATHS": [
                     "$(inherited)",
                     "@executable_path/Frameworks",
@@ -2067,6 +2072,7 @@ $(INTERNAL_DIR)/targets/a1b2c/A 2/A.link.params
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/B 1",
                 "BAZEL_TARGET_ID": "B 1",
                 "GENERATE_INFOPLIST_FILE": "YES",
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-ivfsoverlay",
                     "$(BUILD_DIR)/gen_dir-overlay.yaml",
@@ -2088,6 +2094,7 @@ $(INTERNAL_DIR)/targets/a1b2c/A 2/A.link.params
                 "BUNDLE_LOADER": "$(TEST_HOST)",
                 "DEPLOYMENT_LOCATION": "NO",
                 "GENERATE_INFOPLIST_FILE": "YES",
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-ivfsoverlay",
                     "$(BUILD_DIR)/gen_dir-overlay.yaml",
@@ -2115,6 +2122,7 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2/A.app/A_ExecutableName
                 "CODE_SIGNING_ALLOWED": "YES",
                 "DEPLOYMENT_LOCATION": "NO",
                 "GENERATE_INFOPLIST_FILE": "YES",
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-ivfsoverlay",
                     "$(BUILD_DIR)/gen_dir-overlay.yaml",
@@ -2136,6 +2144,7 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2/A.app/A_ExecutableName
                 "EXECUTABLE_EXTENSION": "lo",
                 "GCC_PREFIX_HEADER": "a/b/c.pch",
                 "GENERATE_INFOPLIST_FILE": "YES",
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-ivfsoverlay",
                     "$(BUILD_DIR)/gen_dir-overlay.yaml",
@@ -2160,6 +2169,7 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2/A.app/A_ExecutableName
                 "LINK_PARAMS_FILE": """
 $(INTERNAL_DIR)/targets/a1b2c/C 2/d.link.params
 """,
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-ivfsoverlay",
                     "$(BUILD_DIR)/gen_dir-overlay.yaml",
@@ -2190,6 +2200,7 @@ $(INTERNAL_DIR)/targets/a1b2c/C 2/d.link.params
                 "SUPPORTED_PLATFORMS": "watchos",
                 "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/x",
                 "TARGET_NAME": targets["E1"]!.name,
+                "WATCHOS_DEPLOYMENT_TARGET": "9.2",
             ]) { $1 },
             "E2": targets["E2"]!.buildSettings.asDictionary.merging([
                 "ARCHS": "arm64",
@@ -2203,6 +2214,7 @@ $(INTERNAL_DIR)/targets/a1b2c/C 2/d.link.params
                 "SDKROOT": "appletvos",
                 "SUPPORTED_PLATFORMS": "appletvos",
                 "TARGET_NAME": targets["E2"]!.name,
+                "TVOS_DEPLOYMENT_TARGET": "9.2",
             ]) { $1 },
             "I": targets["I"]!.buildSettings.asDictionary.merging([
                 "ARCHS": "arm64",
@@ -2215,6 +2227,7 @@ $(BAZEL_OUT)/some/framework/parent/dir
 """,
                 "GENERATE_INFOPLIST_FILE": "YES",
                 "HEADER_SEARCH_PATHS": "$(BAZEL_OUT)/some/includes/parent/dir",
+                "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
                 "LD_RUNPATH_SEARCH_PATHS": [
                     "$(inherited)",
                     "@executable_path/Frameworks",
@@ -2248,6 +2261,7 @@ $(BAZEL_OUT)/some/quote/includes/parent/dir
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/R 1",
                 "BAZEL_TARGET_ID": "R 1",
                 "GENERATE_INFOPLIST_FILE": "YES",
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-ivfsoverlay",
                     "$(BUILD_DIR)/gen_dir-overlay.yaml",
@@ -2289,12 +2303,14 @@ $(IPHONESIMULATOR_FILES)
                 "INCLUDED_SOURCE_FILE_NAMES[sdk=macosx*]": """
 $(MACOSX_FILES)
 """,
+                "IPHONEOS_DEPLOYMENT_TARGET": "11.0",
                 "IPHONEOS_FILES": """
 "T/T 1/Ta.c" "T/T 1/Ta.png" "T/T 1/Ta.swift"
 """,
                 "IPHONESIMULATOR_FILES": """
 "T/T 2/Ta.c" "T/T 2/Ta.png" "T/T 2/Ta.swift"
 """,
+                "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "MACOSX_FILES": """
 "T/T 3/Ta.c" "T/T 3/Ta.png" "T/T 3/Ta.swift"
 """,
@@ -2327,6 +2343,7 @@ $(MACOSX_FILES)
                 "SDKROOT": "watchos",
                 "SUPPORTED_PLATFORMS": "watchos",
                 "TARGET_NAME": targets["W"]!.name,
+                "WATCHOS_DEPLOYMENT_TARGET": "11.0",
             ]) { $1 },
             "WDKE": targets["WDKE"]!.buildSettings.asDictionary.merging([
                 "ARCHS": "arm64",
@@ -2336,6 +2353,7 @@ $(MACOSX_FILES)
                 "BAZEL_HOST_TARGET_ID_0": "I",
                 "DEPLOYMENT_LOCATION": "NO",
                 "GENERATE_INFOPLIST_FILE": "YES",
+                "IPHONEOS_DEPLOYMENT_TARGET": "11.0",
                 "LD_RUNPATH_SEARCH_PATHS": [
                     "$(inherited)",
                     "@executable_path/Frameworks",
@@ -2380,6 +2398,7 @@ $(MACOSX_FILES)
                 "SDKROOT": "watchos",
                 "SUPPORTED_PLATFORMS": "watchos",
                 "TARGET_NAME": targets["WKE"]!.name,
+                "WATCHOS_DEPLOYMENT_TARGET": "11.0",
             ]) { $1 },
         ]
         for (key, buildSettings) in buildSettings {

--- a/tools/generator/test/SetTargetConfigurationsTests.swift
+++ b/tools/generator/test/SetTargetConfigurationsTests.swift
@@ -420,6 +420,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
                         os: os,
                         arch: "arm64",
                         minimumOsVersion: "11.0",
+                        minimumDeploymentOsVersion: "11.1",
                         environment: nil
                     ),
                     product: .init(

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -56,7 +56,8 @@ extension Platform {
     static func simulator(
         os: Platform.OS = .iOS,
         arch: String = "arm64",
-        minimumOsVersion: String = "11.0"
+        minimumOsVersion: String = "11.0",
+        minimumDeploymentOsVersion: String? = nil
     ) -> Self {
         let name: String
         switch os {
@@ -71,6 +72,8 @@ extension Platform {
             os: os,
             arch: arch,
             minimumOsVersion: minimumOsVersion,
+            minimumDeploymentOsVersion:
+                minimumDeploymentOsVersion ?? minimumOsVersion,
             environment: "Simulator"
         )
     }
@@ -78,7 +81,8 @@ extension Platform {
     static func device(
         os: Platform.OS = .iOS,
         arch: String = "arm64",
-        minimumOsVersion: String = "11.0"
+        minimumOsVersion: String = "11.0",
+        minimumDeploymentOsVersion: String? = nil
     ) -> Self {
         let name: String
         switch os {
@@ -93,19 +97,24 @@ extension Platform {
             os: os,
             arch: arch,
             minimumOsVersion: minimumOsVersion,
+            minimumDeploymentOsVersion:
+                minimumDeploymentOsVersion ?? minimumOsVersion,
             environment: nil
         )
     }
 
     static func macOS(
         arch: String = "arm64",
-        minimumOsVersion: String = "11.0"
+        minimumOsVersion: String = "11.0",
+        minimumDeploymentOsVersion: String? = nil
     ) -> Self {
         return Platform(
             name: "macosx",
             os: .macOS,
             arch: arch,
             minimumOsVersion: minimumOsVersion,
+            minimumDeploymentOsVersion:
+                minimumDeploymentOsVersion ?? minimumOsVersion,
             environment: nil
         )
     }

--- a/tools/generator/test/XcodeScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XcodeScheme+ExtensionsTests.swift
@@ -140,6 +140,7 @@ class XcodeSchemeExtensionsTests: XCTestCase {
         os: .tvOS,
         arch: "arm64",
         minimumOsVersion: "15.0",
+        minimumDeploymentOsVersion: "15.1",
         environment: nil
     )
     let appletvSimulatorPlatform = Platform(
@@ -147,6 +148,7 @@ class XcodeSchemeExtensionsTests: XCTestCase {
         os: .tvOS,
         arch: "x86_64",
         minimumOsVersion: "15.0",
+        minimumDeploymentOsVersion: "15.1",
         environment: Optional("Simulator")
     )
     let iphoneOSPlatform = Platform(
@@ -154,6 +156,7 @@ class XcodeSchemeExtensionsTests: XCTestCase {
         os: .iOS,
         arch: "arm64",
         minimumOsVersion: "15.0",
+        minimumDeploymentOsVersion: "15.1",
         environment: nil
     )
     let iphoneSimulatorPlatform = Platform(
@@ -161,6 +164,7 @@ class XcodeSchemeExtensionsTests: XCTestCase {
         os: .iOS,
         arch: "x86_64",
         minimumOsVersion: "15.0",
+        minimumDeploymentOsVersion: "15.1",
         environment: Optional("Simulator")
     )
     let macOSPlatform = Platform(
@@ -168,6 +172,7 @@ class XcodeSchemeExtensionsTests: XCTestCase {
         os: .macOS,
         arch: "x86_64",
         minimumOsVersion: "11.0",
+        minimumDeploymentOsVersion: "11.1",
         environment: nil
     )
     let watchOSPlatform = Platform(
@@ -175,6 +180,7 @@ class XcodeSchemeExtensionsTests: XCTestCase {
         os: .watchOS,
         arch: "arm64_32",
         minimumOsVersion: "7.0",
+        minimumDeploymentOsVersion: "7.1",
         environment: nil
     )
     let watchSimulatorPlatform = Platform(
@@ -182,6 +188,7 @@ class XcodeSchemeExtensionsTests: XCTestCase {
         os: .watchOS,
         arch: "x86_64",
         minimumOsVersion: "7.0",
+        minimumDeploymentOsVersion: "7.1",
         environment: Optional("Simulator")
     )
 

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -142,17 +142,12 @@ def xcode_target(
         to create a json array string, possibly joining multiples of these
         strings with `","`.
     """
-    platform_dto = platform_info.to_dto(
-        platform,
-        build_settings = build_settings,
-    )
-
     target_json = {
         "name": name,
         "label": str(label),
         "configuration": configuration,
         "package_bin_dir": package_bin_dir,
-        "platform": platform_dto,
+        "platform": platform_info.to_dto(platform),
         "product": product_to_dto(product),
     }
 


### PR DESCRIPTION
This is needed to set it for resource bundles while unblocking the de-stringification of `xcode_target`.