### PR TITLE
Handle `extra_files` correctly with Focused Projects

### DIFF
--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -13,13 +13,9 @@
     "configuration": "darwin_x86_64-fastbuild-ST-1b9bd654f600",
     "custom_xcode_schemes": [],
     "extra_files": [
-        "ExampleNestedResources/BUILD",
-        "ExampleNestedResources/Info.plist",
-        "ExampleResources/BUILD",
-        "ExampleResources/Info.plist",
-        "Example/BUILD",
         "CoreUtilsObjC/BUILD",
         "Utils/BUILD",
+        "Example/BUILD",
         {
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
             "t": "g"
@@ -28,6 +24,10 @@
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/Utils/Utils.swift.modulemap",
             "t": "g"
         },
+        "ExampleNestedResources/BUILD",
+        "ExampleNestedResources/Info.plist",
+        "ExampleResources/BUILD",
+        "ExampleResources/Info.plist",
         "ExampleNestedResources/Assets.xcassets",
         "ExampleNestedResources/en.lproj/Localizable.strings",
         "ExampleNestedResources/es.lproj/Localizable.strings",
@@ -78,10 +78,10 @@
         },
         "Example/en.lproj/unprocessed.json",
         "Example/es.lproj/unprocessed.json",
-        "TestingUtils/BUILD",
         "TestingUtils/Greeting.swift.stencil",
         "TestingUtils/Answer.swift.stencil",
         "TestingUtils/merge.sh",
+        "TestingUtils/BUILD",
         "ExampleTests/BUILD",
         {
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/TestingUtils/TestingUtils.swift.modulemap",
@@ -95,9 +95,9 @@
             "_": "applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleTests/rules_xcodeproj/ExampleTests.__internal__.__test_bundle/Info.plist",
             "t": "g"
         },
+        "ExampleObjcTests/BUILD",
         "OnlyStructuredResources/BUILD",
         "OnlyStructuredResources/Info.plist",
-        "ExampleObjcTests/BUILD",
         {
             "_": "OnlyStructuredResources/Nested",
             "f": true,
@@ -107,11 +107,11 @@
             "_": "applebin_ios-ios_x86_64-dbg-ST-a0d0e3b8f217/bin/ExampleObjcTests/rules_xcodeproj/ExampleObjcTests.__internal__.__test_bundle/Info.plist",
             "t": "g"
         },
+        "ExampleUITests/BUILD",
         {
             "_": "examples_ios_app_external/Info.plist",
             "t": "e"
         },
-        "ExampleUITests/BUILD",
         {
             "_": "examples_ios_app_external/Assets.xcassets",
             "t": "e"

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -13,13 +13,9 @@
     "configuration": "darwin_x86_64-fastbuild-ST-1b9bd654f600",
     "custom_xcode_schemes": [],
     "extra_files": [
-        "ExampleNestedResources/BUILD",
-        "ExampleNestedResources/Info.plist",
-        "ExampleResources/BUILD",
-        "ExampleResources/Info.plist",
-        "Example/BUILD",
         "CoreUtilsObjC/BUILD",
         "Utils/BUILD",
+        "Example/BUILD",
         {
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap",
             "t": "g"
@@ -28,6 +24,10 @@
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Utils/Utils.swift.modulemap",
             "t": "g"
         },
+        "ExampleNestedResources/BUILD",
+        "ExampleNestedResources/Info.plist",
+        "ExampleResources/BUILD",
+        "ExampleResources/Info.plist",
         "Example/Info.plist",
         {
             "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/Example/rules_xcodeproj/Example/Info.plist",
@@ -38,10 +38,10 @@
             "i": false,
             "t": "g"
         },
-        "TestingUtils/BUILD",
         "TestingUtils/Greeting.swift.stencil",
         "TestingUtils/Answer.swift.stencil",
         "TestingUtils/merge.sh",
+        "TestingUtils/BUILD",
         "ExampleTests/BUILD",
         {
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/TestingUtils/TestingUtils.swift.modulemap",
@@ -55,18 +55,18 @@
             "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleTests/rules_xcodeproj/ExampleTests.__internal__.__test_bundle/Info.plist",
             "t": "g"
         },
+        "ExampleObjcTests/BUILD",
         "OnlyStructuredResources/BUILD",
         "OnlyStructuredResources/Info.plist",
-        "ExampleObjcTests/BUILD",
         {
             "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleObjcTests/rules_xcodeproj/ExampleObjcTests.__internal__.__test_bundle/Info.plist",
             "t": "g"
         },
+        "ExampleUITests/BUILD",
         {
             "_": "examples_ios_app_external/Info.plist",
             "t": "e"
         },
-        "ExampleUITests/BUILD",
         {
             "_": "applebin_ios-ios_x86_64-dbg-ST-8100579b5c54/bin/ExampleUITests/rules_xcodeproj/ExampleUITests.__internal__.__test_bundle/Info.plist",
             "t": "g"

--- a/test/fixtures/macos_app/bwb_spec.json
+++ b/test/fixtures/macos_app/bwb_spec.json
@@ -13,9 +13,9 @@
     "configuration": "darwin_x86_64-fastbuild-ST-1b9bd654f600",
     "custom_xcode_schemes": [],
     "extra_files": [
+        "examples/macos_app/third_party/ExampleFramework.framework",
         "examples/macos_app/Example/BUILD",
         "examples/macos_app/third_party/BUILD",
-        "examples/macos_app/third_party/ExampleFramework.framework",
         "examples/macos_app/Example/Info.plist",
         {
             "_": "applebin_macos-darwin_x86_64-dbg-ST-f078ed151a68/bin/examples/macos_app/Example/rules_xcodeproj/Example/Info.plist",

--- a/test/fixtures/macos_app/bwx_spec.json
+++ b/test/fixtures/macos_app/bwx_spec.json
@@ -13,9 +13,9 @@
     "configuration": "darwin_x86_64-fastbuild-ST-1b9bd654f600",
     "custom_xcode_schemes": [],
     "extra_files": [
+        "examples/macos_app/third_party/ExampleFramework.framework",
         "examples/macos_app/Example/BUILD",
         "examples/macos_app/third_party/BUILD",
-        "examples/macos_app/third_party/ExampleFramework.framework",
         "examples/macos_app/Example/Info.plist",
         {
             "_": "applebin_macos-darwin_x86_64-dbg-ST-efd7e4d599dd/bin/examples/macos_app/Example/rules_xcodeproj/Example/Info.plist",

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -13,13 +13,12 @@
     "configuration": "darwin_x86_64-fastbuild-ST-1b9bd654f600",
     "custom_xcode_schemes": [],
     "extra_files": [
-        "examples/multiplatform/AppClip/BUILD",
         {
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
             "t": "e"
         },
         "examples/multiplatform/Lib/BUILD",
-        "examples/multiplatform/iOSApp/BUILD",
+        "examples/multiplatform/AppClip/BUILD",
         "examples/multiplatform/AppClip/Entitlements.entitlements",
         "examples/multiplatform/AppClip/Info.plist",
         {
@@ -28,6 +27,7 @@
         },
         "examples/multiplatform/AppClip/PreviewContent/Preview Assets.xcassets",
         "examples/multiplatform/AppClip/Assets.xcassets",
+        "examples/multiplatform/iOSApp/BUILD",
         {
             "_": "com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework",
             "t": "e"
@@ -40,20 +40,19 @@
             "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework",
             "t": "e"
         },
-        "examples/multiplatform/WidgetExtension/BUILD",
         "examples/multiplatform/WidgetExtension/WidgetExtension.intentdefinition",
+        "examples/multiplatform/WidgetExtension/BUILD",
         "examples/multiplatform/WidgetExtension/Info.plist",
         {
             "_": "applebin_ios-ios_arm64-dbg-ST-28ac48b4d0bf/bin/examples/multiplatform/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
             "t": "g"
         },
         "examples/multiplatform/WidgetExtension/Assets.xcassets",
-        "examples/multiplatform/watchOSApp/BUILD",
-        "examples/multiplatform/watchOSAppExtension/BUILD",
         {
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
             "t": "e"
         },
+        "examples/multiplatform/watchOSAppExtension/BUILD",
         "examples/multiplatform/watchOSAppExtension/Info.plist",
         {
             "_": "applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSAppExtension/Info.withbundleid.plist",
@@ -66,6 +65,7 @@
         "examples/multiplatform/watchOSAppExtension/PreviewContent/Preview Assets.xcassets",
         "examples/multiplatform/watchOSAppExtension/Assets.xcassets",
         "examples/multiplatform/watchOSApp/Info.plist",
+        "examples/multiplatform/watchOSApp/BUILD",
         {
             "_": "applebin_watchos-watchos_arm64_32-dbg-ST-01fecab27ffc/bin/examples/multiplatform/watchOSApp/Info.withbundleid.plist",
             "t": "g"
@@ -165,11 +165,11 @@
             "_": "applebin_ios-ios_x86_64-dbg-ST-e7c08a7bb9db/bin/examples/multiplatform/iMessageApp/rules_xcodeproj/iMessageApp/Info.plist",
             "t": "g"
         },
-        "examples/multiplatform/tvOSApp/BUILD",
         {
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
             "t": "e"
         },
+        "examples/multiplatform/tvOSApp/BUILD",
         "examples/multiplatform/tvOSApp/Info.plist",
         {
             "_": "applebin_tvos-tvos_arm64-dbg-ST-d6d3bf2233f2/bin/examples/multiplatform/tvOSApp/rules_xcodeproj/tvOSApp/Info.plist",

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -13,19 +13,19 @@
     "configuration": "darwin_x86_64-fastbuild-ST-1b9bd654f600",
     "custom_xcode_schemes": [],
     "extra_files": [
-        "examples/multiplatform/AppClip/BUILD",
         {
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
             "t": "e"
         },
         "examples/multiplatform/Lib/BUILD",
-        "examples/multiplatform/iOSApp/BUILD",
+        "examples/multiplatform/AppClip/BUILD",
         "examples/multiplatform/AppClip/Entitlements.entitlements",
         "examples/multiplatform/AppClip/Info.plist",
         {
             "_": "applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/AppClip/rules_xcodeproj/AppClip/Info.plist",
             "t": "g"
         },
+        "examples/multiplatform/iOSApp/BUILD",
         {
             "_": "com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework",
             "t": "e"
@@ -38,19 +38,18 @@
             "_": "com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework",
             "t": "e"
         },
-        "examples/multiplatform/WidgetExtension/BUILD",
         "examples/multiplatform/WidgetExtension/WidgetExtension.intentdefinition",
+        "examples/multiplatform/WidgetExtension/BUILD",
         "examples/multiplatform/WidgetExtension/Info.plist",
         {
             "_": "applebin_ios-ios_arm64-dbg-ST-787a8770ecb8/bin/examples/multiplatform/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
             "t": "g"
         },
-        "examples/multiplatform/watchOSApp/BUILD",
-        "examples/multiplatform/watchOSAppExtension/BUILD",
         {
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
             "t": "e"
         },
+        "examples/multiplatform/watchOSAppExtension/BUILD",
         "examples/multiplatform/watchOSAppExtension/Info.plist",
         {
             "_": "applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSAppExtension/Info.withbundleid.plist",
@@ -61,6 +60,7 @@
             "t": "g"
         },
         "examples/multiplatform/watchOSApp/Info.plist",
+        "examples/multiplatform/watchOSApp/BUILD",
         {
             "_": "applebin_watchos-watchos_arm64_32-dbg-ST-934faf172fd3/bin/examples/multiplatform/watchOSApp/Info.withbundleid.plist",
             "t": "g"
@@ -141,11 +141,11 @@
             "_": "applebin_ios-ios_x86_64-dbg-ST-6fabcb83ef01/bin/examples/multiplatform/iMessageApp/rules_xcodeproj/iMessageApp/Info.plist",
             "t": "g"
         },
-        "examples/multiplatform/tvOSApp/BUILD",
         {
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
             "t": "e"
         },
+        "examples/multiplatform/tvOSApp/BUILD",
         "examples/multiplatform/tvOSApp/Info.plist",
         {
             "_": "applebin_tvos-tvos_arm64-dbg-ST-eb2e402285ef/bin/examples/multiplatform/tvOSApp/rules_xcodeproj/tvOSApp/Info.plist",

--- a/xcodeproj/internal/resources.bzl
+++ b/xcodeproj/internal/resources.bzl
@@ -357,7 +357,7 @@ def collect_resources(
                     id = metadata.id,
                     package_bin_dir = metadata.package_bin_dir,
                     platform = platform,
-                    resources = depset(bundle.resources),
+                    resources = tuple(bundle.resources),
                     dependencies = depset([
                         bundle_metadata[bundle_path].id
                         for bundle_path in bundle.dependency_paths

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -190,11 +190,16 @@ def _write_json_spec(
         target_hosts.setdefault(s.hosted, []).append(s.host)
 
     # `extra_files`
+    extra_files = inputs.extra_files.to_list()
+    extra_files.append((None, [parsed_file_path(ctx.build_file_path)]))
     extra_files = [
-        file_path_to_dto(file)
-        for file in inputs.extra_files.to_list()
+        file
+        for id, files in extra_files
+        for file in files
+        if not id or id in targets
     ]
-    extra_files.append(file_path_to_dto(parsed_file_path(ctx.build_file_path)))
+    extra_files = uniq(extra_files)
+    extra_files_dto = [file_path_to_dto(file) for file in extra_files]
 
     # `custom_xcode_schemes`
     if ctx.attr.schemes_json == "":
@@ -232,7 +237,7 @@ def _write_json_spec(
         bazel_workspace_name = ctx.workspace_name,
         configuration = configuration,
         custom_xcode_schemes = custom_xcode_schemes_json,
-        extra_files = json.encode(extra_files),
+        extra_files = json.encode(extra_files_dto),
         force_bazel_dependencies = json.encode(
             has_focused_targets or inputs.has_generated_files,
         ),


### PR DESCRIPTION
We now no longer show extra files for non-Xcode targets. This mainly means you don't get a bunch of extra `BUILD` files in Focused Projects.