### PR TITLE
Reuse `xcode_target` in place of `target` struct

### DIFF
--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -26,7 +26,7 @@ load(":target_properties.bzl", "should_include_non_xcode_outputs")
 def _collect_transitive_extra_files(info):
     inputs = info.inputs
     transitive = [inputs.extra_files]
-    if not info.target:
+    if not info.xcode_target:
         transitive.append(depset([
             normalized_file_path(file)
             for file in inputs.srcs.to_list()
@@ -43,7 +43,7 @@ def _collect_transitive_extra_files(info):
     return depset(transitive = transitive)
 
 def _collect_transitive_uncategorized(info):
-    if info.target:
+    if info.xcode_target:
         return depset()
     return info.inputs.uncategorized
 
@@ -306,7 +306,7 @@ def _collect(
         if unfocused == None:
             dep_compilation_providers = comp_providers.merge(
                 transitive_compilation_providers = [
-                    (info.target, info.compilation_providers)
+                    (info.xcode_target, info.compilation_providers)
                     for attr, info in transitive_infos
                     if (info.target_type in
                         automatic_target_info.xcode_targets.get(attr, [None]))

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -165,12 +165,6 @@ def process_library_target(
         library = linker_input_files.get_primary_static_library(linker_inputs),
         outputs = outputs,
         search_paths = search_paths,
-        target = struct(
-            id = id,
-            label = label,
-            is_bundle = False,
-            product_path = product.path,
-        ),
         xcode_target = xcode_targets.make(
             id = id,
             name = ctx.rule.attr.name,

--- a/xcodeproj/internal/non_xcode_targets.bzl
+++ b/xcodeproj/internal/non_xcode_targets.bzl
@@ -110,6 +110,5 @@ rules_xcodeproj requires {} to have `{}` set.
             compilation_providers = compilation_providers,
             bin_dir_path = ctx.bin_dir.path,
         ),
-        target = None,
         xcode_target = None,
     )

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -16,7 +16,6 @@ def processed_target(
         potential_target_merges = None,
         resource_bundle_informations = None,
         search_paths,
-        target,
         xcode_target):
     """Generates the return value for target processing functions.
 
@@ -44,9 +43,8 @@ def processed_target(
         resource_bundle_informations: An optional `list` of `struct`s that will
             be in the `XcodeProjInfo.resource_bundle_informations` `depset`.
         search_paths: A value as returned from `target_search_paths.make`.
-        target: An optional `XcodeProjInfo.target` `struct`.
-        xcode_target: An optional string that will be in the
-            `XcodeProjInfo.xcode_targets` `depset`.
+        xcode_target: An optional value returned from `xcode_targets.make` that
+            will be in the `XcodeProjInfo.xcode_targets` `depset`.
 
     Returns:
         A `struct` containing fields for each argument.
@@ -64,7 +62,7 @@ def processed_target(
         potential_target_merges = potential_target_merges,
         resource_bundle_informations = resource_bundle_informations,
         search_paths = search_paths,
-        target = target,
         target_type = target_type,
+        xcode_target = xcode_target,
         xcode_targets = [xcode_target] if xcode_target else None,
     )

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -125,14 +125,13 @@ A value returned from `_process_search_paths`, that contains the search paths
 needed by this target. These search paths should be added to the search paths of
 any target that depends on this target.
 """,
-        "target": """\
-A `struct` that contains information about the current target that is
-potentially needed by the dependent targets.
-""",
         "target_type": """\
 A string that categorizes the type of the current target. This will be one of
 "compile", "resources", or `None`. Even if this target doesn't produce an Xcode
 target, it can still have a non-`None` value for this field.
+""",
+        "xcode_target": """\
+An optional value returned from `xcode_targets.make`.
 """,
         "xcode_targets": """\
 A `depset` of values returned from `xcode_targets.make`, which potentially will

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -75,8 +75,8 @@ def process_dependencies(*, automatic_target_info, transitive_infos):
                     [None],
                 )):
             continue
-        if info.target:
-            direct_dependencies.append(info.target.id)
+        if info.xcode_target:
+            direct_dependencies.append(info.xcode_target.id)
         else:
             # We pass on the next level of dependencies if the previous target
             # didn't create an Xcode target.

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -183,13 +183,13 @@ def process_top_level_target(
         test_host_target[XcodeProjInfo] if test_host_target else None
     )
     test_host = (
-        test_host_target_info.target.id if test_host_target_info else None
+        test_host_target_info.xcode_target.id if test_host_target_info else None
     )
     avoid_deps = [test_host_target] if test_host_target else []
 
     app_clip_targets = getattr(ctx.rule.attr, "app_clips", [])
     app_clips = [
-        extension_target[XcodeProjInfo].target.id
+        extension_target[XcodeProjInfo].xcode_target.id
         for extension_target in app_clip_targets
     ]
 
@@ -198,7 +198,7 @@ def process_top_level_target(
         watch_app_target[XcodeProjInfo] if watch_app_target else None
     )
     watch_application = (
-        watch_app_target_info.target.id if watch_app_target_info else None
+        watch_app_target_info.xcode_target.id if watch_app_target_info else None
     )
 
     extension_targets = getattr(ctx.rule.attr, "extensions", [])
@@ -209,7 +209,7 @@ def process_top_level_target(
         extension_target[XcodeProjInfo]
         for extension_target in extension_targets
     ]
-    extensions = [info.target.id for info in extension_target_infos]
+    extensions = [info.xcode_target.id for info in extension_target_infos]
 
     hosted_target_infos = extension_target_infos
     if watch_app_target_info:
@@ -217,7 +217,7 @@ def process_top_level_target(
     hosted_targets = [
         struct(
             host = id,
-            hosted = info.target.id,
+            hosted = info.xcode_target.id,
         )
         for info in hosted_target_infos
     ]
@@ -312,7 +312,7 @@ def process_top_level_target(
         swift_info = target[SwiftInfo] if SwiftInfo in target else None,
         transitive_compilation_providers = [
             (
-                dep[XcodeProjInfo].target,
+                dep[XcodeProjInfo].xcode_target,
                 dep[XcodeProjInfo].compilation_providers,
             )
             # TODO: Get attr name from `XcodeProjAutomaticTargetProcessingInfo`
@@ -361,7 +361,7 @@ def process_top_level_target(
         potential_target_merges = [struct(
             src = struct(
                 id = mergeable_target.id,
-                product_path = mergeable_target.product_path,
+                product_path = mergeable_target.product.path,
             ),
             dest = id,
         )]
@@ -449,12 +449,6 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
         outputs = outputs,
         potential_target_merges = potential_target_merges,
         search_paths = search_paths,
-        target = struct(
-            id = id,
-            label = label,
-            is_bundle = is_bundle,
-            product_path = product.path,
-        ),
         xcode_target = xcode_targets.make(
             id = id,
             name = ctx.rule.attr.name,

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -74,11 +74,9 @@ def _make(
     """
     return struct(
         _name = name,
-        _label = label,
         _configuration = configuration,
         _package_bin_dir = package_bin_dir,
         _platform = platform,
-        _product = product,
         _is_swift = is_swift,
         _test_host = test_host,
         _build_settings = struct(**build_settings),
@@ -94,6 +92,8 @@ def _make(
         _dependencies = tuple(dependencies.to_list()),
         _outputs = outputs,
         id = id,
+        label = label,
+        product = product,
     )
 
 def _to_dto(xcode_target):
@@ -101,11 +101,11 @@ def _to_dto(xcode_target):
 
     dto = {
         "name": xcode_target._name,
-        "label": str(xcode_target._label),
+        "label": str(xcode_target.label),
         "configuration": xcode_target._configuration,
         "package_bin_dir": xcode_target._package_bin_dir,
         "platform": platform_info.to_dto(xcode_target._platform),
-        "product": product_to_dto(xcode_target._product),
+        "product": product_to_dto(xcode_target.product),
     }
 
     if not xcode_target._is_swift:

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -59,8 +59,8 @@ def _target_info_fields(
         potential_target_merges,
         resource_bundle_informations,
         search_paths,
-        target,
         target_type,
+        xcode_target,
         xcode_targets):
     """Generates target specific fields for the `XcodeProjInfo`.
 
@@ -82,8 +82,8 @@ def _target_info_fields(
         resource_bundle_informations: Maps to the
             `XcodeProjInfo.resource_bundle_informations` field.
         search_paths: Maps to the `XcodeProjInfo.search_paths` field.
-        target: Maps to the `XcodeProjInfo.target` field.
         target_type: Maps to the `XcodeProjInfo.target_type` field.
+        xcode_target: Maps to the `XcodeProjInfo.xcode_target` field.
         xcode_targets: Maps to the `XcodeProjInfo.xcode_targets` field.
 
     Returns:
@@ -100,8 +100,8 @@ def _target_info_fields(
         *   `potential_target_merges`
         *   `resource_bundle_informations`
         *   `search_paths`
-        *   `target`
         *   `target_type`
+        *   `xcode_target`
         *   `xcode_targets`
     """
     return {
@@ -115,8 +115,8 @@ def _target_info_fields(
         "potential_target_merges": potential_target_merges,
         "resource_bundle_informations": resource_bundle_informations,
         "search_paths": search_paths,
-        "target": target,
         "target_type": target_type,
+        "xcode_target": xcode_target,
         "xcode_targets": xcode_targets,
     }
 
@@ -138,7 +138,7 @@ def _skip_target(*, deps, transitive_infos):
     compilation_providers = comp_providers.merge(
         transitive_compilation_providers = [
             (
-                dep[XcodeProjInfo].target,
+                dep[XcodeProjInfo].xcode_target,
                 dep[XcodeProjInfo].compilation_providers,
             )
             for dep in deps
@@ -192,8 +192,8 @@ def _skip_target(*, deps, transitive_infos):
             compilation_providers = None,
             bin_dir_path = None,
         ),
-        target = None,
         target_type = target_type.compile,
+        xcode_target = None,
         xcode_targets = depset(
             transitive = [info.xcode_targets for _, info in transitive_infos],
         ),
@@ -317,8 +317,8 @@ def _create_xcodeprojinfo(*, ctx, target, transitive_infos):
             ],
         ),
         search_paths = processed_target.search_paths,
-        target = processed_target.target,
         target_type = processed_target.automatic_target_info.target_type,
+        xcode_target = processed_target.xcode_target,
         xcode_targets = depset(
             processed_target.xcode_targets,
             transitive = [


### PR DESCRIPTION
`xcode_target` now has all of the same information available, so we don't need two sources of truth.