### PR TITLE
Stop building dependencies of unfocused targets twice in BwX mode

### DIFF
--- a/tools/generator/src/DTO/Target.swift
+++ b/tools/generator/src/DTO/Target.swift
@@ -23,6 +23,7 @@ struct Target: Equatable {
     let appClips: Set<TargetID>
     var dependencies: Set<TargetID>
     var outputs: Outputs
+    let isUnfocusedDependency: Bool
 }
 
 extension Target {
@@ -57,6 +58,7 @@ extension Target: Decodable {
         case appClips
         case dependencies
         case outputs
+        case isUnfocusedDependency
     }
 
     init(from decoder: Decoder) throws {
@@ -99,6 +101,8 @@ extension Target: Decodable {
         dependencies = try container.decodeTargetIDs(.dependencies)
         outputs = try container
             .decodeIfPresent(Outputs.self, forKey: .outputs) ?? .init()
+        isUnfocusedDependency = try container
+            .decodeIfPresent(Bool.self, forKey: .isUnfocusedDependency) ?? false
     }
 }
 

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -508,6 +508,10 @@ extension Generator {
         switch buildMode {
         case .xcode:
             for (_, target) in targets {
+                guard !target.isUnfocusedDependency else {
+                    continue
+                }
+
                 xcodeGeneratedFiles.insert(target.product.path)
                 if let filePath = target.outputs.swift?.module {
                     xcodeGeneratedFiles.insert(filePath)

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -70,6 +70,13 @@ class Generator {
         var targets = project.targets
         try environment.processTargetMerges(&targets, project.targetMerges)
 
+        let isUnfocusedDependencyTargetIDs = Set(
+            targets.filter(\.value.isUnfocusedDependency).keys
+        )
+        for id in targets.keys {
+            targets[id]!.dependencies.subtract(isUnfocusedDependencyTargetIDs)
+        }
+
         let consolidatedTargets = try environment.consolidateTargets(
             targets,
             logger

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -25,7 +25,8 @@ extension Target {
         extensions: Set<TargetID> = [],
         appClips: Set<TargetID> = [],
         dependencies: Set<TargetID> = [],
-        outputs: Outputs = .init()
+        outputs: Outputs = .init(),
+        isUnfocusedDependency: Bool = false
     ) -> Self {
         return Target(
             name: product.name,
@@ -47,7 +48,8 @@ extension Target {
             extensions: extensions,
             appClips: appClips,
             dependencies: dependencies,
-            outputs: outputs
+            outputs: outputs,
+            isUnfocusedDependency: isUnfocusedDependency
         )
     }
 }

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -328,7 +328,7 @@ def _collect(
                     [
                         file_path(file)
                         for file in transitive_libraries
-                    ]
+                    ],
                 )
 
         if unfocused and SwiftInfo in target:

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -96,7 +96,7 @@ def _make(
         product = product,
     )
 
-def _to_dto(xcode_target):
+def _to_dto(xcode_target, *, is_unfocused_dependency = False):
     inputs = xcode_target._inputs
 
     dto = {
@@ -110,6 +110,9 @@ def _to_dto(xcode_target):
 
     if not xcode_target._is_swift:
         dto["is_swift"] = False
+
+    if is_unfocused_dependency:
+        dto["is_unfocused_dependency"] = True
 
     set_if_true(dto, "test_host", xcode_target._test_host)
     set_if_true(dto, "build_settings", xcode_target._build_settings)

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -55,9 +55,17 @@ def _write_json_spec(
         if not sets.contains(non_mergable_targets_set, merge.src.product_path):
             target_merges.setdefault(merge.src.id, []).append(merge.dest)
 
+    unfocused_libraries = sets.make(inputs.unfocused_libraries.to_list())
+
     targets = {}
     for xcode_target in targets_depset.to_list():
-        targets[xcode_target.id] = xcode_targets.to_dto(xcode_target)
+        targets[xcode_target.id] = xcode_targets.to_dto(
+            xcode_target,
+            is_unfocused_dependency = sets.contains(
+                unfocused_libraries,
+                xcode_target.product.path
+            ),
+        )
     targets_json = json.encode(
         flattened_key_values.to_list(targets),
     )

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -63,7 +63,7 @@ def _write_json_spec(
             xcode_target,
             is_unfocused_dependency = sets.contains(
                 unfocused_libraries,
-                xcode_target.product.path
+                xcode_target.product.path,
             ),
         )
     targets_json = json.encode(


### PR DESCRIPTION
Fixes #632.

Dependencies of unfocused targets are now "islands". Their scheme will build them in whatever mode is being used for the project, but their dependencies will be built with Bazel. These targets also won't be set as dependencies of other targets, preventing them from being built twice in BwX mode.