### PR TITLE
Rename `xcodeproj.targets` to `top_level_targets`

### DIFF
--- a/examples/cc/BUILD
+++ b/examples/cc/BUILD
@@ -5,5 +5,5 @@ xcodeproj(
     name = "xcodeproj",
     project_name = "cc",
     tags = ["manual"],
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/examples/command_line/BUILD
+++ b/examples/command_line/BUILD
@@ -5,5 +5,5 @@ xcodeproj(
     name = "xcodeproj",
     project_name = "Command Line",
     tags = ["manual"],
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/examples/ios_app/BUILD
+++ b/examples/ios_app/BUILD
@@ -5,5 +5,5 @@ xcodeproj(
     name = "xcodeproj",
     project_name = "iOS App",
     tags = ["manual"],
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/examples/ios_app/test/fixtures/BUILD
+++ b/examples/ios_app/test/fixtures/BUILD
@@ -9,7 +9,7 @@ load("//:xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
 
 xcodeproj_fixture(
     name = "fixture",
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )
 
 update_fixtures(

--- a/examples/macos_app/BUILD
+++ b/examples/macos_app/BUILD
@@ -5,5 +5,5 @@ xcodeproj(
     name = "xcodeproj",
     project_name = "macOS App",
     tags = ["manual"],
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/examples/multiplatform/BUILD
+++ b/examples/multiplatform/BUILD
@@ -12,7 +12,7 @@ xcodeproj(
     name = "xcodeproj",
     project_name = "Multiplatform",
     tags = ["manual"],
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )
 
 device_and_simulator(

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -15,5 +15,5 @@ xcodeproj(
     build_mode = "bazel",
     project_name = "Simple",
     tags = ["manual"],
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/examples/tvos_app/BUILD
+++ b/examples/tvos_app/BUILD
@@ -5,5 +5,5 @@ xcodeproj(
     name = "xcodeproj",
     project_name = "tvOS App",
     tags = ["manual"],
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/examples/watchos_app/BUILD
+++ b/examples/watchos_app/BUILD
@@ -5,5 +5,5 @@ xcodeproj(
     name = "xcodeproj",
     project_name = "WatchOS App",
     tags = ["manual"],
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/test/fixtures/cc/BUILD
+++ b/test/fixtures/cc/BUILD
@@ -2,5 +2,5 @@ load("//examples/cc:xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
 load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
 
 xcodeproj_fixture(
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/test/fixtures/command_line/BUILD
+++ b/test/fixtures/command_line/BUILD
@@ -3,5 +3,5 @@ load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
 
 xcodeproj_fixture(
     archived_bundles_allowed = True,
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/test/fixtures/macos_app/BUILD
+++ b/test/fixtures/macos_app/BUILD
@@ -3,5 +3,5 @@ load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
 
 xcodeproj_fixture(
     archived_bundles_allowed = True,
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/test/fixtures/multiplatform/BUILD
+++ b/test/fixtures/multiplatform/BUILD
@@ -3,5 +3,5 @@ load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
 
 xcodeproj_fixture(
     archived_bundles_allowed = True,
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/test/fixtures/simple/BUILD
+++ b/test/fixtures/simple/BUILD
@@ -3,5 +3,5 @@ load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
 
 xcodeproj_fixture(
     archived_bundles_allowed = True,
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/test/fixtures/tvos_app/BUILD
+++ b/test/fixtures/tvos_app/BUILD
@@ -3,5 +3,5 @@ load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
 
 xcodeproj_fixture(
     archived_bundles_allowed = True,
-    targets = XCODEPROJ_TARGETS,
+    top_level_targets = XCODEPROJ_TARGETS,
 )

--- a/xcodeproj/internal/fixtures.bzl
+++ b/xcodeproj/internal/fixtures.bzl
@@ -108,7 +108,7 @@ def xcodeproj_fixture(
         name = "xcodeproj",
         archived_bundles_allowed = False,
         modes_and_suffixes = [("xcode", "bwx"), ("bazel", "bwb")],
-        targets = [],
+        top_level_targets = [],
         focused_targets = [],
         unfocused_targets = [],
         schemes = None,
@@ -124,7 +124,7 @@ def xcodeproj_fixture(
         modes_and_suffixes: A `list` of `tuple`s of `build_mode` and `suffix`.
             The `build_mode` will be pass to `xcodeproj.build_mode` and the
             `suffix` will be used as the suffix of the project and spec files.
-        targets: Maps to `xcodeproj.targets`.
+        top_level_targets: Maps to `xcodeproj.top_level_targets`.
         focused_targets: Maps to `xcodeproj.focused_targets`.
         unfocused_targets: Maps to `xcodeproj.unfocused_targets`.
         schemes: Optional. A `list` of `struct` values as returned by
@@ -150,7 +150,7 @@ def xcodeproj_fixture(
             build_mode = mode,
             focused_targets = focused_targets,
             project_name = suffix,
-            targets = targets,
+            top_level_targets = top_level_targets,
             scheme_autogeneration_mode = scheme_autogeneration_mode,
             schemes = schemes,
             unfocused_targets = unfocused_targets,

--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -30,7 +30,10 @@ def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, schemes = None, **kwargs):
     ]
 
     # Combine targets that are specified directly and implicitly via the schemes
-    targets = [bazel_labels.normalize(t) for t in kwargs.pop("targets", [])]
+    top_level_targets = [
+        bazel_labels.normalize(t)
+        for t in kwargs.pop("top_level_targets", [])
+    ]
     schemes_json = None
     if schemes != None:
         targets_from_schemes = xcode_schemes.collect_top_level_targets(schemes)
@@ -45,9 +48,9 @@ def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, schemes = None, **kwargs):
                 focused_targets = focused_targets,
             )
         schemes_json = json.encode(schemes)
-        targets_set = sets.make(targets)
+        targets_set = sets.make(top_level_targets)
         targets_set = sets.union(targets_set, targets_from_schemes)
-        targets = sorted(sets.to_list(targets_set))
+        top_level_targets = sorted(sets.to_list(targets_set))
 
     if kwargs.get("toplevel_cache_buster"):
         fail("`toplevel_cache_buster` is for internal use only")
@@ -69,8 +72,8 @@ def xcodeproj(*, name, xcodeproj_rule = _xcodeproj, schemes = None, **kwargs):
         name = name,
         focused_targets = focused_targets,
         schemes_json = schemes_json,
-        targets = targets,
         testonly = testonly,
+        top_level_targets = top_level_targets,
         toplevel_cache_buster = toplevel_cache_buster,
         unfocused_targets = unfocused_targets,
         **kwargs

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -469,7 +469,7 @@ def _xcodeproj_impl(ctx):
     unfocused_labels = sets.make(ctx.attr.unfocused_targets)
     infos = [
         dep[XcodeProjInfo]
-        for dep in ctx.attr.targets
+        for dep in ctx.attr.top_level_targets
     ]
     configuration = get_configuration(ctx = ctx)
 
@@ -596,7 +596,7 @@ def make_xcodeproj_rule(
 A JSON string representing a list of Xcode schemes to create.\
 """,
         ),
-        "targets": attr.label_list(
+        "top_level_targets": attr.label_list(
             cfg = target_transition,
             mandatory = True,
             allow_empty = False,


### PR DESCRIPTION
There has been some confusion on what targets should or need to be set on `xcodeproj.targets`. They should only be top-level targets, and not any of their dependencies. Setting non-top-level targets will result in misconfigured targets appearing in the project.