### PR TITLE
Pass through custom arguments and environment variables to launch action

### DIFF
--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -128,6 +128,11 @@
       </BuildableProductRunnable>
       <EnvironmentVariables>
          <EnvironmentVariable
+            key = "CUSTOM_ENV_VAR"
+            value = "hello"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
             value = "$(SRCROOT)"
             isEnabled = "YES">

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -30,7 +30,9 @@
             "launch_action": {
                 "args": [],
                 "build_configuration_name": "Debug",
-                "env": {},
+                "env": {
+                    "CUSTOM_ENV_VAR": "hello"
+                },
                 "target": "//tools/generator:generator",
                 "working_directory": null
             },

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -126,6 +126,13 @@
             ReferencedContainer = "container:test/fixtures/generator/bwx.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "CUSTOM_ENV_VAR"
+            value = "hello"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Debug"

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -30,7 +30,9 @@
             "launch_action": {
                 "args": [],
                 "build_configuration_name": "Debug",
-                "env": {},
+                "env": {
+                    "CUSTOM_ENV_VAR": "hello"
+                },
                 "target": "//tools/generator:generator",
                 "working_directory": null
             },

--- a/test/internal/xcode_schemes/model_tests.bzl
+++ b/test/internal/xcode_schemes/model_tests.bzl
@@ -167,20 +167,18 @@ def _launch_action_test(ctx):
     target = "//Sources/App"
     args = ["my arg"]
     env = {"RELEASE_KRAKEN": "true"}
-    working_directory = "/path/to/working/directory"
 
     actual = xcode_schemes.launch_action(
         target = target,
         args = args,
         env = env,
-        working_directory = working_directory,
     )
     expected = struct(
         build_configuration_name = xcode_schemes.DEFAULT_BUILD_CONFIGURATION_NAME,
         target = bazel_labels.normalize(target),
         args = args,
         env = env,
-        working_directory = working_directory,
+        working_directory = None,
     )
     asserts.equals(test_env, expected, actual)
 

--- a/tools/generator/src/Extensions/XCScheme+Extensions.swift
+++ b/tools/generator/src/Extensions/XCScheme+Extensions.swift
@@ -170,6 +170,7 @@ extension XCScheme.LaunchAction {
             envVars.append(contentsOf: productTypeEnvVars)
         }
 
+        // GH933: Add support for custom working directory once it is available in tuist/XcodeProj.
         self.init(
             runnable: launchActionInfo.runnable,
             buildConfiguration: launchActionInfo.buildConfigurationName,

--- a/tools/generator/test/XCScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XCScheme+ExtensionsTests.swift
@@ -107,8 +107,6 @@ extension XCSchemeExtensionsTests {
     func test_LaunchAction_init_customEnvArgsWorkingDir() throws {
         let args = ["--hello"]
         let env = ["CUSTOM_ENV_VAR": "goodbye"]
-        // TODO(chuck): Figure out how to pass the workingDirectory
-        // let workingDirectory = "path/to/direcotry"
         let launchActionInfo = try XCSchemeInfo.LaunchActionInfo(
             resolveHostsFor: .init(
                 buildConfigurationName: "Foo",

--- a/tools/generator/test/XCScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XCScheme+ExtensionsTests.swift
@@ -3,6 +3,10 @@ import XCTest
 
 @testable import generator
 
+// DEBUG BEGIN
+import Darwin
+// DEBUG END
+
 // MARK: - XCScheme.BuildableReference Initializer Tests
 
 extension XCSchemeExtensionsTests {
@@ -66,6 +70,52 @@ extension XCSchemeExtensionsTests {
             ]
         )
         XCTAssertEqual(entry, expected)
+    }
+}
+
+// MARK: XCScheme.LaunchAction Initializer Tests
+
+extension XCSchemeExtensionsTests {
+    func test_LaunchAction_init_noCustomEnvArgsWorkingDir() throws {
+        let launchActionInfo = try XCSchemeInfo.LaunchActionInfo(
+            resolveHostsFor: .init(
+                buildConfigurationName: "Foo",
+                targetInfo: appTargetInfo
+            ),
+            topLevelTargetInfos: []
+        )
+        guard let launchActionInfo = launchActionInfo else {
+            XCTFail("Expected a `LaunchActionInfo`")
+            return
+        }
+
+        let productType = launchActionInfo.targetInfo.productType
+        let launchAction = try XCScheme.LaunchAction(
+            buildMode: .bazel,
+            launchActionInfo: launchActionInfo
+        )
+        let expected = XCScheme.LaunchAction(
+            runnable: launchActionInfo.runnable,
+            buildConfiguration: launchActionInfo.buildConfigurationName,
+            macroExpansion: try launchActionInfo.macroExpansion,
+            selectedDebuggerIdentifier: launchActionInfo.debugger,
+            selectedLauncherIdentifier: launchActionInfo.launcher,
+            askForAppToLaunch: nil,
+            environmentVariables: productType.bazelLaunchEnvironmentVariables,
+            launchAutomaticallySubstyle: productType.launchAutomaticallySubstyle,
+            customLLDBInitFile: XCSchemeConstants.customLLDBInitFile
+        )
+        // DEBUG BEGIN
+        fputs("*** CHUCK launchAction.askForAppToLaunch: \(String(reflecting: launchAction.askForAppToLaunch))\n", stderr)
+        fputs("*** CHUCK expected.askForAppToLaunch: \(String(reflecting: expected.askForAppToLaunch))\n", stderr)
+        fputs("*** CHUCK launchAction.environmentVariables: \(String(reflecting: launchAction.environmentVariables))\n", stderr)
+        fputs("*** CHUCK expected.environmentVariables: \(String(reflecting: expected.environmentVariables))\n", stderr)
+        // DEBUG END
+        XCTAssertEqual(launchAction, expected)
+    }
+
+    func test_LaunchAction_init_customEnvArgsWorkingDir() throws {
+        XCTFail("IMPLEMENT ME!")
     }
 }
 

--- a/tools/generator/test/XCScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XCScheme+ExtensionsTests.swift
@@ -101,21 +101,58 @@ extension XCSchemeExtensionsTests {
             selectedDebuggerIdentifier: launchActionInfo.debugger,
             selectedLauncherIdentifier: launchActionInfo.launcher,
             askForAppToLaunch: nil,
-            environmentVariables: productType.bazelLaunchEnvironmentVariables,
+            environmentVariables: .bazelLaunchVariables,
             launchAutomaticallySubstyle: productType.launchAutomaticallySubstyle,
             customLLDBInitFile: XCSchemeConstants.customLLDBInitFile
         )
-        // DEBUG BEGIN
-        fputs("*** CHUCK launchAction.askForAppToLaunch: \(String(reflecting: launchAction.askForAppToLaunch))\n", stderr)
-        fputs("*** CHUCK expected.askForAppToLaunch: \(String(reflecting: expected.askForAppToLaunch))\n", stderr)
-        fputs("*** CHUCK launchAction.environmentVariables: \(String(reflecting: launchAction.environmentVariables))\n", stderr)
-        fputs("*** CHUCK expected.environmentVariables: \(String(reflecting: expected.environmentVariables))\n", stderr)
-        // DEBUG END
         XCTAssertEqual(launchAction, expected)
     }
 
     func test_LaunchAction_init_customEnvArgsWorkingDir() throws {
-        XCTFail("IMPLEMENT ME!")
+        let args = ["--hello"]
+        let env = ["CUSTOM_ENV_VAR": "goodbye"]
+        // TODO(chuck): Figure out how to pass the workingDirectory
+        // let workingDirectory = "path/to/direcotry"
+        let launchActionInfo = try XCSchemeInfo.LaunchActionInfo(
+            resolveHostsFor: .init(
+                buildConfigurationName: "Foo",
+                targetInfo: appTargetInfo,
+                args: args,
+                env: env
+            ),
+            topLevelTargetInfos: []
+        )
+        guard let launchActionInfo = launchActionInfo else {
+            XCTFail("Expected a `LaunchActionInfo`")
+            return
+        }
+
+        let productType = launchActionInfo.targetInfo.productType
+        let launchAction = try XCScheme.LaunchAction(
+            buildMode: .bazel,
+            launchActionInfo: launchActionInfo
+        )
+        let expected = XCScheme.LaunchAction(
+            runnable: launchActionInfo.runnable,
+            buildConfiguration: launchActionInfo.buildConfigurationName,
+            macroExpansion: try launchActionInfo.macroExpansion,
+            selectedDebuggerIdentifier: launchActionInfo.debugger,
+            selectedLauncherIdentifier: launchActionInfo.launcher,
+            askForAppToLaunch: nil,
+            commandlineArguments: .init(arguments: [.init(name: args[0], enabled: true)]),
+            environmentVariables: [
+                .init(variable: "CUSTOM_ENV_VAR", value: env["CUSTOM_ENV_VAR"]!, enabled: true),
+            ] + .bazelLaunchVariables,
+            launchAutomaticallySubstyle: productType.launchAutomaticallySubstyle,
+            customLLDBInitFile: XCSchemeConstants.customLLDBInitFile
+        )
+        // DEBUG BEGIN
+        fputs("*** CHUCK launchAction.environmentVariables: \(String(reflecting: launchAction.environmentVariables))\n", stderr)
+        fputs("*** CHUCK expected.environmentVariables: \(String(reflecting: expected.environmentVariables))\n", stderr)
+        fputs("*** CHUCK launchAction.commandlineArguments: \(String(reflecting: launchAction.commandlineArguments))\n", stderr)
+        fputs("*** CHUCK expected.commandlineArguments: \(String(reflecting: expected.commandlineArguments))\n", stderr)
+        // DEBUG END
+        XCTAssertEqual(launchAction, expected)
     }
 }
 

--- a/tools/generator/test/XCScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XCScheme+ExtensionsTests.swift
@@ -3,10 +3,6 @@ import XCTest
 
 @testable import generator
 
-// DEBUG BEGIN
-import Darwin
-// DEBUG END
-
 // MARK: - XCScheme.BuildableReference Initializer Tests
 
 extension XCSchemeExtensionsTests {
@@ -146,12 +142,6 @@ extension XCSchemeExtensionsTests {
             launchAutomaticallySubstyle: productType.launchAutomaticallySubstyle,
             customLLDBInitFile: XCSchemeConstants.customLLDBInitFile
         )
-        // DEBUG BEGIN
-        fputs("*** CHUCK launchAction.environmentVariables: \(String(reflecting: launchAction.environmentVariables))\n", stderr)
-        fputs("*** CHUCK expected.environmentVariables: \(String(reflecting: expected.environmentVariables))\n", stderr)
-        fputs("*** CHUCK launchAction.commandlineArguments: \(String(reflecting: launchAction.commandlineArguments))\n", stderr)
-        fputs("*** CHUCK expected.commandlineArguments: \(String(reflecting: expected.commandlineArguments))\n", stderr)
-        // DEBUG END
         XCTAssertEqual(launchAction, expected)
     }
 }

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -43,7 +43,12 @@ def get_xcode_schemes():
                     xcode_schemes.build_for(archiving = True),
                 ),
             ]),
-            launch_action = xcode_schemes.launch_action(_APP_TARGET),
+            launch_action = xcode_schemes.launch_action(
+                _APP_TARGET,
+                # This is not necessary for the generator. It is here to help
+                # verify that custom environment variables are passed along.
+                env = {"CUSTOM_ENV_VAR": "hello"},
+            ),
             test_action = xcode_schemes.test_action([_TEST_TARGET]),
         ),
     ]

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -192,8 +192,7 @@ def make_xcode_schemes(bazel_labels):
     def _launch_action(
             target,
             args = None,
-            env = None,
-            working_directory = None):
+            env = None):
         """Constructs a launch action for an Xcode scheme.
 
         Args:
@@ -202,8 +201,6 @@ def make_xcode_schemes(bazel_labels):
                 the target when executed.
             env: Optional. A `dict` of `string` values that will be set as
                 environment variables when the target is executed.
-            working_directory: Optional. A `string` that will be set as the custom
-                working directory in the Xcode scheme's launch action.
 
         Return:
             A `struct` representing a launch action.
@@ -213,7 +210,6 @@ def make_xcode_schemes(bazel_labels):
             target = bazel_labels.normalize(target),
             args = args,
             env = env,
-            working_directory = working_directory,
         )
 
     return struct(


### PR DESCRIPTION
Related to #573.

I failed to pass the custom values to the `XCScheme.LaunchAction`. This PR rectifies the issue.

- Pass custom command line arguments and environment variables.
- Added a custom environment variable to `tools/generator` custom scheme.
- Remove `working_directory` from `xcode_schemes.launch_action()`. It turns out that `XCScheme.LaunchAction` does not expose a `customWorkingDirectory` attribute. (#933).