### PR TITLE
Set `unfocused_targets` for `generator`

### DIFF
--- a/test/fixtures/generator/BUILD
+++ b/test/fixtures/generator/BUILD
@@ -1,13 +1,13 @@
 load(
     "//tools/generator:xcodeproj_targets.bzl",
-    "GENERATOR_SCHEME_AUTOGENERATION_MODE",
+    "SCHEME_AUTOGENERATION_MODE",
+    "UNFOCUSED_TARGETS",
     "get_xcode_schemes",
-    "get_xcodeproj_targets",
 )
 load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
 
 xcodeproj_fixture(
-    scheme_autogeneration_mode = GENERATOR_SCHEME_AUTOGENERATION_MODE,
+    scheme_autogeneration_mode = SCHEME_AUTOGENERATION_MODE,
     schemes = get_xcode_schemes(),
-    targets = get_xcodeproj_targets(),
+    unfocused_targets = UNFOCUSED_TARGETS,
 )

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -63,7 +63,6 @@
 		1E3DC0A6287F260FE33F89CE /* Path+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2597D69F32EE134D35CA5EED /* Path+Extras.swift */; };
 		1F0BF4776B54936E8152F2E7 /* CompileStub.m in Sources */ = {isa = PBXBuildFile; fileRef = E06CA54BB3677E9BBC8A5D94 /* CompileStub.m */; };
 		209E823873EA39D5C6A8EF66 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3D4E7C841C2C89DF095466 /* Logger.swift */; };
-		2143F6802705E6E45746C463 /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFA193BCD097396D150AF96 /* Document.swift */; };
 		219C3E15651600D4892C4387 /* CollectionDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B9525BCADA7A75978D1FCC /* CollectionDifference.swift */; };
 		21EFB487A4B2DCA0539113C6 /* BuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE677C0FD789C4A0ADDC1901 /* BuildPhase.swift */; };
 		23041301A5060235785895F8 /* CoreImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55071574526ADBF7683AB165 /* CoreImage.swift */; };
@@ -72,7 +71,6 @@
 		25439613FB7D1BD428EED6A1 /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		25608AD5228D99F311C26845 /* PBXBuildRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B537637F91E4A43CAE2CF2 /* PBXBuildRule.swift */; };
 		265A3566719072FF07A20004 /* CustomDumpRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A40DA2B2633E2E5090B39B /* CustomDumpRepresentable.swift */; };
-		2662F5160B7446672BF10AC3 /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A134E3CBDC57315EE1B0221 /* Element.swift */; };
 		277424E39B6FA6040609F4C2 /* XCScheme+CommandLineArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B23BC150E3266757707492 /* XCScheme+CommandLineArguments.swift */; };
 		2809A9CF1B38F525B3D7B0FF /* XCSchemeInfo+TestActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0C928BAD312B54B2B60DFC /* XCSchemeInfo+TestActionInfoTests.swift */; };
 		28B4A387EFBCB5A423A7931B /* OrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B9DF12DB21E355D72FC72A /* OrderedSet.swift */; };
@@ -97,7 +95,6 @@
 		3FFED7370399E11F4214680A /* OrderedSet+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A39A39D49FD8DA86F447684A /* OrderedSet+Codable.swift */; };
 		40EAC86C29279A4490B72640 /* XCSchemeInfo+ProfileActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DFC10F60508ACDCC0E0C85 /* XCSchemeInfo+ProfileActionInfo.swift */; };
 		4200D6B211458A558E256181 /* OrderedDictionary+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F33013AF820E4A2208AA350 /* OrderedDictionary+Equatable.swift */; };
-		42083CE40AC71C796D40C7A7 /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268CB0584C901D862BCEF28A /* Options.swift */; };
 		42EFDAABD5E997C0347FFE60 /* XCSchemeEnvironmentVariablesExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68F397DBABDC12E41113B99 /* XCSchemeEnvironmentVariablesExtensionsTests.swift */; };
 		46565E40B8D7CA2247DF23BF /* OrderedSet+Partial SetAlgebra+Predicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C469D688DDD60A2D8A17B76 /* OrderedSet+Partial SetAlgebra+Predicates.swift */; };
 		4744038ECA6A1F58F45AB520 /* OrderedSet+Partial SetAlgebra+Basics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B803E192ED98560009C6D /* OrderedSet+Partial SetAlgebra+Basics.swift */; };
@@ -137,7 +134,6 @@
 		66DDAAF01C650E4B60FECC5D /* XCSchemeInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388BFA02F2F42F564CC5060D /* XCSchemeInfoTests.swift */; };
 		68E567532FB9A491B36F4344 /* PBXContainerItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B0689562B36DE6F3668B6E /* PBXContainerItemProxy.swift */; };
 		6A8B43D7AB579FFA4EA560A8 /* CustomDumpReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFFE6348E347FF9ED001081 /* CustomDumpReflectable.swift */; };
-		6BB7B640D7C02FE13DE53316 /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		6BD6785813F2AC9561F5C197 /* PBXProj+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0B7B94D16AAD3979ACCEFA /* PBXProj+Testing.swift */; };
 		6BEEFB6F9ABBD9DE61F18D20 /* CreateFilesAndGroupsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42EAB1A5AEF651AF8F6F865 /* CreateFilesAndGroupsTests.swift */; };
 		71F8B1DD599EA5B0F2D03626 /* _HashTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61319B361ABA09FD294600A /* _HashTable.swift */; };
@@ -259,7 +255,6 @@
 		D75E4FF718EDB764C615241B /* Inputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB9D00963E3FECF87A050AA /* Inputs.swift */; };
 		D7A1F37091591B8DF8803498 /* OrderedDictionary+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84817AD8F8BF75C3E9D446A /* OrderedDictionary+Deprecations.swift */; };
 		D8302EB5E3B8A7673E600686 /* XCSchemeEnvrionmentVariables+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3A862371D143A0AB30A956 /* XCSchemeEnvrionmentVariables+Extensions.swift */; };
-		D8706141935099FEB119B28D /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB466879747C3652D74FE85 /* Error.swift */; };
 		D8D3778305DAFBA5A3150598 /* XCWorkspaceDataFileRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97C1C5D545E3B4CA06474BDC /* XCWorkspaceDataFileRef.swift */; };
 		DAEB13CD6BB6B939AE66B3FE /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E27E547A12A951FF64D0C4 /* Box.swift */; };
 		DB319A23886D4E34C33673FC /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6130F9568982104094E3C618 /* Bool+Extras.swift */; };
@@ -275,7 +270,6 @@
 		DFDACE372D86DAF5308E0DE2 /* XCScheme+TestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0654DDFDA028387BCAF843F8 /* XCScheme+TestItem.swift */; };
 		E03D87E9889E3039B602C0D7 /* OrderedDictionary+CustomDebugStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED0F122B168D474ADA615A76 /* OrderedDictionary+CustomDebugStringConvertible.swift */; };
 		E1C8DD75EBE5491687687657 /* XCScheme+StoreKitConfigurationFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC122F4DE7028197FE1C177 /* XCScheme+StoreKitConfigurationFileReference.swift */; };
-		E2339489F3322934D224B39B /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3504926798E0F993FC929F /* Parser.swift */; };
 		E296F8785FF730A70F61CB6A /* BuildSettingConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5638047BDE3BC92B3CE6C189 /* BuildSettingConditional.swift */; };
 		E34D297ACAC512E3C961FB43 /* XCScheme+TestPlanReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB97F8B9DCAC47C22823253 /* XCScheme+TestPlanReference.swift */; };
 		E6E2253B141C9F567309CE52 /* _HashTable+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61681F3C9FD6052FDD18510B /* _HashTable+CustomStringConvertible.swift */; };
@@ -353,13 +347,6 @@
 			remoteGlobalIDString = 302F4C6E9EE3F09D4809EF0A;
 			remoteInfo = CustomDump;
 		};
-		5860D57390AE14C57D4A302E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 886150B3C63D0DBEF9BB4E6B;
-			remoteInfo = AEXML;
-		};
 		5DC7EE59040383A84FE9D924 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -423,13 +410,6 @@
 			remoteGlobalIDString = 023B2C041CD79AF5B2FDAFE1;
 			remoteInfo = OrderedCollections;
 		};
-		D8B8700D5948E731503D5220 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
 		EDEE3873CD6E83B2191E0B52 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -492,7 +472,6 @@
 		253A2904128D2EFC18CEA676 /* XcodeScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeScheme.swift; sourceTree = "<group>"; };
 		2597D69F32EE134D35CA5EED /* Path+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+Extras.swift"; sourceTree = "<group>"; };
 		260960CB90CADC8133DF9725 /* OrderedDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderedDictionary.swift; sourceTree = "<group>"; };
-		268CB0584C901D862BCEF28A /* Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		27A40DA2B2633E2E5090B39B /* CustomDumpRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDumpRepresentable.swift; sourceTree = "<group>"; };
 		27B1BBF60EFF9DE0F3873504 /* OrderedDictionary+ExpressibleByDictionaryLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+ExpressibleByDictionaryLiteral.swift"; sourceTree = "<group>"; };
 		29A1E648AD1793142280604D /* XCScheme+AditionalOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+AditionalOption.swift"; sourceTree = "<group>"; };
@@ -508,12 +487,10 @@
 		35DFC10F60508ACDCC0E0C85 /* XCSchemeInfo+ProfileActionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+ProfileActionInfo.swift"; sourceTree = "<group>"; };
 		388BFA02F2F42F564CC5060D /* XCSchemeInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCSchemeInfoTests.swift; sourceTree = "<group>"; };
 		3A955F486C1C731F148887B6 /* ConsolidateTargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsolidateTargets.swift; sourceTree = "<group>"; };
-		3BCF6545A3BFB3B32552A669 /* libAEXML.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libAEXML.a; path = "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tadija_aexml/libAEXML.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BD57C9800BE7773DBBA107B /* PBXProductTypeExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProductTypeExtensionsTests.swift; sourceTree = "<group>"; };
 		3C03DA1E6BE6639739CB623F /* OrderedSet+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Hashable.swift"; sourceTree = "<group>"; };
 		3C1F008B03E81D8D0104DB8C /* ExtensionPointIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionPointIdentifier.swift; sourceTree = "<group>"; };
 		3CEA06E5C81DCD25281036C7 /* PBXGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXGroup.swift; sourceTree = "<group>"; };
-		3E3504926798E0F993FC929F /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		411840C33954055F18B35AD2 /* Dictionary+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extensions.swift"; sourceTree = "<group>"; };
 		425B4EC528B607EEF98825F6 /* BuildSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettings.swift; sourceTree = "<group>"; };
 		430A0E83DF369E5ED390CA3A /* XCScheme+AnalyzeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+AnalyzeAction.swift"; sourceTree = "<group>"; };
@@ -581,14 +558,12 @@
 		77B0689562B36DE6F3668B6E /* PBXContainerItemProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXContainerItemProxy.swift; sourceTree = "<group>"; };
 		789CE33EA9AD15B97F5AA88F /* UserNotificationsUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationsUI.swift; sourceTree = "<group>"; };
 		7A11A26366495E4A9EFBEC0B /* OrderedDictionary+Invariants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Invariants.swift"; sourceTree = "<group>"; };
-		7A134E3CBDC57315EE1B0221 /* Element.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Element.swift; sourceTree = "<group>"; };
 		7AC44F6F9D5F1EBF4D7110DD /* XCConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCConfig.swift; sourceTree = "<group>"; };
 		7C55220CE7606CF936497C6E /* XCScheme+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		7CC88A1EC5D00732D7576F9A /* XCSchemeInfo+BuildActionInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+BuildActionInfoTests.swift"; sourceTree = "<group>"; };
 		7D7BF60244CDDEB8780E0A1B /* PBXHeadersBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXHeadersBuildPhase.swift; sourceTree = "<group>"; };
 		7DD377ABEF6A8CECEE71C6A3 /* _HashTable+BucketIterator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+BucketIterator.swift"; sourceTree = "<group>"; };
 		7E6551A5EEE9CC51C5A05BD3 /* CreateXCSharedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateXCSharedData.swift; sourceTree = "<group>"; };
-		7EFA193BCD097396D150AF96 /* Document.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
 		8169934D430D8F6CC14E5E40 /* BazelLabel+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BazelLabel+TestExtensions.swift"; sourceTree = "<group>"; };
 		817B04CE0868E15EFE7D8C44 /* OrderedDictionary+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Hashable.swift"; sourceTree = "<group>"; };
 		8645BE71A723C3736CCE7131 /* OrderedSet+Initializers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Initializers.swift"; sourceTree = "<group>"; };
@@ -640,7 +615,6 @@
 		AA8657DAF8012A508E7FEE54 /* PBXObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXObjects.swift; sourceTree = "<group>"; };
 		AB622F4E8EA478F6C3D642F6 /* PBXTargets+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXTargets+ExtensionsTests.swift"; sourceTree = "<group>"; };
 		ABA91ACA2E565D0C6F88DE03 /* XCSchemeInfo+BuildActionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+BuildActionInfo.swift"; sourceTree = "<group>"; };
-		ABB466879747C3652D74FE85 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		AC11446A42A073B91FFC6262 /* PBXProjEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProjEncoder.swift; sourceTree = "<group>"; };
 		AC7F0486AC72B3E68F194D01 /* PathKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathKit.swift; sourceTree = "<group>"; };
 		ACF678DB87E07DDDF0999336 /* OrderedSet+Testing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Testing.swift"; sourceTree = "<group>"; };
@@ -888,14 +862,6 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
-		3892FC006C39FA3AEF7C87B8 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				5472C482D2DA7A009D92EF3B /* AEXML */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
 		3CD4C9DD5760967263828581 /* CustomDump */ = {
 			isa = PBXGroup;
 			children = (
@@ -958,23 +924,10 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
-		5472C482D2DA7A009D92EF3B /* AEXML */ = {
-			isa = PBXGroup;
-			children = (
-				7EFA193BCD097396D150AF96 /* Document.swift */,
-				7A134E3CBDC57315EE1B0221 /* Element.swift */,
-				ABB466879747C3652D74FE85 /* Error.swift */,
-				268CB0584C901D862BCEF28A /* Options.swift */,
-				3E3504926798E0F993FC929F /* Parser.swift */,
-			);
-			path = AEXML;
-			sourceTree = "<group>";
-		};
 		593E7C82FAAD94A7E6A04318 /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				8D6BEA2725F47B747D67B18F /* generator */,
-				3BCF6545A3BFB3B32552A669 /* libAEXML.a */,
 				5FBDAA5A97ECD9AA378B9305 /* libCustomDump.a */,
 				87D5D2AB0B152D5CA6FB9ADF /* libgenerator.library.a */,
 				F30BDE4E484ED0AD847BE4C5 /* libOrderedCollections.a */,
@@ -1042,14 +995,6 @@
 				926156400E723502E6048C74 /* generator */,
 			);
 			path = tools;
-			sourceTree = "<group>";
-		};
-		7D18D899CB85410F3722734E /* com_github_tadija_aexml */ = {
-			isa = PBXGroup;
-			children = (
-				3892FC006C39FA3AEF7C87B8 /* Sources */,
-			);
-			path = com_github_tadija_aexml;
 			sourceTree = "<group>";
 		};
 		926156400E723502E6048C74 /* generator */ = {
@@ -1122,7 +1067,6 @@
 				4CD9FD851AAB9D67FD19FF81 /* com_github_kylef_pathkit */,
 				D7FFCD6C56706B85E75B3AF7 /* com_github_pointfreeco_swift_custom_dump */,
 				2328A8EAE944F9AE4107A7D9 /* com_github_pointfreeco_xctest_dynamic_overlay */,
-				7D18D899CB85410F3722734E /* com_github_tadija_aexml */,
 				CCD52FD22F080CD6DA9BD957 /* com_github_tuist_xcodeproj */,
 			);
 			name = "Bazel External Repositories";
@@ -1522,22 +1466,6 @@
 			productReference = 8D6BEA2725F47B747D67B18F /* generator */;
 			productType = "com.apple.product-type.tool";
 		};
-		886150B3C63D0DBEF9BB4E6B /* AEXML */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 87A63B9392379C37ECE35BB3 /* Build configuration list for PBXNativeTarget "AEXML" */;
-			buildPhases = (
-				2CC3E7B8A0B864ED19664596 /* Copy Bazel Outputs */,
-				CC35872CAB45EE11F90DA749 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				F549E104AB686D4C3383DB6E /* PBXTargetDependency */,
-			);
-			name = AEXML;
-			productName = AEXML;
-			productType = "com.apple.product-type.library.static";
-		};
 		979D12680661F4B864602CE6 /* tests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2AE3F241DE7B5C62A4FBFD3F /* Build configuration list for PBXNativeTarget "tests" */;
@@ -1585,7 +1513,6 @@
 			);
 			dependencies = (
 				49193367A3BB0A1F434F8451 /* PBXTargetDependency */,
-				15C9D6D9FFC25DEDBF1B4FB1 /* PBXTargetDependency */,
 				2A18DCEDD62C0092B4434B53 /* PBXTargetDependency */,
 			);
 			name = XcodeProj;
@@ -1640,10 +1567,6 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
-					886150B3C63D0DBEF9BB4E6B = {
-						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
-					};
 					979D12680661F4B864602CE6 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -1676,7 +1599,6 @@
 			projectRoot = "";
 			targets = (
 				7E7D155EBCA520F35DEA3571 /* BazelDependencies */,
-				886150B3C63D0DBEF9BB4E6B /* AEXML */,
 				302F4C6E9EE3F09D4809EF0A /* CustomDump */,
 				85C876DB90D51CD225023BB2 /* generator */,
 				F12050E30563A81EEBB2EA9B /* generator.library */,
@@ -1690,23 +1612,6 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2CC3E7B8A0B864ED19664596 /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/_BazelForcedCompile_.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libAEXML.a\" \\\n  \"\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3B581A2D7C1575EF22D8ECDA /* Copy Bazel Outputs */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -2067,19 +1972,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CC35872CAB45EE11F90DA749 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6BB7B640D7C02FE13DE53316 /* _BazelForcedCompile_.swift in Sources */,
-				2143F6802705E6E45746C463 /* Document.swift in Sources */,
-				2662F5160B7446672BF10AC3 /* Element.swift in Sources */,
-				D8706141935099FEB119B28D /* Error.swift in Sources */,
-				42083CE40AC71C796D40C7A7 /* Options.swift in Sources */,
-				E2339489F3322934D224B39B /* Parser.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		CD48CA78C6E062C9AC7C30B5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2258,12 +2150,6 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 1B37F14BCD93FD7AB94FD7E0 /* PBXContainerItemProxy */;
 		};
-		15C9D6D9FFC25DEDBF1B4FB1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AEXML;
-			target = 886150B3C63D0DBEF9BB4E6B /* AEXML */;
-			targetProxy = 5860D57390AE14C57D4A302E /* PBXContainerItemProxy */;
-		};
 		248C27B8CD62810B45507CD6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -2348,12 +2234,6 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 9C160353EC1D44BF4328F010 /* PBXContainerItemProxy */;
 		};
-		F549E104AB686D4C3383DB6E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = D8B8700D5948E731503D5220 /* PBXContainerItemProxy */;
-		};
 		F95C6EAD9F7184C6730E9F61 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -2424,34 +2304,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				TARGET_NAME = XcodeProj;
-				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
-				);
-			};
-			name = Debug;
-		};
-		89C4F2F8967BBC9C91979C2F /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tadija_aexml";
-				BAZEL_TARGET_ID = "@com_github_tadija_aexml//:AEXML darwin_x86_64-dbg-ST-e86416d3a8c7";
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-vfsoverlay $(BUILD_DIR)/gen_dir-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
-				PRODUCT_MODULE_NAME = AEXML;
-				PRODUCT_NAME = AEXML;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5;
-				TARGET_NAME = AEXML;
 				USER_HEADER_SEARCH_PATHS = (
 					.,
 					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
@@ -2729,14 +2581,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				B0892EE2AB907B40AA4EB960 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		87A63B9392379C37ECE35BB3 /* Build configuration list for PBXNativeTarget "AEXML" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				89C4F2F8967BBC9C91979C2F /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/external.xcfilelist
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/external.xcfilelist
@@ -75,11 +75,6 @@ $(BAZEL_EXTERNAL)/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/In
 $(BAZEL_EXTERNAL)/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/String.swift
 $(BAZEL_EXTERNAL)/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/XCTAssertNoDifference.swift
 $(BAZEL_EXTERNAL)/com_github_pointfreeco_xctest_dynamic_overlay/Sources/XCTestDynamicOverlay/XCTFail.swift
-$(BAZEL_EXTERNAL)/com_github_tadija_aexml/Sources/AEXML/Document.swift
-$(BAZEL_EXTERNAL)/com_github_tadija_aexml/Sources/AEXML/Element.swift
-$(BAZEL_EXTERNAL)/com_github_tadija_aexml/Sources/AEXML/Error.swift
-$(BAZEL_EXTERNAL)/com_github_tadija_aexml/Sources/AEXML/Options.swift
-$(BAZEL_EXTERNAL)/com_github_tadija_aexml/Sources/AEXML/Parser.swift
 $(BAZEL_EXTERNAL)/com_github_tuist_xcodeproj/Sources/XcodeProj/Errors/Errors.swift
 $(BAZEL_EXTERNAL)/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
 $(BAZEL_EXTERNAL)/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Array+Extras.swift

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -1100,90 +1100,6 @@
                 ]
             }
         },
-        "@com_github_tadija_aexml//:AEXML darwin_x86_64-dbg-ST-e86416d3a8c7",
-        {
-            "build_settings": {
-                "DEBUG_INFORMATION_FORMAT": "dwarf",
-                "ENABLE_BITCODE": false,
-                "ENABLE_TESTABILITY": true,
-                "GCC_OPTIMIZATION_LEVEL": "0",
-                "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
-                "PRODUCT_MODULE_NAME": "AEXML",
-                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
-                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
-                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5"
-            },
-            "configuration": "darwin_x86_64-dbg-ST-e86416d3a8c7",
-            "inputs": {
-                "srcs": [
-                    {
-                        "_": "com_github_tadija_aexml/Sources/AEXML/Document.swift",
-                        "t": "e"
-                    },
-                    {
-                        "_": "com_github_tadija_aexml/Sources/AEXML/Element.swift",
-                        "t": "e"
-                    },
-                    {
-                        "_": "com_github_tadija_aexml/Sources/AEXML/Error.swift",
-                        "t": "e"
-                    },
-                    {
-                        "_": "com_github_tadija_aexml/Sources/AEXML/Options.swift",
-                        "t": "e"
-                    },
-                    {
-                        "_": "com_github_tadija_aexml/Sources/AEXML/Parser.swift",
-                        "t": "e"
-                    }
-                ]
-            },
-            "label": "@com_github_tadija_aexml//:AEXML",
-            "name": "AEXML",
-            "outputs": {
-                "s": {
-                    "d": {
-                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tadija_aexml/AEXML.swiftdoc",
-                        "t": "g"
-                    },
-                    "m": {
-                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tadija_aexml/AEXML.swiftsourceinfo",
-                        "t": "g"
-                    }
-                }
-            },
-            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tadija_aexml",
-            "platform": {
-                "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
-                "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
-            },
-            "product": {
-                "executable_name": null,
-                "name": "AEXML",
-                "path": {
-                    "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tadija_aexml/libAEXML.a",
-                    "t": "g"
-                },
-                "type": "com.apple.product-type.library.static"
-            },
-            "search_paths": {
-                "quote_includes": [
-                    ".",
-                    {
-                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
-                        "t": "g"
-                    }
-                ]
-            }
-        },
         "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-dbg-ST-e86416d3a8c7",
         {
             "build_settings": {
@@ -1200,7 +1116,6 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-e86416d3a8c7",
             "dependencies": [
-                "@com_github_tadija_aexml//:AEXML darwin_x86_64-dbg-ST-e86416d3a8c7",
                 "@com_github_kylef_pathkit//:PathKit darwin_x86_64-dbg-ST-e86416d3a8c7"
             ],
             "inputs": {

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -74,7 +74,6 @@
 		2EF43FD3B7F4AA363B0EE6CF /* SchemeAutogenerationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2C605A9270255AFA43DD80 /* SchemeAutogenerationMode.swift */; };
 		2F23E98B7032105D6B0D28C8 /* OrderedSet+UnstableInternals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8415E01540549AB7D9DC7775 /* OrderedSet+UnstableInternals.swift */; };
 		3468B9267DEA583FB703DC62 /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB78F15F8AFA4FD268CBC7BD /* KeyedDecodingContainer+Additions.swift */; };
-		34AA2315505226D74BC238A6 /* Element.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1140300C723A6A3D0EC452A4 /* Element.swift */; };
 		35E9B6637FCD832D7DA6AEE7 /* String+md5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5285231423E12A7D4A411306 /* String+md5.swift */; };
 		37B871D3339996C12526978C /* XCScheme+TestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0BD1CBCC9A4B6877AA90F0 /* XCScheme+TestAction.swift */; };
 		37D980D7EF5382A6BB2247E3 /* SetTargetConfigurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 280848D0817DF92FDA8FBCE5 /* SetTargetConfigurations.swift */; };
@@ -203,7 +202,6 @@
 		A5D66766F9D7772EE82F9FDA /* StoreKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4AAE743094CADD9B1460D18 /* StoreKit.swift */; };
 		A78684FED72049D4F92F6FAD /* OrderedDictionary+Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF7D954BC6981F149890B01 /* OrderedDictionary+Initializers.swift */; };
 		A8DB5738284E29AF2C26C019 /* CreateCustomXCSchemesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DCCA641AA41C40218CFC8D /* CreateCustomXCSchemesTests.swift */; };
-		A8FEFDA57FA92AD7D99D445F /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = 909D2CD42D7D467BABD29667 /* Options.swift */; };
 		A9BD7EB305E42D13573F092B /* OrderedSet+Partial MutableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E672A55CA5879B1199B3F39 /* OrderedSet+Partial MutableCollection.swift */; };
 		AA1ED0B4D05856EC1D8F35F0 /* XCSchemeInfo+BuildActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C073844239D812B1D0C1 /* XCSchemeInfo+BuildActionInfoTests.swift */; };
 		AACDE105D330A480D07B435A /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006BA29C0C61C275AD3E5F44 /* PBXProject.swift */; };
@@ -258,11 +256,9 @@
 		DBFC6572F672F0F7DB57E376 /* PBXRezBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 816ABF7E49ECC39FF0C2BD7C /* PBXRezBuildPhase.swift */; };
 		DC8C087E54F34F07F6AF1D09 /* PBXShellScriptBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD728395ABCED96F30DDD20 /* PBXShellScriptBuildPhase.swift */; };
 		DCB475A0CDD931D6F861D386 /* PBXObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A9D8A89C2E98C67BF8A8AD /* PBXObjects.swift */; };
-		DD245AFB1668F2EFE8156046 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CC2D5E3BD42DA1195EE7D9 /* Error.swift */; };
 		DDA0D6C91761C86FAC9E4EF5 /* OrderedSet+SubSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61C5D6C3C0A4507A95C4911 /* OrderedSet+SubSequence.swift */; };
 		DE2AE8FDCDFF91E303EA7466 /* XCSchemeInfo+HostInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19324EEB6DC61A66DA1BDD /* XCSchemeInfo+HostInfo.swift */; };
 		DF31D0BD58CB2F6647DDCE3A /* String+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C5676FE6D1E8E366E560E4 /* String+Utils.swift */; };
-		E03759F8513D66371C63D812 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E0F5A1B53AB6636177FF3 /* Parser.swift */; };
 		E075DBD2EA75DCF884EDB18E /* XCSchemeInfo+ProfileActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1F9D8A83D1365CE469B854 /* XCSchemeInfo+ProfileActionInfoTests.swift */; };
 		E09BED012CA4DFD4E19FB5D8 /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7647397F45D0244E2A792F55 /* Main.swift */; };
 		E145F1D987DDE58833EE7808 /* JSONDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B75E96572AFED3A0BCC7CB /* JSONDecoding.swift */; };
@@ -290,7 +286,6 @@
 		F43BE9CA61F86296449E282E /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E33D45F79608C7292CC9CA /* PBXContainerItem.swift */; };
 		F4FC0609C3D762CAC16924D2 /* PBXTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BC264ECA2884D8C55BD24D /* PBXTarget.swift */; };
 		F577A753538CDA4348644127 /* XCWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD042334686EC625458D787 /* XCWorkspace.swift */; };
-		F77DC82AF2E7B7C09CD0A809 /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF2F4371F6A9202D496F255 /* Document.swift */; };
 		F7AF351045488A3B16AB2A6A /* OrderedSet+CustomDebugStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB6D4C1A760E0F5039DCA16 /* OrderedSet+CustomDebugStringConvertible.swift */; };
 		F7F5AA2F9A629D2B0EAD99CC /* Outputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC96161706C3865948E383F4 /* Outputs.swift */; };
 		F8A6256D74FA8C3A7DA7253C /* PBXSourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3134774196A92DDFE6467A90 /* PBXSourcesBuildPhase.swift */; };
@@ -331,13 +326,6 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		336B5CF2DDE3D0B832C12168 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
-		};
 		3A1A9FA674016F6D082BD8E2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -351,13 +339,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
-		};
-		4FA052E4857080583368FC00 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = AFE4D24E5783CFEA55476089;
-			remoteInfo = AEXML;
 		};
 		57526E39DC1C23E02C838E67 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -435,7 +416,6 @@
 		006BA29C0C61C275AD3E5F44 /* PBXProject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProject.swift; sourceTree = "<group>"; };
 		016123E30A6AE3BE1D9FC323 /* _HashTable+Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+Constants.swift"; sourceTree = "<group>"; };
 		01F7979EAE7C1D8DEAEB8B63 /* libOrderedCollections.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libOrderedCollections.a; path = "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections/libOrderedCollections.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		026DBBF837F683191890587B /* libAEXML.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libAEXML.a; path = "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/libAEXML.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		027E9B9019409A4B799BF4E8 /* XCSchemeInfo+OtherActionInfos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+OtherActionInfos.swift"; sourceTree = "<group>"; };
 		03610C8A88B668CC0E52047B /* CommentedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentedString.swift; sourceTree = "<group>"; };
 		036C24C34D6A40418EF9FF68 /* PopulateMainGroupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopulateMainGroupTests.swift; sourceTree = "<group>"; };
@@ -460,7 +440,6 @@
 		10430B01FC239C6F7D75D87D /* XCSchemeInfo+TargetInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+TargetInfo.swift"; sourceTree = "<group>"; };
 		112B87FF9C843E171D58BB93 /* OrderedSet+UnorderedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+UnorderedView.swift"; sourceTree = "<group>"; };
 		1133DC1402E9C43EE1126DC4 /* PBXTarget+ExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXTarget+ExtensionsTests.swift"; sourceTree = "<group>"; };
-		1140300C723A6A3D0EC452A4 /* Element.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Element.swift; sourceTree = "<group>"; };
 		1168458212BA2875894C312C /* OrderedSet+Diffing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Diffing.swift"; sourceTree = "<group>"; };
 		11A9D8A89C2E98C67BF8A8AD /* PBXObjects.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXObjects.swift; sourceTree = "<group>"; };
 		1267D8B9A2E0172402C0AD0C /* XCScheme+Runnable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+Runnable.swift"; sourceTree = "<group>"; };
@@ -489,7 +468,6 @@
 		246DA27DDBB9DDC350093B5E /* XCTAssertNoDifference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTAssertNoDifference.swift; sourceTree = "<group>"; };
 		27146594D2586076268359D4 /* OrderedDictionary+Elements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Elements.swift"; sourceTree = "<group>"; };
 		280848D0817DF92FDA8FBCE5 /* SetTargetConfigurations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetTargetConfigurations.swift; sourceTree = "<group>"; };
-		2AF2F4371F6A9202D496F255 /* Document.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Document.swift; sourceTree = "<group>"; };
 		2FF7D954BC6981F149890B01 /* OrderedDictionary+Initializers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Initializers.swift"; sourceTree = "<group>"; };
 		30F60F75C8E9D96863387FEB /* OrderedSet+Partial SetAlgebra+Predicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial SetAlgebra+Predicates.swift"; sourceTree = "<group>"; };
 		3100C1877D8D628B02BF5584 /* PathKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathKit.swift; sourceTree = "<group>"; };
@@ -583,7 +561,6 @@
 		7CF6CCE92E630FB3BC410DEB /* UserNotificationsUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserNotificationsUI.swift; sourceTree = "<group>"; };
 		7DCA334E10977F8A11144FFE /* PBXObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXObject.swift; sourceTree = "<group>"; };
 		7E0BD1CBCC9A4B6877AA90F0 /* XCScheme+TestAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+TestAction.swift"; sourceTree = "<group>"; };
-		7E3E0F5A1B53AB6636177FF3 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		800C070BE73507A0C2F78615 /* OrderedSet+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Equatable.swift"; sourceTree = "<group>"; };
 		810DCDDB6E489CA88A3F0683 /* PBXObjectParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXObjectParser.swift; sourceTree = "<group>"; };
 		816ABF7E49ECC39FF0C2BD7C /* PBXRezBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXRezBuildPhase.swift; sourceTree = "<group>"; };
@@ -606,7 +583,6 @@
 		8E03630DAABDBF841E3953BE /* XCWorkspaceDataElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataElement.swift; sourceTree = "<group>"; };
 		8E960E7EE6E2FD116C069453 /* BuildSettingsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettingsProvider.swift; sourceTree = "<group>"; };
 		8EBC103C15263D4855CC5FEA /* OrderedSet+Insertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Insertions.swift"; sourceTree = "<group>"; };
-		909D2CD42D7D467BABD29667 /* Options.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		90FC2D965C257C3B93C28D06 /* XCConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCConfig.swift; sourceTree = "<group>"; };
 		911DB2F0F959CA569B2FB2CA /* AEXML+XcodeFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AEXML+XcodeFormat.swift"; sourceTree = "<group>"; };
 		9125F5C08D2ECD569EE90D8D /* PBXProjEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProjEncoder.swift; sourceTree = "<group>"; };
@@ -653,7 +629,6 @@
 		B85F30A6B61E80F5E31CB607 /* DisambiguateTargetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisambiguateTargetsTests.swift; sourceTree = "<group>"; };
 		B8CF865CD92AF227C4505C9F /* PBXProductType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXProductType+Extensions.swift"; sourceTree = "<group>"; };
 		B9570F5DB90273906103037E /* BuildSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettings.swift; sourceTree = "<group>"; };
-		B9CC2D5E3BD42DA1195EE7D9 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		BB3B7B3EF55DEF23CEA21525 /* XCSchemeInfo+TestActionInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+TestActionInfoTests.swift"; sourceTree = "<group>"; };
 		BCB6D4C1A760E0F5039DCA16 /* OrderedSet+CustomDebugStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+CustomDebugStringConvertible.swift"; sourceTree = "<group>"; };
 		BD4DFC45C9538AD37FAE2610 /* BazelLabel+TestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BazelLabel+TestExtensions.swift"; sourceTree = "<group>"; };
@@ -995,7 +970,6 @@
 			isa = PBXGroup;
 			children = (
 				35A20E5A35DA3971E891B8B7 /* generator */,
-				026DBBF837F683191890587B /* libAEXML.a */,
 				469CF9DFF63FD8C4A17E9BBD /* libCustomDump.a */,
 				3C5481AFA2D7E3DECBAFE9CB /* libgenerator.library.a */,
 				01F7979EAE7C1D8DEAEB8B63 /* libOrderedCollections.a */,
@@ -1141,7 +1115,6 @@
 				F2D68F20699F3913E96788DA /* com_github_kylef_pathkit */,
 				461E6FE63185BFED40509795 /* com_github_pointfreeco_swift_custom_dump */,
 				ED84486FE276E94F67256F83 /* com_github_pointfreeco_xctest_dynamic_overlay */,
-				A57E33E52FB737BB3821C445 /* com_github_tadija_aexml */,
 				FDA6D5213A699DBCBE8C3656 /* com_github_tuist_xcodeproj */,
 			);
 			name = "Bazel External Repositories";
@@ -1165,14 +1138,6 @@
 				08A3C79E4BAF2C7A4BE71577 /* Sources */,
 			);
 			path = com_github_apple_swift_collections;
-			sourceTree = "<group>";
-		};
-		A57E33E52FB737BB3821C445 /* com_github_tadija_aexml */ = {
-			isa = PBXGroup;
-			children = (
-				EDE6B7E8A7A3A7BF18C9D7BD /* Sources */,
-			);
-			path = com_github_tadija_aexml;
 			sourceTree = "<group>";
 		};
 		A61FCE87C253B18D1339CA0F /* Scheme */ = {
@@ -1365,32 +1330,12 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
-		EC069F565DFE6D70F720A9BF /* AEXML */ = {
-			isa = PBXGroup;
-			children = (
-				2AF2F4371F6A9202D496F255 /* Document.swift */,
-				1140300C723A6A3D0EC452A4 /* Element.swift */,
-				B9CC2D5E3BD42DA1195EE7D9 /* Error.swift */,
-				909D2CD42D7D467BABD29667 /* Options.swift */,
-				7E3E0F5A1B53AB6636177FF3 /* Parser.swift */,
-			);
-			path = AEXML;
-			sourceTree = "<group>";
-		};
 		ED84486FE276E94F67256F83 /* com_github_pointfreeco_xctest_dynamic_overlay */ = {
 			isa = PBXGroup;
 			children = (
 				EA1D4343AF2E6782E5269039 /* Sources */,
 			);
 			path = com_github_pointfreeco_xctest_dynamic_overlay;
-			sourceTree = "<group>";
-		};
-		EDE6B7E8A7A3A7BF18C9D7BD /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				EC069F565DFE6D70F720A9BF /* AEXML */,
-			);
-			path = Sources;
 			sourceTree = "<group>";
 		};
 		F2741CE740C2974318EDD953 /* Sources */ = {
@@ -1454,7 +1399,6 @@
 			);
 			dependencies = (
 				9180B355ABFEE76581F29E80 /* PBXTargetDependency */,
-				D5F65B44A3A5B58EC00BF47B /* PBXTargetDependency */,
 				4460D0461ECFE2C5DB3906C8 /* PBXTargetDependency */,
 			);
 			name = XcodeProj;
@@ -1510,21 +1454,6 @@
 			);
 			name = generator.library;
 			productName = generator.library;
-			productType = "com.apple.product-type.library.static";
-		};
-		AFE4D24E5783CFEA55476089 /* AEXML */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8BDAB75DB6FB9D9F61CD91B1 /* Build configuration list for PBXNativeTarget "AEXML" */;
-			buildPhases = (
-				81EFBB1AEA99739370BA7DBA /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				9D4168B49068A541B3B09FA0 /* PBXTargetDependency */,
-			);
-			name = AEXML;
-			productName = AEXML;
 			productType = "com.apple.product-type.library.static";
 		};
 		B0128CCFCF9E56DA6D808193 /* OrderedCollections */ = {
@@ -1618,10 +1547,6 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
 					};
-					AFE4D24E5783CFEA55476089 = {
-						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
-					};
 					B0128CCFCF9E56DA6D808193 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 1320;
@@ -1657,7 +1582,6 @@
 			projectRoot = "";
 			targets = (
 				FE59281FE487F27A37DC2EE7 /* BazelDependencies */,
-				AFE4D24E5783CFEA55476089 /* AEXML */,
 				CFD3DFAB502EFF52937E5E51 /* CustomDump */,
 				2FED647E7A6091DF616D345B /* generator */,
 				3A4021D8F5FC68CD4FB8B6F1 /* generator.library */,
@@ -1836,18 +1760,6 @@
 				0C0684F526818ABFCEC92D99 /* XCSchemeInfoTests.swift in Sources */,
 				3D9A78660D051C58D312CA3A /* XcodeProj+CustomDump.swift in Sources */,
 				D6CA9A027D3B6D18C7DE1EE3 /* XcodeScheme+ExtensionsTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		81EFBB1AEA99739370BA7DBA /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F77DC82AF2E7B7C09CD0A809 /* Document.swift in Sources */,
-				34AA2315505226D74BC238A6 /* Element.swift in Sources */,
-				DD245AFB1668F2EFE8156046 /* Error.swift in Sources */,
-				A8FEFDA57FA92AD7D99D445F /* Options.swift in Sources */,
-				E03759F8513D66371C63D812 /* Parser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2126,12 +2038,6 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = DB651C00CC6C7BD07F2AAF7E /* PBXContainerItemProxy */;
 		};
-		9D4168B49068A541B3B09FA0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = 336B5CF2DDE3D0B832C12168 /* PBXContainerItemProxy */;
-		};
 		B12061704177081637FBB0E6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -2149,12 +2055,6 @@
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 98B7F3DF7B13B0E6ABB67592 /* PBXContainerItemProxy */;
-		};
-		D5F65B44A3A5B58EC00BF47B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = AEXML;
-			target = AFE4D24E5783CFEA55476089 /* AEXML */;
-			targetProxy = 4FA052E4857080583368FC00 /* PBXContainerItemProxy */;
 		};
 		DA2AC3E8FD27B24B1FC6BBA1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2231,7 +2131,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit";
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -2261,7 +2161,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit $(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -2378,7 +2278,7 @@
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_xctest_dynamic_overlay $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_swift_custom_dump";
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit $(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_xctest_dynamic_overlay $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_swift_custom_dump";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
@@ -2484,35 +2384,6 @@
 			};
 			name = Debug;
 		};
-		F09EE6C5BBA4629004FA365E /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml";
-				BAZEL_TARGET_ID = "@com_github_tadija_aexml//:AEXML darwin_x86_64-dbg-ST-02316c4eb12c";
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GENERATE_INFOPLIST_FILE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				OTHER_SWIFT_FLAGS = "-vfsoverlay $(BUILD_DIR)/gen_dir-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
-				PRODUCT_MODULE_NAME = AEXML;
-				PRODUCT_NAME = AEXML;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5;
-				TARGET_NAME = AEXML;
-				USER_HEADER_SEARCH_PATHS = (
-					.,
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin",
-				);
-			};
-			name = Debug;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2552,14 +2423,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A61DA4363E35A22443265F05 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		8BDAB75DB6FB9D9F61CD91B1 /* Build configuration list for PBXNativeTarget "AEXML" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				F09EE6C5BBA4629004FA365E /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/external.xcfilelist
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/external.xcfilelist
@@ -75,11 +75,6 @@ $(BAZEL_EXTERNAL)/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/In
 $(BAZEL_EXTERNAL)/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Internal/String.swift
 $(BAZEL_EXTERNAL)/com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/XCTAssertNoDifference.swift
 $(BAZEL_EXTERNAL)/com_github_pointfreeco_xctest_dynamic_overlay/Sources/XCTestDynamicOverlay/XCTFail.swift
-$(BAZEL_EXTERNAL)/com_github_tadija_aexml/Sources/AEXML/Document.swift
-$(BAZEL_EXTERNAL)/com_github_tadija_aexml/Sources/AEXML/Element.swift
-$(BAZEL_EXTERNAL)/com_github_tadija_aexml/Sources/AEXML/Error.swift
-$(BAZEL_EXTERNAL)/com_github_tadija_aexml/Sources/AEXML/Options.swift
-$(BAZEL_EXTERNAL)/com_github_tadija_aexml/Sources/AEXML/Parser.swift
 $(BAZEL_EXTERNAL)/com_github_tuist_xcodeproj/Sources/XcodeProj/Errors/Errors.swift
 $(BAZEL_EXTERNAL)/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/AEXML+XcodeFormat.swift
 $(BAZEL_EXTERNAL)/com_github_tuist_xcodeproj/Sources/XcodeProj/Extensions/Array+Extras.swift

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-02316c4eb12c/tools/generator/generator.link.params
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-02316c4eb12c/tools/generator/generator.link.params
@@ -1,7 +1,7 @@
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator/generator.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/AEXML.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
+-Wl,-add_ast_path,$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/AEXML.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
 -L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib
 -ObjC
@@ -14,5 +14,5 @@
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator/libgenerator.library.a
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/libAEXML.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/libAEXML.a
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit/libPathKit.a

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-02316c4eb12c/tools/generator/test/tests.link.params
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-02316c4eb12c/tools/generator/test/tests.link.params
@@ -2,7 +2,7 @@
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator/generator.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/AEXML.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
+-Wl,-add_ast_path,$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/AEXML.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule/$(ARCHS)-$(LLVM_TARGET_TRIPLE_VENDOR)-$(SWIFT_PLATFORM_TARGET_PREFIX)$(LLVM_TARGET_TRIPLE_SUFFIX).swiftmodule
@@ -17,7 +17,7 @@
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator/libgenerator.library.a
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/libAEXML.a
+$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/libAEXML.a
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit/libPathKit.a
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
 $(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -1100,90 +1100,6 @@
                 ]
             }
         },
-        "@com_github_tadija_aexml//:AEXML darwin_x86_64-dbg-ST-02316c4eb12c",
-        {
-            "build_settings": {
-                "DEBUG_INFORMATION_FORMAT": "dwarf",
-                "ENABLE_BITCODE": false,
-                "ENABLE_TESTABILITY": true,
-                "GCC_OPTIMIZATION_LEVEL": "0",
-                "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
-                "PRODUCT_MODULE_NAME": "AEXML",
-                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
-                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
-                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-                "SWIFT_VERSION": "5"
-            },
-            "configuration": "darwin_x86_64-dbg-ST-02316c4eb12c",
-            "inputs": {
-                "srcs": [
-                    {
-                        "_": "com_github_tadija_aexml/Sources/AEXML/Document.swift",
-                        "t": "e"
-                    },
-                    {
-                        "_": "com_github_tadija_aexml/Sources/AEXML/Element.swift",
-                        "t": "e"
-                    },
-                    {
-                        "_": "com_github_tadija_aexml/Sources/AEXML/Error.swift",
-                        "t": "e"
-                    },
-                    {
-                        "_": "com_github_tadija_aexml/Sources/AEXML/Options.swift",
-                        "t": "e"
-                    },
-                    {
-                        "_": "com_github_tadija_aexml/Sources/AEXML/Parser.swift",
-                        "t": "e"
-                    }
-                ]
-            },
-            "label": "@com_github_tadija_aexml//:AEXML",
-            "name": "AEXML",
-            "outputs": {
-                "s": {
-                    "d": {
-                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/AEXML.swiftdoc",
-                        "t": "g"
-                    },
-                    "m": {
-                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/AEXML.swiftsourceinfo",
-                        "t": "g"
-                    }
-                }
-            },
-            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml",
-            "platform": {
-                "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
-                "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
-            },
-            "product": {
-                "executable_name": null,
-                "name": "AEXML",
-                "path": {
-                    "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/libAEXML.a",
-                    "t": "g"
-                },
-                "type": "com.apple.product-type.library.static"
-            },
-            "search_paths": {
-                "quote_includes": [
-                    ".",
-                    {
-                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
-                        "t": "g"
-                    }
-                ]
-            }
-        },
         "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-dbg-ST-02316c4eb12c",
         {
             "build_settings": {
@@ -1200,7 +1116,6 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-02316c4eb12c",
             "dependencies": [
-                "@com_github_tadija_aexml//:AEXML darwin_x86_64-dbg-ST-02316c4eb12c",
                 "@com_github_kylef_pathkit//:PathKit darwin_x86_64-dbg-ST-02316c4eb12c"
             ],
             "inputs": {

--- a/tools/generator/BUILD
+++ b/tools/generator/BUILD
@@ -6,7 +6,8 @@ load(
 load("//xcodeproj:xcodeproj.bzl", "xcodeproj")
 load(
     ":xcodeproj_targets.bzl",
-    "GENERATOR_SCHEME_AUTOGENERATION_MODE",
+    "SCHEME_AUTOGENERATION_MODE",
+    "UNFOCUSED_TARGETS",
     "get_xcode_schemes",
 )
 
@@ -34,9 +35,10 @@ xcodeproj(
     name = "xcodeproj",
     build_mode = "bazel",
     project_name = "generator",
-    scheme_autogeneration_mode = GENERATOR_SCHEME_AUTOGENERATION_MODE,
+    scheme_autogeneration_mode = SCHEME_AUTOGENERATION_MODE,
     schemes = get_xcode_schemes(),
     tags = ["manual"],
+    unfocused_targets = UNFOCUSED_TARGETS,
 )
 
 # Integration test related targets

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -1,26 +1,22 @@
 """Exposes targets used by `xcodeproj` to allow use in fixture tests."""
 
-load("@bazel_skylib//lib:sets.bzl", "sets")
 load("//xcodeproj:xcodeproj.bzl", "xcode_schemes")
 
-GENERATOR_SCHEME_AUTOGENERATION_MODE = "none"
+UNFOCUSED_TARGETS = [
+    "@com_github_tadija_aexml//:AEXML",
+]
+
+SCHEME_AUTOGENERATION_MODE = "none"
 
 def get_xcode_schemes():
     return [
         xcode_schemes.scheme(
             name = "generator",
             launch_action = xcode_schemes.launch_action(
-                "//tools/generator:generator",
+                "//tools/generator",
             ),
             test_action = xcode_schemes.test_action([
                 "//tools/generator/test:tests",
             ]),
         ),
     ]
-
-def get_xcodeproj_targets():
-    return sets.to_list(
-        xcode_schemes.collect_top_level_targets(
-            get_xcode_schemes(),
-        ),
-    )


### PR DESCRIPTION
This is mainly to have an example of `unfocused_targets` in the fixtures. While we don't have Bazel index importing we want to minimize the use of focused targets, as we don't have indexing for unfocused targets.