### PR TITLE
Merge `Target.platform`

### DIFF
--- a/tools/generator/src/DTO/Target.swift
+++ b/tools/generator/src/DTO/Target.swift
@@ -5,7 +5,7 @@ struct Target: Equatable {
     let label: BazelLabel
     let configuration: String
     var packageBinDir: Path
-    let platform: Platform
+    var platform: Platform
     let product: Product
     var isSwift: Bool
     let testHost: TargetID?

--- a/tools/generator/src/Generator/ProcessTargetMerges.swift
+++ b/tools/generator/src/Generator/ProcessTargetMerges.swift
@@ -51,6 +51,9 @@ exist
                 // but that currently seems like too much work.
                 merged.packageBinDir = merging.packageBinDir
 
+                // Update platform
+                merged.platform = merging.platform
+
                 // Update isSwift
                 merged.isSwift = merging.isSwift
 

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -48,6 +48,7 @@ enum Fixtures {
     static let targets: [TargetID: Target] = [
         "A 1": Target.mock(
             packageBinDir: "bazel-out/a1b2c/bin/A 1",
+            platform: .macOS(minimumOsVersion: "10.0"),
             product: .init(
                 type: .staticLibrary,
                 name: "a",
@@ -79,6 +80,7 @@ enum Fixtures {
         ),
         "A 2": Target.mock(
             packageBinDir: "bazel-out/a1b2c/bin/A 2",
+            platform: .macOS(minimumOsVersion: "11.0"),
             product: .init(
                 type: .application,
                 name: "A",
@@ -2097,7 +2099,7 @@ perl -pe 's/^("?)(.*\$\(.*\).*?)("?)$/"$2"/ ; s/\$(\()?([a-zA-Z_]\w*)(?(1)\))/$E
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/A 1",
                 "BAZEL_TARGET_ID": "A 1",
                 "GENERATE_INFOPLIST_FILE": "YES",
-                "MACOSX_DEPLOYMENT_TARGET": "11.0",
+                "MACOSX_DEPLOYMENT_TARGET": "10.0",
                 "OTHER_SWIFT_FLAGS": #"""
 -vfsoverlay $(OBJROOT)/gen_dir-overlay.yaml
 """#,

--- a/tools/generator/test/ProcessTargetMergesTests.swift
+++ b/tools/generator/test/ProcessTargetMergesTests.swift
@@ -39,6 +39,7 @@ final class TargetMergingTests: XCTestCase {
         expectedTargets.removeValue(forKey: "B 1")
         expectedTargets["A 2"] = Target.mock(
             packageBinDir: targets["A 1"]!.packageBinDir,
+            platform: targets["A 1"]!.platform,
             product: targets["A 2"]!.product,
             isSwift: targets["A 1"]!.isSwift,
             buildSettings: [
@@ -68,6 +69,7 @@ final class TargetMergingTests: XCTestCase {
         )
         expectedTargets["B 2"] = Target.mock(
             packageBinDir: targets["B 1"]!.packageBinDir,
+            platform: targets["B 1"]!.platform,
             product: targets["B 2"]!.product,
             isSwift: targets["A 2"]!.isSwift,
             testHost: "A 2",
@@ -89,6 +91,7 @@ final class TargetMergingTests: XCTestCase {
         )
         expectedTargets["B 3"] = Target.mock(
             packageBinDir: targets["B 1"]!.packageBinDir,
+            platform: targets["B 1"]!.platform,
             product: targets["B 3"]!.product,
             isSwift: targets["B 1"]!.isSwift,
             testHost: "A 2",


### PR DESCRIPTION
The library being merged into a top level target might have a different minimum os version. Now that 1ab36b4c6814faa73849c71e9d02a20181c13336 has landed, we need to account for the differences.