### PR TITLE
Fix handling of odd `AppleResourceInfo` structures

### DIFF
--- a/xcodeproj/internal/resources.bzl
+++ b/xcodeproj/internal/resources.bzl
@@ -116,6 +116,9 @@ def _add_structured_resources_to_bundle(
         else:
             dir = file.dirname
 
+        if not dir.endswith(nested_path):
+            continue
+
         fp = file_path(
             file,
             path = paths.join(dir[:-(1 + len(nested_path))], inner_dir),


### PR DESCRIPTION
This prevents incorrect files from appearing in the Project navigator, possibly at the expense of needed files appearing at all. This should only be an issue in BwX mode though.