### PR TITLE
Refactor macro expansion logic

### DIFF
--- a/tools/generator/src/Generator/XCSchemeInfo+LaunchActionInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+LaunchActionInfo.swift
@@ -92,14 +92,7 @@ extension XCSchemeInfo.LaunchActionInfo {
 extension XCSchemeInfo.LaunchActionInfo {
     var macroExpansion: XCScheme.BuildableReference? {
         get throws {
-            if let hostBuildableReference = try targetInfo.selectedHostInfo?.buildableReference,
-                !targetInfo.productType.isWatchApplication
-            {
-                return hostBuildableReference
-            } else if targetInfo.pbxTarget.isTestable {
-                return targetInfo.buildableReference
-            }
-            return nil
+            try targetInfo.macroExpansion
         }
     }
 }

--- a/tools/generator/src/Generator/XCSchemeInfo+TargetInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+TargetInfo.swift
@@ -164,6 +164,23 @@ extension XCSchemeInfo.TargetInfo {
     }
 }
 
+// MARK: `macroExpansion`
+
+extension XCSchemeInfo.TargetInfo {
+    var macroExpansion: XCScheme.BuildableReference? {
+        get throws {
+            if let hostBuildableReference = try selectedHostInfo?.buildableReference,
+                !productType.isWatchApplication
+            {
+                return hostBuildableReference
+            } else if pbxTarget.isTestable {
+                return buildableReference
+            }
+            return nil
+        }
+    }
+}
+
 // MARK: Sequence Extensions
 
 extension Sequence where Element == XCSchemeInfo.TargetInfo {

--- a/tools/generator/test/XCSchemeInfo+LaunchActionInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+LaunchActionInfoTests.swift
@@ -267,13 +267,11 @@ class XCSchemeInfoLaunchActionInfoTests: XCTestCase {
     lazy var appPlatform = Fixtures.targets["A 2"]!.platform
     lazy var unitTestPlatform = Fixtures.targets["B 2"]!.platform
     lazy var widgetKitExtPlatform = Fixtures.targets["WDKE"]!.platform
-    lazy var watchAppPlatform = Fixtures.targets["W"]!.platform
 
     lazy var libraryPBXTarget = pbxTargetsDict["A 1"]!
     lazy var appPBXTarget = pbxTargetsDict["A 2"]!
     lazy var unitTestPBXTarget = pbxTargetsDict["B 2"]!
     lazy var widgetKitExtPBXTarget = pbxTargetsDict["WDKE"]!
-    lazy var watchAppPBXTarget = pbxTargetsDict["W"]!
 
     lazy var libraryTargetInfo = XCSchemeInfo.TargetInfo(
         pbxTarget: libraryPBXTarget,
@@ -299,20 +297,6 @@ class XCSchemeInfoLaunchActionInfoTests: XCTestCase {
     lazy var unitTestTargetInfo = XCSchemeInfo.TargetInfo(
         pbxTarget: unitTestPBXTarget,
         platforms: [unitTestPlatform],
-        referencedContainer: filePathResolver.containerReference,
-        hostInfos: [appHostInfo],
-        extensionPointIdentifiers: []
-    )
-    lazy var unitTestNoHostTargetInfo = XCSchemeInfo.TargetInfo(
-        pbxTarget: unitTestPBXTarget,
-        platforms: [unitTestPlatform],
-        referencedContainer: filePathResolver.containerReference,
-        hostInfos: [],
-        extensionPointIdentifiers: []
-    )
-    lazy var watchAppTargetInfo = XCSchemeInfo.TargetInfo(
-        pbxTarget: watchAppPBXTarget,
-        platforms: [watchAppPlatform],
         referencedContainer: filePathResolver.containerReference,
         hostInfos: [appHostInfo],
         extensionPointIdentifiers: []

--- a/tools/generator/test/XCSchemeInfo+LaunchActionInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+LaunchActionInfoTests.swift
@@ -122,72 +122,8 @@ extension XCSchemeInfoLaunchActionInfoTests {
 // MARK: - `macroExpansion` Tests
 
 extension XCSchemeInfoLaunchActionInfoTests {
-    func test_macroExpansion_hasHostAndIsNotWatchApp() throws {
-        let actionInfo = try XCSchemeInfo.LaunchActionInfo(
-            resolveHostsFor: .init(
-                buildConfigurationName: buildConfigurationName,
-                targetInfo: unitTestTargetInfo
-            ),
-            topLevelTargetInfos: []
-        )
-        guard let launchActionInfo = actionInfo else {
-            XCTFail("Expected a `LaunchActionInfo`")
-            return
-        }
-        guard let macroExpansion = try launchActionInfo.macroExpansion else {
-            XCTFail("Expected a `macroExpansion`")
-            return
-        }
-        XCTAssertEqual(macroExpansion, appHostInfo.buildableReference)
-    }
-
-    func test_macroExpansion_hasHostAndIsWatchApp() throws {
-        let actionInfo = try XCSchemeInfo.LaunchActionInfo(
-            resolveHostsFor: .init(
-                buildConfigurationName: buildConfigurationName,
-                targetInfo: watchAppTargetInfo
-            ),
-            topLevelTargetInfos: []
-        )
-        guard let launchActionInfo = actionInfo else {
-            XCTFail("Expected a `LaunchActionInfo`")
-            return
-        }
-        XCTAssertNil(try launchActionInfo.macroExpansion)
-    }
-
-    func test_macroExpansion_noHostIsTestable() throws {
-        let actionInfo = try XCSchemeInfo.LaunchActionInfo(
-            resolveHostsFor: .init(
-                buildConfigurationName: buildConfigurationName,
-                targetInfo: unitTestNoHostTargetInfo
-            ),
-            topLevelTargetInfos: []
-        )
-        guard let launchActionInfo = actionInfo else {
-            XCTFail("Expected a `LaunchActionInfo`")
-            return
-        }
-        guard let macroExpansion = try launchActionInfo.macroExpansion else {
-            XCTFail("Expected a `macroExpansion`")
-            return
-        }
-        XCTAssertEqual(macroExpansion, unitTestNoHostTargetInfo.buildableReference)
-    }
-
-    func test_macroExpansion_noHostIsNotTestable() throws {
-        let actionInfo = try XCSchemeInfo.LaunchActionInfo(
-            resolveHostsFor: .init(
-                buildConfigurationName: buildConfigurationName,
-                targetInfo: appTargetInfo
-            ),
-            topLevelTargetInfos: []
-        )
-        guard let launchActionInfo = actionInfo else {
-            XCTFail("Expected a `LaunchActionInfo`")
-            return
-        }
-        XCTAssertNil(try launchActionInfo.macroExpansion)
+    func test_macroExpansion() throws {
+        XCTFail("IMPLEMENT ME!")
     }
 }
 

--- a/tools/generator/test/XCSchemeInfo+LaunchActionInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+LaunchActionInfoTests.swift
@@ -123,7 +123,22 @@ extension XCSchemeInfoLaunchActionInfoTests {
 
 extension XCSchemeInfoLaunchActionInfoTests {
     func test_macroExpansion() throws {
-        XCTFail("IMPLEMENT ME!")
+        let actionInfo = try XCSchemeInfo.LaunchActionInfo(
+            resolveHostsFor: .init(
+                buildConfigurationName: buildConfigurationName,
+                targetInfo: unitTestTargetInfo
+            ),
+            topLevelTargetInfos: []
+        )
+        guard let launchActionInfo = actionInfo else {
+            XCTFail("Expected a `LaunchActionInfo`")
+            return
+        }
+        guard let macroExpansion = try launchActionInfo.macroExpansion else {
+            XCTFail("Expected a `macroExpansion`")
+            return
+        }
+        XCTAssertEqual(macroExpansion, appHostInfo.buildableReference)
     }
 }
 
@@ -314,6 +329,7 @@ class XCSchemeInfoLaunchActionInfoTests: XCTestCase {
     let customEnv = ["RELEASE_KRAKEN": "TRUE"]
     let customWorkingDirectory = "/path/to/work"
 
+    // swiftlint:disable:next force_try
     lazy var xcodeScheme = try! XcodeScheme(
         name: "My Scheme",
         launchAction: .init(

--- a/tools/generator/test/XCSchemeInfo+TargetInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+TargetInfoTests.swift
@@ -149,54 +149,54 @@ extension XCSchemeInfoTargetInfoTests {
         XCTAssertEqual(macroExpansion, appHostInfo.buildableReference)
     }
 
-    // func test_macroExpansion_hasHostAndIsWatchApp() throws {
-    //     let actionInfo = try XCSchemeInfo.LaunchActionInfo(
-    //         resolveHostsFor: .init(
-    //             buildConfigurationName: buildConfigurationName,
-    //             targetInfo: watchAppTargetInfo
-    //         ),
-    //         topLevelTargetInfos: []
-    //     )
-    //     guard let launchActionInfo = actionInfo else {
-    //         XCTFail("Expected a `LaunchActionInfo`")
-    //         return
-    //     }
-    //     XCTAssertNil(try launchActionInfo.macroExpansion)
-    // }
+    func test_macroExpansion_hasHostAndIsWatchApp() throws {
+        // let actionInfo = try XCSchemeInfo.LaunchActionInfo(
+        //     resolveHostsFor: .init(
+        //         buildConfigurationName: buildConfigurationName,
+        //         targetInfo: watchAppTargetInfo
+        //     ),
+        //     topLevelTargetInfos: []
+        // )
+        // guard let launchActionInfo = actionInfo else {
+        //     XCTFail("Expected a `LaunchActionInfo`")
+        //     return
+        // }
+        XCTAssertNil(try watchAppTargetInfo.macroExpansion)
+    }
 
-    // func test_macroExpansion_noHostIsTestable() throws {
-    //     let actionInfo = try XCSchemeInfo.LaunchActionInfo(
-    //         resolveHostsFor: .init(
-    //             buildConfigurationName: buildConfigurationName,
-    //             targetInfo: unitTestNoHostTargetInfo
-    //         ),
-    //         topLevelTargetInfos: []
-    //     )
-    //     guard let launchActionInfo = actionInfo else {
-    //         XCTFail("Expected a `LaunchActionInfo`")
-    //         return
-    //     }
-    //     guard let macroExpansion = try launchActionInfo.macroExpansion else {
-    //         XCTFail("Expected a `macroExpansion`")
-    //         return
-    //     }
-    //     XCTAssertEqual(macroExpansion, unitTestNoHostTargetInfo.buildableReference)
-    // }
+    func test_macroExpansion_noHostIsTestable() throws {
+        // let actionInfo = try XCSchemeInfo.LaunchActionInfo(
+        //     resolveHostsFor: .init(
+        //         buildConfigurationName: buildConfigurationName,
+        //         targetInfo: unitTestNoHostTargetInfo
+        //     ),
+        //     topLevelTargetInfos: []
+        // )
+        // guard let launchActionInfo = actionInfo else {
+        //     XCTFail("Expected a `LaunchActionInfo`")
+        //     return
+        // }
+        guard let macroExpansion = try unitTestNoHostTargetInfo.macroExpansion else {
+            XCTFail("Expected a `macroExpansion`")
+            return
+        }
+        XCTAssertEqual(macroExpansion, unitTestNoHostTargetInfo.buildableReference)
+    }
 
-    // func test_macroExpansion_noHostIsNotTestable() throws {
-    //     let actionInfo = try XCSchemeInfo.LaunchActionInfo(
-    //         resolveHostsFor: .init(
-    //             buildConfigurationName: buildConfigurationName,
-    //             targetInfo: appTargetInfo
-    //         ),
-    //         topLevelTargetInfos: []
-    //     )
-    //     guard let launchActionInfo = actionInfo else {
-    //         XCTFail("Expected a `LaunchActionInfo`")
-    //         return
-    //     }
-    //     XCTAssertNil(try launchActionInfo.macroExpansion)
-    // }
+    func test_macroExpansion_noHostIsNotTestable() throws {
+        // let actionInfo = try XCSchemeInfo.LaunchActionInfo(
+        //     resolveHostsFor: .init(
+        //         buildConfigurationName: buildConfigurationName,
+        //         targetInfo: appTargetInfo
+        //     ),
+        //     topLevelTargetInfos: []
+        // )
+        // guard let launchActionInfo = actionInfo else {
+        //     XCTFail("Expected a `LaunchActionInfo`")
+        //     return
+        // }
+        XCTAssertNil(try appTargetInfo.macroExpansion)
+    }
 }
 
 // MARK: - `bazelBuildPreAction` Tests
@@ -302,12 +302,14 @@ class XCSchemeInfoTargetInfoTests: XCTestCase {
     lazy var anotherAppPlatform = Fixtures.targets["I"]!.platform
     lazy var widgetKitExtPlatform = Fixtures.targets["WDKE"]!.platform
     lazy var unitTestPlatform = Fixtures.targets["B 2"]!.platform
+    lazy var watchAppPlatform = Fixtures.targets["W"]!.platform
 
     lazy var libraryPBXTarget = pbxTargetsDict["A 1"]!
     lazy var appPBXTarget = pbxTargetsDict["A 2"]!
     lazy var anotherAppPBXTarget = pbxTargetsDict["I"]!
     lazy var widgetKitExtPBXTarget = pbxTargetsDict["WDKE"]!
     lazy var unitTestPBXTarget = pbxTargetsDict["B 2"]!
+    lazy var watchAppPBXTarget = pbxTargetsDict["W"]!
 
     lazy var appHostInfo = XCSchemeInfo.HostInfo(
         pbxTarget: appPBXTarget,
@@ -370,6 +372,26 @@ class XCSchemeInfoTargetInfoTests: XCTestCase {
             hostInfos: [appHostInfo],
             extensionPointIdentifiers: []
         ),
-        topLevelTargetInfos: [appTargetInfo]
+        topLevelTargetInfos: []
+    )
+    lazy var unitTestNoHostTargetInfo = XCSchemeInfo.TargetInfo(
+        resolveHostFor: .init(
+            pbxTarget: unitTestPBXTarget,
+            platforms: [unitTestPlatform],
+            referencedContainer: filePathResolver.containerReference,
+            hostInfos: [],
+            extensionPointIdentifiers: []
+        ),
+        topLevelTargetInfos: []
+    )
+    lazy var watchAppTargetInfo = XCSchemeInfo.TargetInfo(
+        resolveHostFor: .init(
+            pbxTarget: watchAppPBXTarget,
+            platforms: [watchAppPlatform],
+            referencedContainer: filePathResolver.containerReference,
+            hostInfos: [appHostInfo],
+            extensionPointIdentifiers: []
+        ),
+        topLevelTargetInfos: []
     )
 }

--- a/tools/generator/test/XCSchemeInfo+TargetInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+TargetInfoTests.swift
@@ -131,17 +131,6 @@ extension XCSchemeInfoTargetInfoTests {
 
 extension XCSchemeInfoTargetInfoTests {
     func test_macroExpansion_hasHostAndIsNotWatchApp() throws {
-        // let actionInfo = try XCSchemeInfo.LaunchActionInfo(
-        //     resolveHostsFor: .init(
-        //         buildConfigurationName: buildConfigurationName,
-        //         targetInfo: unitTestTargetInfo
-        //     ),
-        //     topLevelTargetInfos: []
-        // )
-        // guard let launchActionInfo = actionInfo else {
-        //     XCTFail("Expected a `LaunchActionInfo`")
-        //     return
-        // }
         guard let macroExpansion = try unitTestTargetInfo.macroExpansion else {
             XCTFail("Expected a `macroExpansion`")
             return
@@ -150,32 +139,10 @@ extension XCSchemeInfoTargetInfoTests {
     }
 
     func test_macroExpansion_hasHostAndIsWatchApp() throws {
-        // let actionInfo = try XCSchemeInfo.LaunchActionInfo(
-        //     resolveHostsFor: .init(
-        //         buildConfigurationName: buildConfigurationName,
-        //         targetInfo: watchAppTargetInfo
-        //     ),
-        //     topLevelTargetInfos: []
-        // )
-        // guard let launchActionInfo = actionInfo else {
-        //     XCTFail("Expected a `LaunchActionInfo`")
-        //     return
-        // }
         XCTAssertNil(try watchAppTargetInfo.macroExpansion)
     }
 
     func test_macroExpansion_noHostIsTestable() throws {
-        // let actionInfo = try XCSchemeInfo.LaunchActionInfo(
-        //     resolveHostsFor: .init(
-        //         buildConfigurationName: buildConfigurationName,
-        //         targetInfo: unitTestNoHostTargetInfo
-        //     ),
-        //     topLevelTargetInfos: []
-        // )
-        // guard let launchActionInfo = actionInfo else {
-        //     XCTFail("Expected a `LaunchActionInfo`")
-        //     return
-        // }
         guard let macroExpansion = try unitTestNoHostTargetInfo.macroExpansion else {
             XCTFail("Expected a `macroExpansion`")
             return
@@ -184,17 +151,6 @@ extension XCSchemeInfoTargetInfoTests {
     }
 
     func test_macroExpansion_noHostIsNotTestable() throws {
-        // let actionInfo = try XCSchemeInfo.LaunchActionInfo(
-        //     resolveHostsFor: .init(
-        //         buildConfigurationName: buildConfigurationName,
-        //         targetInfo: appTargetInfo
-        //     ),
-        //     topLevelTargetInfos: []
-        // )
-        // guard let launchActionInfo = actionInfo else {
-        //     XCTFail("Expected a `LaunchActionInfo`")
-        //     return
-        // }
         XCTAssertNil(try appTargetInfo.macroExpansion)
     }
 }

--- a/tools/generator/test/XCSchemeInfo+TargetInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+TargetInfoTests.swift
@@ -127,6 +127,78 @@ extension XCSchemeInfoTargetInfoTests {
     }
 }
 
+// MARK: - `macroExpansion` Tests
+
+extension XCSchemeInfoTargetInfoTests {
+    func test_macroExpansion_hasHostAndIsNotWatchApp() throws {
+        // let actionInfo = try XCSchemeInfo.LaunchActionInfo(
+        //     resolveHostsFor: .init(
+        //         buildConfigurationName: buildConfigurationName,
+        //         targetInfo: unitTestTargetInfo
+        //     ),
+        //     topLevelTargetInfos: []
+        // )
+        // guard let launchActionInfo = actionInfo else {
+        //     XCTFail("Expected a `LaunchActionInfo`")
+        //     return
+        // }
+        guard let macroExpansion = try unitTestTargetInfo.macroExpansion else {
+            XCTFail("Expected a `macroExpansion`")
+            return
+        }
+        XCTAssertEqual(macroExpansion, appHostInfo.buildableReference)
+    }
+
+    // func test_macroExpansion_hasHostAndIsWatchApp() throws {
+    //     let actionInfo = try XCSchemeInfo.LaunchActionInfo(
+    //         resolveHostsFor: .init(
+    //             buildConfigurationName: buildConfigurationName,
+    //             targetInfo: watchAppTargetInfo
+    //         ),
+    //         topLevelTargetInfos: []
+    //     )
+    //     guard let launchActionInfo = actionInfo else {
+    //         XCTFail("Expected a `LaunchActionInfo`")
+    //         return
+    //     }
+    //     XCTAssertNil(try launchActionInfo.macroExpansion)
+    // }
+
+    // func test_macroExpansion_noHostIsTestable() throws {
+    //     let actionInfo = try XCSchemeInfo.LaunchActionInfo(
+    //         resolveHostsFor: .init(
+    //             buildConfigurationName: buildConfigurationName,
+    //             targetInfo: unitTestNoHostTargetInfo
+    //         ),
+    //         topLevelTargetInfos: []
+    //     )
+    //     guard let launchActionInfo = actionInfo else {
+    //         XCTFail("Expected a `LaunchActionInfo`")
+    //         return
+    //     }
+    //     guard let macroExpansion = try launchActionInfo.macroExpansion else {
+    //         XCTFail("Expected a `macroExpansion`")
+    //         return
+    //     }
+    //     XCTAssertEqual(macroExpansion, unitTestNoHostTargetInfo.buildableReference)
+    // }
+
+    // func test_macroExpansion_noHostIsNotTestable() throws {
+    //     let actionInfo = try XCSchemeInfo.LaunchActionInfo(
+    //         resolveHostsFor: .init(
+    //             buildConfigurationName: buildConfigurationName,
+    //             targetInfo: appTargetInfo
+    //         ),
+    //         topLevelTargetInfos: []
+    //     )
+    //     guard let launchActionInfo = actionInfo else {
+    //         XCTFail("Expected a `LaunchActionInfo`")
+    //         return
+    //     }
+    //     XCTAssertNil(try launchActionInfo.macroExpansion)
+    // }
+}
+
 // MARK: - `bazelBuildPreAction` Tests
 
 extension XCSchemeInfoTargetInfoTests {
@@ -229,11 +301,13 @@ class XCSchemeInfoTargetInfoTests: XCTestCase {
     lazy var appPlatform = Fixtures.targets["A 2"]!.platform
     lazy var anotherAppPlatform = Fixtures.targets["I"]!.platform
     lazy var widgetKitExtPlatform = Fixtures.targets["WDKE"]!.platform
+    lazy var unitTestPlatform = Fixtures.targets["B 2"]!.platform
 
     lazy var libraryPBXTarget = pbxTargetsDict["A 1"]!
     lazy var appPBXTarget = pbxTargetsDict["A 2"]!
     lazy var anotherAppPBXTarget = pbxTargetsDict["I"]!
     lazy var widgetKitExtPBXTarget = pbxTargetsDict["WDKE"]!
+    lazy var unitTestPBXTarget = pbxTargetsDict["B 2"]!
 
     lazy var appHostInfo = XCSchemeInfo.HostInfo(
         pbxTarget: appPBXTarget,
@@ -287,5 +361,15 @@ class XCSchemeInfoTargetInfoTests: XCTestCase {
     lazy var libraryTargetInfoWithHosts = XCSchemeInfo.TargetInfo(
         resolveHostFor: unresolvedLibraryTargetInfoWithHosts,
         topLevelTargetInfos: []
+    )
+    lazy var unitTestTargetInfo = XCSchemeInfo.TargetInfo(
+        resolveHostFor: .init(
+            pbxTarget: unitTestPBXTarget,
+            platforms: [unitTestPlatform],
+            referencedContainer: filePathResolver.containerReference,
+            hostInfos: [appHostInfo],
+            extensionPointIdentifiers: []
+        ),
+        topLevelTargetInfos: [appTargetInfo]
     )
 }


### PR DESCRIPTION
Related to #906.

- Move the macro expansion logic to `XCSchemeInfo.TargetInfo` so that it can be shared with `XCSchemeInfo.TargetInfo` (subsequent PR).