### PR TITLE
Use `Label` type for `fozen_bundle.label`

### DIFF
--- a/xcodeproj/internal/resources.bzl
+++ b/xcodeproj/internal/resources.bzl
@@ -355,7 +355,7 @@ def collect_resources(
             frozen_bundles.append(
                 struct(
                     name = bundle.name,
-                    label = str(metadata.label),
+                    label = metadata.label,
                     configuration = metadata.configuration,
                     id = metadata.id,
                     package_bin_dir = metadata.package_bin_dir,


### PR DESCRIPTION
Fixes the type to match other label types.