### PR TITLE
Allow top-level targets to have multiple dependencies

### DIFF
--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -345,22 +345,20 @@ def process_top_level_target(
         ),
     )
 
-    xcode_library_targets = comp_providers.get_xcode_library_targets(
-        compilation_providers = compilation_providers,
-    )
-    if len(xcode_library_targets) == 1 and not inputs.srcs:
-        mergeable_target = xcode_library_targets[0]
-        potential_target_merges = [struct(
-            src = struct(
-                id = mergeable_target.id,
-                product_path = mergeable_target.product.path,
-            ),
-            dest = id,
-        )]
-    elif bundle_info and len(xcode_library_targets) > 1:
-        fail("""\
-The xcodeproj rule requires {} rules to have a single library dep. {} has {}.\
-""".format(ctx.rule.kind, label, len(xcode_library_targets)))
+    if not inputs.srcs:
+        xcode_library_targets = comp_providers.get_xcode_library_targets(
+            compilation_providers = compilation_providers,
+        )
+        potential_target_merges = [
+            struct(
+                src = struct(
+                    id = mergeable_target.id,
+                    product_path = mergeable_target.product.path,
+                ),
+                dest = id,
+            )
+            for mergeable_target in xcode_library_targets
+        ]
     else:
         potential_target_merges = None
 

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -161,11 +161,18 @@ def _write_json_spec(
         transitive = [info.potential_target_merges for info in infos],
     ).to_list()
 
-    target_merges = {}
+    target_merge_dests = {}
     for merge in potential_target_merges:
         if merge.src.id not in targets or merge.dest not in targets:
             continue
-        target_merges.setdefault(merge.src.id, []).append(merge.dest)
+        target_merge_dests.setdefault(merge.dest, []).append(merge.src.id)
+
+    target_merges = {}
+    for dest, src_ids in target_merge_dests.items():
+        if len(src_ids) > 1:
+            # We can only merge targets with a single library dependency
+            continue
+        target_merges.setdefault(src_ids[0], []).append(dest)
 
     # `target_hosts`
     hosted_targets = depset(


### PR DESCRIPTION
If top-level targets have multiple dependencies, and they all remain focused targets, then the top-level target will be un-merged, with a compile stub.