### PR TITLE
Implement best host logic when a host is not one of the top-level targets

### DIFF
--- a/tools/generator/src/Extensions/Platform+Extensions.swift
+++ b/tools/generator/src/Extensions/Platform+Extensions.swift
@@ -38,9 +38,18 @@ extension Platform {
 // MARK: `Platform.compatibleWith`
 
 extension Platform {
+    /// Determines whether the `Platform` is compatible with any of the specified `Platform` values.
     func compatibleWith<Platforms: Sequence>(
         anyOf platforms: Platforms
     ) -> Bool where Platforms.Element == Platform {
         return platforms.contains { self.compatibility(with: $0).isCompatible }
+    }
+}
+
+extension Sequence where Element == Platform {
+    /// Determines whether any of the `Platform` values are compatible with the specified `Platform`
+    /// value.
+    func compatibleWith(_ platform: Platform) -> Bool {
+        return contains { $0.compatibility(with: platform).isCompatible }
     }
 }

--- a/tools/generator/src/Generator/XCSchemeInfo+HostInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+HostInfo.swift
@@ -82,14 +82,21 @@ extension Collection where Element == XCSchemeInfo.HostInfo {
 
         // Look for a host that is one of the top-level targets.
         let topLevelPBXTargetInfos = Set(topLevelTargetInfos.map(\.pbxTarget))
-        if let selected = filter({ topLevelPBXTargetInfos.contains($0.pbxTarget) }).first {
+        if let selected = first(where: { topLevelPBXTargetInfos.contains($0.pbxTarget) }) {
             return .selected(selected)
         }
 
-        // Find the first host that has a top-level platform
-        // GH573: Implement top-level platform check
+        // Find the first host that has the best top-level platform
+        let topLevelPlatforms = Set(topLevelTargetInfos.flatMap(\.platforms)).sorted()
+        for topLevelPlatform in topLevelPlatforms {
+            if let selected = first(where: { $0.platforms.compatibleWith(topLevelPlatform) }) {
+                return .selected(selected)
+            }
+        }
 
-        // Just pick one of the hosts.
+        // Pick the first host. If the host infos collection is from a `XCSchemeInfo.TargetInfo`,
+        // the hosts are sorted by best `Platform`. Hence, the first `HostInfo` is the best one to
+        // select.
         if let selected = first {
             return .selected(selected)
         }

--- a/tools/generator/src/Generator/XCSchemeInfo+HostInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+HostInfo.swift
@@ -69,3 +69,31 @@ extension XCSchemeInfo.HostInfo: Comparable {
         return lhsFirstPlatform < rhsFirstPlatform
     }
 }
+
+// MARK: Host Resolution
+
+extension Collection where Element == XCSchemeInfo.HostInfo {
+    func resolve<TargetInfos: Sequence>(
+        topLevelTargetInfos: TargetInfos
+    ) -> XCSchemeInfo.HostResolution where TargetInfos.Element == XCSchemeInfo.TargetInfo {
+        guard !isEmpty else {
+            return .none
+        }
+
+        // Look for a host that is one of the top-level targets.
+        let topLevelPBXTargetInfos = Set(topLevelTargetInfos.map(\.pbxTarget))
+        if let selected = filter({ topLevelPBXTargetInfos.contains($0.pbxTarget) }).first {
+            return .selected(selected)
+        }
+
+        // Find the first host that has a top-level platform
+        // GH573: Implement top-level platform check
+
+        // Just pick one of the hosts.
+        if let selected = first {
+            return .selected(selected)
+        }
+
+        return .none
+    }
+}

--- a/tools/generator/src/Generator/XCSchemeInfo+TargetInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+TargetInfo.swift
@@ -99,32 +99,6 @@ extension XCSchemeInfo.TargetInfo {
     }
 }
 
-extension Collection where Element == XCSchemeInfo.HostInfo {
-    func resolve<TargetInfos: Sequence>(
-        topLevelTargetInfos: TargetInfos
-    ) -> XCSchemeInfo.HostResolution where TargetInfos.Element == XCSchemeInfo.TargetInfo {
-        guard !isEmpty else {
-            return .none
-        }
-
-        // Look for a host that is one of the top-level targets.
-        let topLevelPBXTargetInfos = Set(topLevelTargetInfos.map(\.pbxTarget))
-        if let selected = filter({ topLevelPBXTargetInfos.contains($0.pbxTarget) }).first {
-            return .selected(selected)
-        }
-
-        // Find the first host that has a top-level platform
-        // GH573: Implement top-level platform check
-
-        // Just pick one of the hosts.
-        if let selected = first {
-            return .selected(selected)
-        }
-
-        return .none
-    }
-}
-
 // MARK: `selectedHostInfo`
 
 extension XCSchemeInfo.TargetInfo {

--- a/tools/generator/test/Platform+ExtensionsTests.swift
+++ b/tools/generator/test/Platform+ExtensionsTests.swift
@@ -13,7 +13,7 @@ extension PlatformExtensionsTests {
     func test_compatibility_variantMismatch() throws {
         let platform = Platform(
             os: iOSarm64Platform.os,
-            variant: .tvOSDevice,
+            variant: .iOSSimulator,
             arch: iOSarm64Platform.arch,
             minimumOsVersion: iOSarm64Platform.minimumOsVersion
         )

--- a/tools/generator/test/Platform+ExtensionsTests.swift
+++ b/tools/generator/test/Platform+ExtensionsTests.swift
@@ -7,37 +7,36 @@ import XCTest
 extension PlatformExtensionsTests {
     func test_compatibility_osMismatch() throws {
         let platform = Platform.device(os: .tvOS)
-        XCTAssertEqual(platform.compatibility(with: other), .osNotEqual)
+        XCTAssertEqual(platform.compatibility(with: iOSarm64Platform), .osNotEqual)
     }
 
     func test_compatibility_variantMismatch() throws {
         let platform = Platform(
-            os: other.os,
+            os: iOSarm64Platform.os,
             variant: .tvOSDevice,
-            arch: other.arch,
-            minimumOsVersion: other.minimumOsVersion
+            arch: iOSarm64Platform.arch,
+            minimumOsVersion: iOSarm64Platform.minimumOsVersion
         )
-        XCTAssertEqual(platform.compatibility(with: other), .variantNotEqual)
+        XCTAssertEqual(platform.compatibility(with: iOSarm64Platform), .variantNotEqual)
     }
 
     func test_compatibility_archMismatch() throws {
-        let platform = Platform.device(os: .iOS, arch: "x86_64")
-        XCTAssertEqual(platform.compatibility(with: other), .archNotEqual)
+        XCTAssertEqual(iOSx8664Platform.compatibility(with: iOSarm64Platform), .archNotEqual)
     }
 
     func test_compatibility_minOsGreaterThan() throws {
         let platform = Platform.device(os: .iOS, minimumOsVersion: "12.0")
-        XCTAssertEqual(platform.compatibility(with: other), .minimumOsVersionGreaterThanOther)
+        XCTAssertEqual(platform.compatibility(with: iOSarm64Platform), .minimumOsVersionGreaterThanOther)
     }
 
     func test_compatibility_minOsEqual() throws {
-        let platform = other
-        XCTAssertEqual(platform.compatibility(with: other), .compatible)
+        let platform = iOSarm64Platform
+        XCTAssertEqual(platform.compatibility(with: iOSarm64Platform), .compatible)
     }
 
     func test_compatibility_minOsLessThan() throws {
         let platform = Platform.device(os: .iOS, minimumOsVersion: "10.0")
-        XCTAssertEqual(platform.compatibility(with: other), .compatible)
+        XCTAssertEqual(platform.compatibility(with: iOSarm64Platform), .compatible)
     }
 }
 
@@ -57,18 +56,38 @@ extension PlatformExtensionsTests {
 
 extension PlatformExtensionsTests {
     func test_compatibleWith_compatible() throws {
-        let platforms: [Platform] = [.macOS(), other]
-        let platform = other
+        let platforms: [Platform] = [.macOS(), iOSarm64Platform]
+        let platform = iOSarm64Platform
         XCTAssertTrue(platform.compatibleWith(anyOf: platforms))
     }
 
     func test_compatibleWith_notCompatible() throws {
         let platforms: [Platform] = [.macOS(), .device(os: .tvOS)]
-        let platform = other
+        let platform = iOSarm64Platform
         XCTAssertFalse(platform.compatibleWith(anyOf: platforms))
     }
 }
 
+// MARK: `compatibilityWith()` Tests
+
+extension PlatformExtensionsTests {
+    func test_Sequence_compatibleWith_noPlatforms() throws {
+        let platforms = [Platform]()
+        XCTAssertFalse(platforms.compatibleWith(iOSarm64Platform))
+    }
+
+    func test_Sequence_compatibleWith_isCompatible() throws {
+        let platforms = [iOSarm64Platform, iOSx8664Platform]
+        XCTAssertTrue(platforms.compatibleWith(iOSarm64Platform))
+    }
+
+    func test_Sequence_compatibleWith_isNotCompatible() throws {
+        let platforms = [iOSx8664Platform]
+        XCTAssertFalse(platforms.compatibleWith(iOSarm64Platform))
+    }
+}
+
 class PlatformExtensionsTests: XCTestCase {
-    let other = Platform.device(os: .iOS)
+    let iOSarm64Platform = Platform.device(os: .iOS)
+    let iOSx8664Platform = Platform.device(os: .iOS, arch: "x86_64")
 }

--- a/tools/generator/test/XCSchemeInfo+HostInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+HostInfoTests.swift
@@ -2,6 +2,8 @@ import XCTest
 
 @testable import generator
 
+// MARK: Initializer Tests
+
 extension XCSchemeInfoHostInfoTests {
     func test_init_storesUniqSortedPlatforms() throws {
         let hostInfo = XCSchemeInfo.HostInfo(
@@ -14,6 +16,8 @@ extension XCSchemeInfoHostInfoTests {
         XCTAssertEqual(hostInfo.platforms, [iOSSimulatorPlatform, iOSDevicePlatform])
     }
 }
+
+// MARK: Comparable Tests
 
 extension XCSchemeInfoHostInfoTests {
     func test_Comparable() throws {
@@ -29,6 +33,16 @@ extension XCSchemeInfoHostInfoTests {
         XCTAssertTrue(macApp < iOSApp, "macApp should be less than iOSApp")
     }
 }
+
+// MARK: Host Resolution Tests
+
+extension XCSchemeInfoHostInfoTests {
+    func test_resolve() throws {
+        XCTFail("IMPLEMENT ME!")
+    }
+}
+
+// MARK: Test Data
 
 class XCSchemeInfoHostInfoTests: XCTestCase {
     let iOSDevicePlatform = Platform.device(os: .iOS)

--- a/tools/generator/test/XCSchemeInfo+HostInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+HostInfoTests.swift
@@ -37,8 +37,41 @@ extension XCSchemeInfoHostInfoTests {
 // MARK: Host Resolution Tests
 
 extension XCSchemeInfoHostInfoTests {
-    func test_resolve() throws {
-        XCTFail("IMPLEMENT ME!")
+    func test_Collection_resolve_isEmpty() throws {
+        let hostInfos = [XCSchemeInfo.HostInfo]()
+        XCTAssertEqual(hostInfos.resolve(topLevelTargetInfos: topLevelTargetInfos), .none)
+    }
+
+    func test_Collection_resolve_matchTopLevelTarget() throws {
+        // Make sure the expected host info is not first
+        let hostInfos = [watchOSAppHostInfo, macOSAppHostInfo]
+        let result = hostInfos.resolve(topLevelTargetInfos: topLevelTargetInfos)
+        guard case let .selected(selected) = result else {
+            XCTFail("Expected host resolution selected, but was \(result)")
+            return
+        }
+        XCTAssertEqual(selected, macOSAppHostInfo)
+    }
+
+    func test_Collection_resolve_matchTopLevelPlatform() throws {
+        // Make sure the expected host info is not first
+        let hostInfos = [watchOSAppHostInfo, anotheriOSAppHostInfo]
+        let result = hostInfos.resolve(topLevelTargetInfos: topLevelTargetInfos)
+        guard case let .selected(selected) = result else {
+            XCTFail("Expected host resolution selected, but was \(result)")
+            return
+        }
+        XCTAssertEqual(selected, anotheriOSAppHostInfo)
+    }
+
+    func test_Collection_resolve_matchFirst() throws {
+        let hostInfos = [watchOSAppHostInfo]
+        let result = hostInfos.resolve(topLevelTargetInfos: topLevelTargetInfos)
+        guard case let .selected(selected) = result else {
+            XCTFail("Expected host resolution selected, but was \(result)")
+            return
+        }
+        XCTAssertEqual(selected, watchOSAppHostInfo)
     }
 }
 
@@ -57,5 +90,37 @@ class XCSchemeInfoHostInfoTests: XCTestCase {
 
     lazy var targetResolver = Fixtures.targetResolver(
         referencedContainer: filePathResolver.containerReference
+    )
+
+    lazy var macOSAppPBXTargetInfo = targetResolver.pbxTargetInfos["A 2"]!
+    lazy var iOSAppPBXTargetInfo = targetResolver.pbxTargetInfos["I"]!
+    lazy var anotheriOSAppPBXTargetInfo = targetResolver.pbxTargetInfos["AC"]!
+    lazy var watchOSAppPBXTargetInfo = targetResolver.pbxTargetInfos["W"]!
+
+    lazy var macOSAppTargetInfo = XCSchemeInfo.TargetInfo(
+        pbxTargetInfo: macOSAppPBXTargetInfo,
+        hostInfos: []
+    )
+    lazy var iOSAppTargetInfo = XCSchemeInfo.TargetInfo(
+        pbxTargetInfo: iOSAppPBXTargetInfo,
+        hostInfos: []
+    )
+    lazy var topLevelTargetInfos = [macOSAppTargetInfo, iOSAppTargetInfo]
+
+    lazy var macOSAppHostInfo = XCSchemeInfo.HostInfo(
+        pbxTargetInfo: macOSAppPBXTargetInfo,
+        index: 3
+    )
+    lazy var iOSAppHostInfo = XCSchemeInfo.HostInfo(
+        pbxTargetInfo: iOSAppPBXTargetInfo,
+        index: 2
+    )
+    lazy var anotheriOSAppHostInfo = XCSchemeInfo.HostInfo(
+        pbxTargetInfo: anotheriOSAppPBXTargetInfo,
+        index: 4
+    )
+    lazy var watchOSAppHostInfo = XCSchemeInfo.HostInfo(
+        pbxTargetInfo: watchOSAppPBXTargetInfo,
+        index: 1
     )
 }


### PR DESCRIPTION
Related to #573.

- Implement `compatibleWith()` for a `Sequence` of `Platform` values.
- Move `HostInfo` resolution logic to `HostInfo` file.
- Add unit tests for host resolution logic.
