### PR TITLE
Handle `forced_swift_compile_file` better

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-readonly forced_swift_compile_file="$1"
+# readonly forced_swift_compile_file="$1"
 readonly product_basename="$2"
 readonly exclude_list="$3"
 
-# Touching this file on an error allows indexing to work better
-trap 'touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
+# # Touching this file on an error allows indexing to work better
+# trap 'echo "private let touch = \"$(date +%s)\"" > "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
 
 if [[ "$ACTION" == indexbuild ]]; then
   # Write to "$BAZEL_BUILD_OUTPUT_GROUPS_FILE" to allow next index to catch up
@@ -61,5 +61,5 @@ fi
 
 # TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
 # Copy diagnostics, and on a change
-# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# `echo "private let touch = \"$(date +%s)\"" > $DERIVED_FILE_DIR/$forced_swift_compile_file"`
 # See git blame for this comment for an example

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-readonly forced_swift_compile_file="$1"
+# readonly forced_swift_compile_file="$1"
 readonly product_basename="$2"
 readonly exclude_list="$3"
 
-# Touching this file on an error allows indexing to work better
-trap 'touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
+# # Touching this file on an error allows indexing to work better
+# trap 'echo "private let touch = \"$(date +%s)\"" > "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
 
 if [[ "$ACTION" == indexbuild ]]; then
   # Write to "$BAZEL_BUILD_OUTPUT_GROUPS_FILE" to allow next index to catch up
@@ -61,5 +61,5 @@ fi
 
 # TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
 # Copy diagnostics, and on a change
-# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# `echo "private let touch = \"$(date +%s)\"" > $DERIVED_FILE_DIR/$forced_swift_compile_file"`
 # See git blame for this comment for an example

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-readonly forced_swift_compile_file="$1"
+# readonly forced_swift_compile_file="$1"
 readonly product_basename="$2"
 readonly exclude_list="$3"
 
-# Touching this file on an error allows indexing to work better
-trap 'touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
+# # Touching this file on an error allows indexing to work better
+# trap 'echo "private let touch = \"$(date +%s)\"" > "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
 
 if [[ "$ACTION" == indexbuild ]]; then
   # Write to "$BAZEL_BUILD_OUTPUT_GROUPS_FILE" to allow next index to catch up
@@ -61,5 +61,5 @@ fi
 
 # TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
 # Copy diagnostics, and on a change
-# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# `echo "private let touch = \"$(date +%s)\"" > $DERIVED_FILE_DIR/$forced_swift_compile_file"`
 # See git blame for this comment for an example

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-readonly forced_swift_compile_file="$1"
+# readonly forced_swift_compile_file="$1"
 readonly product_basename="$2"
 readonly exclude_list="$3"
 
-# Touching this file on an error allows indexing to work better
-trap 'touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
+# # Touching this file on an error allows indexing to work better
+# trap 'echo "private let touch = \"$(date +%s)\"" > "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
 
 if [[ "$ACTION" == indexbuild ]]; then
   # Write to "$BAZEL_BUILD_OUTPUT_GROUPS_FILE" to allow next index to catch up
@@ -61,5 +61,5 @@ fi
 
 # TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
 # Copy diagnostics, and on a change
-# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# `echo "private let touch = \"$(date +%s)\"" > $DERIVED_FILE_DIR/$forced_swift_compile_file"`
 # See git blame for this comment for an example

--- a/test/fixtures/macos_app/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/macos_app/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-readonly forced_swift_compile_file="$1"
+# readonly forced_swift_compile_file="$1"
 readonly product_basename="$2"
 readonly exclude_list="$3"
 
-# Touching this file on an error allows indexing to work better
-trap 'touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
+# # Touching this file on an error allows indexing to work better
+# trap 'echo "private let touch = \"$(date +%s)\"" > "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
 
 if [[ "$ACTION" == indexbuild ]]; then
   # Write to "$BAZEL_BUILD_OUTPUT_GROUPS_FILE" to allow next index to catch up
@@ -61,5 +61,5 @@ fi
 
 # TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
 # Copy diagnostics, and on a change
-# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# `echo "private let touch = \"$(date +%s)\"" > $DERIVED_FILE_DIR/$forced_swift_compile_file"`
 # See git blame for this comment for an example

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-readonly forced_swift_compile_file="$1"
+# readonly forced_swift_compile_file="$1"
 readonly product_basename="$2"
 readonly exclude_list="$3"
 
-# Touching this file on an error allows indexing to work better
-trap 'touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
+# # Touching this file on an error allows indexing to work better
+# trap 'echo "private let touch = \"$(date +%s)\"" > "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
 
 if [[ "$ACTION" == indexbuild ]]; then
   # Write to "$BAZEL_BUILD_OUTPUT_GROUPS_FILE" to allow next index to catch up
@@ -61,5 +61,5 @@ fi
 
 # TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
 # Copy diagnostics, and on a change
-# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# `echo "private let touch = \"$(date +%s)\"" > $DERIVED_FILE_DIR/$forced_swift_compile_file"`
 # See git blame for this comment for an example

--- a/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-readonly forced_swift_compile_file="$1"
+# readonly forced_swift_compile_file="$1"
 readonly product_basename="$2"
 readonly exclude_list="$3"
 
-# Touching this file on an error allows indexing to work better
-trap 'touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
+# # Touching this file on an error allows indexing to work better
+# trap 'echo "private let touch = \"$(date +%s)\"" > "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
 
 if [[ "$ACTION" == indexbuild ]]; then
   # Write to "$BAZEL_BUILD_OUTPUT_GROUPS_FILE" to allow next index to catch up
@@ -61,5 +61,5 @@ fi
 
 # TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
 # Copy diagnostics, and on a change
-# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# `echo "private let touch = \"$(date +%s)\"" > $DERIVED_FILE_DIR/$forced_swift_compile_file"`
 # See git blame for this comment for an example

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-readonly forced_swift_compile_file="$1"
+# readonly forced_swift_compile_file="$1"
 readonly product_basename="$2"
 readonly exclude_list="$3"
 
-# Touching this file on an error allows indexing to work better
-trap 'touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
+# # Touching this file on an error allows indexing to work better
+# trap 'echo "private let touch = \"$(date +%s)\"" > "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
 
 if [[ "$ACTION" == indexbuild ]]; then
   # Write to "$BAZEL_BUILD_OUTPUT_GROUPS_FILE" to allow next index to catch up
@@ -61,5 +61,5 @@ fi
 
 # TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
 # Copy diagnostics, and on a change
-# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# `echo "private let touch = \"$(date +%s)\"" > $DERIVED_FILE_DIR/$forced_swift_compile_file"`
 # See git blame for this comment for an example

--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-readonly forced_swift_compile_file="$1"
+# readonly forced_swift_compile_file="$1"
 readonly product_basename="$2"
 readonly exclude_list="$3"
 
-# Touching this file on an error allows indexing to work better
-trap 'touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
+# # Touching this file on an error allows indexing to work better
+# trap 'echo "private let touch = \"$(date +%s)\"" > "$DERIVED_FILE_DIR/$forced_swift_compile_file"' ERR
 
 if [[ "$ACTION" == indexbuild ]]; then
   # Write to "$BAZEL_BUILD_OUTPUT_GROUPS_FILE" to allow next index to catch up
@@ -61,5 +61,5 @@ fi
 
 # TODO: https://github.com/buildbuddy-io/rules_xcodeproj/issues/402
 # Copy diagnostics, and on a change
-# `touch "$DERIVED_FILE_DIR/$forced_swift_compile_file"`
+# `echo "private let touch = \"$(date +%s)\"" > $DERIVED_FILE_DIR/$forced_swift_compile_file"`
 # See git blame for this comment for an example


### PR DESCRIPTION
To work around an Xcode "serial queue" bug, we need to make a "meaningful change" to swift modules.

https://ios-dev-at-scale.slack.com/archives/C5QA0UGR1/p1659130548904439?thread_ts=1654971314.938379&cid=C5QA0UGR1

I know this is all still commented code, but I plan to uncomment it in the future when implementing #402.