### PR TITLE
Disable upgrade warnings

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -847,24 +847,24 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					34820134F30D904FFA06D27A = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					64AE6000A6317B9C077F3B1E = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					703D7AC89C4B9C9E4B61A58F = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					7E5DFA29686635FDE423D8F4 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
 					};
 					7E7D155EBCA520F35DEA3571 = {
@@ -872,21 +872,21 @@
 					};
 					BBF4D59A51801FF17E35E34E = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
 					};
 					D133FDFF63F008FDDB07BE99 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
 					};
 					DEF15AA97EC0FE28A9A97CAA = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					F175A7E1019A952CA7F66BBC = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 				};
 			};

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleObjcTests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleObjcTests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/FXPageControl.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/FXPageControl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/TestingUtils.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/TestingUtils.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/Utils.xcscheme
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/Utils.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -1012,58 +1012,58 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					225701F2BB3EA192424F07FE = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					42A7256A505DA3DFEA69C941 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					42E984F26D5B4ECBE0F0F076 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					4BF4D16D8EFD29114BC29B92 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 						TestTargetID = 9E46111B59CD5CC4865299C2;
 					};
 					5742A33EA302007E9758E24B = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 						TestTargetID = 9E46111B59CD5CC4865299C2;
 					};
 					63A26735968A55ECFF1DB504 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					7F729945D22504E87B43A144 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					967BEB9EDFB3230C10A206A8 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					9E46111B59CD5CC4865299C2 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					9EEE562EF383D06390A55602 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					A0257519AD63A69C6DF51958 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					BDC5BB543739DEC8809249F9 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 						TestTargetID = 9E46111B59CD5CC4865299C2;
 					};
 					FE59281FE487F27A37DC2EE7 = {

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleNestedResources.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleNestedResources.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleObjcTests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleObjcTests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleResources.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleResources.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExternalResources.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ExternalResources.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/FXPageControl.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/FXPageControl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/OnlyStructuredResources.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/OnlyStructuredResources.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/TestingUtils.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/TestingUtils.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/Utils.xcscheme
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/Utils.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -322,27 +322,27 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					0CEAA3455274D4DE9B4B82BF = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					27EDD304E889980DC176FF62 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					373A62571D2CA8826AD4F92C = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					7E7D155EBCA520F35DEA3571 = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
 					E180851AE3E1EEC8C4944F10 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 				};
 			};

--- a/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
+++ b/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
+++ b/test/fixtures/cc/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
@@ -321,24 +321,24 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					9DF8EA4260F38FC7243F6241 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					B2EDA6BA27C01B7B8423DADB = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					BCD9FA95C7CBE2A799AC3DF9 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					EC6A68AC956C60AA25485960 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					FE59281FE487F27A37DC2EE7 = {
 						CreatedOnToolsVersion = 13.2.1;

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/@examples_cc_external___lib_impl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib2_lib_impl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/__examples_cc_lib_lib_impl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
+++ b/test/fixtures/cc/bwx.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -680,39 +680,39 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					27EDD304E889980DC176FF62 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					48A1FAB71CA4985ACB147363 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					7E7D155EBCA520F35DEA3571 = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
 					8E3B6C47A6106921076BC573 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					BC691472A2BC47F8E1D5D637 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					E56E8F91E4327755D5B09E30 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					EAFF1E96A87B75E6BA080719 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					FB5A7F9FB506F44F296BDD73 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 				};
 			};

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/LibSwiftTests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/LibSwiftTests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/c_lib.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/c_lib.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/lib_impl.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/lib_impl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/lib_swift.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/lib_swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/private_lib.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/private_lib.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/private_swift_lib.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/private_swift_lib.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
+++ b/test/fixtures/command_line/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -677,36 +677,36 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					0290E727C546D76C651A3B2D = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					195FCD65F4EB377830E3E996 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					6396BE04B02BD1C6408F61EC = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					8329F08BE01D4CC32B819CE9 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					BB180DABF9AB371C353A7F0D = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					EC6A68AC956C60AA25485960 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					F38BE7F734335EF255F553F2 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					FE59281FE487F27A37DC2EE7 = {
 						CreatedOnToolsVersion = 13.2.1;

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/LibSwiftTests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/LibSwiftTests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/c_lib.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/c_lib.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_impl.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_impl.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_swift.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/lib_swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/private_lib.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/private_lib.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/private_swift_lib.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/private_swift_lib.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
+++ b/test/fixtures/command_line/bwx.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -1661,43 +1661,43 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					023B2C041CD79AF5B2FDAFE1 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					302F4C6E9EE3F09D4809EF0A = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					4A2EC1B2D6969F717CB890DE = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					7E7D155EBCA520F35DEA3571 = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
 					85C876DB90D51CD225023BB2 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					979D12680661F4B864602CE6 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					9DF90F35406923EA23C68CFC = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					A09CE18EBBDAC65CD0C6B7D1 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					F12050E30563A81EEBB2EA9B = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 				};
 			};

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -1653,40 +1653,40 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					19FA71657765A036575B20D8 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					299DA591171C10F8AF73F244 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					2FED647E7A6091DF616D345B = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					3A4021D8F5FC68CD4FB8B6F1 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					B0128CCFCF9E56DA6D808193 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					CE60FB500B781C8126957C5A = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					CFD3DFAB502EFF52937E5E51 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					F5FCEC7426929BDA7F9F1875 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					FE59281FE487F27A37DC2EE7 = {
 						CreatedOnToolsVersion = 13.2.1;

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
@@ -254,15 +254,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					7E7D155EBCA520F35DEA3571 = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
 					DEF15AA97EC0FE28A9A97CAA = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 				};
 			};

--- a/test/fixtures/macos_app/bwb.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/test/fixtures/macos_app/bwb.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/macos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/macos_app/bwx.xcodeproj/project.pbxproj
@@ -272,12 +272,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					9E46111B59CD5CC4865299C2 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					FE59281FE487F27A37DC2EE7 = {
 						CreatedOnToolsVersion = 13.2.1;

--- a/test/fixtures/macos_app/bwx.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/test/fixtures/macos_app/bwx.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -2068,55 +2068,55 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					06E3C912B8DE52D274641347 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					13A68B4984727F4B3DAE6AFB = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					1765D91CC168F25A5BC51603 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					2BECDF067E07C69468ED23A3 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					2DBD14C7DE92127B94265B10 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					343F031FB3DF1E87C3568525 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					632D255CE04E97FB997EBDD7 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					7E7D155EBCA520F35DEA3571 = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
 					83D00AD7532094902D925C83 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					9A91A239ECE812E066012BAF = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					9D6BB9A04FEC771667C78F54 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					ACEF2F653E0F6BEA37D2C7B6 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 				};
 			};

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(iOS,_tvOS).xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(iOS,_tvOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(watchOS).xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Lib_(watchOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    wasCreatedForAppExtension = "YES"
    version = "1.7">
    <BuildAction

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    wasCreatedForAppExtension = "YES"
    version = "1.7">
    <BuildAction

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
@@ -2169,52 +2169,52 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					182B42EFE70A5561F1C023E5 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					2B369B164AB3542A258E8E5F = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					4A81F3A0DADC86D2FCF01DB1 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					5CFDBC4E4DBF6C4D68352F7F = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					801E2436A69733A307109C9A = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					8CE3F1871538818303774A7D = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					A6969986F4330BE56701A5EC = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					D094AA317C2527FB0FCC5015 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					EDF8F127D3EA3E7481E6D3D5 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					F3451D8089613E01522F3373 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					FDA59F09C0DC31A1D18B6509 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					FE59281FE487F27A37DC2EE7 = {
 						CreatedOnToolsVersion = 13.2.1;

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(iOS,_tvOS).xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(iOS,_tvOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(watchOS).xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Lib_(watchOS).xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    wasCreatedForAppExtension = "YES"
    version = "1.7">
    <BuildAction

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    wasCreatedForAppExtension = "YES"
    version = "1.7">
    <BuildAction

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/simple/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/simple/bwb.xcodeproj/project.pbxproj
@@ -137,12 +137,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					364D5AA9408E41F7F9C99C9B = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					7E7D155EBCA520F35DEA3571 = {
 						CreatedOnToolsVersion = 13.2.1;

--- a/test/fixtures/simple/bwb.xcodeproj/xcshareddata/xcschemes/SwiftBin.xcscheme
+++ b/test/fixtures/simple/bwb.xcodeproj/xcshareddata/xcschemes/SwiftBin.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/simple/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/simple/bwx.xcodeproj/project.pbxproj
@@ -110,12 +110,12 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					5365B2022C99A98F03DF07CA = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 				};
 			};

--- a/test/fixtures/simple/bwx.xcodeproj/xcshareddata/xcschemes/SwiftBin.xcscheme
+++ b/test/fixtures/simple/bwx.xcodeproj/xcshareddata/xcschemes/SwiftBin.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -407,25 +407,25 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					7E7D155EBCA520F35DEA3571 = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
 					BBF4D59A51801FF17E35E34E = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
 					};
 					D133FDFF63F008FDDB07BE99 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
 					};
 					DEF15AA97EC0FE28A9A97CAA = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 				};
 			};

--- a/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
@@ -406,21 +406,21 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1320;
-				LastUpgradeCheck = 1320;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
 				TargetAttributes = {
 					5742A33EA302007E9758E24B = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 						TestTargetID = 9E46111B59CD5CC4865299C2;
 					};
 					9E46111B59CD5CC4865299C2 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 					};
 					BDC5BB543739DEC8809249F9 = {
 						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 1320;
+						LastSwiftMigration = 9999;
 						TestTargetID = 9E46111B59CD5CC4865299C2;
 					};
 					FE59281FE487F27A37DC2EE7 = {

--- a/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleTests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/xcshareddata/xcschemes/ExampleUITests.__internal__.__test_bundle.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "9999"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/tools/generator/src/Extensions/XCScheme+Extensions.swift
+++ b/tools/generator/src/Extensions/XCScheme+Extensions.swift
@@ -1,8 +1,8 @@
 import XcodeProj
 
 enum XCSchemeConstants {
-    // GH399: Derive the defaultLastUpgradeVersion
-    static let defaultLastUpgradeVersion = "1320"
+    // GH399: Derive `defaultLastUpgradeVersion`/make it an option
+    static let defaultLastUpgradeVersion = "9999"
     static let lldbInitVersion = "1.7"
     static let posixSpawnLauncher = "Xcode.IDEFoundation.Launcher.PosixSpawn"
     static let customLLDBInitFile = "$(BAZEL_LLDB_INIT)"

--- a/tools/generator/src/Generator/CreateProject.swift
+++ b/tools/generator/src/Generator/CreateProject.swift
@@ -96,9 +96,9 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)
 
         let attributes = [
             "BuildIndependentTargetsInParallel": 1,
-            // TODO: Generate these. Hardcoded to Xcode 13.2.0 for now.
-            "LastSwiftUpdateCheck": 1320,
-            "LastUpgradeCheck": 1320,
+            // TODO: Make these an option? Hardcoded to never warn for now.
+            "LastSwiftUpdateCheck": 9999,
+            "LastUpgradeCheck": 9999,
         ]
 
         let pbxProject = PBXProject(

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -31,7 +31,7 @@ Target "\(key)" not found in `pbxTargets`
                 // TODO: Generate this value
                 "CreatedOnToolsVersion": "13.2.1",
                 // TODO: Only include properties that make sense for the target
-                "LastSwiftMigration": 1320,
+                "LastSwiftMigration": 9999,
             ]
 
             var buildSettings = try calculateBuildSettings(

--- a/tools/generator/test/CreateProjectTests.swift
+++ b/tools/generator/test/CreateProjectTests.swift
@@ -83,8 +83,8 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)
 
         let attributes: [String: Any] = [
             "BuildIndependentTargetsInParallel": 1,
-            "LastSwiftUpdateCheck": 1320,
-            "LastUpgradeCheck": 1320,
+            "LastSwiftUpdateCheck": 9999,
+            "LastUpgradeCheck": 9999,
         ]
 
         let expectedPBXProject = PBXProject(
@@ -201,8 +201,8 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)
 
         let attributes: [String: Any] = [
             "BuildIndependentTargetsInParallel": 1,
-            "LastSwiftUpdateCheck": 1320,
-            "LastUpgradeCheck": 1320,
+            "LastSwiftUpdateCheck": 9999,
+            "LastUpgradeCheck": 9999,
         ]
 
         let expectedPBXProject = PBXProject(

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -2034,7 +2034,7 @@ perl -pe 's/^("?)(.*\$\(.*\).*?)("?)$/"$2"/ ; s/\$(\()?([a-zA-Z_]\w*)(?(1)\))/$E
 
         let baseAttributes: [String: Any] = [
             "CreatedOnToolsVersion": "13.2.1",
-            "LastSwiftMigration": 1320,
+            "LastSwiftMigration": 9999,
         ]
 
         let attributes: [ConsolidatedTarget.Key: [String: Any]] = [


### PR DESCRIPTION
Related to #399.

These are not actionable by users. We will probably want to make this configurable in the future, minimally for the Swift migration support.