### PR TITLE
Add `BAZEL_WORKSPACE_ROOT` build setting var

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1716,6 +1716,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CC = "$(BAZEL_INTEGRATION_DIR)/cc.sh";

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -2181,6 +2181,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -802,6 +802,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CC = "$(BAZEL_INTEGRATION_DIR)/cc.sh";

--- a/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
@@ -592,6 +592,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -1330,6 +1330,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CC = "$(BAZEL_INTEGRATION_DIR)/cc.sh";

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -1191,6 +1191,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -2536,6 +2536,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CC = "$(BAZEL_INTEGRATION_DIR)/cc.sh";

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -2589,6 +2589,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
@@ -400,6 +400,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CC = "$(BAZEL_INTEGRATION_DIR)/cc.sh";

--- a/test/fixtures/macos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/macos_app/bwx.xcodeproj/project.pbxproj
@@ -454,6 +454,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -3320,6 +3320,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CC = "$(BAZEL_INTEGRATION_DIR)/cc.sh";

--- a/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
@@ -3216,6 +3216,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/test/fixtures/simple/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/simple/bwb.xcodeproj/project.pbxproj
@@ -314,6 +314,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CC = "$(BAZEL_INTEGRATION_DIR)/cc.sh";

--- a/test/fixtures/simple/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/simple/bwx.xcodeproj/project.pbxproj
@@ -213,6 +213,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -714,6 +714,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CC = "$(BAZEL_INTEGRATION_DIR)/cc.sh";

--- a/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
@@ -754,6 +754,8 @@
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
 				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				CLANG_ENABLE_OBJC_ARC = YES;

--- a/tools/generator/src/Generator/CreateProject.swift
+++ b/tools/generator/src/Generator/CreateProject.swift
@@ -25,6 +25,7 @@ extension Generator {
             "BAZEL_INTEGRATION_DIR": "$(INTERNAL_DIR)/bazel",
             "BAZEL_LLDB_INIT": "$(OBJROOT)/bazel.lldbinit",
             "BAZEL_OUT": filePathResolver.bazelOutDirectory.string,
+            "BAZEL_WORKSPACE_DIRECTORY": "$(SRCROOT)",
             "BAZEL_WORKSPACE_ROOT": "$(SRCROOT)",
             // `BUILT_PRODUCTS_DIR` isn't actually used by the build, since
             // `DEPLOYMENT_LOCATION` is set. It does prevent `DYLD_LIBRARY_PATH`

--- a/tools/generator/src/Generator/CreateProject.swift
+++ b/tools/generator/src/Generator/CreateProject.swift
@@ -25,6 +25,7 @@ extension Generator {
             "BAZEL_INTEGRATION_DIR": "$(INTERNAL_DIR)/bazel",
             "BAZEL_LLDB_INIT": "$(OBJROOT)/bazel.lldbinit",
             "BAZEL_OUT": filePathResolver.bazelOutDirectory.string,
+            "BAZEL_WORKSPACE_ROOT": "$(SRCROOT)",
             // `BUILT_PRODUCTS_DIR` isn't actually used by the build, since
             // `DEPLOYMENT_LOCATION` is set. It does prevent `DYLD_LIBRARY_PATH`
             // from being modified though.

--- a/tools/generator/test/CreateProjectTests.swift
+++ b/tools/generator/test/CreateProjectTests.swift
@@ -33,6 +33,8 @@ final class CreateProjectTests: XCTestCase {
                 "BAZEL_EXTERNAL": filePathResolver.externalDirectory.string,
                 "BAZEL_LLDB_INIT": "$(OBJROOT)/bazel.lldbinit",
                 "BAZEL_OUT": filePathResolver.bazelOutDirectory.string,
+                "BAZEL_WORKSPACE_DIRECTORY": "$(SRCROOT)",
+                "BAZEL_WORKSPACE_ROOT": "$(SRCROOT)",
                 "BAZEL_INTEGRATION_DIR": "$(INTERNAL_DIR)/bazel",
                 "BUILT_PRODUCTS_DIR": """
 $(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))
@@ -143,6 +145,8 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)
                 "BAZEL_EXTERNAL": filePathResolver.externalDirectory.string,
                 "BAZEL_LLDB_INIT": "$(OBJROOT)/bazel.lldbinit",
                 "BAZEL_OUT": filePathResolver.bazelOutDirectory.string,
+                "BAZEL_WORKSPACE_DIRECTORY": "$(SRCROOT)",
+                "BAZEL_WORKSPACE_ROOT": "$(SRCROOT)",
                 "BAZEL_INTEGRATION_DIR": "$(INTERNAL_DIR)/bazel",
                 "BUILT_PRODUCTS_DIR": """
 $(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))


### PR DESCRIPTION
This var simply points to `$(SRCROOT)` and helps users who have relied on
this variable prior to using
rules_xcodeproj