### PR TITLE
Ensure application icons are specified correctly in Xcode project

### DIFF
--- a/doc/rules-xcodeproj.md
+++ b/doc/rules-xcodeproj.md
@@ -37,7 +37,7 @@ xcodeproj(<a href="#xcodeproj-name">name</a>, <a href="#xcodeproj-archived_bundl
 ## XcodeProjAutomaticTargetProcessingInfo
 
 <pre>
-XcodeProjAutomaticTargetProcessingInfo(<a href="#XcodeProjAutomaticTargetProcessingInfo-bazel_build_mode_error">bazel_build_mode_error</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-bundle_id">bundle_id</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-codesignopts">codesignopts</a>,
+XcodeProjAutomaticTargetProcessingInfo(<a href="#XcodeProjAutomaticTargetProcessingInfo-app_icons">app_icons</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-bazel_build_mode_error">bazel_build_mode_error</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-bundle_id">bundle_id</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-codesignopts">codesignopts</a>,
                                        <a href="#XcodeProjAutomaticTargetProcessingInfo-entitlements">entitlements</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-exported_symbols_lists">exported_symbols_lists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-infoplists">infoplists</a>,
                                        <a href="#XcodeProjAutomaticTargetProcessingInfo-launchdplists">launchdplists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-non_arc_srcs">non_arc_srcs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-pch">pch</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-provisioning_profile">provisioning_profile</a>,
                                        <a href="#XcodeProjAutomaticTargetProcessingInfo-should_generate_target">should_generate_target</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-srcs">srcs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-target_type">target_type</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-xcode_targets">xcode_targets</a>)
@@ -55,6 +55,7 @@ return a `XcodeProjInfo` provider instance instead.
 
 | Name  | Description |
 | :------------- | :------------- |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-app_icons"></a>app_icons |  An attribute name (or <code>None</code>) to collect the application icons.    |
 | <a id="XcodeProjAutomaticTargetProcessingInfo-bazel_build_mode_error"></a>bazel_build_mode_error |  If <code>build_mode = "bazel"</code>, then if this is non-<code>None</code>, it will be raised as an error during analysis.    |
 | <a id="XcodeProjAutomaticTargetProcessingInfo-bundle_id"></a>bundle_id |  An attribute name (or <code>None</code>) to collect the bundle id string from.    |
 | <a id="XcodeProjAutomaticTargetProcessingInfo-codesignopts"></a>codesignopts |  An attribute name (or <code>None</code>) to collect the <code>codesignopts</code> <code>list</code> from.    |

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1850,6 +1850,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-cdd2ed13d150/bin/Example/Example.app";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-cdd2ed13d150/bin/Example";
 				BAZEL_TARGET_ID = "//Example:Example applebin_ios-ios_x86_64-dbg-ST-cdd2ed13d150";

--- a/examples/ios_app/test/fixtures/bwb_spec.json
+++ b/examples/ios_app/test/fixtures/bwb_spec.json
@@ -278,6 +278,7 @@
         "//Example:Example applebin_ios-ios_x86_64-dbg-ST-cdd2ed13d150",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -2124,6 +2124,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5d7979fe7f9e/bin/Example";
 				BAZEL_TARGET_ID = "//Example:Example applebin_ios-ios_x86_64-dbg-ST-5d7979fe7f9e";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";

--- a/examples/ios_app/test/fixtures/bwx_spec.json
+++ b/examples/ios_app/test/fixtures/bwx_spec.json
@@ -223,6 +223,7 @@
         "//Example:Example applebin_ios-ios_x86_64-dbg-ST-5d7979fe7f9e",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,

--- a/examples/tvos_app/Example/BUILD
+++ b/examples/tvos_app/Example/BUILD
@@ -9,13 +9,20 @@ swift_library(
     visibility = ["//visibility:public"],
 )
 
+_APP_ICONS_GLOB = "Assets.xcassets/App Icon & Top Shelf Image.brandassets/**"
+
 tvos_application(
     name = "Example",
+    app_icons = glob([_APP_ICONS_GLOB]),
     bundle_id = "io.buildbuddy.example",
     bundle_name = "Example",
     entitlements = ":entitlements",
     infoplists = ["Info.plist"],
     minimum_os_version = "15.0",
+    resources = glob(
+        ["Assets.xcassets/**"],
+        exclude = [_APP_ICONS_GLOB],
+    ),
     visibility = ["//visibility:public"],
     deps = [":Example.library"],
 )

--- a/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
@@ -441,6 +441,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-e2b2f145e00a/bin/examples/macos_app/Example/Example.zip";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-e2b2f145e00a/bin/examples/macos_app/Example";
 				BAZEL_TARGET_ID = "//examples/macos_app/Example:Example applebin_macos-darwin_x86_64-dbg-ST-e2b2f145e00a";

--- a/test/fixtures/macos_app/bwb_spec.json
+++ b/test/fixtures/macos_app/bwb_spec.json
@@ -40,6 +40,7 @@
         "//examples/macos_app/Example:Example applebin_macos-darwin_x86_64-dbg-ST-e2b2f145e00a",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,

--- a/test/fixtures/macos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/macos_app/bwx.xcodeproj/project.pbxproj
@@ -407,6 +407,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-804117482b23/bin/examples/macos_app/Example";
 				BAZEL_TARGET_ID = "//examples/macos_app/Example:Example applebin_macos-darwin_x86_64-dbg-ST-804117482b23";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";

--- a/test/fixtures/macos_app/bwx_spec.json
+++ b/test/fixtures/macos_app/bwx_spec.json
@@ -38,6 +38,7 @@
         "//examples/macos_app/Example:Example applebin_macos-darwin_x86_64-dbg-ST-804117482b23",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -2699,6 +2699,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-b0487734b487/bin/examples/multiplatform/iOSApp/iOSApp.ipa";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-11143c310cbd/bin/examples/multiplatform/iOSApp/iOSApp.ipa";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-b0487734b487/bin/examples/multiplatform/iOSApp";
@@ -2977,6 +2978,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-b0487734b487/bin/examples/multiplatform/AppClip/AppClip.ipa";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-11143c310cbd/bin/examples/multiplatform/AppClip/AppClip.ipa";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-b0487734b487/bin/examples/multiplatform/AppClip";
@@ -3205,6 +3207,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-b0487734b487/bin/examples/multiplatform/iMessageApp/iMessageApp.ipa";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-ST-b0487734b487/bin/examples/multiplatform/iMessageApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-ST-b0487734b487";
@@ -3367,6 +3370,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=watchos*]" = arm64_32;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_HOST_TARGET_ID_0 = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_x86_64-dbg-ST-b0487734b487";
 				"BAZEL_HOST_TARGET_ID_0[sdk=watchos*]" = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_arm64-dbg-ST-11143c310cbd";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-ST-fce54d0d8316/bin/examples/multiplatform/watchOSApp/watchOSApp.zip";

--- a/test/fixtures/multiplatform/bwb_spec.json
+++ b/test/fixtures/multiplatform/bwb_spec.json
@@ -277,6 +277,7 @@
         "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_arm64-dbg-ST-11143c310cbd",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Automatic",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -460,6 +461,7 @@
         "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_x86_64-dbg-ST-b0487734b487",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
@@ -2054,6 +2056,7 @@
         "//examples/multiplatform/iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-ST-b0487734b487",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
@@ -2392,6 +2395,7 @@
                 "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_arm64-dbg-ST-11143c310cbd"
             ],
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Automatic",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -2653,6 +2657,7 @@
                 "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_x86_64-dbg-ST-b0487734b487"
             ],
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
@@ -3701,6 +3706,7 @@
         "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-342d62bd0d8f",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Automatic",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -3767,6 +3773,7 @@
         "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-fce54d0d8316",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,

--- a/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
@@ -2691,6 +2691,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=watchos*]" = arm64_32;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_HOST_TARGET_ID_0 = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_x86_64-dbg-ST-2ad05e4ea665";
 				"BAZEL_HOST_TARGET_ID_0[sdk=watchos*]" = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_arm64-dbg-ST-448892de289e";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-fc1b06e257b9/bin/examples/multiplatform/watchOSApp";
@@ -2746,6 +2747,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-ST-2ad05e4ea665/bin/examples/multiplatform/iMessageApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-ST-2ad05e4ea665";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
@@ -2802,6 +2804,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2ad05e4ea665/bin/examples/multiplatform/iOSApp";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-448892de289e/bin/examples/multiplatform/iOSApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_x86_64-dbg-ST-2ad05e4ea665";
@@ -2883,6 +2886,7 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2ad05e4ea665/bin/examples/multiplatform/AppClip";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-448892de289e/bin/examples/multiplatform/AppClip";
 				BAZEL_TARGET_ID = "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_x86_64-dbg-ST-2ad05e4ea665";

--- a/test/fixtures/multiplatform/bwx_spec.json
+++ b/test/fixtures/multiplatform/bwx_spec.json
@@ -251,6 +251,7 @@
         "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_arm64-dbg-ST-448892de289e",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Automatic",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -364,6 +365,7 @@
         "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_x86_64-dbg-ST-2ad05e4ea665",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
@@ -1731,6 +1733,7 @@
         "//examples/multiplatform/iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-ST-2ad05e4ea665",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
@@ -2006,6 +2009,7 @@
                 "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_arm64-dbg-ST-448892de289e"
             ],
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Automatic",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -2174,6 +2178,7 @@
                 "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_x86_64-dbg-ST-2ad05e4ea665"
             ],
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
@@ -2993,6 +2998,7 @@
         "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-5960e51a8876",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Automatic",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -3064,6 +3070,7 @@
         "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-fc1b06e257b9",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		22E09E2F209B63781257371E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		39004B79217BED4A67CB9A93 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		44C19A56FE797949930D145D /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4E2E287D3B9BA9E6E4FC9C03 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		50D13467AC1061414CAD92AA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		75AFCD0AE3F74ABC41475218 /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
 		7AA5099693507C637AF512F2 /* app.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = app.entitlements; sourceTree = "<group>"; };
@@ -190,6 +191,7 @@
 		8A4520AA26B6158FA29DFA58 /* Example */ = {
 			isa = PBXGroup;
 			children = (
+				4E2E287D3B9BA9E6E4FC9C03 /* Assets.xcassets */,
 				39004B79217BED4A67CB9A93 /* BUILD */,
 				50D13467AC1061414CAD92AA /* ContentView.swift */,
 				FA0E59FF263E41FFE42D58A1 /* ExampleApp.swift */,
@@ -753,6 +755,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-b75970214d2d/bin/examples/tvos_app/Example/Example.ipa";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b75970214d2d/bin/examples/tvos_app/Example";
 				BAZEL_TARGET_ID = "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-b75970214d2d";

--- a/test/fixtures/tvos_app/bwb_spec.json
+++ b/test/fixtures/tvos_app/bwb_spec.json
@@ -19,6 +19,7 @@
             "_": "applebin_tvos-tvos_x86_64-dbg-ST-b75970214d2d/bin/examples/tvos_app/Example/rules_xcodeproj/Example/Info.plist",
             "t": "g"
         },
+        "examples/tvos_app/Example/Assets.xcassets",
         "examples/tvos_app/ExampleTests/BUILD",
         {
             "_": "build_bazel_rules_apple/apple/testing/DefaultTestBundle.plist",
@@ -58,6 +59,7 @@
         "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-b75970214d2d",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "App Icon & Top Shelf Image",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,

--- a/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		5098BCCB1868B198F4419656 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B15598E2A225AF0402DDCF /* ExampleApp.swift */; };
 		76271681871DA5585583391E /* ExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A6CF9C9CD7BEED9F65CA3 /* ExampleUITestsLaunchTests.swift */; };
 		931C2ECF6AA4E6846D19871F /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB9EDA6F321B496D89ECD94 /* ExampleUITests.swift */; };
+		94614B984C53B88AC9ACC190 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35BDF811504C7A1D635A8ED1 /* Assets.xcassets */; };
 		CE43F065AC3E7BA68AE0E2F5 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDCF5497AF5CB6FD82EB9AB /* ExampleTests.swift */; };
 		EB6A255551CEB04337D41DCB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BDA7F5F96E7A0A135F45B2 /* ContentView.swift */; };
 /* End PBXBuildFile section */
@@ -74,6 +75,7 @@
 		122A98FA505350325F6740CA /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		1452248E39E2C6D3CB3559F0 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		1D174B1D4C25E9FD21719679 /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		35BDF811504C7A1D635A8ED1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		61BDA7F5F96E7A0A135F45B2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		63FED2BCB0D71387EAD8B52A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		6D716145772914014B1460C6 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 		1064E5B9DD0CD4D72A92A1E4 /* Example */ = {
 			isa = PBXGroup;
 			children = (
+				35BDF811504C7A1D635A8ED1 /* Assets.xcassets */,
 				1452248E39E2C6D3CB3559F0 /* BUILD */,
 				61BDA7F5F96E7A0A135F45B2 /* ContentView.swift */,
 				99B15598E2A225AF0402DDCF /* ExampleApp.swift */,
@@ -366,6 +369,7 @@
 			buildPhases = (
 				B53A70A8850ED09CF7C2348A /* Create link.params */,
 				158225A69996B833609C215D /* Sources */,
+				EC82FDE86D73A4710E6DBDE5 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -444,6 +448,17 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		EC82FDE86D73A4710E6DBDE5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				94614B984C53B88AC9ACC190 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
@@ -691,6 +706,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-93b70069dc11/bin/examples/tvos_app/Example";
 				BAZEL_TARGET_ID = "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-93b70069dc11";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";

--- a/test/fixtures/tvos_app/bwx_spec.json
+++ b/test/fixtures/tvos_app/bwx_spec.json
@@ -58,6 +58,7 @@
         "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-93b70069dc11",
         {
             "build_settings": {
+                "ASSETCATALOG_COMPILER_APPICON_NAME": "App Icon & Top Shelf Image",
                 "CODE_SIGN_STYLE": "Manual",
                 "DEBUG_INFORMATION_FORMAT": "dwarf",
                 "ENABLE_BITCODE": false,
@@ -79,7 +80,10 @@
                 "entitlements": {
                     "_": "applebin_tvos-tvos_x86_64-dbg-ST-93b70069dc11/bin/examples/tvos_app/Example/app.entitlements",
                     "t": "g"
-                }
+                },
+                "resources": [
+                    "examples/tvos_app/Example/Assets.xcassets"
+                ]
             },
             "is_swift": false,
             "label": "//examples/tvos_app/Example:Example",

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -13,8 +13,8 @@ load(":providers.bzl", "XcodeProjAutomaticTargetProcessingInfo", "target_type")
 _UNSUPPORTED_SRCS_EXTENSIONS = {
     "a": True,
     "lo": True,
-    "so": True,
     "o": True,
+    "so": True,
 }
 
 def _get_target_type(*, target):
@@ -59,6 +59,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
     else:
         srcs = []
 
+    app_icons = None
     bundle_id = None
     codesignopts = None
     entitlements = None
@@ -104,6 +105,8 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
             xcode_targets["test_host"] = [target_type.compile]
         if "app_clips" in attrs:
             xcode_targets["app_clips"] = [target_type.compile]
+        if "app_icons" in attrs:
+            app_icons = "app_icons"
         if "codesignopts" in attrs:
             codesignopts = "codesignopts"
         if "entitlements" in attrs:
@@ -174,6 +177,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
             launchdplists = launchdplists,
             entitlements = entitlements,
             bazel_build_mode_error = bazel_build_mode_error,
+            app_icons = app_icons,
         ),
     ]
 

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -98,6 +98,9 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
         infoplists = ["infoplists"]
         should_generate_target = False
     elif AppleBundleInfo in target:
+        # DEBUG BEGIN
+        print("*** CHUCK AppleBundleInfo target.label: ", target.label)
+        # DEBUG END
         xcode_targets = {
             "deps": [target_type.compile, None],
         }
@@ -106,6 +109,9 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
         if "app_clips" in attrs:
             xcode_targets["app_clips"] = [target_type.compile]
         if "app_icons" in attrs:
+            # DEBUG BEGIN
+            print("*** CHUCK Has app_icons")
+            # DEBUG END
             app_icons = "app_icons"
         if "codesignopts" in attrs:
             codesignopts = "codesignopts"

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -98,9 +98,6 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
         infoplists = ["infoplists"]
         should_generate_target = False
     elif AppleBundleInfo in target:
-        # DEBUG BEGIN
-        print("*** CHUCK AppleBundleInfo target.label: ", target.label)
-        # DEBUG END
         xcode_targets = {
             "deps": [target_type.compile, None],
         }
@@ -109,9 +106,6 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
         if "app_clips" in attrs:
             xcode_targets["app_clips"] = [target_type.compile]
         if "app_icons" in attrs:
-            # DEBUG BEGIN
-            print("*** CHUCK Has app_icons")
-            # DEBUG END
             app_icons = "app_icons"
         if "codesignopts" in attrs:
             codesignopts = "codesignopts"

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -163,21 +163,21 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
 
     return [
         XcodeProjAutomaticTargetProcessingInfo(
-            codesignopts = codesignopts,
-            exported_symbols_lists = exported_symbols_lists,
-            should_generate_target = should_generate_target,
-            target_type = this_target_type,
-            xcode_targets = xcode_targets,
-            non_arc_srcs = non_arc_srcs,
-            srcs = srcs,
-            pch = pch,
+            app_icons = app_icons,
+            bazel_build_mode_error = bazel_build_mode_error,
             bundle_id = bundle_id,
-            provisioning_profile = provisioning_profile,
+            codesignopts = codesignopts,
+            entitlements = entitlements,
+            exported_symbols_lists = exported_symbols_lists,
             infoplists = infoplists,
             launchdplists = launchdplists,
-            entitlements = entitlements,
-            bazel_build_mode_error = bazel_build_mode_error,
-            app_icons = app_icons,
+            non_arc_srcs = non_arc_srcs,
+            pch = pch,
+            provisioning_profile = provisioning_profile,
+            should_generate_target = should_generate_target,
+            srcs = srcs,
+            target_type = this_target_type,
+            xcode_targets = xcode_targets,
         ),
     ]
 

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -17,6 +17,9 @@ If you need more control over how a target or it's dependencies are processed,
 return a `XcodeProjInfo` provider instance instead.
 """,
     fields = {
+        "app_icons": """\
+An attribute name (or `None`) to collect the application icons.
+""",
         "bazel_build_mode_error": """\
 If `build_mode = "bazel"`, then if this is non-`None`, it will be raised as an
 error during analysis.
@@ -104,14 +107,14 @@ generated `Files` and all of the `Files` that should be added to the Xcode
 project, but are not associated with any targets.
 """,
         "lldb_context": "A value returned from `lldb_context.collect`.",
+        "outputs": """\
+A value returned from `output_files.collect`, that contains information about
+the output files for this target and its transitive dependencies.
+""",
         "potential_target_merges": """\
 A `depset` of `struct`s with 'src' and 'dest' fields. The 'src' field is the id
 of the target that can be merged into the target with the id of the 'dest'
 field.
-""",
-        "outputs": """\
-A value returned from `output_files.collect`, that contains information about
-the output files for this target and its transitive dependencies.
 """,
         "resource_bundle_informations": """\
 A `depset` of `struct`s with information used to generate resource bundles,
@@ -154,12 +157,12 @@ XcodeProjOutputInfo = provider(
 XcodeProjProvisioningProfileInfo = provider(
     "Provides information about a provisioning profile.",
     fields = {
+        "is_xcode_managed": "Whether the profile is managed by Xcode.",
         "profile_name": """\
 The profile name (e.g. "iOS Team Provisioning Profile: com.example.app").
 """,
         "team_id": """\
 The Team ID the profile is associated with (e.g. "V82V4GQZXM").
 """,
-        "is_xcode_managed": "Whether the profile is managed by Xcode.",
     },
 )

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -107,14 +107,14 @@ generated `Files` and all of the `Files` that should be added to the Xcode
 project, but are not associated with any targets.
 """,
         "lldb_context": "A value returned from `lldb_context.collect`.",
-        "outputs": """\
-A value returned from `output_files.collect`, that contains information about
-the output files for this target and its transitive dependencies.
-""",
         "potential_target_merges": """\
 A `depset` of `struct`s with 'src' and 'dest' fields. The 'src' field is the id
 of the target that can be merged into the target with the id of the 'dest'
 field.
+""",
+        "outputs": """\
+A value returned from `output_files.collect`, that contains information about
+the output files for this target and its transitive dependencies.
 """,
         "resource_bundle_informations": """\
 A `depset` of `struct`s with information used to generate resource bundles,
@@ -157,12 +157,12 @@ XcodeProjOutputInfo = provider(
 XcodeProjProvisioningProfileInfo = provider(
     "Provides information about a provisioning profile.",
     fields = {
-        "is_xcode_managed": "Whether the profile is managed by Xcode.",
         "profile_name": """\
 The profile name (e.g. "iOS Team Provisioning Profile: com.example.app").
 """,
         "team_id": """\
 The Team ID the profile is associated with (e.g. "V82V4GQZXM").
 """,
+        "is_xcode_managed": "Whether the profile is managed by Xcode.",
     },
 )

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -493,11 +493,11 @@ def _get_app_icon_name(ctx, automatic_target_info):
     Returns:
         The application icon name, if found. Otherwise, None.
     """
-    if automatic_target_info.app_icons == None:
+    if not automatic_target_info.app_icons:
         return None
 
     app_icons = getattr(ctx.rule.attr, automatic_target_info.app_icons, None)
-    if app_icons == None:
+    if not app_icons:
         return None
 
     for target in app_icons:

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -436,9 +436,11 @@ def process_top_level_target(
         transitive_infos = deps_infos,
     )
 
-    app_icon_name = _get_app_icon_name(ctx, automatic_target_info)
-    if app_icon_name != None:
-        build_settings["ASSETCATALOG_COMPILER_APPICON_NAME"] = app_icon_name
+    set_if_true(
+        build_settings,
+        "ASSETCATALOG_COMPILER_APPICON_NAME",
+         _get_app_icon_name(ctx, automatic_target_info),
+    )
 
     return processed_target(
         automatic_target_info = automatic_target_info,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -438,12 +438,6 @@ def process_top_level_target(
 
     app_icon_name = _get_app_icon_name(ctx, automatic_target_info)
 
-    # DEBUG BEGIN
-    print("*** CHUCK =====================")
-    print("*** CHUCK target.label: ", target.label)
-    print("*** CHUCK app_icon_name: ", app_icon_name)
-
-    # DEBUG END
     if app_icon_name != None:
         build_settings["ASSETCATALOG_COMPILER_APPICON_NAME"] = app_icon_name
 
@@ -488,6 +482,16 @@ def process_top_level_target(
     )
 
 def _get_app_icon_name(ctx, automatic_target_info):
+    """Attempts to find the applicaiton icon name.
+
+    Args:
+        ctx: The aspect context.
+        automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
+            `target`.
+
+    Returns:
+        The application icon name, if found. Otherwise, None.
+    """
     if automatic_target_info.app_icons == None:
         return None
 

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -2,14 +2,6 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
-
-# DEBUG BEGIN
-load(
-    "@build_bazel_rules_apple//apple:providers.bzl",
-    "AppleResourceInfo",
-)
-# DEBUG END
-
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
     ":build_settings.bzl",
@@ -237,12 +229,12 @@ def process_top_level_target(
     is_swift = SwiftInfo in target
     swift_info = target[SwiftInfo] if is_swift else None
 
-    # DEBUG BEGIN
-    if AppleResourceInfo in target:
-        apple_resource_info = target[AppleResourceInfo]
-        build_settings["ASSETCATALOG_COMPILER_APPICON_NAME"] = "AppIcon"
+    # # DEBUG BEGIN
+    # if AppleResourceInfo in target:
+    #     apple_resource_info = target[AppleResourceInfo]
+    #     build_settings["ASSETCATALOG_COMPILER_APPICON_NAME"] = "AppIcon"
 
-    # DEBUG END
+    # # DEBUG END
 
     modulemaps = process_modulemaps(swift_info = swift_info)
     additional_files.extend(list(modulemaps.files))

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -1,7 +1,7 @@
 """ Functions for processing top level targets """
 
-load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
     ":build_settings.bzl",
@@ -19,10 +19,11 @@ load(":lldb_contexts.bzl", "lldb_contexts")
 load(":opts.bzl", "process_opts")
 load(":output_files.bzl", "output_files")
 load(":platform.bzl", "platform_info")
+load(":providers.bzl", "XcodeProjInfo")
 load(":processed_target.bzl", "processed_target")
 load(":product.bzl", "process_product")
-load(":providers.bzl", "XcodeProjInfo")
 load(":provisioning_profiles.bzl", "provisioning_profiles")
+load(":target_search_paths.bzl", "target_search_paths")
 load(":target_id.bzl", "get_id")
 load(
     ":target_properties.bzl",
@@ -35,7 +36,6 @@ load(
     "should_include_outputs",
     "should_include_outputs_output_groups",
 )
-load(":target_search_paths.bzl", "target_search_paths")
 load(":xcode_targets.bzl", "xcode_targets")
 
 def get_tree_artifact_enabled(*, ctx, bundle_info):
@@ -437,7 +437,6 @@ def process_top_level_target(
     )
 
     app_icon_name = _get_app_icon_name(ctx, automatic_target_info)
-
     if app_icon_name != None:
         build_settings["ASSETCATALOG_COMPILER_APPICON_NAME"] = app_icon_name
 

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -494,11 +494,7 @@ def _get_app_icon_name(ctx, automatic_target_info):
     if automatic_target_info.app_icons == None:
         return None
 
-    app_icons = getattr(
-        ctx.rule.attr,
-        automatic_target_info.app_icons,
-        None,
-    )
+    app_icons = getattr(ctx.rule.attr, automatic_target_info.app_icons, None)
     if app_icons == None:
         return None
 

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -1,7 +1,15 @@
 """ Functions for processing top level targets """
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
+# DEBUG BEGIN
+load(
+    "@build_bazel_rules_apple//apple:providers.bzl",
+    "AppleResourceInfo",
+)
+# DEBUG END
+
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
     ":build_settings.bzl",
@@ -19,11 +27,10 @@ load(":lldb_contexts.bzl", "lldb_contexts")
 load(":opts.bzl", "process_opts")
 load(":output_files.bzl", "output_files")
 load(":platform.bzl", "platform_info")
-load(":providers.bzl", "XcodeProjInfo")
 load(":processed_target.bzl", "processed_target")
 load(":product.bzl", "process_product")
+load(":providers.bzl", "XcodeProjInfo")
 load(":provisioning_profiles.bzl", "provisioning_profiles")
-load(":target_search_paths.bzl", "target_search_paths")
 load(":target_id.bzl", "get_id")
 load(
     ":target_properties.bzl",
@@ -36,6 +43,7 @@ load(
     "should_include_outputs",
     "should_include_outputs_output_groups",
 )
+load(":target_search_paths.bzl", "target_search_paths")
 load(":xcode_targets.bzl", "xcode_targets")
 
 def get_tree_artifact_enabled(*, ctx, bundle_info):
@@ -172,6 +180,13 @@ def process_top_level_target(
         transitive_infos = transitive_infos,
     )
 
+    # DEBUG BEGIN
+    print("*** CHUCK =====================")
+    print("*** CHUCK target.label: ", target.label)
+    print("*** CHUCK bundle_info: ", bundle_info)
+
+    # DEBUG END
+
     test_host_target = getattr(ctx.rule.attr, "test_host", None)
     test_host_target_info = (
         test_host_target[XcodeProjInfo] if test_host_target else None
@@ -221,6 +236,13 @@ def process_top_level_target(
     is_bundle = bundle_info != None
     is_swift = SwiftInfo in target
     swift_info = target[SwiftInfo] if is_swift else None
+
+    # DEBUG BEGIN
+    if AppleResourceInfo in target:
+        apple_resource_info = target[AppleResourceInfo]
+        build_settings["ASSETCATALOG_COMPILER_APPICON_NAME"] = "AppIcon"
+
+    # DEBUG END
 
     modulemaps = process_modulemaps(swift_info = swift_info)
     additional_files.extend(list(modulemaps.files))

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -1,7 +1,7 @@
 """ Functions for processing top level targets """
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@build_bazel_rules_swift//swift:swift.bzl", "SwiftInfo")
 load(
     ":build_settings.bzl",
@@ -19,11 +19,10 @@ load(":lldb_contexts.bzl", "lldb_contexts")
 load(":opts.bzl", "process_opts")
 load(":output_files.bzl", "output_files")
 load(":platform.bzl", "platform_info")
-load(":providers.bzl", "XcodeProjInfo")
 load(":processed_target.bzl", "processed_target")
 load(":product.bzl", "process_product")
+load(":providers.bzl", "XcodeProjInfo")
 load(":provisioning_profiles.bzl", "provisioning_profiles")
-load(":target_search_paths.bzl", "target_search_paths")
 load(":target_id.bzl", "get_id")
 load(
     ":target_properties.bzl",
@@ -36,6 +35,7 @@ load(
     "should_include_outputs",
     "should_include_outputs_output_groups",
 )
+load(":target_search_paths.bzl", "target_search_paths")
 load(":xcode_targets.bzl", "xcode_targets")
 
 def get_tree_artifact_enabled(*, ctx, bundle_info):
@@ -436,14 +436,10 @@ def process_top_level_target(
         transitive_infos = deps_infos,
     )
 
-    # DEBUG BEGIN
-    print("*** CHUCK top_level_targets ctx.label: ", ctx.label)
-    print("*** CHUCK top_level_targets automatic_target_info.app_icons: ", automatic_target_info.app_icons)
-    # DEBUG END
     set_if_true(
         build_settings,
         "ASSETCATALOG_COMPILER_APPICON_NAME",
-         _get_app_icon_name(ctx, automatic_target_info),
+        _get_app_icon_name(ctx, automatic_target_info),
     )
 
     return processed_target(
@@ -496,7 +492,7 @@ def _get_resource_set_name(path, suffix):
     else:
         name_start_idx = prev_delimiter_idx + 1
     return path[name_start_idx:suffix_idx]
-    
+
 _RESOURCE_SET_SUFFIXES = [".appiconset", ".brandassets"]
 
 def _get_app_icon_name(ctx, automatic_target_info):
@@ -514,11 +510,6 @@ def _get_app_icon_name(ctx, automatic_target_info):
         return None
 
     app_icons = getattr(ctx.rule.attr, automatic_target_info.app_icons, None)
-    # DEBUG BEGIN
-    print("*** CHUCK ==================")
-    print("*** CHUCK _get_app_icon_name ctx.label: ", ctx.label)
-    print("*** CHUCK _get_app_icon_name app_icons: ", app_icons)
-    # DEBUG END
     if not app_icons:
         return None
 
@@ -530,10 +521,6 @@ def _get_app_icon_name(ctx, automatic_target_info):
     for file in resource_files:
         for suffix in _RESOURCE_SET_SUFFIXES:
             resource_name = _get_resource_set_name(file.short_path, suffix)
-            # DEBUG BEGIN
-            print("*** CHUCK file.short_path: ", file.short_path)
-            print("*** CHUCK resource_name: ", resource_name)
-            # DEBUG END
             if resource_name:
                 return resource_name
 


### PR DESCRIPTION
Related to #949.

Goal: Xcode finds the application icon and uses it for Xcode schemes.