### PR TITLE
Add default context info to `Dictionary` and `Optional` helpers

### DIFF
--- a/tools/generator/src/Extensions/Dictionary+Extensions.swift
+++ b/tools/generator/src/Extensions/Dictionary+Extensions.swift
@@ -3,15 +3,21 @@ extension Dictionary {
     func value(
         for key: Key,
         context: @autoclosure () -> String = "",
-        message: @autoclosure () -> String = ""
+        message: @autoclosure () -> String = "",
+        file: String = #file,
+        line: Int = #line,
+        function: String = #function
     ) throws -> Value {
         return try self[key].orThrow({
             let userMessage = message()
             guard userMessage != "" else {
                 let contextStr = context()
                 let endOfMsg = contextStr.isEmpty ? "" : ", while \(contextStr)"
+                let postMsg = endOfMsg.isEmpty ?
+                    " (function: \(function), file: \(file), line: \(line))" :
+                    ""
                 return """
-Unable to find the `\(Value.self)` for the `\(Key.self)`, "\(key)"\(endOfMsg).
+Unable to find the `\(Value.self)` for the `\(Key.self)`, "\(key)"\(endOfMsg).\(postMsg)
 """
             }
             return userMessage

--- a/tools/generator/src/Extensions/Optional+Extensions.swift
+++ b/tools/generator/src/Extensions/Optional+Extensions.swift
@@ -1,7 +1,18 @@
 extension Optional {
-    func orThrow(_ message: @autoclosure () -> String) throws -> Wrapped {
+    func orThrow(
+        _ message: @autoclosure () -> String = "",
+        file: String = #file,
+        line: Int = #line,
+        function: String = #function
+    ) throws -> Wrapped {
         guard let value = self else {
-            throw PreconditionError(message: message())
+            var errMsg = message()
+            if errMsg == "" {
+                errMsg = """
+Expected non-nil value. (function: \(function), file: \(file), line: \(line))
+"""
+            }
+            throw PreconditionError(message: errMsg)
         }
         return value
     }

--- a/tools/generator/test/Dictionary+ExtensionTests.swift
+++ b/tools/generator/test/Dictionary+ExtensionTests.swift
@@ -19,9 +19,12 @@ extension DictionaryExtensionTests {
             XCTFail("Expected a `PreconditionError`.")
             return
         }
-        XCTAssertEqual(error.message, """
+        let expectedMainMsg = """
 Unable to find the `TargetID` for the `BazelLabel`, "//:does_not_exist".
-""")
+"""
+        XCTAssertTrue(error.message.contains(expectedMainMsg))
+        let expectedPostMsgFragment = "function: test_value_keyDoesNotExist_noContext()"
+        XCTAssertTrue(error.message.contains(expectedPostMsgFragment))
     }
 
     func test_value_keyDoesNotExist_withContext() throws {

--- a/tools/generator/test/Optional+ExtensionsTests.swift
+++ b/tools/generator/test/Optional+ExtensionsTests.swift
@@ -12,7 +12,7 @@ class OptionalExtensionTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
-    func test_orThrow_noValue() throws {
+    func test_orThrow_noValue_withErrorMessage() throws {
         let opt: String? = nil
         var thrown: Error?
         XCTAssertThrowsError(try opt.orThrow(errorMessage)) {
@@ -23,5 +23,21 @@ class OptionalExtensionTests: XCTestCase {
             return
         }
         XCTAssertEqual(preconditionError.message, errorMessage)
+    }
+
+    func test_orThrow_noValue_noErrorMessage() throws {
+        let opt: String? = nil
+        var thrown: Error?
+        XCTAssertThrowsError(try opt.orThrow()) {
+            thrown = $0
+        }
+        guard let preconditionError = thrown as? PreconditionError else {
+            XCTFail("Expected a `PreconditionError`.")
+            return
+        }
+        let expectedMsgFragment = """
+Expected non-nil value. (function: \(#function),
+"""
+        XCTAssertTrue(preconditionError.message.contains(expectedMsgFragment))
     }
 }


### PR DESCRIPTION
- Add default context info to `Dictionary.value(for:context:message:)`, if no context or message is provided. The default context includes the function name, filename, and line number.
- Add default error message to `Optional.orThrow()`. The default error message includes the function name, filename, and line number.
