### PR TITLE
Add more docs to `xcodeproj` macro

### DIFF
--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -4,7 +4,7 @@ load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 
 _DOC_SRCS = [
     "experimental",
-    "xcodeproj.doc",
+    "xcodeproj",
 ]
 
 [

--- a/doc/rules-xcodeproj.md
+++ b/doc/rules-xcodeproj.md
@@ -2,36 +2,6 @@
 
 Public rules, macros, and libraries.
 
-<a id="xcodeproj"></a>
-
-## xcodeproj
-
-<pre>
-xcodeproj(<a href="#xcodeproj-name">name</a>, <a href="#xcodeproj-archived_bundles_allowed">archived_bundles_allowed</a>, <a href="#xcodeproj-bazel_path">bazel_path</a>, <a href="#xcodeproj-build_mode">build_mode</a>, <a href="#xcodeproj-focused_targets">focused_targets</a>, <a href="#xcodeproj-project_name">project_name</a>,
-          <a href="#xcodeproj-scheme_autogeneration_mode">scheme_autogeneration_mode</a>, <a href="#xcodeproj-schemes_json">schemes_json</a>, <a href="#xcodeproj-top_level_targets">top_level_targets</a>, <a href="#xcodeproj-toplevel_cache_buster">toplevel_cache_buster</a>,
-          <a href="#xcodeproj-unfocused_targets">unfocused_targets</a>)
-</pre>
-
-Creates an `.xcodeproj` file in the workspace when run.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="xcodeproj-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="xcodeproj-archived_bundles_allowed"></a>archived_bundles_allowed |  -   | Boolean | optional | False |
-| <a id="xcodeproj-bazel_path"></a>bazel_path |  The path to the <code>bazel</code> binary or wrapper script. If the path is relative it will be resolved using the <code>PATH</code> environment variable (which is set to <code>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</code> in Xcode). If you wan to specify a path to a workspace-relative binary, you must prepend the path with <code>./</code> (e.g. <code>"./bazelw"</code>).   | String | optional | "bazel" |
-| <a id="xcodeproj-build_mode"></a>build_mode |  The build mode the generated project should use.<br><br>If this is set to <code>"xcode"</code>, the project will use the Xcode build system to build targets. Generated files and unfocused targets (see the <code>focused_targets</code> and <code>unfocused_targets</code> attributes) will be built with Bazel.<br><br>If this is set to <code>"bazel"</code>, the project will use Bazel to build targets, inside of Xcode. The Xcode build system still unavoidably orchestrates some things at a high level.   | String | optional | "xcode" |
-| <a id="xcodeproj-focused_targets"></a>focused_targets |  A <code>list</code> of target labels as <code>string</code> values. If specified, only these targets will be included in the generated project; all other targets will be excluded, as if they were listed explicitly in the <code>unfocused_targets</code> attribute. The labels must match transitive dependencies of the targets specified in the <code>top_level_targets</code> attribute.   | List of strings | optional | [] |
-| <a id="xcodeproj-project_name"></a>project_name |  The name to use for the <code>.xcodeproj</code> file. If not specified, the value of the <code>name</code> attribute is used.   | String | optional | "" |
-| <a id="xcodeproj-scheme_autogeneration_mode"></a>scheme_autogeneration_mode |  Specifies how Xcode schemes are automatically generated.   | String | optional | "auto" |
-| <a id="xcodeproj-schemes_json"></a>schemes_json |  A JSON string representing a list of Xcode schemes to create.   | String | optional | "" |
-| <a id="xcodeproj-top_level_targets"></a>top_level_targets |  -   | <a href="https://bazel.build/concepts/labels">List of labels</a> | required |  |
-| <a id="xcodeproj-toplevel_cache_buster"></a>toplevel_cache_buster |  For internal use only. Do not set this value yourself.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | [] |
-| <a id="xcodeproj-unfocused_targets"></a>unfocused_targets |  A <code>list</code> of target labels as <code>string</code> values. Any targets in the transitive dependencies of the targets specified in the <code>top_level_targets</code> attribute with a matching label will be excluded from the generated project. This overrides any targets specified in the <code>focused_targets</code> attribute.   | List of strings | optional | [] |
-
-
 <a id="XcodeProjAutomaticTargetProcessingInfo"></a>
 
 ## XcodeProjAutomaticTargetProcessingInfo
@@ -267,5 +237,40 @@ A `sequence` of values returned by `xcode_schemes.scheme`.
   Will only include schemes that have at least one target not in
   `unfocused_targets`. Some actions might be removed if they reference
   unfocused targets.
+
+
+<a id="xcodeproj"></a>
+
+## xcodeproj
+
+<pre>
+xcodeproj(<a href="#xcodeproj-name">name</a>, <a href="#xcodeproj-bazel_path">bazel_path</a>, <a href="#xcodeproj-build_mode">build_mode</a>, <a href="#xcodeproj-focused_targets">focused_targets</a>, <a href="#xcodeproj-project_name">project_name</a>, <a href="#xcodeproj-scheme_autogeneration_mode">scheme_autogeneration_mode</a>,
+          <a href="#xcodeproj-schemes">schemes</a>, <a href="#xcodeproj-top_level_targets">top_level_targets</a>, <a href="#xcodeproj-unfocused_targets">unfocused_targets</a>, <a href="#xcodeproj-kwargs">kwargs</a>)
+</pre>
+
+Creates an `.xcodeproj` file in the workspace when run.
+
+The is a wrapper macro for the
+[actual `xcodeproj` rule](../xcodeproj/internal/xcodeproj_rule.bzl), which
+can't be used directly. All public API is documented below. The `kwargs`
+argument will pass forward values for globally available attributes (e.g.
+`visibility`, `features`, etc.) to the underlying rule.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="xcodeproj-name"></a>name |  A unique name for this target.   |  none |
+| <a id="xcodeproj-bazel_path"></a>bazel_path |  Optional. The path the <code>bazel</code> binary or wrapper script. If the path is relative it will be resolved using the <code>PATH</code> environment variable (which is set to <code>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</code> in Xcode). If you want to specify a path to a workspace-relative binary, you must prepend the path with <code>./</code> (e.g. <code>"./bazelw"</code>).   |  <code>"bazel"</code> |
+| <a id="xcodeproj-build_mode"></a>build_mode |  Optional. The build mode the generated project should use.<br><br>If this is set to <code>"xcode"</code>, the project will use the Xcode build system to build targets. Generated files and unfocused targets (see the <code>focused_targets</code> and <code>unfocused_targets</code> arguments) will be built with Bazel.<br><br>If this is set to <code>"bazel"</code>, the project will use Bazel to build targets, inside of Xcode. The Xcode build system still unavoidably orchestrates some things at a high level.   |  <code>"xcode"</code> |
+| <a id="xcodeproj-focused_targets"></a>focused_targets |  Optional. A <code>list</code> of target labels as <code>string</code> values. If specified, only these targets will be included in the generated project; all other targets will be excluded, as if they were listed explicitly in the <code>unfocused_targets</code> argument. The labels must match transitive dependencies of the targets specified in the <code>top_level_targets</code> argument.   |  <code>[]</code> |
+| <a id="xcodeproj-project_name"></a>project_name |  Optional. The name to use for the <code>.xcodeproj</code> file. If not specified, the value of the <code>name</code> argument is used.   |  <code>None</code> |
+| <a id="xcodeproj-scheme_autogeneration_mode"></a>scheme_autogeneration_mode |  Optional. Specifies how Xcode schemes are automatically generated.   |  <code>"auto"</code> |
+| <a id="xcodeproj-schemes"></a>schemes |  Optional. A <code>list</code> of values returned by <code>xcode_schemes.scheme</code>.   |  <code>[]</code> |
+| <a id="xcodeproj-top_level_targets"></a>top_level_targets |  A <code>list</code> of top-level targets labels.   |  none |
+| <a id="xcodeproj-unfocused_targets"></a>unfocused_targets |  Optional. A <code>list</code> of target labels as <code>string</code> values. Any targets in the transitive dependencies of the targets specified in the <code>top_level_targets</code> argument with a matching label will be excluded from the generated project. This overrides any targets specified in the <code>focused_targets</code> argument.   |  <code>[]</code> |
+| <a id="xcodeproj-kwargs"></a>kwargs |  Additional arguments to pass to the underlying <code>xcodeproj</code> rule specified by <code>xcodeproj_rule</code>.   |  none |
 
 

--- a/xcodeproj/BUILD
+++ b/xcodeproj/BUILD
@@ -2,7 +2,7 @@
 
 exports_files([
     "experimental.bzl",
-    "xcodeproj.doc.bzl",
+    "xcodeproj.bzl",
 ])
 
 # Release

--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -7,8 +7,11 @@ load(":xcodeproj_rule.bzl", _xcodeproj = "xcodeproj")
 def xcodeproj(
         *,
         name,
+        bazel_path = "bazel",
+        build_mode = "xcode",
         focused_targets = [],
         project_name = None,
+        scheme_autogeneration_mode = "auto",
         schemes = [],
         top_level_targets,
         unfocused_targets = [],
@@ -23,6 +26,22 @@ def xcodeproj(
 
     Args:
         name: A unique name for this target.
+        bazel_path: Optional. The path the `bazel` binary or wrapper script. If
+            the path is relative it will be resolved using the `PATH`
+            environment variable (which is set to
+            `/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` in
+            Xcode). If you want to specify a path to a workspace-relative
+            binary, you must prepend the path with `./` (e.g. `"./bazelw"`).
+        build_mode: Optional. The build mode the generated project should use.
+
+            If this is set to `"xcode"`, the project will use the Xcode build
+            system to build targets. Generated files and unfocused targets (see
+            the `focused_targets` and `unfocused_targets` arguments) will be
+            built with Bazel.
+
+            If this is set to `"bazel"`, the project will use Bazel to build
+            targets, inside of Xcode. The Xcode build system still unavoidably
+            orchestrates some things at a high level.
         focused_targets: Optional. A `list` of target labels as `string` values.
             If specified, only these targets will be included in the generated
             project; all other targets will be excluded, as if they were
@@ -31,6 +50,8 @@ def xcodeproj(
             `top_level_targets` argument.
         project_name: Optional. The name to use for the `.xcodeproj` file. If
             not specified, the value of the `name` argument is used.
+        scheme_autogeneration_mode: Optional. Specifies how Xcode schemes are
+            automatically generated.
         schemes: Optional. A `list` of values returned by
             `xcode_schemes.scheme`.
         top_level_targets: A `list` of top-level targets labels.
@@ -44,6 +65,11 @@ def xcodeproj(
     """
     testonly = kwargs.pop("testonly", True)
 
+    # Apply defaults
+    if not bazel_path:
+        bazel_path = "bazel"
+    if not build_mode:
+        build_mode = "xcode"
     if not project_name:
         project_name = name
 
@@ -93,8 +119,11 @@ def xcodeproj(
 
     xcodeproj_rule(
         name = name,
+        build_mode = build_mode,
+        bazel_path = bazel_path,
         focused_targets = focused_targets,
         project_name = project_name,
+        scheme_autogeneration_mode = scheme_autogeneration_mode,
         schemes_json = schemes_json,
         testonly = testonly,
         top_level_targets = top_level_targets,

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -513,7 +513,7 @@ def make_target_transition(
 
 def _xcodeproj_impl(ctx):
     build_mode = ctx.attr.build_mode
-    project_name = ctx.attr.project_name or ctx.attr.name
+    project_name = ctx.attr.project_name
     focused_labels = sets.make(ctx.attr.focused_targets)
     unfocused_labels = sets.make(ctx.attr.unfocused_targets)
     infos = [
@@ -634,7 +634,7 @@ will be resolved using the `PATH` environment variable (which is set to
 you wan to specify a path to a workspace-relative binary, you must prepend the
 path with `./` (e.g. `"./bazelw"`).
 """,
-            default = "bazel",
+            mandatory = True,
         ),
         "build_mode": attr.string(
             doc = """\
@@ -648,7 +648,7 @@ If this is set to `"bazel"`, the project will use Bazel to build targets, inside
 of Xcode. The Xcode build system still unavoidably orchestrates some things at a
 high level.
 """,
-            default = "xcode",
+            mandatory = True,
             values = ["xcode", "bazel"],
         ),
         "focused_targets": attr.string_list(
@@ -663,9 +663,9 @@ labels must match transitive dependencies of the targets specified in the
         ),
         "project_name": attr.string(
             doc = """\
-The name to use for the `.xcodeproj` file. If not specified, the value of the
-`name` attribute is used.
+The name to use for the `.xcodeproj` file.
 """,
+            mandatory = True,
         ),
         "scheme_autogeneration_mode": attr.string(
             doc = "Specifies how Xcode schemes are automatically generated.",


### PR DESCRIPTION
Also adjust the docs to use the macro again. This adds clarity around `schemes` and is needed for future changes to the macro.