### PR TITLE
Correctly set `*_DEPLOYMENT_TARGET`

### DIFF
--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -241,7 +241,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -337,7 +336,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -427,7 +425,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -520,7 +517,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleObjcTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -648,7 +644,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleObjcTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -742,7 +737,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -839,7 +833,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -933,7 +926,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1001,7 +993,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1074,7 +1065,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1189,7 +1179,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -186,7 +186,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/CoreUtilsObjC",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -304,7 +303,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -398,7 +396,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -459,7 +456,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleNestedResources",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -546,7 +542,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleObjcTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -677,7 +672,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleObjcTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -739,7 +733,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleResources",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -825,7 +818,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -922,7 +914,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1016,7 +1007,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1087,7 +1077,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1132,7 +1121,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/OnlyStructuredResources",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1196,7 +1184,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1311,7 +1298,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Utils",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1368,7 +1354,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/external/examples_ios_app_external",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"

--- a/examples/multiplatform/watchOSAppExtension/BUILD
+++ b/examples/multiplatform/watchOSAppExtension/BUILD
@@ -30,6 +30,7 @@ watchos_extension(
     name = "watchOSAppExtension",
     bundle_id = "{}.extension".format(WATCHOS_BUNDLE_ID),
     infoplists = [":infoplist"],
+    minimum_deployment_os_version = "8.0",
     minimum_os_version = "7.0",
     provisioning_profile = select({
         ":device_build": ":xcode_profile",

--- a/test/fixtures/cc/bwb_spec.json
+++ b/test/fixtures/cc/bwb_spec.json
@@ -84,7 +84,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/examples/cc/lib2",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -168,7 +167,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/examples/cc/lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -286,7 +284,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/examples/cc/tool",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -398,7 +395,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/examples_cc_external",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"

--- a/test/fixtures/cc/bwx_spec.json
+++ b/test/fixtures/cc/bwx_spec.json
@@ -84,7 +84,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/examples/cc/lib2",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -168,7 +167,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/examples/cc/lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -286,7 +284,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/examples/cc/tool",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -398,7 +395,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/examples_cc_external",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"

--- a/test/fixtures/command_line/bwb_spec.json
+++ b/test/fixtures/command_line/bwb_spec.json
@@ -181,7 +181,6 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/Tests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -286,7 +285,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/Tests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -408,7 +406,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -502,7 +499,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -600,7 +596,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -665,7 +660,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -743,7 +737,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/swift_c_module",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -871,7 +864,6 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/tool",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1006,7 +998,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/command_line/tool",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"

--- a/test/fixtures/command_line/bwx_spec.json
+++ b/test/fixtures/command_line/bwx_spec.json
@@ -181,7 +181,6 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-3e9e205cb29c/bin/examples/command_line/Tests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -286,7 +285,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-3e9e205cb29c/bin/examples/command_line/Tests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -408,7 +406,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-3e9e205cb29c/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -502,7 +499,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-3e9e205cb29c/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -600,7 +596,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-3e9e205cb29c/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -665,7 +660,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-3e9e205cb29c/bin/examples/command_line/lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -743,7 +737,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-3e9e205cb29c/bin/examples/command_line/swift_c_module",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -871,7 +864,6 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-3e9e205cb29c/bin/examples/command_line/tool",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1006,7 +998,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-3e9e205cb29c/bin/examples/command_line/tool",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -127,7 +127,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/tools/generator/test",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -236,7 +235,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/tools/generator/test",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -355,7 +353,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/tools/generator",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -485,7 +482,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/tools/generator",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -767,7 +763,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_apple_swift_collections",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -835,7 +830,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_kylef_pathkit",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1002,7 +996,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_pointfreeco_swift_custom_dump",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1076,7 +1069,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_pointfreeco_xctest_dynamic_overlay",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1523,7 +1515,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-e86416d3a8c7/bin/external/com_github_tuist_xcodeproj",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -127,7 +127,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator/test",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -236,7 +235,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator/test",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -355,7 +353,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -485,7 +482,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/tools/generator",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -767,7 +763,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_apple_swift_collections",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -835,7 +830,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_kylef_pathkit",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1002,7 +996,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_swift_custom_dump",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1076,7 +1069,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_pointfreeco_xctest_dynamic_overlay",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1523,7 +1515,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/external/com_github_tuist_xcodeproj",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"

--- a/test/fixtures/macos_app/bwb_spec.json
+++ b/test/fixtures/macos_app/bwb_spec.json
@@ -91,7 +91,6 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin/examples/macos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -167,7 +166,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin/examples/macos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "macos",
                 "variant": "macosx"

--- a/test/fixtures/macos_app/bwx_spec.json
+++ b/test/fixtures/macos_app/bwx_spec.json
@@ -95,7 +95,6 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin/examples/macos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -171,7 +170,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin/examples/macos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "macos",
                 "variant": "macosx"

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -362,7 +362,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -471,7 +470,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -560,7 +558,6 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -655,7 +652,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -749,7 +745,6 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -837,7 +832,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -925,7 +919,6 @@
             "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvos"
@@ -1013,7 +1006,6 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -1101,7 +1093,6 @@
             "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64_32",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchos"
@@ -1189,7 +1180,6 @@
             "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchsimulator"
@@ -1276,7 +1266,6 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/multiplatform/Tool",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1341,7 +1330,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-01f14ffe769b/bin/examples/multiplatform/Tool",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1431,7 +1419,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -1534,7 +1521,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1626,7 +1612,6 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -1724,7 +1709,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1812,7 +1796,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -1879,7 +1862,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1969,7 +1951,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -2072,7 +2053,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -2160,7 +2140,6 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -2254,7 +2233,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -2395,7 +2373,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -2550,7 +2527,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -2672,7 +2648,6 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -2799,7 +2774,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -2928,7 +2902,6 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvos"
@@ -3030,7 +3003,6 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -3119,7 +3091,6 @@
             "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvos"
@@ -3214,7 +3185,6 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-ae85ff5caa67/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -3301,7 +3271,6 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp",
             "platform": {
                 "arch": "arm64_32",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchos"
@@ -3367,7 +3336,6 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchsimulator"
@@ -3456,7 +3424,6 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "arm64_32",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchos"
@@ -3558,7 +3525,6 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchsimulator"
@@ -3647,7 +3613,6 @@
             "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "arm64_32",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchos"
@@ -3742,7 +3707,6 @@
             "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-2fd25852cc8a/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchsimulator"

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -340,7 +340,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -453,7 +452,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -542,7 +540,6 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -637,7 +634,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/AppClip",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -731,7 +727,6 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -819,7 +814,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -907,7 +901,6 @@
             "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvos"
@@ -995,7 +988,6 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -1083,7 +1075,6 @@
             "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "arm64_32",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchos"
@@ -1171,7 +1162,6 @@
             "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/Lib",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchsimulator"
@@ -1258,7 +1248,6 @@
             "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-3e9e205cb29c/bin/examples/multiplatform/Tool",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1323,7 +1312,6 @@
             "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-3e9e205cb29c/bin/examples/multiplatform/Tool",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"
@@ -1418,7 +1406,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -1526,7 +1513,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1618,7 +1604,6 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -1716,7 +1701,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/WidgetExtension",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1809,7 +1793,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -1881,7 +1864,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -1977,7 +1959,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -2086,7 +2067,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -2174,7 +2154,6 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -2268,7 +2247,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -2422,7 +2400,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -2590,7 +2567,6 @@
             "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -2712,7 +2688,6 @@
             "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphoneos"
@@ -2839,7 +2814,6 @@
             "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iOSApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "ios",
                 "variant": "iphonesimulator"
@@ -2974,7 +2948,6 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvos"
@@ -3082,7 +3055,6 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -3171,7 +3143,6 @@
             "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "arm64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvos"
@@ -3266,7 +3237,6 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-37edb098dc53/bin/examples/multiplatform/tvOSApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -3358,7 +3328,6 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSApp",
             "platform": {
                 "arch": "arm64_32",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchos"
@@ -3429,7 +3398,6 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSApp",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchsimulator"
@@ -3524,7 +3492,6 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "arm64_32",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchos"
@@ -3632,7 +3599,6 @@
             "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchsimulator"
@@ -3721,7 +3687,6 @@
             "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "arm64_32",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchos"
@@ -3816,7 +3781,6 @@
             "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-07c4a284aeba/bin/examples/multiplatform/watchOSAppExtension",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "7.0",
                 "minimum_os_version": "7.0",
                 "os": "watchos",
                 "variant": "watchsimulator"

--- a/test/fixtures/simple/bwb_spec.json
+++ b/test/fixtures/simple/bwb_spec.json
@@ -62,7 +62,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-166905362225/bin/examples/simple",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"

--- a/test/fixtures/simple/bwx_spec.json
+++ b/test/fixtures/simple/bwx_spec.json
@@ -62,7 +62,6 @@
             "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-02316c4eb12c/bin/examples/simple",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "11.0",
                 "minimum_os_version": "11.0",
                 "os": "macos",
                 "variant": "macosx"

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -112,7 +112,6 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -178,7 +177,6 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -255,7 +253,6 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -325,7 +322,6 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -407,7 +403,6 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -475,7 +470,6 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-d2947f5560a1/bin/examples/tvos_app/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -112,7 +112,6 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -178,7 +177,6 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/Example",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -255,7 +253,6 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -325,7 +322,6 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleTests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -407,7 +403,6 @@
             "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"
@@ -475,7 +470,6 @@
             "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-9b53edbb74de/bin/examples/tvos_app/ExampleUITests",
             "platform": {
                 "arch": "x86_64",
-                "minimum_deployment_os_version": "15.0",
                 "minimum_os_version": "15.0",
                 "os": "tvos",
                 "variant": "appletvsimulator"

--- a/test/internal/platform/platform_info_to_dto_tests.bzl
+++ b/test/internal/platform/platform_info_to_dto_tests.bzl
@@ -11,7 +11,6 @@ def _platform_info_to_dto_test_impl(ctx):
 
     platform = struct(
         _arch = ctx.attr.arch,
-        _deployment_os_version = ctx.attr.minimum_deployment_os_version,
         _os_version = ctx.attr.minimum_os_version,
         _platform = getattr(apple_common.platform, ctx.attr.platform_key),
     )
@@ -32,7 +31,6 @@ platform_info_to_dto_test = unittest.make(
     attrs = {
         "arch": attr.string(mandatory = True),
         "expected_platform_dict": attr.string_dict(mandatory = True),
-        "minimum_deployment_os_version": attr.string(mandatory = False),
         "minimum_os_version": attr.string(mandatory = True),
         "platform_key": attr.string(mandatory = True),
     },
@@ -53,7 +51,6 @@ def platform_info_to_dto_test_suite(name):
             platform_key,
             arch,
             minimum_os_version,
-            minimum_deployment_os_version,
             expected_platform_dict):
         test_names.append(name)
         platform_info_to_dto_test(
@@ -61,7 +58,6 @@ def platform_info_to_dto_test_suite(name):
             platform_key = platform_key,
             arch = arch,
             minimum_os_version = minimum_os_version,
-            minimum_deployment_os_version = minimum_deployment_os_version,
             expected_platform_dict = expected_platform_dict,
             timeout = "short",
         )
@@ -73,28 +69,11 @@ def platform_info_to_dto_test_suite(name):
         platform_key = "tvos_device",
         arch = "wild",
         minimum_os_version = "12.0",
-        minimum_deployment_os_version = None,
         expected_platform_dict = {
             "arch": "wild",
             "minimum_os_version": "12.0",
-            "minimum_deployment_os_version": "12.0",
             "os": "tvos",
             "variant": "appletvos",
-        },
-    )
-
-    _add_test(
-        name = "{}_deployment_os_version".format(name),
-        platform_key = "ios_simulator",
-        arch = "x86_64",
-        minimum_os_version = "11.0",
-        minimum_deployment_os_version = "13.0",
-        expected_platform_dict = {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "minimum_deployment_os_version": "13.0",
-            "os": "ios",
-            "variant": "iphonesimulator",
         },
     )
 
@@ -105,11 +84,9 @@ def platform_info_to_dto_test_suite(name):
         platform_key = "macos",
         arch = "arm64",
         minimum_os_version = "12.1",
-        minimum_deployment_os_version = None,
         expected_platform_dict = {
             "arch": "arm64",
             "minimum_os_version": "12.1",
-            "minimum_deployment_os_version": "12.1",
             "os": "macos",
             "variant": "macosx",
         },

--- a/test/internal/target/process_top_level_properties_tests.bzl
+++ b/test/internal/target/process_top_level_properties_tests.bzl
@@ -39,12 +39,6 @@ def _process_top_level_properties_test_impl(ctx):
     )
     asserts.equals(
         env,
-        ctx.attr.expected_minimum_deployment_version or None,
-        properties.minimum_deployment_os_version,
-        "minimum_deployment_os_version",
-    )
-    asserts.equals(
-        env,
         ctx.attr.expected_product_name,
         properties.product_name,
         "product_name",
@@ -94,7 +88,6 @@ def _bundle_info(
         bundle_extension,
         bundle_name,
         executable_name,
-        minimum_deployment_os_version,
         product_type):
     return {
         "archive.path": archive_path,
@@ -103,7 +96,6 @@ def _bundle_info(
         "bundle_id": bundle_id,
         "bundle_name": bundle_name,
         "executable_name": executable_name,
-        "minimum_deployment_os_version": minimum_deployment_os_version,
         "product_type": product_type,
     }
 
@@ -120,7 +112,6 @@ def _bundle_info_stub(dict):
         bundle_extension = dict["bundle_extension"],
         bundle_name = dict["bundle_name"],
         executable_name = dict["executable_name"],
-        minimum_deployment_os_version = dict["minimum_deployment_os_version"],
         product_type = dict["product_type"],
     )
 
@@ -142,7 +133,6 @@ def process_top_level_properties_test_suite(name):
             tree_artifact_enabled,
             expected_bundle_path,
             expected_executable_name,
-            expected_minimum_deployment_os_version,
             expected_product_name,
             expected_product_type,
             expected_build_settings):
@@ -155,8 +145,6 @@ def process_top_level_properties_test_suite(name):
             tree_artifact_enabled = tree_artifact_enabled,
             expected_bundle_path = expected_bundle_path,
             expected_executable_name = expected_executable_name,
-            expected_minimum_deployment_version =
-                expected_minimum_deployment_os_version,
             expected_product_name = expected_product_name,
             expected_product_type = expected_product_type,
             expected_build_settings = stringify_dict(expected_build_settings),
@@ -173,7 +161,6 @@ def process_top_level_properties_test_suite(name):
         tree_artifact_enabled = True,
         expected_bundle_path = None,
         expected_executable_name = "binary",
-        expected_minimum_deployment_os_version = None,
         expected_product_name = "binary",
         expected_product_type = "com.apple.product-type.tool",
         expected_build_settings = {},
@@ -187,7 +174,6 @@ def process_top_level_properties_test_suite(name):
         tree_artifact_enabled = True,
         expected_bundle_path = "some/test.xctest",
         expected_executable_name = "test",
-        expected_minimum_deployment_os_version = None,
         expected_product_name = "test",
         expected_product_type = "com.apple.product-type.bundle.unit-test",
         expected_build_settings = {},
@@ -205,14 +191,12 @@ def process_top_level_properties_test_suite(name):
             bundle_id = "com.example.flagship",
             bundle_extension = ".app",
             bundle_name = "flagship",
-            minimum_deployment_os_version = "13.1",
             product_type = "com.apple.product-type.application",
             executable_name = "executable_name",
         ),
         tree_artifact_enabled = True,
         expected_bundle_path = "some/flagship.app",
         expected_executable_name = "executable_name",
-        expected_minimum_deployment_os_version = "13.1",
         expected_product_name = "flagship",
         expected_product_type = "com.apple.product-type.application",
         expected_build_settings = {
@@ -230,14 +214,12 @@ def process_top_level_properties_test_suite(name):
             bundle_id = "com.example.flagship",
             bundle_extension = ".app",
             bundle_name = "flagship",
-            minimum_deployment_os_version = "11.2",
             product_type = "com.apple.product-type.application",
             executable_name = "executable_name",
         ),
         tree_artifact_enabled = False,
         expected_bundle_path = "some/intermediate/Payload/flagship.app",
         expected_executable_name = "executable_name",
-        expected_minimum_deployment_os_version = "11.2",
         expected_product_name = "flagship",
         expected_product_type = "com.apple.product-type.application",
         expected_build_settings = {
@@ -255,14 +237,12 @@ def process_top_level_properties_test_suite(name):
             bundle_id = "com.example.flagship.test",
             bundle_extension = ".xctest",
             bundle_name = "flagship",
-            minimum_deployment_os_version = "12.1",
             product_type = "com.apple.product-type.bundle.unit-test",
             executable_name = "executable_name",
         ),
         tree_artifact_enabled = False,
         expected_bundle_path = "some/intermediate/flagship.xctest",
         expected_executable_name = "executable_name",
-        expected_minimum_deployment_os_version = "12.1",
         expected_product_name = "flagship",
         expected_product_type = "com.apple.product-type.bundle.unit-test",
         expected_build_settings = {

--- a/tools/generator/src/DTO/Platform.swift
+++ b/tools/generator/src/DTO/Platform.swift
@@ -44,7 +44,6 @@ struct Platform: Equatable, Hashable, Decodable {
     let variant: Variant
     let arch: String
     let minimumOsVersion: OSVersion
-    let minimumDeploymentOsVersion: OSVersion
 }
 
 extension Platform {

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -257,7 +257,7 @@ Target with id "\(id)" not found in `consolidatedTarget.uniqueFiles`
 
         buildSettings.set(
             target.platform.os.deploymentTargetBuildSettingKey,
-            to: target.platform.minimumDeploymentOsVersion.rawValue
+            to: target.platform.minimumOsVersion.rawValue
         )
 
         let executableExtension = target.product.path.path.extension ?? ""

--- a/tools/generator/test/BuildSettingConditionalTests.swift
+++ b/tools/generator/test/BuildSettingConditionalTests.swift
@@ -9,29 +9,25 @@ final class BuildSettingConditionalTests: XCTestCase {
             os: .macOS,
             variant: .macOS,
             arch: "arm64",
-            minimumOsVersion: "11.0",
-            minimumDeploymentOsVersion: "13.0"
+            minimumOsVersion: "11.0"
         )),
         "B": .init(platform: .init(
             os: .iOS,
             variant: .iOSSimulator,
             arch: "arm64",
-            minimumOsVersion: "11.0",
-            minimumDeploymentOsVersion: "13.0"
+            minimumOsVersion: "11.0"
         )),
         "C": .init(platform: .init(
             os: .iOS,
             variant: .iOSDevice,
             arch: "arm64",
-            minimumOsVersion: "11.0",
-            minimumDeploymentOsVersion: "13.0"
+            minimumOsVersion: "11.0"
         )),
         "D": .init(platform: .init(
             os: .iOS,
             variant: .iOSSimulator,
             arch: "arm64",
-            minimumOsVersion: "11.0",
-            minimumDeploymentOsVersion: "13.0"
+            minimumOsVersion: "11.0"
         )),
         "any": .any,
     ]

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -193,8 +193,7 @@ enum Fixtures {
                 os: .watchOS,
                 variant: .watchOSDevice,
                 arch: "x86_64",
-                minimumOsVersion: "9.1",
-                minimumDeploymentOsVersion: "9.2"
+                minimumOsVersion: "9.1"
             ),
             product: .init(
                 type: .staticLibrary,
@@ -212,8 +211,7 @@ enum Fixtures {
                 os: .tvOS,
                 variant: .tvOSDevice,
                 arch: "arm64",
-                minimumOsVersion: "9.1",
-                minimumDeploymentOsVersion: "9.2"
+                minimumOsVersion: "9.1"
             ),
             product: .init(
                 type: .staticLibrary,
@@ -225,7 +223,7 @@ enum Fixtures {
         ),
         "I": Target.mock(
             packageBinDir: "bazel-out/a1b2c/bin/I",
-            platform: .device(os: .iOS, minimumDeploymentOsVersion: "13.0"),
+            platform: .device(os: .iOS, minimumOsVersion: "12.0"),
             product: .init(
                 type: .application,
                 name: "I",
@@ -2198,7 +2196,7 @@ $(INTERNAL_DIR)/targets/a1b2c/C 2/d.link.params
                 "SUPPORTED_PLATFORMS": "watchos",
                 "SWIFT_INCLUDE_PATHS": "$(BUILD_DIR)/bazel-out/x",
                 "TARGET_NAME": targets["E1"]!.name,
-                "WATCHOS_DEPLOYMENT_TARGET": "9.2",
+                "WATCHOS_DEPLOYMENT_TARGET": "9.1",
             ]) { $1 },
             "E2": targets["E2"]!.buildSettings.asDictionary.merging([
                 "ARCHS": "arm64",
@@ -2212,7 +2210,7 @@ $(INTERNAL_DIR)/targets/a1b2c/C 2/d.link.params
                 "SDKROOT": "appletvos",
                 "SUPPORTED_PLATFORMS": "appletvos",
                 "TARGET_NAME": targets["E2"]!.name,
-                "TVOS_DEPLOYMENT_TARGET": "9.2",
+                "TVOS_DEPLOYMENT_TARGET": "9.1",
             ]) { $1 },
             "I": targets["I"]!.buildSettings.asDictionary.merging([
                 "ARCHS": "arm64",
@@ -2225,7 +2223,7 @@ $(BAZEL_OUT)/some/framework/parent/dir
 """,
                 "GENERATE_INFOPLIST_FILE": "YES",
                 "HEADER_SEARCH_PATHS": "$(BAZEL_OUT)/some/includes/parent/dir",
-                "IPHONEOS_DEPLOYMENT_TARGET": "13.0",
+                "IPHONEOS_DEPLOYMENT_TARGET": "12.0",
                 "LD_RUNPATH_SEARCH_PATHS": [
                     "$(inherited)",
                     "@executable_path/Frameworks",

--- a/tools/generator/test/SetTargetConfigurationsTests.swift
+++ b/tools/generator/test/SetTargetConfigurationsTests.swift
@@ -424,8 +424,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
                         os: os,
                         variant: variant,
                         arch: "arm64",
-                        minimumOsVersion: "11.0",
-                        minimumDeploymentOsVersion: "11.1"
+                        minimumOsVersion: "11.0"
                     ),
                     product: .init(
                         type: input.productType,

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -58,8 +58,7 @@ extension Platform {
     static func simulator(
         os: Platform.OS = .iOS,
         arch: String = "arm64",
-        minimumOsVersion: Platform.OSVersion = "11.0",
-        minimumDeploymentOsVersion: Platform.OSVersion? = nil
+        minimumOsVersion: Platform.OSVersion = "11.0"
     ) -> Self {
         var variant: Variant {
             switch os {
@@ -74,17 +73,14 @@ extension Platform {
             os: os,
             variant: variant,
             arch: arch,
-            minimumOsVersion: minimumOsVersion,
-            minimumDeploymentOsVersion:
-                minimumDeploymentOsVersion ?? minimumOsVersion
+            minimumOsVersion: minimumOsVersion
         )
     }
 
     static func device(
         os: Platform.OS = .iOS,
         arch: String = "arm64",
-        minimumOsVersion: Platform.OSVersion = "11.0",
-        minimumDeploymentOsVersion: Platform.OSVersion? = nil
+        minimumOsVersion: Platform.OSVersion = "11.0"
     ) -> Self {
         var variant: Variant {
             switch os {
@@ -99,24 +95,19 @@ extension Platform {
             os: os,
             variant: variant,
             arch: arch,
-            minimumOsVersion: minimumOsVersion,
-            minimumDeploymentOsVersion:
-                minimumDeploymentOsVersion ?? minimumOsVersion
+            minimumOsVersion: minimumOsVersion
         )
     }
 
     static func macOS(
         arch: String = "arm64",
-        minimumOsVersion: Platform.OSVersion = "11.0",
-        minimumDeploymentOsVersion: Platform.OSVersion? = nil
+        minimumOsVersion: Platform.OSVersion = "11.0"
     ) -> Self {
         return Platform(
             os: .macOS,
             variant: .macOS,
             arch: arch,
-            minimumOsVersion: minimumOsVersion,
-            minimumDeploymentOsVersion:
-                minimumDeploymentOsVersion ?? minimumOsVersion
+            minimumOsVersion: minimumOsVersion
         )
     }
 }

--- a/tools/generator/test/XcodeScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XcodeScheme+ExtensionsTests.swift
@@ -139,50 +139,43 @@ class XcodeSchemeExtensionsTests: XCTestCase {
         os: .tvOS,
         variant: .tvOSDevice,
         arch: "arm64",
-        minimumOsVersion: "15.0",
-        minimumDeploymentOsVersion: "15.1"
+        minimumOsVersion: "15.0"
     )
     let appletvSimulatorPlatform = Platform(
         os: .tvOS,
         variant: .tvOSSimulator,
         arch: "x86_64",
-        minimumOsVersion: "15.0",
-        minimumDeploymentOsVersion: "15.1"
+        minimumOsVersion: "15.0"
     )
     let iphoneOSPlatform = Platform(
         os: .iOS,
         variant: .iOSDevice,
         arch: "arm64",
-        minimumOsVersion: "15.0",
-        minimumDeploymentOsVersion: "15.1"
+        minimumOsVersion: "15.0"
     )
     let iphoneSimulatorPlatform = Platform(
         os: .iOS,
         variant: .iOSSimulator,
         arch: "x86_64",
-        minimumOsVersion: "15.0",
-        minimumDeploymentOsVersion: "15.1"
+        minimumOsVersion: "15.0"
     )
     let macOSPlatform = Platform(
         os: .macOS,
         variant: .macOS,
         arch: "x86_64",
-        minimumOsVersion: "11.0",
-        minimumDeploymentOsVersion: "11.1"
+        minimumOsVersion: "11.0"
     )
     let watchOSPlatform = Platform(
         os: .watchOS,
         variant: .watchOSDevice,
         arch: "arm64_32",
-        minimumOsVersion: "7.0",
-        minimumDeploymentOsVersion: "7.1"
+        minimumOsVersion: "7.0"
     )
     let watchSimulatorPlatform = Platform(
         os: .watchOS,
         variant: .watchOSSimulator,
         arch: "x86_64",
-        minimumOsVersion: "7.0",
-        minimumDeploymentOsVersion: "7.1"
+        minimumOsVersion: "7.0"
     )
 
     // Targets and TargetIDs

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -107,10 +107,7 @@ def process_library_target(
         getattr(ctx.rule.attr, "testonly", False),
     )
 
-    platform = platform_info.collect(
-        ctx = ctx,
-        minimum_deployment_os_version = None,
-    )
+    platform = platform_info.collect(ctx = ctx)
     product = process_product(
         target = target,
         product_name = product_name,

--- a/xcodeproj/internal/platform.bzl
+++ b/xcodeproj/internal/platform.bzl
@@ -10,13 +10,11 @@ _PLATFORM_NAME = {
     apple_common.platform.watchos_simulator: "watchsimulator",
 }
 
-def _collect(*, ctx, minimum_deployment_os_version):
+def _collect(*, ctx):
     """Collects information about a target's platform.
 
     Args:
         ctx: The aspect context.
-        minimum_deployment_os_version: The minimum deployment OS version for the
-            target.
 
     Returns:
         An opaque `struct` to be used with `platform_info.to_dto`.
@@ -30,7 +28,6 @@ def _collect(*, ctx, minimum_deployment_os_version):
 
     return struct(
         _arch = apple_fragment.single_arch_cpu,
-        _deployment_os_version = minimum_deployment_os_version,
         _os_version = minimum_os_version,
         _platform = platform,
     )
@@ -44,15 +41,11 @@ def _to_dto(platform):
     apple_platform = platform._platform
     platform_type = apple_platform.platform_type
 
-    os_version = platform._os_version
-    deployment_os_version = platform._deployment_os_version or os_version
-
     dto = {
         "os": str(platform_type),
         "variant": _PLATFORM_NAME[apple_platform],
         "arch": platform._arch,
-        "minimum_os_version": os_version,
-        "minimum_deployment_os_version": deployment_os_version,
+        "minimum_os_version": platform._os_version,
     }
 
     return dto

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -89,11 +89,6 @@ def process_top_level_properties(
     if bundle_info:
         bundle_name = bundle_info.bundle_name
         executable_name = getattr(bundle_info, "executable_name", bundle_name)
-        minimum_deployment_version = getattr(
-            bundle_info,
-            "minimum_deployment_os_version",
-            getattr(bundle_info, "minimum_os_version", None),
-        )
         product_name = bundle_name
         product_type = bundle_info.product_type
 
@@ -118,7 +113,6 @@ def process_top_level_properties(
         build_settings["PRODUCT_BUNDLE_IDENTIFIER"] = bundle_info.bundle_id
     else:
         executable_name = target_name
-        minimum_deployment_version = None
         product_name = target_name
 
         xctest = None
@@ -144,7 +138,6 @@ def process_top_level_properties(
     return struct(
         bundle_file_path = bundle_file_path,
         executable_name = executable_name,
-        minimum_deployment_os_version = minimum_deployment_version,
         product_name = product_name,
         product_type = product_type,
     )
@@ -276,10 +269,7 @@ def process_top_level_target(
         tree_artifact_enabled = tree_artifact_enabled,
         build_settings = build_settings,
     )
-    platform = platform_info.collect(
-        ctx = ctx,
-        minimum_deployment_os_version = props.minimum_deployment_os_version,
-    )
+    platform = platform_info.collect(ctx = ctx)
 
     package_bin_dir = join_paths_ignoring_empty(
         ctx.bin_dir.path,


### PR DESCRIPTION
This should be set to the compilation minimum os version. The actual _deployment_ version is set in the `Info.plist`, which is handled by Bazel.