### PR TITLE
Convert `Platform.name` into strongly typed `Platform.variant`

### DIFF
--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -241,11 +241,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -338,11 +337,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "Example_ExecutableName",
@@ -429,11 +427,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -523,11 +520,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleObjcTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "ExampleObjcTests",
@@ -652,11 +648,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleObjcTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -747,11 +742,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "ExampleTests",
@@ -845,11 +839,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -940,11 +933,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "ExampleUITests",
@@ -1009,11 +1001,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1083,11 +1074,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1199,11 +1189,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -186,11 +186,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/CoreUtilsObjC",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -305,11 +304,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Example",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "Example_ExecutableName",
@@ -400,11 +398,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Example",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -462,11 +459,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleNestedResources",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -550,11 +546,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleObjcTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "ExampleObjcTests",
@@ -682,11 +677,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleObjcTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -745,11 +739,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleResources",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -832,11 +825,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "ExampleTests",
@@ -930,11 +922,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1025,11 +1016,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "ExampleUITests",
@@ -1097,11 +1087,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1143,11 +1132,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/OnlyStructuredResources",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1208,11 +1196,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1324,11 +1311,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Utils",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1382,11 +1368,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/external/examples_ios_app_external",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/cc/bwb_spec.json
+++ b/test/fixtures/cc/bwb_spec.json
@@ -86,8 +86,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -170,8 +170,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -288,8 +288,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "tool",
@@ -400,8 +400,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/cc/bwx_spec.json
+++ b/test/fixtures/cc/bwx_spec.json
@@ -86,8 +86,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -170,8 +170,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -288,8 +288,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "tool",
@@ -400,8 +400,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -183,8 +183,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "LibSwiftTests",
@@ -288,8 +288,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -410,8 +410,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -504,8 +504,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -602,8 +602,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -667,8 +667,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -745,8 +745,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -873,8 +873,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "tool",
@@ -1008,8 +1008,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -183,8 +183,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "LibSwiftTests",
@@ -288,8 +288,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -410,8 +410,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -504,8 +504,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -602,8 +602,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -667,8 +667,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -745,8 +745,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -873,8 +873,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "tool",
@@ -1008,8 +1008,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -129,8 +129,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "tests",
@@ -238,8 +238,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -357,8 +357,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "generator",
@@ -487,8 +487,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -769,8 +769,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -837,8 +837,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -1004,8 +1004,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -1078,8 +1078,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -1525,8 +1525,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -129,8 +129,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "tests",
@@ -238,8 +238,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -357,8 +357,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "generator",
@@ -487,8 +487,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -769,8 +769,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -837,8 +837,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -1004,8 +1004,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -1078,8 +1078,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -1525,8 +1525,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/macos_app/bwb_spec.json
+++ b/test/fixtures/macos_app/bwb_spec.json
@@ -93,8 +93,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "macOSApp",
@@ -169,8 +169,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/macos_app/bwx_spec.json
+++ b/test/fixtures/macos_app/bwx_spec.json
@@ -97,8 +97,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "macOSApp",
@@ -173,8 +173,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -364,8 +364,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": "AppClip",
@@ -471,11 +471,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "AppClip",
@@ -563,8 +562,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": null,
@@ -656,11 +655,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -753,8 +751,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": null,
@@ -839,11 +837,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -930,8 +927,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvos",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvos"
             },
             "product": {
                 "executable_name": null,
@@ -1016,11 +1013,10 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1107,8 +1103,8 @@
                 "arch": "arm64_32",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchos",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchos"
             },
             "product": {
                 "executable_name": null,
@@ -1193,11 +1189,10 @@
             "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchsimulator",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchsimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1283,8 +1278,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "Tool",
@@ -1348,8 +1343,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -1438,8 +1433,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": "WidgetExtension",
@@ -1539,11 +1534,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "WidgetExtension",
@@ -1634,8 +1628,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": null,
@@ -1730,11 +1724,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1821,8 +1814,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": "iMessageApp",
@@ -1886,11 +1879,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "iMessageApp",
@@ -1979,8 +1971,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": "iMessageAppExtension",
@@ -2080,11 +2072,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "iMessageAppExtension",
@@ -2171,8 +2162,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": null,
@@ -2263,11 +2254,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -2407,8 +2397,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": "iOSApp",
@@ -2560,11 +2550,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "iOSApp",
@@ -2685,8 +2674,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": null,
@@ -2810,11 +2799,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -2942,8 +2930,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvos",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvos"
             },
             "product": {
                 "executable_name": "tvOSApp",
@@ -3042,11 +3030,10 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": "tvOSApp",
@@ -3134,8 +3121,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvos",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvos"
             },
             "product": {
                 "executable_name": null,
@@ -3227,11 +3214,10 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": null,
@@ -3317,8 +3303,8 @@
                 "arch": "arm64_32",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchos",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchos"
             },
             "product": {
                 "executable_name": "watchOSApp",
@@ -3381,11 +3367,10 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchsimulator",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchsimulator"
             },
             "product": {
                 "executable_name": "watchOSApp",
@@ -3473,8 +3458,8 @@
                 "arch": "arm64_32",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchos",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchos"
             },
             "product": {
                 "executable_name": "watchOSAppExtension",
@@ -3573,11 +3558,10 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchsimulator",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchsimulator"
             },
             "product": {
                 "executable_name": "watchOSAppExtension",
@@ -3665,8 +3649,8 @@
                 "arch": "arm64_32",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchos",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchos"
             },
             "product": {
                 "executable_name": null,
@@ -3758,11 +3742,10 @@
             "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchsimulator",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchsimulator"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -342,8 +342,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": "AppClip",
@@ -453,11 +453,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "AppClip",
@@ -545,8 +544,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": null,
@@ -638,11 +637,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -735,8 +733,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": null,
@@ -821,11 +819,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -912,8 +909,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvos",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvos"
             },
             "product": {
                 "executable_name": null,
@@ -998,11 +995,10 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1089,8 +1085,8 @@
                 "arch": "arm64_32",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchos",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchos"
             },
             "product": {
                 "executable_name": null,
@@ -1175,11 +1171,10 @@
             "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchsimulator",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchsimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1265,8 +1260,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "Tool",
@@ -1330,8 +1325,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": null,
@@ -1425,8 +1420,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": "WidgetExtension",
@@ -1531,11 +1526,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "WidgetExtension",
@@ -1626,8 +1620,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": null,
@@ -1722,11 +1716,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -1818,8 +1811,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": "iMessageApp",
@@ -1888,11 +1881,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "iMessageApp",
@@ -1987,8 +1979,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": "iMessageAppExtension",
@@ -2094,11 +2086,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "iMessageAppExtension",
@@ -2185,8 +2176,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": null,
@@ -2277,11 +2268,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -2434,8 +2424,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": "iOSApp",
@@ -2600,11 +2590,10 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": "iOSApp",
@@ -2725,8 +2714,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphoneos",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphoneos"
             },
             "product": {
                 "executable_name": null,
@@ -2850,11 +2839,10 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "iphonesimulator",
-                "os": "ios"
+                "os": "ios",
+                "variant": "iphonesimulator"
             },
             "product": {
                 "executable_name": null,
@@ -2988,8 +2976,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvos",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvos"
             },
             "product": {
                 "executable_name": "tvOSApp",
@@ -3094,11 +3082,10 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": "tvOSApp",
@@ -3186,8 +3173,8 @@
                 "arch": "arm64",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvos",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvos"
             },
             "product": {
                 "executable_name": null,
@@ -3279,11 +3266,10 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": null,
@@ -3374,8 +3360,8 @@
                 "arch": "arm64_32",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchos",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchos"
             },
             "product": {
                 "executable_name": "watchOSApp",
@@ -3443,11 +3429,10 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSApp",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchsimulator",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchsimulator"
             },
             "product": {
                 "executable_name": "watchOSApp",
@@ -3541,8 +3526,8 @@
                 "arch": "arm64_32",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchos",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchos"
             },
             "product": {
                 "executable_name": "watchOSAppExtension",
@@ -3647,11 +3632,10 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchsimulator",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchsimulator"
             },
             "product": {
                 "executable_name": "watchOSAppExtension",
@@ -3739,8 +3723,8 @@
                 "arch": "arm64_32",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchos",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchos"
             },
             "product": {
                 "executable_name": null,
@@ -3832,11 +3816,10 @@
             "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
-                "name": "watchsimulator",
-                "os": "watchos"
+                "os": "watchos",
+                "variant": "watchsimulator"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/simple/bwb_spec.json
+++ b/test/fixtures/simple/bwb_spec.json
@@ -64,8 +64,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "SwiftBin",

--- a/test/fixtures/simple/bwx_spec.json
+++ b/test/fixtures/simple/bwx_spec.json
@@ -64,8 +64,8 @@
                 "arch": "x86_64",
                 "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
-                "name": "macosx",
-                "os": "macos"
+                "os": "macos",
+                "variant": "macosx"
             },
             "product": {
                 "executable_name": "SwiftBin",

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -112,11 +112,10 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": "Example",
@@ -179,11 +178,10 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": null,
@@ -257,11 +255,10 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": "ExampleTests",
@@ -328,11 +325,10 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": null,
@@ -411,11 +407,10 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": "ExampleUITests",
@@ -480,11 +475,10 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": null,

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -112,11 +112,10 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": "Example",
@@ -179,11 +178,10 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": null,
@@ -257,11 +255,10 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": "ExampleTests",
@@ -328,11 +325,10 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": null,
@@ -411,11 +407,10 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": "ExampleUITests",
@@ -480,11 +475,10 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "environment": "Simulator",
                 "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
-                "name": "appletvsimulator",
-                "os": "tvos"
+                "os": "tvos",
+                "variant": "appletvsimulator"
             },
             "product": {
                 "executable_name": null,

--- a/test/internal/platform/platform_info_to_dto_tests.bzl
+++ b/test/internal/platform/platform_info_to_dto_tests.bzl
@@ -78,8 +78,8 @@ def platform_info_to_dto_test_suite(name):
             "arch": "wild",
             "minimum_os_version": "12.0",
             "minimum_deployment_os_version": "12.0",
-            "name": "appletvos",
             "os": "tvos",
+            "variant": "appletvos",
         },
     )
 
@@ -91,11 +91,10 @@ def platform_info_to_dto_test_suite(name):
         minimum_deployment_os_version = "13.0",
         expected_platform_dict = {
             "arch": "x86_64",
-            "environment": "Simulator",
-            "name": "iphonesimulator",
             "minimum_os_version": "11.0",
             "minimum_deployment_os_version": "13.0",
             "os": "ios",
+            "variant": "iphonesimulator",
         },
     )
 
@@ -109,10 +108,10 @@ def platform_info_to_dto_test_suite(name):
         minimum_deployment_os_version = None,
         expected_platform_dict = {
             "arch": "arm64",
-            "name": "macosx",
             "minimum_os_version": "12.1",
             "minimum_deployment_os_version": "12.1",
             "os": "macos",
+            "variant": "macosx",
         },
     )
 

--- a/tools/generator/src/BuildSettingConditional.swift
+++ b/tools/generator/src/BuildSettingConditional.swift
@@ -17,10 +17,10 @@ extension BuildSettingConditional {
         // The order here is the order that Xcode likes them (sdk before arch)
         var components = [key]
         if sdkConditionalAllowed(on: key) {
-            components.append("[sdk=\(platform.name)*]")
+            components.append("[sdk=\(platform.variant.rawValue)*]")
         }
         if archConditionalAllowed(on: key) {
-            components.append("[arch=\(platform.arch)]")
+            components.append("[arch=\(platform.variant.rawValue)]")
         }
         return components.joined()
     }

--- a/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
+++ b/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
@@ -48,7 +48,8 @@ env -i \
                 // with duplicated outputs during Index Build, but it also
                 // has to be a platform that one of the targets uses, otherwise
                 // it's not invoked at all. Index Build is so weird...
-                "SUPPORTED_PLATFORMS": projectPlatforms.sorted().first!.name,
+                "SUPPORTED_PLATFORMS": projectPlatforms.sorted()
+                    .first!.variant.rawValue,
                 "SUPPORTS_MACCATALYST": true,
                 "TARGET_NAME": "BazelDependencies",
             ]

--- a/tools/generator/src/Generator/ConsolidateTargets.swift
+++ b/tools/generator/src/Generator/ConsolidateTargets.swift
@@ -26,8 +26,9 @@ extension Generator {
         //   directory related build settings, so it's non-trivial to support.
         var consolidateGroups: [Set<TargetID>] = []
         for ids in consolidatable.values {
-            var configurations: [String: [PlatformAndConfiguration: TargetID]] =
-                [:]
+            var configurations: [
+                Platform.Variant: [PlatformAndConfiguration: TargetID]
+            ] = [:]
             for id in ids {
                 let target = targets[id]!
                 let platform = target.platform
@@ -35,7 +36,8 @@ extension Generator {
                     platform: platform,
                     configuration: target.configuration
                 )
-                configurations[platform.name, default: [:]][configuration] = id
+                configurations[platform.variant, default: [:]][configuration] =
+                    id
             }
 
             var buckets: [Int: Set<TargetID>] = [:]

--- a/tools/generator/src/Generator/DisambiguateTargets.swift
+++ b/tools/generator/src/Generator/DisambiguateTargets.swift
@@ -361,7 +361,7 @@ struct VersionedOperatingSystemComponents {
     /// Adds another `Target` into consideration for `distinguisher()`.
     mutating func add(target: Target, consolidatedKey: ConsolidatedTarget.Key) {
         consolidatedKeys.insert(consolidatedKey)
-        environments[target.platform.environment ?? "Device", default: .init()]
+        environments[target.platform.variant.environment, default: .init()]
             .add(target: target, consolidatedKey: consolidatedKey)
     }
 
@@ -393,7 +393,7 @@ struct VersionedOperatingSystemComponents {
         let environmentDistinguisher: EnvironmentSystemComponents.Distinguisher?
         if needsSubcomponents {
             environmentDistinguisher = environments[
-                platform.environment ?? "Device"
+                platform.variant.environment
             ]!.distinguisher(
                 target: target,
                 includeEnvironment: forceIncludeEnvironment ||
@@ -465,7 +465,7 @@ struct EnvironmentSystemComponents {
         let needsSubcomponents = consolidatedKeys.count > 1
 
         let prefix = needsSubcomponents && archs.count > 1 ? platform.arch : nil
-        let suffix = includeEnvironment ? platform.environment ?? "Device" : nil
+        let suffix = includeEnvironment ? platform.variant.environment : nil
 
         return Distinguisher(prefix: prefix, suffix: suffix)
     }
@@ -494,7 +494,7 @@ private extension Target {
             platform.arch,
             platform.os.rawValue,
             platform.minimumOsVersion,
-            platform.environment ?? "Device",
+            platform.variant.environment,
         ].joined(separator: "-")
     }
 }

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -102,7 +102,9 @@ Target with id "\(id)" not found in `consolidatedTarget.uniqueFiles`
                 // This key needs to not have `-` in it
                 // TODO: If we ever add support for Universal targets this needs
                 //   to include more than just the platform name
-                let key = "\(target.platform.name.uppercased())_FILES"
+                let key = """
+\(target.platform.variant.rawValue.uppercased())_FILES
+"""
                 conditionalFileNames[key] = try uniqueFiles
                     .map { filePath in
                         try filePathResolver.resolve(filePath, useGenDir: true)
@@ -247,7 +249,10 @@ Target with id "\(id)" not found in `consolidatedTarget.uniqueFiles`
         buildSettings.set("BAZEL_TARGET_ID", to: id.rawValue)
         buildSettings.set("PRODUCT_NAME", to: target.product.name)
         buildSettings.set("SDKROOT", to: target.platform.os.sdkRoot)
-        buildSettings.set("SUPPORTED_PLATFORMS", to: target.platform.name)
+        buildSettings.set(
+            "SUPPORTED_PLATFORMS",
+            to: target.platform.variant.rawValue
+        )
         buildSettings.set("TARGET_NAME", to: target.name)
 
         buildSettings.set(

--- a/tools/generator/test/BuildSettingConditionalTests.swift
+++ b/tools/generator/test/BuildSettingConditionalTests.swift
@@ -6,36 +6,32 @@ import XCTest
 final class BuildSettingConditionalTests: XCTestCase {
     static let conditionals: [String: BuildSettingConditional] = [
         "A": .init(platform: .init(
-            name: "A",
             os: .macOS,
+            variant: .macOS,
             arch: "arm64",
             minimumOsVersion: "11.0",
-            minimumDeploymentOsVersion: "13.0",
-            environment: nil
+            minimumDeploymentOsVersion: "13.0"
         )),
         "B": .init(platform: .init(
-            name: "B",
             os: .iOS,
+            variant: .iOSSimulator,
             arch: "arm64",
             minimumOsVersion: "11.0",
-            minimumDeploymentOsVersion: "13.0",
-            environment: "Simulator"
+            minimumDeploymentOsVersion: "13.0"
         )),
         "C": .init(platform: .init(
-            name: "C",
             os: .iOS,
+            variant: .iOSDevice,
             arch: "arm64",
             minimumOsVersion: "11.0",
-            minimumDeploymentOsVersion: "13.0",
-            environment: nil
+            minimumDeploymentOsVersion: "13.0"
         )),
         "D": .init(platform: .init(
-            name: "D",
             os: .iOS,
+            variant: .iOSSimulator,
             arch: "arm64",
             minimumOsVersion: "11.0",
-            minimumDeploymentOsVersion: "13.0",
-            environment: "Device"
+            minimumDeploymentOsVersion: "13.0"
         )),
         "any": .any,
     ]
@@ -65,8 +61,8 @@ final class BuildSettingConditionalTests: XCTestCase {
             conditionals["any"]!,
             conditionals["A"]!,
             conditionals["B"]!,
-            conditionals["C"]!,
             conditionals["D"]!,
+            conditionals["C"]!,
         ]
 
         // Act
@@ -85,10 +81,10 @@ final class BuildSettingConditionalTests: XCTestCase {
         let conditionals = Self.conditionals
         let expectedConditionalizedKeys = [
             "SOME_SETTING",
-            "SOME_SETTING[sdk=A*]",
-            "SOME_SETTING[sdk=B*]",
-            "SOME_SETTING[sdk=C*]",
-            "SOME_SETTING[sdk=D*]",
+            "SOME_SETTING[sdk=macosx*]",
+            "SOME_SETTING[sdk=iphonesimulator*]",
+            "SOME_SETTING[sdk=iphoneos*]",
+            "SOME_SETTING[sdk=iphonesimulator*]",
         ]
 
         // Act
@@ -113,10 +109,10 @@ final class BuildSettingConditionalTests: XCTestCase {
         let conditionals = Self.conditionals
         let expectedConditionalizedKeys = [
             "ARCHS",
-            "ARCHS[sdk=A*]",
-            "ARCHS[sdk=B*]",
-            "ARCHS[sdk=C*]",
-            "ARCHS[sdk=D*]",
+            "ARCHS[sdk=macosx*]",
+            "ARCHS[sdk=iphonesimulator*]",
+            "ARCHS[sdk=iphoneos*]",
+            "ARCHS[sdk=iphonesimulator*]",
         ]
 
         // Act

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -190,12 +190,11 @@ enum Fixtures {
         "E1": Target.mock(
             packageBinDir: "bazel-out/a1b2c/bin/E1",
             platform: .init(
-                name: "watchos",
                 os: .watchOS,
+                variant: .watchOSDevice,
                 arch: "x86_64",
                 minimumOsVersion: "9.1",
-                minimumDeploymentOsVersion: "9.2",
-                environment: nil
+                minimumDeploymentOsVersion: "9.2"
             ),
             product: .init(
                 type: .staticLibrary,
@@ -210,12 +209,11 @@ enum Fixtures {
         "E2": Target.mock(
             packageBinDir: "bazel-out/a1b2c/bin/E2",
             platform: .init(
-                name: "appletvos",
                 os: .tvOS,
+                variant: .tvOSDevice,
                 arch: "arm64",
                 minimumOsVersion: "9.1",
-                minimumDeploymentOsVersion: "9.2",
-                environment: nil
+                minimumDeploymentOsVersion: "9.2"
             ),
             product: .init(
                 type: .staticLibrary,

--- a/tools/generator/test/SetTargetConfigurationsTests.swift
+++ b/tools/generator/test/SetTargetConfigurationsTests.swift
@@ -410,23 +410,22 @@ final class SetTargetConfigurationsTests: XCTestCase {
             for os in input.oses {
                 let targetID = TargetID("\(os)-\(input.productType)")
 
-                var platformName: String {
+                var variant: Platform.Variant {
                     switch os {
-                    case .macOS: return "macosx"
-                    case .iOS: return "iphoneos"
-                    case .tvOS: return "appletvos"
-                    case .watchOS: return "watchos"
+                    case .macOS: return .macOS
+                    case .iOS: return .iOSDevice
+                    case .tvOS: return .tvOSDevice
+                    case .watchOS: return .watchOSDevice
                     }
                 }
 
                 let target = Target.mock(
                     platform: .init(
-                        name: platformName,
                         os: os,
+                        variant: variant,
                         arch: "arm64",
                         minimumOsVersion: "11.0",
-                        minimumDeploymentOsVersion: "11.1",
-                        environment: nil
+                        minimumDeploymentOsVersion: "11.1"
                     ),
                     product: .init(
                         type: input.productType,

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -61,22 +61,22 @@ extension Platform {
         minimumOsVersion: String = "11.0",
         minimumDeploymentOsVersion: String? = nil
     ) -> Self {
-        let name: String
-        switch os {
-        case .macOS: preconditionFailure("use `.macOS`")
-        case .iOS: name = "iphonesimulator"
-        case .tvOS: name = "appletvsimulator"
-        case .watchOS: name = "watchsimulator"
+        var variant: Variant {
+            switch os {
+            case .macOS: preconditionFailure("use `.macOS`")
+            case .iOS: return .iOSSimulator
+            case .tvOS: return .tvOSSimulator
+            case .watchOS: return .watchOSSimulator
+            }
         }
 
         return Platform(
-            name: name,
             os: os,
+            variant: variant,
             arch: arch,
             minimumOsVersion: minimumOsVersion,
             minimumDeploymentOsVersion:
-                minimumDeploymentOsVersion ?? minimumOsVersion,
-            environment: "Simulator"
+                minimumDeploymentOsVersion ?? minimumOsVersion
         )
     }
 
@@ -86,22 +86,22 @@ extension Platform {
         minimumOsVersion: String = "11.0",
         minimumDeploymentOsVersion: String? = nil
     ) -> Self {
-        let name: String
-        switch os {
-        case .macOS: preconditionFailure("use `.macOS`")
-        case .iOS: name = "iphoneos"
-        case .tvOS: name = "appletvos"
-        case .watchOS: name = "watchos"
+        var variant: Variant {
+            switch os {
+            case .macOS: preconditionFailure("use `.macOS`")
+            case .iOS: return .iOSDevice
+            case .tvOS: return.tvOSDevice
+            case .watchOS: return .watchOSDevice
+            }
         }
 
         return Platform(
-            name: name,
             os: os,
+            variant: variant,
             arch: arch,
             minimumOsVersion: minimumOsVersion,
             minimumDeploymentOsVersion:
-                minimumDeploymentOsVersion ?? minimumOsVersion,
-            environment: nil
+                minimumDeploymentOsVersion ?? minimumOsVersion
         )
     }
 
@@ -111,13 +111,12 @@ extension Platform {
         minimumDeploymentOsVersion: String? = nil
     ) -> Self {
         return Platform(
-            name: "macosx",
             os: .macOS,
+            variant: .macOS,
             arch: arch,
             minimumOsVersion: minimumOsVersion,
             minimumDeploymentOsVersion:
-                minimumDeploymentOsVersion ?? minimumOsVersion,
-            environment: nil
+                minimumDeploymentOsVersion ?? minimumOsVersion
         )
     }
 }

--- a/tools/generator/test/XcodeScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XcodeScheme+ExtensionsTests.swift
@@ -136,60 +136,53 @@ class XcodeSchemeExtensionsTests: XCTestCase {
     // Platforms
 
     let appletvOSPlatform = Platform(
-        name: "appletvos",
         os: .tvOS,
+        variant: .tvOSDevice,
         arch: "arm64",
         minimumOsVersion: "15.0",
-        minimumDeploymentOsVersion: "15.1",
-        environment: nil
+        minimumDeploymentOsVersion: "15.1"
     )
     let appletvSimulatorPlatform = Platform(
-        name: "appletvsimulator",
         os: .tvOS,
+        variant: .tvOSSimulator,
         arch: "x86_64",
         minimumOsVersion: "15.0",
-        minimumDeploymentOsVersion: "15.1",
-        environment: Optional("Simulator")
+        minimumDeploymentOsVersion: "15.1"
     )
     let iphoneOSPlatform = Platform(
-        name: "iphoneos",
         os: .iOS,
+        variant: .iOSDevice,
         arch: "arm64",
         minimumOsVersion: "15.0",
-        minimumDeploymentOsVersion: "15.1",
-        environment: nil
+        minimumDeploymentOsVersion: "15.1"
     )
     let iphoneSimulatorPlatform = Platform(
-        name: "iphonesimulator",
         os: .iOS,
+        variant: .iOSSimulator,
         arch: "x86_64",
         minimumOsVersion: "15.0",
-        minimumDeploymentOsVersion: "15.1",
-        environment: Optional("Simulator")
+        minimumDeploymentOsVersion: "15.1"
     )
     let macOSPlatform = Platform(
-        name: "macosx",
         os: .macOS,
+        variant: .macOS,
         arch: "x86_64",
         minimumOsVersion: "11.0",
-        minimumDeploymentOsVersion: "11.1",
-        environment: nil
+        minimumDeploymentOsVersion: "11.1"
     )
     let watchOSPlatform = Platform(
-        name: "watchos",
         os: .watchOS,
+        variant: .watchOSDevice,
         arch: "arm64_32",
         minimumOsVersion: "7.0",
-        minimumDeploymentOsVersion: "7.1",
-        environment: nil
+        minimumDeploymentOsVersion: "7.1"
     )
     let watchSimulatorPlatform = Platform(
-        name: "watchsimulator",
         os: .watchOS,
+        variant: .watchOSSimulator,
         arch: "x86_64",
         minimumOsVersion: "7.0",
-        minimumDeploymentOsVersion: "7.1",
-        environment: Optional("Simulator")
+        minimumDeploymentOsVersion: "7.1"
     )
 
     // Targets and TargetIDs

--- a/xcodeproj/internal/platform.bzl
+++ b/xcodeproj/internal/platform.bzl
@@ -43,20 +43,17 @@ def _to_dto(platform):
     """
     apple_platform = platform._platform
     platform_type = apple_platform.platform_type
-    is_device = apple_platform.is_device
 
     os_version = platform._os_version
     deployment_os_version = platform._deployment_os_version or os_version
 
     dto = {
-        "name": _PLATFORM_NAME[apple_platform],
         "os": str(platform_type),
+        "variant": _PLATFORM_NAME[apple_platform],
         "arch": platform._arch,
         "minimum_os_version": os_version,
         "minimum_deployment_os_version": deployment_os_version,
     }
-    if not is_device:
-        dto["environment"] = "Simulator"
 
     return dto
 


### PR DESCRIPTION
This also removes the need for a separate `environment` property.