### PR TITLE
Fix docstring formatting

### DIFF
--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -143,7 +143,7 @@ def process_codesignopts(*, codesignopts, build_settings):
         codesignopts: A `list` of code sign options
         build_settings: A mutable `dict` that will be updated with code signing
             flag build settings that are processed.
-    Return:
+    Returns:
         The modified build settings object
     """
     if codesignopts and build_settings != None:
@@ -158,7 +158,7 @@ def process_defines(*, compilation_providers, build_settings):
         build_settings: A mutable `dict` that will be updated with the
             `GCC_PREPROCESSOR_DEFINITIONS` build setting.
 
-    Return:
+    Returns:
         The modified build settings object
     """
     cc_info = compilation_providers._cc_info

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -178,7 +178,7 @@ def make_xcode_schemes(bazel_labels):
         Args:
             targets: A `sequence` of target labels as `string` values.
 
-        Return:
+        Returns:
             A `struct` representing a test action.
         """
         return xcode_schemes_internal.test_action(
@@ -202,7 +202,7 @@ def make_xcode_schemes(bazel_labels):
             env: Optional. A `dict` of `string` values that will be set as
                 environment variables when the target is executed.
 
-        Return:
+        Returns:
             A `struct` representing a launch action.
         """
         return xcode_schemes_internal.launch_action(

--- a/xcodeproj/internal/xcode_schemes_internal.bzl
+++ b/xcodeproj/internal/xcode_schemes_internal.bzl
@@ -33,7 +33,7 @@ def _build_action(targets):
         targets: A `sequence` of `struct` values as created by
             `xcode_schemes.build_target`.
 
-    Return:
+    Returns:
         A `struct` representing a build action.
     """
     return struct(
@@ -116,7 +116,7 @@ def _test_action(targets, build_configuration_name):
         build_configuration_name: The name of the build configuration as a
             `string` value.
 
-    Return:
+    Returns:
         A `struct` representing a test action.
     """
     return struct(
@@ -143,7 +143,7 @@ def _launch_action(
         working_directory: Optional. A `string` that will be set as the custom
             working directory in the Xcode scheme's launch action.
 
-    Return:
+    Returns:
         A `struct` representing a launch action.
     """
     return struct(


### PR DESCRIPTION
In preparation for generating the docs with `stardoc`, this PR fixes a few violations that were causing failures in parsing the docs.