### PR TITLE
Set `target.swift-*` lldb settings

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = 914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				9A630CF63C380FAE522825A9 /* Bazel Build */,
+				20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -870,6 +871,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"ExampleObjcTests.xctest\" \\\n  \"\"\n";
+			showEnvVarsInLog = 0;
+		};
+		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		21D8AA3BEA3F6C89F37D75A1 /* Copy Bazel Outputs */ = {

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,144 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+  "x86_64-apple-ios15.0.0-simulator Example.app/Example_ExecutableName" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin\" -I \"CoreUtilsObjC\" -I \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC\" -fmodule-map-file=\"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/Utils.swift.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+
+    ]
+  },
+  "x86_64-apple-ios15.0.0-simulator ExampleObjcTests.xctest/ExampleObjcTests" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DAWESOME -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin\" -I \"CoreUtilsObjC\" -I \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC\" -fmodule-map-file=\"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/Utils.swift.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+
+    ]
+  },
+  "x86_64-apple-ios15.0.0-simulator ExampleTests.xctest/ExampleTests" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin\" -I \"CoreUtilsObjC\" -I \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC\" -fmodule-map-file=\"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/Utils.swift.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/TestingUtils.swift.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DAWESOME -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DAWESOME -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin\" -I \"CoreUtilsObjC\" -I \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC\" -fmodule-map-file=\"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/Utils.swift.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example",
+      "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils"
+    ]
+  },
+  "x86_64-apple-ios15.0.0-simulator ExampleUITests.xctest/ExampleUITests" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin\" -I \"CoreUtilsObjC\" -I \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC\" -fmodule-map-file=\"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/Utils.swift.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+
+    ]
+  }
+}
+
+_FALLBACK_KEYS = {
+  "x86_64-apple-ios-simulator Example.app/Example_ExecutableName" : "x86_64-apple-ios15.0.0-simulator Example.app/Example_ExecutableName",
+  "x86_64-apple-ios-simulator ExampleObjcTests.xctest/ExampleObjcTests" : "x86_64-apple-ios15.0.0-simulator ExampleObjcTests.xctest/ExampleObjcTests",
+  "x86_64-apple-ios-simulator ExampleTests.xctest/ExampleTests" : "x86_64-apple-ios15.0.0-simulator ExampleTests.xctest/ExampleTests",
+  "x86_64-apple-ios-simulator ExampleUITests.xctest/ExampleUITests" : "x86_64-apple-ios15.0.0-simulator ExampleUITests.xctest/ExampleUITests"
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -326,6 +326,37 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "i": [
+                            "CoreUtilsObjC",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",
+                                "t": "g"
+                            }
+                        ],
+                        "m": [
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
+                                "t": "g"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/Utils.swift.modulemap",
+                                "t": "g"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ]
+            },
             "name": "Example",
             "outputs": {
                 "p": {
@@ -504,6 +535,47 @@
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/libTestingUtils.a",
                         "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DAWESOME",
+                        "q": [
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "i": [
+                            "CoreUtilsObjC",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",
+                                "t": "g"
+                            }
+                        ],
+                        "m": [
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
+                                "t": "g"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/Utils.swift.modulemap",
+                                "t": "g"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                                "t": "g"
+                            }
+                        ]
                     }
                 ]
             },
@@ -727,6 +799,88 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "i": [
+                            "CoreUtilsObjC",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",
+                                "t": "g"
+                            }
+                        ],
+                        "m": [
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
+                                "t": "g"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/Utils.swift.modulemap",
+                                "t": "g"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/TestingUtils.swift.modulemap",
+                                "t": "g"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DAWESOME",
+                        "q": [
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DAWESOME",
+                        "q": [
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "i": [
+                            "CoreUtilsObjC",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",
+                                "t": "g"
+                            }
+                        ],
+                        "m": [
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
+                                "t": "g"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/Utils.swift.modulemap",
+                                "t": "g"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example/Example.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/TestingUtils.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "ExampleTests.__internal__.__test_bundle",
             "outputs": {
                 "p": {
@@ -913,6 +1067,47 @@
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleUITests/libExampleUITests.library.a",
                         "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "i": [
+                            "CoreUtilsObjC",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",
+                                "t": "g"
+                            }
+                        ],
+                        "m": [
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
+                                "t": "g"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/Utils.swift.modulemap",
+                                "t": "g"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin",
+                                "t": "g"
+                            }
+                        ]
                     }
                 ]
             },

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				773C70B69E7F801B38FDC01C /* Generate Files */,
+				2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -1124,6 +1125,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [[ -z \"${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}\" ]]; then\n  exit 0\nfi\n\ncp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		756C89B8F706948AE067F27F /* Create link.params */ = {

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+
+}
+
+_FALLBACK_KEYS = {
+
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = 914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				9A630CF63C380FAE522825A9 /* Bazel Build */,
+				20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -367,6 +368,23 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		26791BE0095D398A817F4CFA /* Create link.params */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+
+}
+
+_FALLBACK_KEYS = {
+
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				790733B6E675C2785F8020AC /* Fetch External Repositories */,
+				2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -366,6 +367,23 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		790733B6E675C2785F8020AC /* Fetch External Repositories */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+
+}
+
+_FALLBACK_KEYS = {
+
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = 914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				9A630CF63C380FAE522825A9 /* Bazel Build */,
+				20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -754,6 +755,23 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		25FF47201EFF86EC5EE22D7D /* Create link.params */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+  "x86_64-apple-macosx11.0.0 LibSwiftTests.xctest/Contents/MacOS/LibSwiftTests" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/examples_command_line_external\" -iquote \".\" -iquote \"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin\" -iquote \"$(BAZEL_EXTERNAL)/examples_command_line_external\" -iquote \"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external\" -fmodule-map-file=\"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/lib_impl.swift.modulemap\" -fmodule-map-file=\"examples/command_line/swift_c_module/c_lib.modulemap\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external/Library.swift.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/lib_swift.swift.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DSECRET_3=\"Hello\" -DSECRET_2=\"World!\" -iquote \".\" -iquote \"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin\" -iquote \"$(BAZEL_EXTERNAL)/examples_command_line_external\" -iquote \"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external\" -fmodule-map-file=\"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/lib_impl.swift.modulemap\" -fmodule-map-file=\"examples/command_line/swift_c_module/c_lib.modulemap\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external/Library.swift.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/private_lib.swift.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DSECRET_3=\"Hello\" -DSECRET_2=\"World!\" -iquote \".\" -iquote \"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/examples_command_line_external"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib"
+    ]
+  },
+  "x86_64-apple-macosx11.0.0 tool" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/examples_command_line_external\" -iquote \".\" -iquote \"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin\" -iquote \"$(BAZEL_EXTERNAL)/examples_command_line_external\" -iquote \"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external\" -fmodule-map-file=\"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/lib_impl.swift.modulemap\" -fmodule-map-file=\"examples/command_line/swift_c_module/c_lib.modulemap\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external/Library.swift.modulemap\" -fmodule-map-file=\"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/private_lib.swift.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DSECRET_3=\"Hello\" -DSECRET_2=\"World!\" -iquote \".\" -iquote \"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/examples_command_line_external"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib"
+    ]
+  }
+}
+
+_FALLBACK_KEYS = {
+  "x86_64-apple-macosx LibSwiftTests.xctest/Contents/MacOS/LibSwiftTests" : "x86_64-apple-macosx11.0.0 LibSwiftTests.xctest/Contents/MacOS/LibSwiftTests",
+  "x86_64-apple-macosx tool" : "x86_64-apple-macosx11.0.0 tool"
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -171,6 +171,110 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/lib_impl.swift.modulemap",
+                                "t": "g"
+                            },
+                            "examples/command_line/swift_c_module/c_lib.modulemap",
+                            {
+                                "_": "examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap",
+                                "t": "e"
+                            },
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external/Library.swift.modulemap",
+                                "t": "g"
+                            },
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/lib_swift.swift.modulemap",
+                                "t": "g"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DSECRET_3=\"Hello\" -DSECRET_2=\"World!\"",
+                        "q": [
+                            ".",
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin",
+                                "t": "g"
+                            },
+                            {
+                                "_": "examples_command_line_external",
+                                "t": "e"
+                            },
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/lib_impl.swift.modulemap",
+                                "t": "g"
+                            },
+                            "examples/command_line/swift_c_module/c_lib.modulemap",
+                            {
+                                "_": "examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap",
+                                "t": "e"
+                            },
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external/Library.swift.modulemap",
+                                "t": "g"
+                            },
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/private_lib.swift.modulemap",
+                                "t": "g"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DSECRET_3=\"Hello\" -DSECRET_2=\"World!\"",
+                        "q": [
+                            ".",
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin",
+                                "t": "g"
+                            },
+                            {
+                                "_": "examples_command_line_external",
+                                "t": "e"
+                            },
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "examples_command_line_external",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/LibSwift.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/_SwiftLib.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "LibSwiftTests.__internal__.__test_bundle",
             "outputs": {
                 "p": {
@@ -851,6 +955,69 @@
                     {
                         "_": "examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
                         "t": "e"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/lib_impl.swift.modulemap",
+                                "t": "g"
+                            },
+                            "examples/command_line/swift_c_module/c_lib.modulemap",
+                            {
+                                "_": "examples_command_line_external/ExternalFramework.framework/Modules/module.modulemap",
+                                "t": "e"
+                            },
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external/Library.swift.modulemap",
+                                "t": "g"
+                            },
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/private_lib.swift.modulemap",
+                                "t": "g"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -DSECRET_3=\"Hello\" -DSECRET_2=\"World!\"",
+                        "q": [
+                            ".",
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin",
+                                "t": "g"
+                            },
+                            {
+                                "_": "examples_command_line_external",
+                                "t": "e"
+                            },
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/external/examples_command_line_external",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "examples_command_line_external",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib/_SwiftLib.swiftmodule",
+                        "t": "g"
                     }
                 ]
             },

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				773C70B69E7F801B38FDC01C /* Generate Files */,
+				2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -737,6 +738,23 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		773C70B69E7F801B38FDC01C /* Generate Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+
+}
+
+_FALLBACK_KEYS = {
+
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = 914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				9A630CF63C380FAE522825A9 /* Bazel Build */,
+				20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -298,6 +299,7 @@
 		F7E6FDDF50AAB650480FB900 /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		F87890E59D29431994A8AD60 /* XCBuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9354E6340A0B10BEB1FDEE /* XCBuildConfiguration.swift */; };
 		F8DAB8FCE71E293402C101A7 /* OrderedSet+Invariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2062B3E1312EAF079BC5E26C /* OrderedSet+Invariants.swift */; };
+		F8ED6A8FFAE1FC9C86D48897 /* LLDBContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BC73B37056313056FED47E /* LLDBContext.swift */; };
 		F9312E0C5F409E17F509CC96 /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		FD2B9E3F88E7E36B11EBE9C9 /* _BazelForcedCompile_.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61C1B860E7015FBB3750A95 /* _BazelForcedCompile_.swift */; };
 		FD83242BF95B2ED90590668A /* PBXShellScriptBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133D091B34B3EB60A9400C02 /* PBXShellScriptBuildPhase.swift */; };
@@ -673,6 +675,7 @@
 		DFD9A9F50CD3972B0F674265 /* XCSchemeInfo+ProfileActionInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+ProfileActionInfoTests.swift"; sourceTree = "<group>"; };
 		E0413D918157ADBE8DAEA92D /* Mirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mirror.swift; sourceTree = "<group>"; };
 		E06CA54BB3677E9BBC8A5D94 /* CompileStub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CompileStub.m; sourceTree = "<group>"; };
+		E2BC73B37056313056FED47E /* LLDBContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLDBContext.swift; sourceTree = "<group>"; };
 		E37E1D8F0FD9F2FEEC62C2B3 /* BazelLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BazelLabelTests.swift; sourceTree = "<group>"; };
 		E4142BB8EF88F4DD2D5440E4 /* OrderedDictionary+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+CustomStringConvertible.swift"; sourceTree = "<group>"; };
 		E43EBF1E6F26B25BB157D396 /* PBXBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildPhase.swift; sourceTree = "<group>"; };
@@ -1322,6 +1325,7 @@
 				742FB8D5E3AD34B60B65B2A9 /* FilePath.swift */,
 				0EB9D00963E3FECF87A050AA /* Inputs.swift */,
 				05B53AF9EB4EE0D76B72A641 /* LinkerInputs.swift */,
+				E2BC73B37056313056FED47E /* LLDBContext.swift */,
 				50E1D04A9DAAEC9FAC5461AF /* Outputs.swift */,
 				CCAD7D38A6606771FA4A7436 /* Platform.swift */,
 				963808B2F3A1F2B83E6AE6DF /* Product.swift */,
@@ -1618,6 +1622,23 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B581A2D7C1575EF22D8ECDA /* Copy Bazel Outputs */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -1991,6 +2012,7 @@
 				8FCC7D3937EEC9B1D3C1D237 /* ExtensionPointIdentifier.swift in Sources */,
 				F4721D1F8FF6BFDF701622EB /* FilePath.swift in Sources */,
 				D75E4FF718EDB764C615241B /* Inputs.swift in Sources */,
+				F8ED6A8FFAE1FC9C86D48897 /* LLDBContext.swift in Sources */,
 				83401B70003CB4C9642FF821 /* LinkerInputs.swift in Sources */,
 				F446405A297DF486D5E599C9 /* Outputs.swift in Sources */,
 				1532FA28D9B68BDD436146B2 /* Platform.swift in Sources */,

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+  "x86_64-apple-macosx11.0.0 generator" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_apple_swift_collections",
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tuist_xcodeproj",
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tadija_aexml",
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_kylef_pathkit"
+    ]
+  },
+  "x86_64-apple-macosx11.0.0 tests.xctest/Contents/MacOS/tests" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/tools/generator",
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_pointfreeco_swift_custom_dump",
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_apple_swift_collections",
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tuist_xcodeproj",
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tadija_aexml",
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_kylef_pathkit",
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_pointfreeco_xctest_dynamic_overlay"
+    ]
+  }
+}
+
+_FALLBACK_KEYS = {
+  "x86_64-apple-macosx generator" : "x86_64-apple-macosx11.0.0 generator",
+  "x86_64-apple-macosx tests.xctest/Contents/MacOS/tests" : "x86_64-apple-macosx11.0.0 tests.xctest/Contents/MacOS/tests"
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -117,6 +117,120 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/tools/generator/generator.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "tests",
             "outputs": {
                 "p": {
@@ -344,6 +458,78 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "generator",
             "outputs": {
                 "p": {
@@ -406,6 +592,7 @@
                     "tools/generator/src/DTO/ExtensionPointIdentifier.swift",
                     "tools/generator/src/DTO/FilePath.swift",
                     "tools/generator/src/DTO/Inputs.swift",
+                    "tools/generator/src/DTO/LLDBContext.swift",
                     "tools/generator/src/DTO/LinkerInputs.swift",
                     "tools/generator/src/DTO/Outputs.swift",
                     "tools/generator/src/DTO/Platform.swift",

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				790733B6E675C2785F8020AC /* Fetch External Repositories */,
+				2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -141,6 +142,7 @@
 		68A371646C2B0DB2E26FBDBE /* XCSchemeInfo+OtherActionInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027E9B9019409A4B799BF4E8 /* XCSchemeInfo+OtherActionInfos.swift */; };
 		69F20613E945D04313E4C5AE /* Path+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34470E90F69D7ED48ABEC831 /* Path+Extensions.swift */; };
 		6B508F325A109B724C7DF650 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BD10545E43D4098F65BF1B /* PBXResourcesBuildPhase.swift */; };
+		6BD9A192D0DD98964D796656 /* LLDBContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F864B729FC2C55DF15D2009F /* LLDBContext.swift */; };
 		6C0F21DFD137550450A0509F /* BuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEF08408AA24ED19A83FA6BD /* BuildPhase.swift */; };
 		6CFA2C81CE43D952A35D3574 /* XCScheme+AditionalOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFADB50BD68C503E0DF38007 /* XCScheme+AditionalOption.swift */; };
 		6D90EE9AA1D0A96B9089B21E /* ProcessTargetMergesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F43A51D4C138E626542CF2C /* ProcessTargetMergesTests.swift */; };
@@ -693,6 +695,7 @@
 		F1E252313444698DA3574515 /* OrderedSet+RandomAccessCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+RandomAccessCollection.swift"; sourceTree = "<group>"; };
 		F4E71029096D6AC34B84A74A /* BuildSettingConditionalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettingConditionalTests.swift; sourceTree = "<group>"; };
 		F558A7D953A3C20394B3D8D0 /* Generator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generator.swift; sourceTree = "<group>"; };
+		F864B729FC2C55DF15D2009F /* LLDBContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLDBContext.swift; sourceTree = "<group>"; };
 		F989E51F5A4A6F6C61A92D70 /* _HashTable+Bucket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_HashTable+Bucket.swift"; sourceTree = "<group>"; };
 		FA0FEDB45F02638177A108FC /* ConsolidatedTargetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsolidatedTargetTests.swift; sourceTree = "<group>"; };
 		FA83272F166637CFAFC4C79C /* OrderedDictionary+Hashable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Hashable.swift"; sourceTree = "<group>"; };
@@ -948,6 +951,7 @@
 				14F770CF5035EED0B12C3D5E /* FilePath.swift */,
 				5A50CE6E3E953B2F9187B002 /* Inputs.swift */,
 				C019F3F4CCAA69A6F5565C0D /* LinkerInputs.swift */,
+				F864B729FC2C55DF15D2009F /* LLDBContext.swift */,
 				CC96161706C3865948E383F4 /* Outputs.swift */,
 				374062F4D95CF3BB823766C7 /* Platform.swift */,
 				1D4ACDF966B98589F92E7A9B /* Product.swift */,
@@ -1618,6 +1622,23 @@
 			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
+		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		622B48F68197B4404F5C2432 /* Create link.params */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1789,6 +1810,7 @@
 				5106D7C8071619FD00716C9C /* ExtensionPointIdentifier.swift in Sources */,
 				2450EF1FE18130D9D0FFA51A /* FilePath.swift in Sources */,
 				D7B28561F18BA62588284779 /* Inputs.swift in Sources */,
+				6BD9A192D0DD98964D796656 /* LLDBContext.swift in Sources */,
 				5ECED6299B24791AC2FDCE47 /* LinkerInputs.swift in Sources */,
 				F7F5AA2F9A629D2B0EAD99CC /* Outputs.swift in Sources */,
 				3C4D30A3FE92DC35C432D1DC /* Platform.swift in Sources */,

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+  "x86_64-apple-macosx11.0.0 generator" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+      "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections",
+      "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj",
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml",
+      "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit"
+    ]
+  },
+  "x86_64-apple-macosx11.0.0 tests.xctest/Contents/MacOS/tests" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+      "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator",
+      "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_swift_custom_dump",
+      "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections",
+      "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj",
+      "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml",
+      "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit",
+      "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_xctest_dynamic_overlay"
+    ]
+  }
+}
+
+_FALLBACK_KEYS = {
+  "x86_64-apple-macosx generator" : "x86_64-apple-macosx11.0.0 generator",
+  "x86_64-apple-macosx tests.xctest/Contents/MacOS/tests" : "x86_64-apple-macosx11.0.0 tests.xctest/Contents/MacOS/tests"
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -117,6 +117,120 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator/generator.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "tests",
             "outputs": {
                 "p": {
@@ -344,6 +458,78 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "generator",
             "outputs": {
                 "p": {
@@ -406,6 +592,7 @@
                     "tools/generator/src/DTO/ExtensionPointIdentifier.swift",
                     "tools/generator/src/DTO/FilePath.swift",
                     "tools/generator/src/DTO/Inputs.swift",
+                    "tools/generator/src/DTO/LLDBContext.swift",
                     "tools/generator/src/DTO/LinkerInputs.swift",
                     "tools/generator/src/DTO/Outputs.swift",
                     "tools/generator/src/DTO/Platform.swift",

--- a/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = 914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				9A630CF63C380FAE522825A9 /* Bazel Build */,
+				20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -297,6 +298,23 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3C5F7018A60EE40574F4CDA0 /* Create link.params */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/test/fixtures/macos_app/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/macos_app/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/macos_app/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/macos_app/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,113 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+  "x86_64-apple-macosx15.0.0 macOSApp.app/Contents/MacOS/macOSApp" : {
+    "clang" : "\"-Fexamples/macos_app/third_party\" -iquote \".\" -iquote \"$(BAZEL_OUT)/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin\" -fmodule-map-file=\"examples/macos_app/third_party/ExampleFramework.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "examples/macos_app/third_party"
+    ],
+    "includes" : [
+
+    ]
+  }
+}
+
+_FALLBACK_KEYS = {
+  "x86_64-apple-macosx macOSApp.app/Contents/MacOS/macOSApp" : "x86_64-apple-macosx15.0.0 macOSApp.app/Contents/MacOS/macOSApp"
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/macos_app/bwb_spec.json
+++ b/test/fixtures/macos_app/bwb_spec.json
@@ -81,6 +81,26 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            "examples/macos_app/third_party/ExampleFramework.framework/Modules/module.modulemap"
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    "examples/macos_app/third_party"
+                ]
+            },
             "name": "Example",
             "outputs": {
                 "p": {

--- a/test/fixtures/macos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/macos_app/bwx.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				773C70B69E7F801B38FDC01C /* Generate Files */,
+				2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -315,6 +316,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		773C70B69E7F801B38FDC01C /* Generate Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/test/fixtures/macos_app/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/macos_app/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/macos_app/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/macos_app/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+
+}
+
+_FALLBACK_KEYS = {
+
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = 914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				9A630CF63C380FAE522825A9 /* Bazel Build */,
+				20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -2158,6 +2159,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libLib.a\" \\\n  \"\"\n";
+			showEnvVarsInLog = 0;
+		};
+		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		3814AF42FEC0097CAA68D5F7 /* Create link.params */ = {

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,283 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+  "arm64_32-apple-watchos7.0.0 watchOSApp.app/watchOSApp" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "arm64_32-apple-watchos7.0.0 watchOSAppExtension.appex/watchOSAppExtension" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "arm64-apple-ios15.0.0 AppClip.app/AppClip" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "arm64-apple-ios15.0.0 iMessageApp.app/iMessageApp" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "arm64-apple-ios15.0.0 iMessageAppExtension.appex/iMessageAppExtension" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "arm64-apple-ios15.0.0 iOSApp.app/iOSApp" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64\" \"-F$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64\" \"-F$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMaps.xcframework/ios-arm64\" \"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7\" \"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_EXTERNAL)/com_google_google_maps\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_google_google_maps\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/Modules/module.modulemap\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework/Modules/module.modulemap\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64",
+      "$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64",
+      "$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMaps.xcframework/ios-arm64",
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7",
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib",
+      "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "arm64-apple-ios15.0.0 WidgetExtension.appex/WidgetExtension" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "arm64-apple-tvos15.0.0 tvOSApp.app/tvOSApp" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "x86_64-apple-ios15.0.0-simulator AppClip.app/AppClip" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "x86_64-apple-ios15.0.0-simulator iMessageApp.app/iMessageApp" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "x86_64-apple-ios15.0.0-simulator iMessageAppExtension.appex/iMessageAppExtension" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "x86_64-apple-ios15.0.0-simulator iOSApp.app/iOSApp" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator\" \"-F$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator\" \"-F$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator\" \"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator\" \"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_EXTERNAL)/com_google_google_maps\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_google_google_maps\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator",
+      "$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator",
+      "$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator",
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator",
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib",
+      "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "x86_64-apple-ios15.0.0-simulator WidgetExtension.appex/WidgetExtension" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "x86_64-apple-macosx11.0.0 Tool" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+
+    ]
+  },
+  "x86_64-apple-tvos15.0.0-simulator tvOSApp.app/tvOSApp" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "x86_64-apple-watchos7.0.0-simulator watchOSApp.app/watchOSApp" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib"
+    ]
+  },
+  "x86_64-apple-watchos7.0.0-simulator watchOSAppExtension.appex/watchOSAppExtension" : {
+    "clang" : "\"-F$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator\" -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift\" -iquote \".\" -iquote \"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin\" -fmodule-map-file=\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+      "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator"
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib"
+    ]
+  }
+}
+
+_FALLBACK_KEYS = {
+  "arm64_32-apple-watchos watchOSApp.app/watchOSApp" : "arm64_32-apple-watchos7.0.0 watchOSApp.app/watchOSApp",
+  "arm64_32-apple-watchos watchOSAppExtension.appex/watchOSAppExtension" : "arm64_32-apple-watchos7.0.0 watchOSAppExtension.appex/watchOSAppExtension",
+  "arm64-apple-ios AppClip.app/AppClip" : "arm64-apple-ios15.0.0 AppClip.app/AppClip",
+  "arm64-apple-ios iMessageApp.app/iMessageApp" : "arm64-apple-ios15.0.0 iMessageApp.app/iMessageApp",
+  "arm64-apple-ios iMessageAppExtension.appex/iMessageAppExtension" : "arm64-apple-ios15.0.0 iMessageAppExtension.appex/iMessageAppExtension",
+  "arm64-apple-ios iOSApp.app/iOSApp" : "arm64-apple-ios15.0.0 iOSApp.app/iOSApp",
+  "arm64-apple-ios WidgetExtension.appex/WidgetExtension" : "arm64-apple-ios15.0.0 WidgetExtension.appex/WidgetExtension",
+  "arm64-apple-tvos tvOSApp.app/tvOSApp" : "arm64-apple-tvos15.0.0 tvOSApp.app/tvOSApp",
+  "x86_64-apple-ios-simulator AppClip.app/AppClip" : "x86_64-apple-ios15.0.0-simulator AppClip.app/AppClip",
+  "x86_64-apple-ios-simulator iMessageApp.app/iMessageApp" : "x86_64-apple-ios15.0.0-simulator iMessageApp.app/iMessageApp",
+  "x86_64-apple-ios-simulator iMessageAppExtension.appex/iMessageAppExtension" : "x86_64-apple-ios15.0.0-simulator iMessageAppExtension.appex/iMessageAppExtension",
+  "x86_64-apple-ios-simulator iOSApp.app/iOSApp" : "x86_64-apple-ios15.0.0-simulator iOSApp.app/iOSApp",
+  "x86_64-apple-ios-simulator WidgetExtension.appex/WidgetExtension" : "x86_64-apple-ios15.0.0-simulator WidgetExtension.appex/WidgetExtension",
+  "x86_64-apple-macosx Tool" : "x86_64-apple-macosx11.0.0 Tool",
+  "x86_64-apple-tvos-simulator tvOSApp.app/tvOSApp" : "x86_64-apple-tvos15.0.0-simulator tvOSApp.app/tvOSApp",
+  "x86_64-apple-watchos-simulator watchOSApp.app/watchOSApp" : "x86_64-apple-watchos7.0.0-simulator watchOSApp.app/watchOSApp",
+  "x86_64-apple-watchos-simulator watchOSAppExtension.appex/watchOSAppExtension" : "x86_64-apple-watchos7.0.0-simulator watchOSAppExtension.appex/watchOSAppExtension"
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -352,6 +352,70 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "AppClip",
             "outputs": {
                 "p": {
@@ -456,6 +520,70 @@
                 "static_libraries": [
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/AppClip/libAppClip.library.a",
+                        "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/Lib.swiftmodule",
                         "t": "g"
                     }
                 ]
@@ -1256,6 +1384,20 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ]
+            },
             "name": "Tool",
             "outputs": {
                 "p": {
@@ -1409,6 +1551,70 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "WidgetExtension",
             "outputs": {
                 "p": {
@@ -1507,6 +1713,70 @@
                 "static_libraries": [
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/WidgetExtension/libWidgetExtension.library.a",
+                        "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/Lib.swiftmodule",
                         "t": "g"
                     }
                 ]
@@ -1786,6 +2056,70 @@
                     "-lc++"
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "iMessageApp",
             "outputs": {
                 "p": {
@@ -1850,6 +2184,70 @@
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    }
                 ]
             },
             "name": "iMessageApp",
@@ -1937,6 +2335,70 @@
                 "static_libraries": [
                     {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp/libiMessageAppExtension.library.a",
+                        "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/Lib.swiftmodule",
                         "t": "g"
                     }
                 ]
@@ -2039,6 +2501,70 @@
                 "static_libraries": [
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp/libiMessageAppExtension.library.a",
+                        "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/Lib.swiftmodule",
                         "t": "g"
                     }
                 ]
@@ -2363,6 +2889,206 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            },
+                            {
+                                "_": "com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/Modules/module.modulemap",
+                                "t": "e"
+                            },
+                            {
+                                "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework/Modules/module.modulemap",
+                                "t": "e"
+                            },
+                            {
+                                "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            {
+                                "_": "com_google_google_maps",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_google_google_maps",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "iOSApp",
             "outputs": {
                 "p": {
@@ -2513,6 +3239,206 @@
                 "static_libraries": [
                     {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp/libiOSApp.library.a",
+                        "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            },
+                            {
+                                "_": "com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap",
+                                "t": "e"
+                            },
+                            {
+                                "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap",
+                                "t": "e"
+                            },
+                            {
+                                "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            {
+                                "_": "com_google_google_maps",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_google_google_maps",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    },
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    },
+                    {
+                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib/Lib.swiftmodule",
                         "t": "g"
                     }
                 ]
@@ -2892,6 +3818,70 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "tvOSApp",
             "outputs": {
                 "p": {
@@ -2989,6 +3979,70 @@
                 "static_libraries": [
                     {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp/libtvOSApp.library.a",
+                        "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib/Lib.swiftmodule",
                         "t": "g"
                     }
                 ]
@@ -3261,6 +4315,70 @@
                     "-lc++"
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    }
+                ]
+            },
             "name": "watchOSApp",
             "outputs": {
                 "p": {
@@ -3324,6 +4442,70 @@
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib/Lib.swiftmodule",
+                        "t": "g"
+                    }
                 ]
             },
             "name": "watchOSApp",
@@ -3410,6 +4592,70 @@
                 "static_libraries": [
                     {
                         "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/libwatchOSAppExtension.library.a",
+                        "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib/Lib.swiftmodule",
                         "t": "g"
                     }
                 ]
@@ -3511,6 +4757,70 @@
                 "static_libraries": [
                     {
                         "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSAppExtension/libwatchOSAppExtension.library.a",
+                        "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "m": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap",
+                                "t": "e"
+                            }
+                        ],
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            {
+                                "_": "com_github_krzyzanowskim_cryptoswift",
+                                "t": "e"
+                            },
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/external/com_github_krzyzanowskim_cryptoswift",
+                                "t": "g"
+                            },
+                            ".",
+                            {
+                                "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "f": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator",
+                        "t": "e"
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib/Lib.swiftmodule",
                         "t": "g"
                     }
                 ]

--- a/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				773C70B69E7F801B38FDC01C /* Generate Files */,
+				2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -2350,6 +2351,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		304DC41FA7966C35A933F2AB /* Create link.params */ = {

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+
+}
+
+_FALLBACK_KEYS = {
+
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/simple/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/simple/bwb.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = 914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				9A630CF63C380FAE522825A9 /* Bazel Build */,
+				20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -168,6 +169,23 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9A630CF63C380FAE522825A9 /* Bazel Build */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+
+}
+
+_FALLBACK_KEYS = {
+
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/simple/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/simple/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/simple/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/simple/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+
+}
+
+_FALLBACK_KEYS = {
+
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = 914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				9A630CF63C380FAE522825A9 /* Bazel Build */,
+				20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -462,6 +463,23 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		21D8AA3BEA3F6C89F37D75A1 /* Copy Bazel Outputs */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+  "x86_64-apple-tvos15.0.0-simulator Example.app/Example" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+
+    ]
+  },
+  "x86_64-apple-tvos15.0.0-simulator ExampleTests.xctest/ExampleTests" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+      "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example"
+    ]
+  },
+  "x86_64-apple-tvos15.0.0-simulator ExampleUITests.xctest/ExampleUITests" : {
+    "clang" : "-iquote \".\" -iquote \"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all -iquote \".\" -iquote \"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+
+    ]
+  }
+}
+
+_FALLBACK_KEYS = {
+  "x86_64-apple-tvos-simulator Example.app/Example" : "x86_64-apple-tvos15.0.0-simulator Example.app/Example",
+  "x86_64-apple-tvos-simulator ExampleTests.xctest/ExampleTests" : "x86_64-apple-tvos15.0.0-simulator ExampleTests.xctest/ExampleTests",
+  "x86_64-apple-tvos-simulator ExampleUITests.xctest/ExampleUITests" : "x86_64-apple-tvos15.0.0-simulator ExampleUITests.xctest/ExampleUITests"
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -102,6 +102,20 @@
                     }
                 ]
             },
+            "lldb_context": {
+                "c": [
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ]
+            },
             "name": "Example",
             "outputs": {
                 "p": {
@@ -239,6 +253,36 @@
                 "static_libraries": [
                     {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleTests/libExampleTests.library.a",
+                        "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ],
+                "s": [
+                    {
+                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example/Example.swiftmodule",
                         "t": "g"
                     }
                 ]
@@ -390,6 +434,30 @@
                     {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleUITests/libExampleUITests.library.a",
                         "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin",
+                                "t": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "o": "-O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+                        "q": [
+                            ".",
+                            {
+                                "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin",
+                                "t": "g"
+                            }
+                        ]
                     }
                 ]
             },

--- a/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 			buildConfigurationList = A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
 				773C70B69E7F801B38FDC01C /* Generate Files */,
+				2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */,
 			);
 			dependencies = (
 			);
@@ -445,6 +446,23 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(BUILD_DIR)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		756C89B8F706948AE067F27F /* Create link.params */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+
+}
+
+_FALLBACK_KEYS = {
+
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True

--- a/tools/generator/src/DTO/LLDBContext.swift
+++ b/tools/generator/src/DTO/LLDBContext.swift
@@ -1,0 +1,91 @@
+import PathKit
+
+struct LLDBContext: Equatable {
+    struct Clang: Equatable {
+        let quoteIncludes: [FilePath]
+        let includes: [FilePath]
+        let systemIncludes: [FilePath]
+        let modulemaps: [FilePath]
+        let opts: String?
+
+        init(
+            quoteIncludes: [FilePath] = [],
+            includes: [FilePath] = [],
+            systemIncludes: [FilePath] = [],
+            modulemaps: [FilePath] = [],
+            opts: String? = nil
+        ) {
+            self.quoteIncludes = quoteIncludes
+            self.includes = includes
+            self.systemIncludes = systemIncludes
+            self.modulemaps = modulemaps
+            self.opts = opts
+        }
+    }
+
+    let frameworkSearchPaths: [FilePath]
+    let swiftmodules: [FilePath]
+    let clang: [Clang]
+
+    init(
+        frameworkSearchPaths: [FilePath] = [],
+        swiftmodules: [FilePath] = [],
+        clang: [Clang] = []
+    ) {
+        self.frameworkSearchPaths = frameworkSearchPaths
+        self.swiftmodules = swiftmodules
+        self.clang = clang
+    }
+}
+
+// MARK: - Decodable
+
+extension LLDBContext: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case frameworkSearchPaths = "f"
+        case swiftmodules = "s"
+        case clang = "c"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        frameworkSearchPaths = try container
+            .decodeFilePaths(.frameworkSearchPaths)
+        swiftmodules = try container.decodeFilePaths(.swiftmodules)
+        clang = try container
+            .decodeIfPresent([Clang].self, forKey: .clang) ?? []
+    }
+}
+
+extension LLDBContext.Clang: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case quoteIncludes = "q"
+        case includes = "i"
+        case systemIncludes = "s"
+        case modulemaps = "m"
+        case opts = "o"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        quoteIncludes = try container.decodeFilePaths(.quoteIncludes)
+        includes = try container.decodeFilePaths(.includes)
+        systemIncludes = try container.decodeFilePaths(.systemIncludes)
+        modulemaps = try container.decodeFilePaths(.modulemaps)
+        opts = try container.decodeIfPresent(String.self, forKey: .opts)
+    }
+}
+
+private extension KeyedDecodingContainer where K == LLDBContext.CodingKeys {
+    func decodeFilePaths(_ key: K) throws -> [FilePath] {
+        return try decodeIfPresent([FilePath].self, forKey: key) ?? []
+    }
+}
+
+private extension KeyedDecodingContainer where K == LLDBContext.Clang.CodingKeys {
+    func decodeFilePaths(_ key: K) throws -> [FilePath] {
+        return try decodeIfPresent([FilePath].self, forKey: key) ?? []
+    }
+}

--- a/tools/generator/src/DTO/Platform.swift
+++ b/tools/generator/src/DTO/Platform.swift
@@ -50,6 +50,14 @@ extension Platform {
     var triple: String {
         return "\(arch)-apple-\(variant.triple)"
     }
+
+    var fullTriple: String {
+        let osVersion = minimumOsVersion.fullVersion
+
+        return """
+\(arch)-apple-\(variant.triplePrefix)\(osVersion)\(variant.tripleSuffix)
+"""
+    }
 }
 
 extension Platform.OS {
@@ -80,14 +88,30 @@ extension Platform.Variant {
     }
 
     var triple: String {
+        return "\(triplePrefix)\(tripleSuffix)"
+    }
+
+    var triplePrefix: String {
         switch self {
         case .macOS: return "macosx"
         case .iOSDevice: return "ios"
-        case .iOSSimulator: return "ios-simulator"
+        case .iOSSimulator: return "ios"
         case .tvOSDevice: return "tvos"
-        case .tvOSSimulator: return "tvos-simulator"
+        case .tvOSSimulator: return "tvos"
         case .watchOSDevice: return "watchos"
-        case .watchOSSimulator: return "watchos-simulator"
+        case .watchOSSimulator: return "watchos"
+        }
+    }
+
+    var tripleSuffix: String {
+        switch self {
+        case .macOS: return ""
+        case .iOSDevice: return ""
+        case .iOSSimulator: return "-simulator"
+        case .tvOSDevice: return ""
+        case .tvOSSimulator: return "-simulator"
+        case .watchOSDevice: return ""
+        case .watchOSSimulator: return "-simulator"
         }
     }
 }

--- a/tools/generator/src/DTO/Target.swift
+++ b/tools/generator/src/DTO/Target.swift
@@ -23,6 +23,7 @@ struct Target: Equatable {
     let appClips: Set<TargetID>
     var dependencies: Set<TargetID>
     var outputs: Outputs
+    let lldbContext: LLDBContext?
     let isUnfocusedDependency: Bool
 }
 
@@ -58,6 +59,7 @@ extension Target: Decodable {
         case appClips
         case dependencies
         case outputs
+        case lldbContext
         case isUnfocusedDependency
     }
 
@@ -101,6 +103,8 @@ extension Target: Decodable {
         dependencies = try container.decodeTargetIDs(.dependencies)
         outputs = try container
             .decodeIfPresent(Outputs.self, forKey: .outputs) ?? .init()
+        lldbContext = try container
+            .decodeIfPresent(LLDBContext.self, forKey: .lldbContext)
         isUnfocusedDependency = try container
             .decodeIfPresent(Bool.self, forKey: .isUnfocusedDependency) ?? false
     }

--- a/tools/generator/src/Extensions/Path+Extensions.swift
+++ b/tools/generator/src/Extensions/Path+Extensions.swift
@@ -65,7 +65,7 @@ extension Path {
 }
 
 extension String {
-    /// Wraps the path in quotes if it needs it
+    /// Wraps the path in quotes if it needs it.
     var quoted: String {
         guard rangeOfCharacter(from: .whitespaces) != nil else {
             return self

--- a/tools/generator/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generator/test/CreateFilesAndGroupsTests.swift
@@ -48,7 +48,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
 
         // Act
 
-        let (
+        var (
             createdFiles,
             createdRootElements,
             _
@@ -70,6 +70,9 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         try expectedPBXProj.fixReferences()
 
         // Assert
+
+        // Remove `.internal("swift_debug_settings.py")` as it's a pain to check
+        createdFiles.removeValue(forKey: .internal("swift_debug_settings.py"))
 
         XCTAssertNoDifference(createdRootElements, expectedRootElements)
         XCTAssertNoDifference(createdFiles, expectedFiles)

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1037,6 +1037,118 @@ $(BUILD_DIR)/bazel-out/a/c.lo
 
 """)
 
+        // swift_debug_settings.py
+
+        files[.internal("swift_debug_settings.py")] =
+            .nonReferencedContent(#"""
+#!/usr/bin/python3
+
+"""An lldb module that registers a stop hook to set swift settings."""
+
+import lldb
+
+_BUNDLE_EXTENSIONS = [
+    ".app",
+    ".appex",
+    ".bundle",
+    ".framework",
+    ".xctest",
+]
+
+_SETTINGS = {
+
+}
+
+_FALLBACK_KEYS = {
+
+}
+
+def __lldb_init_module(debugger, _internal_dict):
+    # Register the stop hook when this module is loaded in lldb
+    ci = debugger.GetCommandInterpreter()
+        res = lldb.SBCommandReturnObject()
+        ci.HandleCommand(
+            "target stop-hook add -P swift_debug_settings.StopHook",
+            res,
+        )
+        if not res.Succeeded():
+            print(f"""\
+    Failed to register Swift debug options stop hook:
+
+    {res.GetError()}
+    Please file a bug report here: \
+    https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.
+    """)
+            return
+
+def _get_relative_executable_path(module):
+    for extension in _BUNDLE_EXTENSIONS:
+        prefix, _, suffix = module.rpartition(extension)
+        if prefix:
+            return prefix.split("/")[-1] + extension + suffix
+    return module.split("/")[-1]
+
+class StopHook:
+    "An lldb stop hook class, that sets swift settings for the current module."
+
+    def __init__(self, _target, _extra_args, _internal_dict):
+        pass
+
+    def handle_stop(self, exe_ctx, _stream):
+        "Method that is called when the user stops in lldb."
+        module = exe_ctx.frame.module
+        module_name = module.file.__get_fullpath__()
+        target_triple = module.GetTriple()
+        executable_path = _get_relative_executable_path(module_name)
+        key = f"{target_triple} {executable_path}"
+
+        settings = _SETTINGS.get(key)
+        if not settings:
+            fallback_key = _FALLBACK_KEYS.get(key)
+            if fallback_key:
+                settings = _SETTINGS.get(fallback_key)
+
+        if settings:
+            frameworks = " ".join([
+                f'"{path}"'
+                for path in settings["frameworks"]
+            ])
+            if frameworks:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-framework-search-paths {frameworks}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-framework-search-paths",
+                )
+
+            includes = " ".join([
+                f'"{path}"'
+                for path in settings["includes"]
+            ])
+            if includes:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-module-search-paths {includes}",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-module-search-paths",
+                )
+
+            clang = settings["clang"]
+            if clang:
+                lldb.debugger.HandleCommand(
+                    f"settings set -- target.swift-extra-clang-flags '{clang}'",
+                )
+            else:
+                lldb.debugger.HandleCommand(
+                    "settings clear target.swift-extra-clang-flags",
+                )
+
+        return True
+
+"""#)
+
         // `xcodegeneratedfiles`
 
         let xcodeGeneratedFiles: Set<FilePath> = [

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -26,6 +26,7 @@ extension Target {
         appClips: Set<TargetID> = [],
         dependencies: Set<TargetID> = [],
         outputs: Outputs = .init(),
+        lldbContext: LLDBContext? = nil,
         isUnfocusedDependency: Bool = false
     ) -> Self {
         return Target(
@@ -49,6 +50,7 @@ extension Target {
             appClips: appClips,
             dependencies: dependencies,
             outputs: outputs,
+            lldbContext: lldbContext,
             isUnfocusedDependency: isUnfocusedDependency
         )
     }

--- a/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
+++ b/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
@@ -52,3 +52,10 @@ echo "settings append target.source-map ./external/ \"$build_external\""
 
 # Project files
 echo "settings append target.source-map ./ \"$SRCROOT\""
+
+# Import swift_debug_settings.py
+#
+# This Python module sets a stop hook, that when hit, sets the Swift debug
+# settings (i.e. `target.swift-*``) for the module of the current frame. This
+# fixes debugging when using `-serialize-debugging-options`.
+echo "command script import \"$BUILD_DIR/swift_debug_settings.py\""

--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -38,7 +38,7 @@ def _merge(
         objc: The `ObjcProvider` of the target, or `None`.
         swift_info: The `SwiftInfo` of the target, or `None`.
         transitive_compilation_providers: A `list` of
-            `(target(), XcodeProjInfo)` tuples of transitive dependencies that
+            `(xcode_target, XcodeProjInfo)` tuples of transitive dependencies that
             should have compilation providers merged.
 
     Returns:

--- a/xcodeproj/internal/lldb_contexts.bzl
+++ b/xcodeproj/internal/lldb_contexts.bzl
@@ -1,0 +1,187 @@
+"""Module containing functions dealing with the `LLDBContext` DTO."""
+
+load(":collections.bzl", "set_if_true")
+load(
+    ":files.bzl",
+    "file_path_to_dto",
+    "is_generated_file_path",
+    "parsed_file_path",
+)
+load(":opts.bzl", "swift_pcm_copts")
+
+def _collect(
+        *,
+        compilation_mode = None,
+        objc_fragment = None,
+        id,
+        is_swift,
+        search_paths,
+        modulemaps = None,
+        swiftmodules = None,
+        transitive_infos):
+    """Collects lldb context information for a target.
+
+    Args:
+        compilation_mode: The current compilation mode.
+        objc_fragment: The `objc` configuration fragment.
+        id: The unique identifier of the target.
+        is_swift: Whether the target compiles Swift code.
+        search_paths: A value returned from `target_search_paths.make`.
+        modulemaps: The value returned from `process_modulemaps`.
+        swiftmodules: The value returned from `process_swiftmodules`.
+        transitive_infos: A `list` of `XcodeProjInfo`s for the transitive
+            dependencies of the target.
+
+    Returns:
+        An opaque `struct` that should be passed to `lldb_contexts.to_dto`.
+    """
+    framework_paths = []
+    clang = []
+    if id and is_swift and search_paths and search_paths._compilation_providers:
+        clang_opts = " ".join(swift_pcm_copts(
+            compilation_mode = compilation_mode,
+            objc_fragment = objc_fragment,
+            cc_info = search_paths._compilation_providers._cc_info,
+        ))
+
+        clang = [(
+            id,
+            struct(
+                search_paths = search_paths,
+                modulemaps = modulemaps,
+                opts = clang_opts,
+            ),
+        )]
+
+        objc = search_paths._compilation_providers._objc
+        if objc:
+            framework_paths = [depset(
+                transitive = [
+                    objc.static_framework_paths,
+                    objc.dynamic_framework_paths,
+                ],
+            )]
+
+    return struct(
+        _clang = depset(
+            clang,
+            transitive = [
+                info.lldb_context._clang
+                for info in transitive_infos
+            ],
+            order = "topological",
+        ),
+        _framework_search_paths = depset(
+            transitive = framework_paths + [
+                info.lldb_context._framework_search_paths
+                for info in transitive_infos
+            ],
+            order = "topological",
+        ),
+        _swiftmodules = depset(
+            swiftmodules,
+            transitive = [
+                info.lldb_context._swiftmodules
+                for info in transitive_infos
+            ],
+            order = "topological",
+        ),
+    )
+
+def _to_dto(lldb_context):
+    if not lldb_context:
+        return {}
+
+    dto = {}
+
+    framework_file_paths = [
+        parsed_file_path(path)
+        for path in lldb_context._framework_search_paths.to_list()
+    ]
+    set_if_true(
+        dto,
+        "f",
+        [
+            file_path_to_dto(fp)
+            for fp in framework_file_paths
+            if not is_generated_file_path(fp)
+        ],
+    )
+
+    set_if_true(
+        dto,
+        "s",
+        [file_path_to_dto(fp) for fp in lldb_context._swiftmodules.to_list()],
+    )
+
+    clang_dtos = []
+    for _, clang in lldb_context._clang.to_list():
+        # TODO: DRY this up with `target_search_paths`
+        search_paths = clang.search_paths
+        cc_info = search_paths._compilation_providers._cc_info
+        compilation_context = cc_info.compilation_context
+        opts_search_paths = search_paths._opts_search_paths
+
+        if opts_search_paths:
+            opts_includes = list(opts_search_paths.includes)
+            opts_quote_includes = list(opts_search_paths.quote_includes)
+            opts_system_includes = list(opts_search_paths.system_includes)
+        else:
+            opts_includes = []
+            opts_quote_includes = []
+            opts_system_includes = []
+
+        quote_includes = depset(
+            [".", search_paths._bin_dir_path] + opts_quote_includes,
+            transitive = [compilation_context.quote_includes],
+        )
+
+        clang_dto = {}
+
+        set_if_true(
+            clang_dto,
+            "q",
+            [
+                file_path_to_dto(parsed_file_path(path))
+                for path in quote_includes.to_list()
+            ],
+        )
+        set_if_true(
+            clang_dto,
+            "i",
+            [
+                file_path_to_dto(parsed_file_path(path))
+                for path in (compilation_context.includes.to_list() +
+                             opts_includes)
+            ],
+        )
+        set_if_true(
+            clang_dto,
+            "s",
+            [
+                file_path_to_dto(parsed_file_path(path))
+                for path in (compilation_context.system_includes.to_list() +
+                             opts_system_includes)
+            ],
+        )
+
+        modulemaps = clang.modulemaps
+        if modulemaps:
+            set_if_true(
+                clang_dto,
+                "m",
+                [file_path_to_dto(fp) for fp in clang.modulemaps.file_paths],
+            )
+
+        set_if_true(clang_dto, "o", clang.opts)
+
+        clang_dtos.append(clang_dto)
+
+    set_if_true(dto, "c", clang_dtos)
+
+    return dto
+
+lldb_contexts = struct(
+    collect = _collect,
+    to_dto = _to_dto,
+)

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -648,7 +648,7 @@ under {}""".format(opt, package_bin_dir))
     if opts:
         unhandled_opts = collections.before_each(
             "-Xcc",
-            _swift_pcm_copts(
+            swift_pcm_copts(
                 compilation_mode = compilation_mode,
                 objc_fragment = objc_fragment,
                 cc_info = cc_info,
@@ -723,7 +723,7 @@ def _process_user_swiftcopts(opts):
 
     return search_paths, has_debug_info
 
-def _swift_pcm_copts(*, compilation_mode, objc_fragment, cc_info):
+def swift_pcm_copts(*, compilation_mode, objc_fragment, cc_info):
     base_pcm_flags = _swift_command_line_objc_copts(
         compilation_mode = compilation_mode,
         objc_fragment = objc_fragment,

--- a/xcodeproj/internal/processed_target.bzl
+++ b/xcodeproj/internal/processed_target.bzl
@@ -11,6 +11,7 @@ def processed_target(
         hosted_targets = None,
         inputs,
         library = None,
+        lldb_context,
         non_mergable_targets = None,
         outputs,
         potential_target_merges = None,
@@ -35,6 +36,7 @@ def processed_target(
             provide values for the `XcodeProjInfo.inputs` field.
         library: A `File` for the static library produced by this target, or
             `None`.
+        lldb_context: A value as returned from `lldb_context.collect`.
         non_mergable_targets: An optional `list` of strings that will be in the
             `XcodeProjInfo.non_mergable_targets` `depset`.
         outputs: A value as returned from `output_files.collect` that will
@@ -60,6 +62,7 @@ def processed_target(
         hosted_targets = hosted_targets,
         inputs = inputs,
         library = library,
+        lldb_context = lldb_context,
         non_mergable_targets = non_mergable_targets,
         outputs = outputs,
         potential_target_merges = potential_target_merges,

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -103,6 +103,7 @@ this target. It also includes the two extra fields that collect all of the
 generated `Files` and all of the `Files` that should be added to the Xcode
 project, but are not associated with any targets.
 """,
+        "lldb_context": "A value returned from `lldb_context.collect`.",
         "potential_target_merges": """\
 A `depset` of `struct`s with 'src' and 'dest' fields. The 'src' field is the id
 of the target that can be merged into the target with the id of the 'dest'

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -211,7 +211,7 @@ def process_swiftmodules(*, swift_info):
         swift_info: The `SwiftInfo` provider for the target.
 
     Returns:
-        The `file_path`s of all direct module swiftmodules.
+        A `list` of `file_path`s of dependent swiftmodules.
     """
     if not swift_info:
         return []

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -15,6 +15,7 @@ load(":files.bzl", "file_path", "join_paths_ignoring_empty")
 load(":info_plists.bzl", "info_plists")
 load(":input_files.bzl", "input_files")
 load(":linker_input_files.bzl", "linker_input_files")
+load(":lldb_contexts.bzl", "lldb_contexts")
 load(":opts.bzl", "process_opts")
 load(":output_files.bzl", "output_files")
 load(":platform.bzl", "platform_info")
@@ -427,6 +428,22 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
         bin_dir_path = ctx.bin_dir.path,
         opts_search_paths = opts_search_paths,
     )
+    swiftmodules = process_swiftmodules(swift_info = swift_info)
+    lldb_context = lldb_contexts.collect(
+        compilation_mode = ctx.var["COMPILATION_MODE"],
+        objc_fragment = ctx.fragments.objc,
+        id = id,
+        is_swift = is_swift,
+        search_paths = search_paths,
+        modulemaps = modulemaps,
+        swiftmodules = swiftmodules,
+        transitive_infos = [
+            info
+            for attr, info in transitive_infos
+            if (info.target_type in
+                automatic_target_info.xcode_targets.get(attr, [None]))
+        ],
+    )
 
     return processed_target(
         automatic_target_info = automatic_target_info,
@@ -435,6 +452,7 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
         extension_infoplists = extension_infoplists,
         hosted_targets = hosted_targets,
         inputs = inputs,
+        lldb_context = lldb_context,
         non_mergable_targets = non_mergable_targets,
         outputs = outputs,
         potential_target_merges = potential_target_merges,
@@ -453,7 +471,7 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
             build_settings = build_settings,
             search_paths = search_paths,
             modulemaps = modulemaps,
-            swiftmodules = process_swiftmodules(swift_info = swift_info),
+            swiftmodules = swiftmodules,
             inputs = inputs,
             linker_inputs = linker_inputs,
             infoplist = infoplist,
@@ -463,5 +481,6 @@ The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
             dependencies = dependencies,
             transitive_dependencies = transitive_dependencies,
             outputs = outputs,
+            lldb_context = lldb_context,
         ),
     )

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -116,6 +116,9 @@ Are you using an `alias`? \
         unfocused_targets = unfocused_targets,
     )
 
+    has_unfocused_libraries = sets.length(unfocused_libraries) > 0
+    has_unfocused_targets = bool(unfocused_targets)
+
     targets = {}
     for xcode_target in actual_targets:
         unfocused_generated = []
@@ -142,7 +145,12 @@ Are you using an `alias`? \
         )
 
         targets[xcode_target.id] = xcode_targets.to_dto(
-            xcode_target,
+            xcode_target = xcode_target,
+            include_lldb_context = (
+                has_unfocused_targets or
+                has_unfocused_libraries or
+                build_mode != "xcode"
+            ),
             is_unfocused_dependency = is_unfocused_dependency,
             unfocused_targets = unfocused_targets,
         )


### PR DESCRIPTION
Part of #617.

This allows lldb to work correctly if using the `-noserialize-debugging-options` `swiftc` flag.