### PR TITLE
Repro issue: Unable to build external `objc_library`

### DIFF
--- a/examples/ios_app/Utils/BUILD
+++ b/examples/ios_app/Utils/BUILD
@@ -10,5 +10,5 @@ objc_library(
     module_name = "Utils",
     tags = ["manual"],
     visibility = ["//visibility:public"],
-    deps = ["//CoreUtilsObjC"],
+    deps = ["//CoreUtilsObjC", "@FXPageControl//:FXPageControl"],
 )

--- a/examples/ios_app/Utils/Foo.m
+++ b/examples/ios_app/Utils/Foo.m
@@ -1,4 +1,5 @@
 #import "Foo.h"
+#import "external/FXPageControl/FXPageControl/FXPageControl.h"
 
 @implementation Foo
 

--- a/examples/ios_app/WORKSPACE
+++ b/examples/ios_app/WORKSPACE
@@ -59,3 +59,21 @@ local_repository(
     name = "examples_ios_app_external",
     path = "external",
 )
+
+http_archive(
+    name = "FXPageControl",
+    url = "https://github.com/nicklockwood/FXPageControl/archive/refs/tags/1.5.tar.gz",
+    sha256 = "1610603d6ccfbc80b17aa2944c2587f4800c06a4e229303f431091e4e2e7a6d1",
+    build_file_content = """
+objc_library(
+    name = "FXPageControl",
+    module_name = "FXPageControl",
+    hdrs = ["FXPageControl/FXPageControl.h"],
+    srcs = ["FXPageControl/FXPageControl.m"],
+    visibility = [
+        "//visibility:public",
+    ]
+)
+""",
+    strip_prefix = "FXPageControl-1.5",
+)


### PR DESCRIPTION
I am unable to build an external `objc_library` target via the generated
xcodeproj, yet it can build on the
command line

Command line build:

```terminal
INFO: Analyzed target //Example:Example (4 packages loaded, 834 targets configured).
INFO: Found 1 target...
INFO: From MomCompile Example/Example-intermediates/Model.momd:
/Users/maxwellelliott/Development/rules_xcodeproj/examples/ios_app/bazel-output-base/sandbox/darwin-sandbox/53/execroot/__main__/Example/Model.xcdatamodeld/Model2.xcdatamodel:Entity2.parent: warning: Entity2.parent should have an inverse [2]
Target //Example:Example up-to-date:
  bazel-out/applebin_ios-ios_x86_64-fastbuild-ST-d63133e8454d/bin/Example/Example.app
  ```

  Xcode Build:

  ```terminal
  error: 'external/FXPageControl/FXPageControl/FXPageControl.h' file not found
  ```