### PR TITLE
Add `archiving` and `analyzing` logic for `buildFor`

### DIFF
--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -61,7 +61,7 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "85C876DB90D51CD225023BB2"
@@ -75,7 +75,7 @@
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "979D12680661F4B864602CE6"

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -61,7 +61,7 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "2FED647E7A6091DF616D345B"
@@ -75,7 +75,7 @@
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F5FCEC7426929BDA7F9F1875"

--- a/tools/generator/src/DTO/XcodeScheme.swift
+++ b/tools/generator/src/DTO/XcodeScheme.swift
@@ -39,22 +39,6 @@ extension XcodeScheme {
         get throws {
             var buildTargets = [BazelLabel: XcodeScheme.BuildTarget]()
 
-            // func enableBuildForValue(
-            //     _ label: BazelLabel,
-            //     _ keyPath: WritableKeyPath<XcodeScheme.BuildFor, XcodeScheme.BuildFor.Value>
-            // ) throws {
-            //     do {
-            //         try buildTargets[label, default: .init(label: label, buildFor: .init())]
-            //             .buildFor[keyPath: keyPath]
-            //             .merge(with: .enabled)
-            //     } catch XcodeScheme.BuildFor.Value.ValueError.incompatibleMerge {
-            //         throw UsageError(message: """
-// The `build_for` value, "\(keyPath.stringValue)", for "\(label)" in the "\(name)" Xcode scheme was \
-// disabled, but the target is referenced in the scheme's \(keyPath.actionType) action.
-// """)
-            //     }
-            // }
-
             func enableBuildForValue(
                 _ label: BazelLabel,
                 _ keyPath: WritableKeyPath<XcodeScheme.BuildFor, XcodeScheme.BuildFor.Value>,

--- a/tools/generator/src/DTO/XcodeScheme.swift
+++ b/tools/generator/src/DTO/XcodeScheme.swift
@@ -103,7 +103,7 @@ extension XcodeScheme {
             try newProfileAction.map { try enableBuildForValue($0.target, \.profiling) }
 
             // If no build targets have running enabled, then enable it for all targets
-            if !buildTargets.values.contains(where: { $0.buildFor.running == .enabled }) {
+            if !buildTargets.values.contains(where: \.buildFor.running.isEnabled) {
                 try buildTargets.keys.forEach { try enableBuildForValue($0, \.running) }
             }
 

--- a/tools/generator/src/DTO/XcodeScheme.swift
+++ b/tools/generator/src/DTO/XcodeScheme.swift
@@ -51,9 +51,9 @@ extension XcodeScheme {
                         try buildTarget.buildFor[keyPath: keyPath].merge(with: .enabled)
                     } catch XcodeScheme.BuildFor.Value.ValueError.incompatibleMerge {
                         throw UsageError(message: """
-    The `build_for` value, "\(keyPath.stringValue)", for "\(label)" in the "\(name)" Xcode scheme was \
-    disabled, but the target is referenced in the scheme's \(keyPath.actionType) action.
-    """)
+The `build_for` value, "\(keyPath.stringValue)", for "\(label)" in the "\(name)" Xcode scheme was \
+disabled, but the target is referenced in the scheme's \(keyPath.actionType) action.
+""")
                     }
                 case .setIfAble:
                     buildTarget.buildFor[keyPath: keyPath].enableIfNotDisabled()

--- a/tools/generator/src/DTO/XcodeScheme.swift
+++ b/tools/generator/src/DTO/XcodeScheme.swift
@@ -29,25 +29,52 @@ No actions were provided for the scheme "\(name)".
 }
 
 extension XcodeScheme {
+    enum EnableBuildForValueMode {
+        case merge
+        case setIfAble
+    }
+
     /// Create a new scheme applying any default actions based upon the current scheme.
     var withDefaults: XcodeScheme {
         get throws {
             var buildTargets = [BazelLabel: XcodeScheme.BuildTarget]()
 
+            // func enableBuildForValue(
+            //     _ label: BazelLabel,
+            //     _ keyPath: WritableKeyPath<XcodeScheme.BuildFor, XcodeScheme.BuildFor.Value>
+            // ) throws {
+            //     do {
+            //         try buildTargets[label, default: .init(label: label, buildFor: .init())]
+            //             .buildFor[keyPath: keyPath]
+            //             .merge(with: .enabled)
+            //     } catch XcodeScheme.BuildFor.Value.ValueError.incompatibleMerge {
+            //         throw UsageError(message: """
+// The `build_for` value, "\(keyPath.stringValue)", for "\(label)" in the "\(name)" Xcode scheme was \
+// disabled, but the target is referenced in the scheme's \(keyPath.actionType) action.
+// """)
+            //     }
+            // }
+
             func enableBuildForValue(
                 _ label: BazelLabel,
-                _ keyPath: WritableKeyPath<XcodeScheme.BuildFor, XcodeScheme.BuildFor.Value>
+                _ keyPath: WritableKeyPath<XcodeScheme.BuildFor, XcodeScheme.BuildFor.Value>,
+                _ mode: EnableBuildForValueMode = .merge
             ) throws {
-                do {
-                    try buildTargets[label, default: .init(label: label, buildFor: .init())]
-                        .buildFor[keyPath: keyPath]
-                        .merge(with: .enabled)
-                } catch XcodeScheme.BuildFor.Value.ValueError.incompatibleMerge {
-                    throw UsageError(message: """
-The `build_for` value, "\(keyPath.stringValue)", for "\(label)" in the "\(name)" Xcode scheme was \
-disabled, but the target is referenced in the scheme's \(keyPath.actionType) action.
-""")
+                var buildTarget = buildTargets[label, default: .init(label: label, buildFor: .init())]
+                switch mode {
+                case .merge:
+                    do {
+                        try buildTarget.buildFor[keyPath: keyPath].merge(with: .enabled)
+                    } catch XcodeScheme.BuildFor.Value.ValueError.incompatibleMerge {
+                        throw UsageError(message: """
+    The `build_for` value, "\(keyPath.stringValue)", for "\(label)" in the "\(name)" Xcode scheme was \
+    disabled, but the target is referenced in the scheme's \(keyPath.actionType) action.
+    """)
+                    }
+                case .setIfAble:
+                    buildTarget.buildFor[keyPath: keyPath].enableIfNotDisabled()
                 }
+                buildTargets[label] = buildTarget
             }
 
             // Popuate the dictionary with any build targets that were explicitly specified.
@@ -79,6 +106,14 @@ disabled, but the target is referenced in the scheme's \(keyPath.actionType) act
             if !buildTargets.values.contains(where: { $0.buildFor.running == .enabled }) {
                 try buildTargets.keys.forEach { try enableBuildForValue($0, \.running) }
             }
+
+            // Enable archiving for any targets that have running enabled
+            try buildTargets.values.filter(\.buildFor.running.isEnabled).map(\.label).forEach {
+                try enableBuildForValue($0, \.archiving, .setIfAble)
+            }
+
+            // Enable analyze for all targets
+            try buildTargets.keys.forEach { try enableBuildForValue($0, \.analyzing, .setIfAble) }
 
             // Create a new build action which includes all of the referenced labels as build targets
             // We must do this after processing all of the other actions.

--- a/tools/generator/src/Generator/XcodeScheme+BuildFor.swift
+++ b/tools/generator/src/Generator/XcodeScheme+BuildFor.swift
@@ -46,6 +46,22 @@ extension XcodeScheme.BuildFor.Value {
 }
 
 extension XcodeScheme.BuildFor.Value {
+    var isEnabled: Bool {
+        guard self == .enabled else {
+            return false
+        }
+        return true
+    }
+
+    var isDisabled: Bool {
+        guard self == .disabled else {
+            return false
+        }
+        return true
+    }
+}
+
+extension XcodeScheme.BuildFor.Value {
     enum ValueError: Error, Equatable {
         case incompatibleMerge
     }
@@ -65,6 +81,15 @@ extension XcodeScheme.BuildFor.Value {
 
     mutating func merge(with other: XcodeScheme.BuildFor.Value) throws {
         self = try merged(with: other)
+    }
+}
+
+extension XcodeScheme.BuildFor.Value {
+    mutating func enableIfNotDisabled() {
+        guard self != .disabled else {
+            return
+        }
+        self = .enabled
     }
 }
 

--- a/tools/generator/test/XCSchemeInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfoTests.swift
@@ -170,11 +170,16 @@ extension XCSchemeInfoTests {
                     ),
                     .init(
                         targetInfo: try targetResolver.targetInfo(targetID: "A 2"),
-                        buildFor: .init(running: .enabled, profiling: .enabled)
+                        buildFor: .init(
+                            running: .enabled,
+                            profiling: .enabled,
+                            archiving: .enabled,
+                            analyzing: .enabled
+                        )
                     ),
                     .init(
                         targetInfo: try targetResolver.targetInfo(targetID: "B 2"),
-                        buildFor: .init(testing: .enabled)
+                        buildFor: .init(testing: .enabled, analyzing: .enabled)
                     ),
                 ]
             ),

--- a/tools/generator/test/XcodeScheme+BuildForTests.swift
+++ b/tools/generator/test/XcodeScheme+BuildForTests.swift
@@ -73,6 +73,44 @@ Expected `ValueError`. value: \(value), other: \(other), expected: \(expected)
     }
 }
 
+// MARK: `Value.isEnabled` Tests
+
+extension XcodeSchemeBuildForTests {
+    func test_Value_isEnabled() throws {
+        XCTAssertTrue(XcodeScheme.BuildFor.Value.enabled.isEnabled)
+        XCTAssertFalse(XcodeScheme.BuildFor.Value.disabled.isEnabled)
+        XCTAssertFalse(XcodeScheme.BuildFor.Value.unspecified.isEnabled)
+    }
+}
+
+// MARK: `Value.isDisabled` Tests
+
+extension XcodeSchemeBuildForTests {
+    func test_Value_isDisabled() throws {
+        XCTAssertTrue(XcodeScheme.BuildFor.Value.disabled.isDisabled)
+        XCTAssertFalse(XcodeScheme.BuildFor.Value.enabled.isDisabled)
+        XCTAssertFalse(XcodeScheme.BuildFor.Value.unspecified.isDisabled)
+    }
+}
+
+// MARK: `Value.enableIfNotDisabled()` Tests
+
+extension XcodeSchemeBuildForTests {
+    func test_Value_enableIfNotDisabled() throws {
+        var value = XcodeScheme.BuildFor.Value.unspecified
+        value.enableIfNotDisabled()
+        XCTAssertEqual(value, .enabled)
+
+        value = XcodeScheme.BuildFor.Value.enabled
+        value.enableIfNotDisabled()
+        XCTAssertEqual(value, .enabled)
+
+        value = XcodeScheme.BuildFor.Value.disabled
+        value.enableIfNotDisabled()
+        XCTAssertEqual(value, .disabled)
+    }
+}
+
 // MARK: `BuildFor.xcSchemeValue` Tests
 
 extension XcodeSchemeBuildForTests {

--- a/tools/generator/test/XcodeSchemeTests.swift
+++ b/tools/generator/test/XcodeSchemeTests.swift
@@ -70,7 +70,12 @@ extension XcodeSchemeTests {
                 targets: [
                     .init(
                         label: macOSAppLabel,
-                        buildFor: .init(running: .enabled, profiling: .enabled)
+                        buildFor: .init(
+                            running: .enabled,
+                            profiling: .enabled,
+                            archiving: .enabled,
+                            analyzing: .enabled
+                        )
                     ),
                 ]
             ),
@@ -93,11 +98,11 @@ extension XcodeSchemeTests {
                 targets: [
                     .init(
                         label: macOSAppLabel,
-                        buildFor: .init(running: .enabled)
+                        buildFor: .init(running: .enabled, archiving: .enabled, analyzing: .enabled)
                     ),
                     .init(
                         label: iOSAppLabel,
-                        buildFor: .init(profiling: .enabled)
+                        buildFor: .init(profiling: .enabled, analyzing: .enabled)
                     ),
                 ]
             ),
@@ -124,7 +129,7 @@ extension XcodeSchemeTests {
             name: schemeName,
             buildAction: try .init(targets: [
                 .init(label: macOSAppLabel, buildFor: .init(
-                    running: .enabled, profiling: .enabled, archiving: .enabled
+                    running: .enabled, profiling: .enabled, archiving: .enabled, analyzing: .enabled
                 )),
             ]),
             launchAction: .init(target: macOSAppLabel),
@@ -149,7 +154,10 @@ extension XcodeSchemeTests {
             name: schemeName,
             buildAction: try .init(targets: [
                 .init(label: macOSAppLabel, buildFor: .init(
-                    running: .enabled, profiling: .disabled
+                    running: .enabled,
+                    profiling: .disabled,
+                    archiving: .enabled,
+                    analyzing: .enabled
                 )),
             ]),
             launchAction: .init(target: macOSAppLabel)
@@ -208,8 +216,24 @@ disabled, but the target is referenced in the scheme's test action.
         let expected = try XcodeScheme(
             name: schemeName,
             buildAction: try .init(targets: [
-                .init(label: unitTestLabel, buildFor: .init(running: .enabled, testing: .enabled)),
-                .init(label: uiTestLabel, buildFor: .init(running: .enabled, testing: .enabled)),
+                .init(
+                    label: unitTestLabel,
+                    buildFor: .init(
+                        running: .enabled,
+                        testing: .enabled,
+                        archiving: .enabled,
+                        analyzing: .enabled
+                    )
+                ),
+                .init(
+                    label: uiTestLabel,
+                    buildFor: .init(
+                        running: .enabled,
+                        testing: .enabled,
+                        archiving: .enabled,
+                        analyzing: .enabled
+                    )
+                ),
             ]),
             testAction: .init(targets: [unitTestLabel, uiTestLabel])
         )


### PR DESCRIPTION
Related to #573 

- Add `isEnabled` and `isDisabled` helpers to `XcodeScheme.BuildFor.Value`.
- Add `enableIfNotIDisabled()` to `XcodeScheme.BuildFor.Value`.
- Add logic to set `analyzing` for all targets.
- Add logic to set `archiving` for all targets with `running` enabled.