### PR TITLE
Ensure `topLevelTargetInfos` is a unique `Set` in `XCSchemeInfo`

### DIFF
--- a/tools/generator/src/Generator/XCSchemeInfo+BuildActionInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+BuildActionInfo.swift
@@ -22,10 +22,10 @@ An `XCSchemeInfo.BuildActionInfo` should have at least one `XCSchemeInfo.TargetI
 
 extension XCSchemeInfo.BuildActionInfo {
     /// Create a copy of the `BuildActionInfo` with the host in `TargetInfo` values resolved.
-    init?(
+    init?<TargetInfos: Sequence>(
         resolveHostsFor buildActionInfo: XCSchemeInfo.BuildActionInfo?,
-        topLevelTargetInfos: [XCSchemeInfo.TargetInfo]
-    ) throws {
+        topLevelTargetInfos: TargetInfos
+    ) throws where TargetInfos.Element == XCSchemeInfo.TargetInfo {
         guard let original = buildActionInfo else {
             return nil
         }

--- a/tools/generator/src/Generator/XCSchemeInfo+LaunchActionInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+LaunchActionInfo.swift
@@ -33,10 +33,10 @@ An `XCSchemeInfo.LaunchActionInfo` should have a launchable `XCSchemeInfo.Target
 
 extension XCSchemeInfo.LaunchActionInfo {
     /// Create a copy of the `LaunchActionInfo` with the host in the `TargetInfo` resolved.
-    init?(
+    init?<TargetInfos: Sequence>(
         resolveHostsFor launchActionInfo: XCSchemeInfo.LaunchActionInfo?,
-        topLevelTargetInfos: [XCSchemeInfo.TargetInfo]
-    ) throws {
+        topLevelTargetInfos: TargetInfos
+    ) throws where TargetInfos.Element == XCSchemeInfo.TargetInfo {
         guard let original = launchActionInfo else {
           return nil
         }

--- a/tools/generator/src/Generator/XCSchemeInfo+ProfileActionInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+ProfileActionInfo.swift
@@ -11,10 +11,10 @@ extension XCSchemeInfo {
 
 extension XCSchemeInfo.ProfileActionInfo {
     /// Create a copy of the `ProfileActionInfo` with host in the `TargetInfo` resolved.
-    init?(
+    init?<TargetInfos: Sequence>(
         resolveHostsFor profileActionInfo: XCSchemeInfo.ProfileActionInfo?,
-        topLevelTargetInfos: [XCSchemeInfo.TargetInfo]
-    ) {
+        topLevelTargetInfos: TargetInfos
+    ) where TargetInfos.Element == XCSchemeInfo.TargetInfo {
         guard let original = profileActionInfo else {
           return nil
         }

--- a/tools/generator/src/Generator/XCSchemeInfo+TargetInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+TargetInfo.swift
@@ -40,10 +40,10 @@ extension XCSchemeInfo {
         }
 
         /// Initializer used when resolving a selected host.
-        init(
+        init<TargetInfos: Sequence>(
             resolveHostFor original: XCSchemeInfo.TargetInfo,
-            topLevelTargetInfos: [XCSchemeInfo.TargetInfo]
-        ) {
+            topLevelTargetInfos: TargetInfos
+        ) where TargetInfos.Element == XCSchemeInfo.TargetInfo {
             // Look for a host that is one of the top-level targets.
             let topLevelPBXTargetInfos = Set(topLevelTargetInfos.map(\.pbxTarget))
             var selectedHostInfo = original.hostInfos

--- a/tools/generator/src/Generator/XCSchemeInfo+TestActionInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+TestActionInfo.swift
@@ -31,10 +31,10 @@ An `XCSchemeInfo.TestActionInfo` should only contain testable `XCSchemeInfo.Targ
 
 extension XCSchemeInfo.TestActionInfo {
     /// Create a copy of the test action info with host in the target infos resolved
-    init?(
+    init?<TargetInfos: Sequence>(
         resolveHostsFor testActionInfo: XCSchemeInfo.TestActionInfo?,
-        topLevelTargetInfos: [XCSchemeInfo.TargetInfo]
-    ) throws {
+        topLevelTargetInfos: TargetInfos
+    ) throws where TargetInfos.Element == XCSchemeInfo.TargetInfo {
         guard let original = testActionInfo else {
           return nil
         }

--- a/tools/generator/src/Generator/XCSchemeInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo.swift
@@ -41,8 +41,11 @@ An `XCSchemeInfo` (\(schemeName)) should have at least one of the following: `bu
         if let testActionInfo = testActionInfo {
             topLevelTargetInfos.formUnion(testActionInfo.targetInfos.filter(\.pbxTarget.isTopLevel))
         }
-        if let launchActionInfo = launchActionInfo, launchActionInfo.targetInfo.pbxTarget.isTopLevel {
-            topLevelTargetInfos.update(with: launchActionInfo.targetInfo)
+        if let targetInfo = launchActionInfo?.targetInfo, targetInfo.pbxTarget.isTopLevel {
+            topLevelTargetInfos.update(with: targetInfo)
+        }
+        if let targetInfo = profileActionInfo?.targetInfo, targetInfo.pbxTarget.isTopLevel {
+            topLevelTargetInfos.update(with: targetInfo)
         }
 
         self.buildActionInfo = try .init(

--- a/tools/generator/src/Generator/XCSchemeInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo.swift
@@ -34,6 +34,7 @@ An `XCSchemeInfo` (\(schemeName)) should have at least one of the following: `bu
 """)
         }
 
+        // TODO(chuck): Switch to Set
         var topLevelTargetInfos = [XCSchemeInfo.TargetInfo]()
         if let testActionInfo = testActionInfo {
             topLevelTargetInfos += testActionInfo.targetInfos

--- a/tools/generator/src/Generator/XCSchemeInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo.swift
@@ -34,19 +34,14 @@ An `XCSchemeInfo` (\(schemeName)) should have at least one of the following: `bu
 """)
         }
 
-        var topLevelTargetInfos = Set<XCSchemeInfo.TargetInfo>()
-        if let buildActionInfo = buildActionInfo {
-            topLevelTargetInfos.formUnion(buildActionInfo.targetInfos.filter(\.pbxTarget.isTopLevel))
-        }
-        if let testActionInfo = testActionInfo {
-            topLevelTargetInfos.formUnion(testActionInfo.targetInfos.filter(\.pbxTarget.isTopLevel))
-        }
-        if let targetInfo = launchActionInfo?.targetInfo, targetInfo.pbxTarget.isTopLevel {
-            topLevelTargetInfos.update(with: targetInfo)
-        }
-        if let targetInfo = profileActionInfo?.targetInfo, targetInfo.pbxTarget.isTopLevel {
-            topLevelTargetInfos.update(with: targetInfo)
-        }
+        let allTargetInfos = [
+            buildActionInfo?.targetInfos,
+            testActionInfo?.targetInfos,
+            launchActionInfo.map { [$0.targetInfo] },
+            profileActionInfo.map { [$0.targetInfo] },
+        ].compactMap { $0 }.flatMap { $0 }
+
+        let topLevelTargetInfos = Set(allTargetInfos.filter(\.pbxTarget.isTopLevel))
 
         self.buildActionInfo = try .init(
             resolveHostsFor: buildActionInfo,

--- a/tools/generator/src/Generator/XCSchemeInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo.swift
@@ -34,13 +34,15 @@ An `XCSchemeInfo` (\(schemeName)) should have at least one of the following: `bu
 """)
         }
 
-        // TODO(chuck): Switch to Set
-        var topLevelTargetInfos = [XCSchemeInfo.TargetInfo]()
-        if let testActionInfo = testActionInfo {
-            topLevelTargetInfos += testActionInfo.targetInfos
+        var topLevelTargetInfos = Set<XCSchemeInfo.TargetInfo>()
+        if let buildActionInfo = buildActionInfo {
+            topLevelTargetInfos.formUnion(buildActionInfo.targetInfos.filter(\.pbxTarget.isTopLevel))
         }
-        if let launchActionInfo = launchActionInfo {
-            topLevelTargetInfos.append(launchActionInfo.targetInfo)
+        if let testActionInfo = testActionInfo {
+            topLevelTargetInfos.formUnion(testActionInfo.targetInfos.filter(\.pbxTarget.isTopLevel))
+        }
+        if let launchActionInfo = launchActionInfo, launchActionInfo.targetInfo.pbxTarget.isTopLevel {
+            topLevelTargetInfos.update(with: launchActionInfo.targetInfo)
         }
 
         self.buildActionInfo = try .init(


### PR DESCRIPTION
Related to #573.

- Simplify the collection of `TargetInfo` values.
- Apply `isTopLevel` filter to all collected `TargetInfo` values.
- Update `init?(resolveHostsFor:topLevelTargetInfos:)` to expect a `Sequence` of `TargetInfo` values.