### PR TITLE
Add stardoc to generate rules docs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -197,3 +197,18 @@ buildifier_prebuilt_deps()
 load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
 
 buildifier_prebuilt_register_toolchains()
+
+# Stardoc
+
+http_archive(
+    name = "io_bazel_stardoc",
+    sha256 = "05fb57bb4ad68a360470420a3b6f5317e4f722839abc5b17ec4ef8ed465aaa47",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/stardoc/releases/download/0.5.2/stardoc-0.5.2.tar.gz",
+        "https://github.com/bazelbuild/stardoc/releases/download/0.5.2/stardoc-0.5.2.tar.gz",
+    ],
+)
+
+load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
+
+stardoc_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,12 +3,12 @@ workspace(name = "com_github_buildbuddy_io_rules_xcodeproj")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # TODO: Remove override and bump `xcodeproj_rules_dependencies` once
-# rules_apple 1.1.0 is released. Needed for `apple_intent_library`.
+# rules_apple 1.1.0 is released. Needed for `apple_intent_library` and stardoc fixes.
 http_archive(
     name = "build_bazel_rules_apple",
-    sha256 = "5620fcaf237444ba088b2c1669c81ff14a7746357487d7a58ea7d90deb21a82d",
-    strip_prefix = "rules_apple-22c292e70cf7169038de9ef25d4b1b25f411c89f",
-    url = "https://github.com/bazelbuild/rules_apple/archive/22c292e70cf7169038de9ef25d4b1b25f411c89f.tar.gz",
+    sha256 = "3167a6e91e57c9ae03c742159dfb1c8f77ada1456413e55642cbd15a4c6a7d9c",
+    strip_prefix = "rules_apple-5bf66848b0bbf902a042595d6adfbabbd7e30357",
+    url = "https://github.com/bazelbuild/rules_apple/archive/5bf66848b0bbf902a042595d6adfbabbd7e30357.tar.gz",
 )
 
 load("//xcodeproj:repositories.bzl", "xcodeproj_rules_dependencies")

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -50,3 +50,14 @@ actions:
           - "*"
     bazel_commands:
       - "run --config=workflows //:buildifier.check"
+
+  - name: Docs Diff Test
+    triggers:
+      push:
+        branches:
+          - "main"
+      pull_request:
+        branches:
+          - "*"
+    bazel_commands:
+      - "test --config=workflows //doc:diff_test"

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -51,7 +51,7 @@ actions:
     bazel_commands:
       - "run --config=workflows //:buildifier.check"
 
-  - name: Docs Diff Test
+  - name: Docs
     triggers:
       push:
         branches:

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -31,6 +31,11 @@ _failure_message = "\nPlease update the docs by running\n    bazel run //doc:upd
     for file in _DOC_SRCS
 ]
 
+test_suite(
+    name = "diff_test",
+    tests = ["check_" + file for file in _DOC_SRCS],
+)
+
 write_file(
     name = "gen_update",
     out = "update.sh",

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+
+_DOC_SRCS = [
+    "xcodeproj",
+    "experimental",
+]
+
+[
+    stardoc(
+        name = file + "_doc",
+        out = file + ".md",
+        input = "//xcodeproj:%s.bzl" % file,
+        tags = ["no-sandbox"],  # https://github.com/bazelbuild/stardoc/issues/112
+        deps = ["//xcodeproj/internal:xcodeproj_internal"],
+    )
+    for file in _DOC_SRCS
+]
+
+# Help developers who get a red CI result by telling them how to fix it
+_failure_message = "\nPlease update the docs by running\n    bazel run //doc:update"
+
+[
+    diff_test(
+        name = "check_" + file,
+        failure_message = _failure_message,
+        file1 = file + ".md",
+        file2 = "rules-%s.md" % file.replace(".doc", ""),
+    )
+    for file in _DOC_SRCS
+]
+
+write_file(
+    name = "gen_update",
+    out = "update.sh",
+    content = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "cd $BUILD_WORKSPACE_DIRECTORY",
+    ] + [
+        "cp -fv bazel-bin/doc/{src}.md doc/rules-{dst}.md".format(
+            src = file,
+            dst = file.replace(".doc", ""),
+        )
+        for file in _DOC_SRCS
+    ],
+)
+
+sh_binary(
+    name = "update",
+    srcs = ["update.sh"],
+    data = [file + ".md" for file in _DOC_SRCS],
+)

--- a/doc/rules-experimental.md
+++ b/doc/rules-experimental.md
@@ -1,0 +1,78 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Public evolving/experimental rules, macros, and libraries.
+
+<a id="xcode_provisioning_profile"></a>
+
+## xcode_provisioning_profile
+
+<pre>
+xcode_provisioning_profile(<a href="#xcode_provisioning_profile-name">name</a>, <a href="#xcode_provisioning_profile-managed_by_xcode">managed_by_xcode</a>, <a href="#xcode_provisioning_profile-profile_name">profile_name</a>, <a href="#xcode_provisioning_profile-provisioning_profile">provisioning_profile</a>, <a href="#xcode_provisioning_profile-team_id">team_id</a>)
+</pre>
+
+This rule declares a target that you can pass to the `provisioning_profile`
+attribute of rules that require it. It wraps another provisioning profile
+target, either a `File` or a rule like rules_apple's
+`local_provisioning_profile`, and allows specifying additional information to
+adjust Xcode related build settings related to code signing.
+
+If you are already using `local_provisioning_profile`, or another rule that
+returns the `AppleProvisioningProfileInfo` provider, you don't need to use this
+rule, unless you want to enable Xcode's "Automatic Code Signing" feature. If you
+are using a `File`, then this rule is needed in order to set the
+`DEVELOPER_TEAM` build setting via the `team_id` attribute.
+
+## Example
+
+```python
+ios_application(
+   ...
+   provisioning_profile = ":xcode_profile",
+   ...
+)
+
+xcode_provisioning_profile(
+   name = "xcode_profile",
+   managed_by_xcode = True,
+   provisioning_profile = ":provisioning_profile",
+)
+
+local_provisioning_profile(
+    name = "provisioning_profile",
+    profile_name = "iOS Team Provisioning Profile: com.example.app",
+    team_id = "A12B3CDEFG",
+)
+```
+
+
+**ATTRIBUTES**
+
+
+| Name  | Description | Type | Mandatory | Default |
+| :------------- | :------------- | :------------- | :------------- | :------------- |
+| <a id="xcode_provisioning_profile-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="xcode_provisioning_profile-managed_by_xcode"></a>managed_by_xcode |  Whether the provisioning profile is managed by Xcode. If <code>True</code>, "Automatic Code Signing" will be enabled in Xcode, and the profile name will be ignored. Xcode will add devices to profiles automatically via the currently logged in Apple Developer Account, and otherwise fully manage the profile. If <code>False</code>, "Manual Code Signing" will be enabled in Xcode, and the profile name will be used to determine which profile to use.<br><br>If <code>xcodeproj.build_mode != "xcode"</code>, then Xcode will still manage the profile when this is <code>True</code>, but otherwise won't use it to actually sign the binary. Instead Bazel will perform the code signing with the file set to <code>provisioning_profile</code>. Using rules_apple's <code>local_provisioning_profile</code> as the target set to <code>provisioning_profile</code> will then allow Bazel to code sign with the Xcode managed profile.   | Boolean | required |  |
+| <a id="xcode_provisioning_profile-profile_name"></a>profile_name |  When <code>managed_by_xcode</code> is <code>False</code>, the <code>PROVISIONING_PROFILE_SPECIFIER</code> Xcode build setting will be set to this value. If this is <code>None</code> (the default), and <code>provisioning_profile</code> returns the <code>AppleProvisioningProfileInfo</code> provider (as <code>local_provisioning_profile</code> does), then <code>AppleProvisioningProfileInfo.profile_name</code> will be used instead.   | String | optional | "" |
+| <a id="xcode_provisioning_profile-provisioning_profile"></a>provisioning_profile |  The <code>File</code> that Bazel will use when code signing. If the target returns the <code>AppleProvisioningProfileInfo</code> provider (as <code>local_provisioning_profile</code> does), then it will provide default values for <code>profile_name</code> and <code>team_id</code>.<br><br>When <code>xcodeproj.build_mode = "xcode"</code>, the actual file isn't used directly by Xcode, but in order to satisfy Bazel constraints this can't be <code>None</code>.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
+| <a id="xcode_provisioning_profile-team_id"></a>team_id |  The <code>DEVELOPER_TEAM</code> Xcode build setting will be set to this value. If this is <code>None</code> (the default), and <code>provisioning_profile</code> returns the <code>AppleProvisioningProfileInfo</code> provider (as <code>local_provisioning_profile</code> does), then <code>AppleProvisioningProfileInfo.team_id</code> will be used instead.<br><br><code>DEVELOPER_TEAM</code> is needed when <code>xcodeproj.build_mode = "xcode"</code>.   | String | optional | "" |
+
+
+<a id="device_and_simulator"></a>
+
+## device_and_simulator
+
+<pre>
+device_and_simulator(<a href="#device_and_simulator-name">name</a>, <a href="#device_and_simulator-kwargs">kwargs</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="device_and_simulator-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="device_and_simulator-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+

--- a/doc/rules-xcodeproj.md
+++ b/doc/rules-xcodeproj.md
@@ -1,0 +1,258 @@
+<!-- Generated with Stardoc: http://skydoc.bazel.build -->
+
+Public rules, macros, and libraries.
+
+<a id="XcodeProjAutomaticTargetProcessingInfo"></a>
+
+## XcodeProjAutomaticTargetProcessingInfo
+
+<pre>
+XcodeProjAutomaticTargetProcessingInfo(<a href="#XcodeProjAutomaticTargetProcessingInfo-bazel_build_mode_error">bazel_build_mode_error</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-bundle_id">bundle_id</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-codesignopts">codesignopts</a>,
+                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-entitlements">entitlements</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-exported_symbols_lists">exported_symbols_lists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-infoplists">infoplists</a>,
+                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-launchdplists">launchdplists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-non_arc_srcs">non_arc_srcs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-pch">pch</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-provisioning_profile">provisioning_profile</a>,
+                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-should_generate_target">should_generate_target</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-srcs">srcs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-target_type">target_type</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-xcode_targets">xcode_targets</a>)
+</pre>
+
+Provides needed information about a target to allow rules_xcodeproj to
+automatically process it.
+
+If you need more control over how a target or it's dependencies are processed,
+return a `XcodeProjInfo` provider instance instead.
+
+
+**FIELDS**
+
+
+| Name  | Description |
+| :------------- | :------------- |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-bazel_build_mode_error"></a>bazel_build_mode_error |  If <code>build_mode = "bazel"</code>, then if this is non-<code>None</code>, it will be raised as an error during analysis.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-bundle_id"></a>bundle_id |  An attribute name (or <code>None</code>) to collect the bundle id string from.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-codesignopts"></a>codesignopts |  An attribute name (or <code>None</code>) to collect the <code>codesignopts</code> <code>list</code> from.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-entitlements"></a>entitlements |  An attribute name (or <code>None</code>) to collect <code>File</code>s from for the <code>entitlements</code>-like attribute.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-exported_symbols_lists"></a>exported_symbols_lists |  A sequence of attribute names to collect <code>File</code>s from for the <code>exported_symbols_lists</code>-like attributes.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-infoplists"></a>infoplists |  A sequence of attribute names to collect <code>File</code>s from for the <code>infoplists</code>-like attributes.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-launchdplists"></a>launchdplists |  A sequence of attribute names to collect <code>File</code>s from for the <code>launchdplists</code>-like attributes.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-non_arc_srcs"></a>non_arc_srcs |  A sequence of attribute names to collect <code>File</code>s from for <code>non_arc_srcs</code>-like attributes.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-pch"></a>pch |  An attribute name (or <code>None</code>) to collect <code>File</code>s from for the <code>pch</code>-like attribute.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-provisioning_profile"></a>provisioning_profile |  An attribute name (or <code>None</code>) to collect <code>File</code>s from for the <code>provisioning_profile</code>-like attribute.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-should_generate_target"></a>should_generate_target |  Whether or an Xcode target should be generated for this target. Even if this value is <code>False</code>, setting values for the other attributes can cause inputs to be collected and shown in the Xcode project.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-srcs"></a>srcs |  A sequence of attribute names to collect <code>File</code>s from for <code>srcs</code>-like attributes.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-target_type"></a>target_type |  See <code>XcodeProjInfo.target_type</code>.    |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-xcode_targets"></a>xcode_targets |  A <code>dict</code> mapping attribute names to target type strings (i.e. "resource" or "compile"). Only Xcode targets from the specified attributes with the specified target type are allowed to propagate.    |
+
+
+<a id="xcode_schemes.scheme"></a>
+
+## xcode_schemes.scheme
+
+<pre>
+xcode_schemes.scheme(<a href="#xcode_schemes.scheme-name">name</a>, <a href="#xcode_schemes.scheme-build_action">build_action</a>, <a href="#xcode_schemes.scheme-test_action">test_action</a>, <a href="#xcode_schemes.scheme-launch_action">launch_action</a>)
+</pre>
+
+Returns a `struct` representing an Xcode scheme.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="xcode_schemes.scheme-name"></a>name |  The user-visible name for the scheme as a <code>string</code>.   |  none |
+| <a id="xcode_schemes.scheme-build_action"></a>build_action |  Optional. A <code>struct</code> as returned by <code>xcode_schemes.build_action</code>.   |  <code>None</code> |
+| <a id="xcode_schemes.scheme-test_action"></a>test_action |  Optional. A <code>struct</code> as returned by <code>xcode_schemes.test_action</code>.   |  <code>None</code> |
+| <a id="xcode_schemes.scheme-launch_action"></a>launch_action |  Optional. A <code>struct</code> as returned by <code>xcode_schemes.launch_action</code>.   |  <code>None</code> |
+
+**RETURNS**
+
+A `struct` representing an Xcode scheme.
+
+
+<a id="xcode_schemes.build_action"></a>
+
+## xcode_schemes.build_action
+
+<pre>
+xcode_schemes.build_action(<a href="#xcode_schemes.build_action-targets">targets</a>)
+</pre>
+
+Constructs a build action for an Xcode scheme.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="xcode_schemes.build_action-targets"></a>targets |  A <code>sequence</code> of <code>struct</code> values as created by <code>xcode_schemes.build_target</code>.   |  none |
+
+**RETURNS**
+
+A `struct` representing a build action.
+
+
+<a id="xcode_schemes.build_target"></a>
+
+## xcode_schemes.build_target
+
+<pre>
+xcode_schemes.build_target(<a href="#xcode_schemes.build_target-label">label</a>, <a href="#xcode_schemes.build_target-build_for">build_for</a>)
+</pre>
+
+Constructs a build target for an Xcode scheme's build action.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="xcode_schemes.build_target-label"></a>label |  A target label as a <code>string</code> value.   |  none |
+| <a id="xcode_schemes.build_target-build_for"></a>build_for |  Optional. The settings that dictate when Xcode will build the target. It is a <code>struct</code> as returned by <code>xcode_schemes.build_for</code>.   |  <code>None</code> |
+
+**RETURNS**
+
+A `struct` representing a build target.
+
+
+<a id="xcode_schemes.build_for"></a>
+
+## xcode_schemes.build_for
+
+<pre>
+xcode_schemes.build_for(<a href="#xcode_schemes.build_for-running">running</a>, <a href="#xcode_schemes.build_for-testing">testing</a>, <a href="#xcode_schemes.build_for-profiling">profiling</a>, <a href="#xcode_schemes.build_for-archiving">archiving</a>, <a href="#xcode_schemes.build_for-analyzing">analyzing</a>)
+</pre>
+
+Construct a `struct` representing the settings that dictate when Xcode     will build a target.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="xcode_schemes.build_for-running"></a>running |  Optional. A <code>bool</code> specifying whether to build for the running phase.   |  <code>None</code> |
+| <a id="xcode_schemes.build_for-testing"></a>testing |  Optional. A <code>bool</code> specifying whether to build for the testing phase.   |  <code>None</code> |
+| <a id="xcode_schemes.build_for-profiling"></a>profiling |  Optional. A <code>bool</code> specifying whether to build for the profiling phase.   |  <code>None</code> |
+| <a id="xcode_schemes.build_for-archiving"></a>archiving |  Optional. A <code>bool</code> specifying whether to build for the archiving phase.   |  <code>None</code> |
+| <a id="xcode_schemes.build_for-analyzing"></a>analyzing |  Optional. A <code>bool</code> specifying whether to build for the analyzing phase.   |  <code>None</code> |
+
+**RETURNS**
+
+A `struct`.
+
+
+<a id="xcode_schemes.test_action"></a>
+
+## xcode_schemes.test_action
+
+<pre>
+xcode_schemes.test_action(<a href="#xcode_schemes.test_action-targets">targets</a>)
+</pre>
+
+Constructs a test action for an Xcode scheme.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="xcode_schemes.test_action-targets"></a>targets |  A <code>sequence</code> of target labels as <code>string</code> values.   |  none |
+
+**RETURNS**
+
+A `struct` representing a test action.
+
+
+<a id="xcode_schemes.launch_action"></a>
+
+## xcode_schemes.launch_action
+
+<pre>
+xcode_schemes.launch_action(<a href="#xcode_schemes.launch_action-target">target</a>, <a href="#xcode_schemes.launch_action-args">args</a>, <a href="#xcode_schemes.launch_action-env">env</a>)
+</pre>
+
+Constructs a launch action for an Xcode scheme.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="xcode_schemes.launch_action-target"></a>target |  A target label as a <code>string</code> value.   |  none |
+| <a id="xcode_schemes.launch_action-args"></a>args |  Optional. A <code>list</code> of <code>string</code> arguments that should be passed to the target when executed.   |  <code>None</code> |
+| <a id="xcode_schemes.launch_action-env"></a>env |  Optional. A <code>dict</code> of <code>string</code> values that will be set as environment variables when the target is executed.   |  <code>None</code> |
+
+**RETURNS**
+
+A `struct` representing a launch action.
+
+
+<a id="xcode_schemes.focus_schemes"></a>
+
+## xcode_schemes.focus_schemes
+
+<pre>
+xcode_schemes.focus_schemes(<a href="#xcode_schemes.focus_schemes-schemes">schemes</a>, <a href="#xcode_schemes.focus_schemes-focused_targets">focused_targets</a>)
+</pre>
+
+Filter/adjust a `sequence` of schemes to only include focused targets.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="xcode_schemes.focus_schemes-schemes"></a>schemes |  A <code>sequence</code> of <code>struct</code> values as returned by <code>xcode_schemes.scheme</code>.   |  none |
+| <a id="xcode_schemes.focus_schemes-focused_targets"></a>focused_targets |  A <code>sequence</code> of <code>string</code> values representing Bazel labels of focused targets.   |  none |
+
+**RETURNS**
+
+A `sequence` of `struct` values as returned by `xcode_schemes.scheme`.
+  Will only include schemes that have at least one target in
+  `focused_targets`. Some actions might be removed if they reference
+  unfocused targets.
+
+
+<a id="xcode_schemes.unfocus_schemes"></a>
+
+## xcode_schemes.unfocus_schemes
+
+<pre>
+xcode_schemes.unfocus_schemes(<a href="#xcode_schemes.unfocus_schemes-schemes">schemes</a>, <a href="#xcode_schemes.unfocus_schemes-unfocused_targets">unfocused_targets</a>)
+</pre>
+
+Filter/adjust a `sequence` of schemes to exclude unfocused targets.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="xcode_schemes.unfocus_schemes-schemes"></a>schemes |  A <code>sequence</code> of <code>struct</code> values as returned by <code>xcode_schemes.scheme</code>.   |  none |
+| <a id="xcode_schemes.unfocus_schemes-unfocused_targets"></a>unfocused_targets |  A <code>sequence</code> of <code>string</code> values representing Bazel labels of unfocused targets.   |  none |
+
+**RETURNS**
+
+A `sequence` of `struct` values as returned by `xcode_schemes.scheme`.
+  Will only include schemes that have at least one target not in
+  `unfocused_targets`. Some actions might be removed if they reference
+  unfocused targets.
+
+
+<a id="xcodeproj"></a>
+
+## xcodeproj
+
+<pre>
+xcodeproj(<a href="#xcodeproj-name">name</a>, <a href="#xcodeproj-xcodeproj_rule">xcodeproj_rule</a>, <a href="#xcodeproj-schemes">schemes</a>, <a href="#xcodeproj-kwargs">kwargs</a>)
+</pre>
+
+Creates an .xcodeproj file in the workspace when run.
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="xcodeproj-name"></a>name |  The name of the target.   |  none |
+| <a id="xcodeproj-xcodeproj_rule"></a>xcodeproj_rule |  The actual <code>xcodeproj</code> rule. This is overridden during fixture testing. You shouldn't need to set it yourself.   |  <code><unknown object com.google.devtools.build.skydoc.fakebuildapi.FakeStarlarkRuleFunctionsApi$RuleDefinitionIdentifier></code> |
+| <a id="xcodeproj-schemes"></a>schemes |  Optional. A <code>list</code> of <code>struct</code> values as returned by <code>xcode_schemes.scheme</code>.   |  <code>None</code> |
+| <a id="xcodeproj-kwargs"></a>kwargs |  Additional arguments to pass to <code>xcodeproj_rule</code>.   |  none |
+
+

--- a/xcodeproj/BUILD
+++ b/xcodeproj/BUILD
@@ -1,3 +1,4 @@
+# Required for stardoc integration.
 exports_files([
     "experimental.bzl",
     "xcodeproj.bzl",

--- a/xcodeproj/BUILD
+++ b/xcodeproj/BUILD
@@ -1,0 +1,4 @@
+exports_files([
+    "experimental.bzl",
+    "xcodeproj.bzl",
+])

--- a/xcodeproj/internal/BUILD
+++ b/xcodeproj/internal/BUILD
@@ -3,6 +3,31 @@ load(
     "bool_setting",
     "string_setting",
 )
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "bazel_tools",
+    srcs = [
+        "@bazel_tools//tools:bzl_srcs",
+    ],
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
+)
+
+bzl_library(
+    name = "xcodeproj_internal",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//:__subpackages__"],
+    deps = [
+        ":bazel_tools",
+        "@bazel_skylib//lib:paths",
+        "@bazel_skylib//lib:sets",
+        "@bazel_skylib//lib:versions",
+        "@bazel_skylib//rules:common_settings",
+        "@build_bazel_rules_apple//apple",
+        "@build_bazel_rules_apple//apple:resources",
+    ],
+)
 
 exports_files([
     "installer.template.sh",

--- a/xcodeproj/internal/BUILD
+++ b/xcodeproj/internal/BUILD
@@ -1,9 +1,9 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(
     "@bazel_skylib//rules:common_settings.bzl",
     "bool_setting",
     "string_setting",
 )
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
     name = "bazel_tools",


### PR DESCRIPTION
Addresses #214.

This PR adds the basic stardoc tooling in order to generate documentation for the public rules. This will allow to better understand the API that we provide. Some follow-up PRs might be needed to get more accurate documentation for certain rules that aren't yet properly documented.

Most of the tooling was inspired by the [`rules_apple`](https://github.com/bazelbuild/rules_apple/tree/master/doc/BUILD.bazel) implementation.