### PR TITLE
Add support for "Compile File" command

### DIFF
--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1326,6 +1326,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/TestingUtils";
 				BAZEL_TARGET_ID = "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -1354,9 +1355,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//ExampleObjcTests:ExampleObjcTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/ExampleObjcTests/ExampleObjcTests.xctest";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/ExampleObjcTests";
 				BAZEL_TARGET_ID = "//ExampleObjcTests:ExampleObjcTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -1476,9 +1480,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//ExampleUITests:ExampleUITests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/ExampleUITests/ExampleUITests.xctest";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/ExampleUITests";
 				BAZEL_TARGET_ID = "//ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_STYLE = Manual;
@@ -1517,9 +1524,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//ExampleTests:ExampleTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/ExampleTests/ExampleTests.xctest";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/ExampleTests";
 				BAZEL_TARGET_ID = "//ExampleTests:ExampleTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Manual;
@@ -1569,6 +1579,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/CoreUtilsObjC";
 				BAZEL_TARGET_ID = "//CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1665,6 +1676,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/Utils";
 				BAZEL_TARGET_ID = "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1811,6 +1823,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/external/FXPageControl";
 				BAZEL_TARGET_ID = "@FXPageControl//:FXPageControl ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1903,9 +1916,12 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BAZEL_COMPILE_TARGET_ID = "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/Example/Example.app";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-80b7926e333b/bin/Example";
 				BAZEL_TARGET_ID = "//Example:Example applebin_ios-ios_x86_64-dbg-ST-80b7926e333b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_ENTITLEMENTS = Example/app.entitlements;
 				CODE_SIGN_STYLE = Manual;

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -1582,6 +1582,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/TestingUtils";
 				BAZEL_TARGET_ID = "//TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -1613,6 +1614,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/external/examples_ios_app_external";
 				BAZEL_TARGET_ID = "@examples_ios_app_external//:ExternalResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
@@ -1638,6 +1640,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/OnlyStructuredResources";
 				BAZEL_TARGET_ID = "//OnlyStructuredResources:OnlyStructuredResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
@@ -1663,6 +1666,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/ExampleNestedResources";
 				BAZEL_TARGET_ID = "//ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
@@ -1686,8 +1690,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//ExampleTests:ExampleTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/ExampleTests";
 				BAZEL_TARGET_ID = "//ExampleTests:ExampleTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Manual;
@@ -1737,6 +1744,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/external/FXPageControl";
 				BAZEL_TARGET_ID = "@FXPageControl//:FXPageControl ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1835,6 +1843,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/ExampleResources";
 				BAZEL_TARGET_ID = "//ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
@@ -1870,6 +1879,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/CoreUtilsObjC";
 				BAZEL_TARGET_ID = "//CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1970,8 +1980,11 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BAZEL_COMPILE_TARGET_ID = "//Example:Example.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/Example";
 				BAZEL_TARGET_ID = "//Example:Example applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = Example/app.entitlements;
@@ -2061,8 +2074,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//ExampleObjcTests:ExampleObjcTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/ExampleObjcTests";
 				BAZEL_TARGET_ID = "//ExampleObjcTests:ExampleObjcTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -2176,8 +2192,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//ExampleUITests:ExampleUITests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/ExampleUITests";
 				BAZEL_TARGET_ID = "//ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_STYLE = Manual;
@@ -2218,6 +2237,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8/bin/Utils";
 				BAZEL_TARGET_ID = "//Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-2b4014b1fbe8";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				DEBUG_INFORMATION_FORMAT = dwarf;

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -527,6 +527,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/external/examples_cc_external";
 				BAZEL_TARGET_ID = "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
@@ -591,6 +592,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/examples/cc/lib";
 				BAZEL_TARGET_ID = "//examples/cc/lib:lib_impl darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
@@ -665,6 +667,7 @@
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/examples/cc/tool/tool";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/examples/cc/tool";
 				BAZEL_TARGET_ID = "//examples/cc/tool:tool darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -737,6 +740,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/examples/cc/lib2";
 				BAZEL_TARGET_ID = "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
@@ -510,6 +510,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/examples/cc/lib";
 				BAZEL_TARGET_ID = "//examples/cc/lib:lib_impl darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
@@ -629,6 +630,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/examples/cc/lib2";
 				BAZEL_TARGET_ID = "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
@@ -695,6 +697,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/examples/cc/tool";
 				BAZEL_TARGET_ID = "//examples/cc/tool:tool darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -772,6 +775,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/external/examples_cc_external";
 				BAZEL_TARGET_ID = "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;

--- a/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwb.xcodeproj/project.pbxproj
@@ -1025,9 +1025,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/command_line/Tests:LibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-757525382804/bin/examples/command_line/Tests/LibSwiftTests.__internal__.__test_bundle.zip";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804/bin/examples/command_line/Tests";
 				BAZEL_TARGET_ID = "//examples/command_line/Tests:LibSwiftTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-ST-757525382804";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1072,6 +1075,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804/bin/examples/command_line/lib";
 				BAZEL_TARGET_ID = "//examples/command_line/lib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -1100,6 +1104,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804/bin/examples/command_line/lib";
 				BAZEL_TARGET_ID = "//examples/command_line/lib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -1142,6 +1147,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804/bin/examples/command_line/lib";
 				BAZEL_TARGET_ID = "//examples/command_line/lib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1223,9 +1229,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/command_line/tool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-757525382804/bin/examples/command_line/tool/tool";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804/bin/examples/command_line/tool";
 				BAZEL_TARGET_ID = "//examples/command_line/tool:tool applebin_macos-darwin_x86_64-dbg-ST-757525382804";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1375,6 +1384,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804/bin/examples/command_line/swift_c_module";
 				BAZEL_TARGET_ID = "//examples/command_line/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
@@ -1432,6 +1442,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804/bin/examples/command_line/lib";
 				BAZEL_TARGET_ID = "//examples/command_line/lib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-757525382804";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;

--- a/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/command_line/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/command_line/bwx.xcodeproj/project.pbxproj
@@ -976,6 +976,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445/bin/examples/command_line/swift_c_module";
 				BAZEL_TARGET_ID = "//examples/command_line/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
@@ -1048,6 +1049,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445/bin/examples/command_line/lib";
 				BAZEL_TARGET_ID = "//examples/command_line/lib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -1081,6 +1083,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445/bin/examples/command_line/lib";
 				BAZEL_TARGET_ID = "//examples/command_line/lib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
@@ -1141,8 +1144,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/command_line/Tests:LibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445/bin/examples/command_line/Tests";
 				BAZEL_TARGET_ID = "//examples/command_line/Tests:LibSwiftTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1228,6 +1234,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445/bin/examples/command_line/lib";
 				BAZEL_TARGET_ID = "//examples/command_line/lib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -1255,8 +1262,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/command_line/tool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445/bin/examples/command_line/tool";
 				BAZEL_TARGET_ID = "//examples/command_line/tool:tool applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -1361,6 +1371,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445/bin/examples/command_line/lib";
 				BAZEL_TARGET_ID = "//examples/command_line/lib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-6f1dd0330445";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				DEBUG_INFORMATION_FORMAT = dwarf;

--- a/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/command_line/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -2471,6 +2471,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/external/com_github_kylef_pathkit";
 				BAZEL_TARGET_ID = "@com_github_kylef_pathkit//:PathKit darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -2509,6 +2510,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/external/com_github_tuist_xcodeproj";
 				BAZEL_TARGET_ID = "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -2587,6 +2589,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/external/com_github_pointfreeco_xctest_dynamic_overlay";
 				BAZEL_TARGET_ID = "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -2615,6 +2618,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/external/com_github_pointfreeco_swift_custom_dump";
 				BAZEL_TARGET_ID = "@com_github_pointfreeco_swift_custom_dump//:CustomDump darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -2642,9 +2646,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//tools/generator/test:tests.library darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/tools/generator/test/tests.xctest";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/tools/generator/test";
 				BAZEL_TARGET_ID = "//tools/generator/test:tests darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_LOCATION = NO;
@@ -2679,6 +2686,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/external/com_github_apple_swift_collections";
 				BAZEL_TARGET_ID = "@com_github_apple_swift_collections//:OrderedCollections darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -2705,9 +2713,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//tools/generator:generator.library darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/tools/generator/generator";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/tools/generator";
 				BAZEL_TARGET_ID = "//tools/generator:generator darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_LOCATION = NO;
@@ -2742,6 +2753,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3e0dd315ada8/bin/tools/generator";
 				BAZEL_TARGET_ID = "//tools/generator:generator.library darwin_x86_64-dbg-ST-3e0dd315ada8";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -2334,6 +2334,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/external/com_github_pointfreeco_swift_custom_dump";
 				BAZEL_TARGET_ID = "@com_github_pointfreeco_swift_custom_dump//:CustomDump darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -2364,6 +2365,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/external/com_github_tuist_xcodeproj";
 				BAZEL_TARGET_ID = "@com_github_tuist_xcodeproj//:XcodeProj darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -2394,6 +2396,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/tools/generator";
 				BAZEL_TARGET_ID = "//tools/generator:generator.library darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -2422,8 +2425,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//tools/generator:generator.library darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/tools/generator";
 				BAZEL_TARGET_ID = "//tools/generator:generator darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_LOCATION = NO;
@@ -2469,6 +2475,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/external/com_github_pointfreeco_xctest_dynamic_overlay";
 				BAZEL_TARGET_ID = "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -2496,8 +2503,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//tools/generator/test:tests.library darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/tools/generator/test";
 				BAZEL_TARGET_ID = "//tools/generator/test:tests darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_LOCATION = NO;
@@ -2533,6 +2543,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/external/com_github_kylef_pathkit";
 				BAZEL_TARGET_ID = "@com_github_kylef_pathkit//:PathKit darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -2562,6 +2573,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/external/com_github_apple_swift_collections";
 				BAZEL_TARGET_ID = "@com_github_apple_swift_collections//:OrderedCollections darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/macos_app/bwb.xcodeproj/project.pbxproj
@@ -1,0 +1,517 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		7E7D155EBCA520F35DEA3571 /* BazelDependencies */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
+			buildPhases = (
+				9A630CF63C380FAE522825A9 /* Bazel Build */,
+				20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */,
+			);
+			dependencies = (
+			);
+			name = BazelDependencies;
+			productName = BazelDependencies;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		30C8A97AD6424D0CEE418C13 /* macOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BD39E40436194BD7493E47 /* macOSApp.swift */; };
+		E5D745C49A3ECC46B9B96B19 /* ExampleFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6962FF4763079A73B20C68BF /* ExampleFramework.framework */; };
+		E99AC4A22EBD2857E1B3BAB4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 050F110B9B46CA02EC8B5D2D /* ContentView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		DDD61C8C1CFA249BBE0E369C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		050F110B9B46CA02EC8B5D2D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		3210934E48164E878737ADD8 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		51BD39E40436194BD7493E47 /* macOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSApp.swift; sourceTree = "<group>"; };
+		63CB3CB70A8F033B9418B547 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		6962FF4763079A73B20C68BF /* ExampleFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExampleFramework.framework; sourceTree = "<group>"; };
+		6BF3863B5440301ED3C9914F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		7ED8A7883F2C4665C69313CB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		91BFEFD7A1555911D65380C4 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		A411C2C29BD32648C0EABE8B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		A6D2339680FEF6849778735A /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		B28790441A2C90C7FEA3E8DC /* macOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = macOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6E426D209568E509FBE28076 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E5D745C49A3ECC46B9B96B19 /* ExampleFramework.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0B9821DDA5E9C44695F7B0C6 /* macos_app */ = {
+			isa = PBXGroup;
+			children = (
+				1E93AE980B325960AF89A113 /* Example */,
+				18E09D954F8369D8939C4623 /* third_party */,
+			);
+			path = macos_app;
+			sourceTree = "<group>";
+		};
+		1377538D89C6225E39C26AFF /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				9A3625FEDEDC8146714FB6FC /* Example */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
+		18E09D954F8369D8939C4623 /* third_party */ = {
+			isa = PBXGroup;
+			children = (
+				63CB3CB70A8F033B9418B547 /* BUILD */,
+				6962FF4763079A73B20C68BF /* ExampleFramework.framework */,
+			);
+			path = third_party;
+			sourceTree = "<group>";
+		};
+		1E93AE980B325960AF89A113 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				482E041460BA282CB51FE6FC /* PreviewContent */,
+				A411C2C29BD32648C0EABE8B /* Assets.xcassets */,
+				3210934E48164E878737ADD8 /* BUILD */,
+				050F110B9B46CA02EC8B5D2D /* ContentView.swift */,
+				7ED8A7883F2C4665C69313CB /* Info.plist */,
+				51BD39E40436194BD7493E47 /* macOSApp.swift */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		2E6D9E4BA36A87B56922910C /* fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				8CEC7934F18C22D38B62C89E /* macos_app */,
+			);
+			path = fixtures;
+			sourceTree = "<group>";
+		};
+		482E041460BA282CB51FE6FC /* PreviewContent */ = {
+			isa = PBXGroup;
+			children = (
+				91BFEFD7A1555911D65380C4 /* Preview Assets.xcassets */,
+			);
+			path = PreviewContent;
+			sourceTree = "<group>";
+		};
+		593E7C82FAAD94A7E6A04318 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B28790441A2C90C7FEA3E8DC /* macOSApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		68A1D737225E7A97337523DE /* test */ = {
+			isa = PBXGroup;
+			children = (
+				2E6D9E4BA36A87B56922910C /* fixtures */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		6ECB327F84BD3B6C9D9D9BD2 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				1377538D89C6225E39C26AFF /* rules_xcodeproj */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		778247E92388349743FB292D /* applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c */ = {
+			isa = PBXGroup;
+			children = (
+				887960979D9C7A3819E029DC /* bin */,
+			);
+			path = "applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c";
+			sourceTree = "<group>";
+		};
+		887960979D9C7A3819E029DC /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				896EAA92C75EEA3E61431FA6 /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
+		896EAA92C75EEA3E61431FA6 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				B77681699BE6B40B67DD4B2E /* macos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		8CEC7934F18C22D38B62C89E /* macos_app */ = {
+			isa = PBXGroup;
+			children = (
+				A6D2339680FEF6849778735A /* BUILD */,
+			);
+			path = macos_app;
+			sourceTree = "<group>";
+		};
+		9A3625FEDEDC8146714FB6FC /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				6BF3863B5440301ED3C9914F /* Info.plist */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		B77681699BE6B40B67DD4B2E /* macos_app */ = {
+			isa = PBXGroup;
+			children = (
+				6ECB327F84BD3B6C9D9D9BD2 /* Example */,
+			);
+			path = macos_app;
+			sourceTree = "<group>";
+		};
+		BB34C210E2A56E7B96B81F9A /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				0B9821DDA5E9C44695F7B0C6 /* macos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		C047AF1D451C7E165914273D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C407A8E68D8C611448A3E699 /* Bazel Generated Files */ = {
+			isa = PBXGroup;
+			children = (
+				778247E92388349743FB292D /* applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c */,
+			);
+			name = "Bazel Generated Files";
+			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+			sourceTree = "<group>";
+		};
+		EC6FEE5AC277A3FEEA95510A = {
+			isa = PBXGroup;
+			children = (
+				BB34C210E2A56E7B96B81F9A /* examples */,
+				68A1D737225E7A97337523DE /* test */,
+				C407A8E68D8C611448A3E699 /* Bazel Generated Files */,
+				593E7C82FAAD94A7E6A04318 /* Products */,
+				C047AF1D451C7E165914273D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		DEF15AA97EC0FE28A9A97CAA /* Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4E80458017EA17FB5B672FEB /* Build configuration list for PBXNativeTarget "Example" */;
+			buildPhases = (
+				91A249C04A86079A36A5303D /* Copy Bazel Outputs */,
+				3C5F7018A60EE40574F4CDA0 /* Create link.params */,
+				F94B766A6F00B6427D27F290 /* Sources */,
+				6E426D209568E509FBE28076 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5F96E438EF4C12858E3D604D /* PBXTargetDependency */,
+			);
+			name = Example;
+			productName = macOSApp;
+			productReference = B28790441A2C90C7FEA3E8DC /* macOSApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0805833D09730531AD081697 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
+				TargetAttributes = {
+					7E7D155EBCA520F35DEA3571 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					DEF15AA97EC0FE28A9A97CAA = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
+				};
+			};
+			buildConfigurationList = 669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = EC6FEE5AC277A3FEEA95510A;
+			productRefGroup = 593E7C82FAAD94A7E6A04318 /* Products */;
+			projectDirPath = ../../..;
+			projectRoot = "";
+			targets = (
+				7E7D155EBCA520F35DEA3571 /* BazelDependencies */,
+				DEF15AA97EC0FE28A9A97CAA /* Example */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(OBJROOT)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3C5F7018A60EE40574F4CDA0 /* Create link.params */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(LINK_PARAMS_FILE)",
+			);
+			name = "Create link.params";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/link.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		91A249C04A86079A36A5303D /* Copy Bazel Outputs */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Copy Bazel Outputs";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"macOSApp.app\" \\\n  \"$INTERNAL_DIR/app.exclude.rsynclist\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9A630CF63C380FAE522825A9 /* Bazel Build */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bazel Build";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/generated.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -euo pipefail\n\n# In Xcode 14 the \"Index\" directory was renamed to \"Index.noindex\".\n# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can\n# use it to determine the name of the directory regardless of Xcode version.\nreadonly index_dir=\"${INDEX_DATA_STORE_DIR%/*}\"\nreadonly index_dir_name=\"${index_dir##*/}\"\n\n# Xcode doesn't adjust `$OBJROOT` in scheme action scripts when building for\n# previews. So we need to look in the non-preview build directory for this file.\nreadonly non_preview_objroot=\"${OBJROOT/\\/Intermediates.noindex\\/Previews\\/*//Intermediates.noindex}\"\nreadonly base_objroot=\"${non_preview_objroot/\\/$index_dir_name\\/Build\\/Intermediates.noindex//Build/Intermediates.noindex}\"\nreadonly scheme_target_ids_file=\"$non_preview_objroot/scheme_target_ids\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  readonly output_group_prefix=i\nelse\n  readonly output_group_prefix=b\nfi\n\n# We need to read from `$output_groups_file` as soon as possible, as concurrent\n# writes to it can happen during indexing, which breaks the off-by-one-by-design\n# nature of it\nIFS=$'\\n' read -r -d '' -a output_groups < \\\n  <( \"$CALCULATE_OUTPUT_GROUPS_SCRIPT\" \\\n       \"$non_preview_objroot\" \\\n       \"$base_objroot\" \\\n       \"$scheme_target_ids_file\" \\\n       $output_group_prefix \\\n       && printf '\\0' )\n\nif [ -z \"${output_groups:-}\" ]; then\n  if [ \"$ACTION\" == \"indexbuild\" ]; then\n    echo \"error: Can't yet determine Index Build output group. Next build should succeed. If not, please file a bug report here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.\" >&2\n    exit 1\n  else\n    echo \"error: BazelDependencies invoked without any output groups set. Please file a bug report here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.\" >&2\n    exit 1\n  fi\nfi\noutput_groups_flag=\"--output_groups=$(IFS=, ; echo \"${output_groups[*]}\")\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\nif [[ \"${COLOR_DIAGNOSTICS:-NO}\" == \"YES\" ]]; then\n  color=yes\nelse\n  color=no\nfi\n\nbazelrcs=(\n  --noworkspace_rc\n  \"--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc\"\n)\nif [[ -s \".bazelrc\" ]]; then\n  bazelrcs+=(\"--bazelrc=.bazelrc\")\nfi\nif [[ -s \"$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc\" ]]; then\n  bazelrcs+=(\"--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc\")\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  \"${bazelrcs[@]}\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --config=rules_xcodeproj_info \\\n  --color=\"$color\" \\\n  --experimental_convenience_symlinks=ignore \\\n  --symlink_prefix=/ \\\n  --bes_backend= \\\n  --bes_results_url= \\\n  output_path)\nexec_root=\"${output_path%/*}\"\n\nif [[ \"$ACTION\" != \"indexbuild\" && \"${ENABLE_PREVIEWS:-}\" != \"YES\" ]]; then\n  \"$BAZEL_INTEGRATION_DIR/create_lldbinit.sh\" \"$exec_root\"  > \"$BAZEL_LLDB_INIT\"\nfi\n\nif [[ \"${BAZEL_OUT:0:1}\" == '/' ]]; then\n  bazel_out_prefix=\nelse\n  bazel_out_prefix=\"$SRCROOT/\"\nfi\n\nabsolute_bazel_out=\"${bazel_out_prefix}$BAZEL_OUT\"\n\nif [[ \"$output_path\" != \"$absolute_bazel_out\" ]]; then\n  # Use current path for bazel-out\n  # This fixes Index Build to use its version of generated files\n  roots=\"{\\\"external-contents\\\": \\\"$output_path\\\",\\\"name\\\": \\\"$absolute_bazel_out\\\",\\\"type\\\": \\\"directory-remap\\\"}\"\nelse\n  roots=\nfi\n\n# Map `$BUILD_DIR` to execroot, to fix SwiftUI Previews and indexing edge cases\nroots=\"${roots:+${roots},}{\\\"external-contents\\\": \\\"$exec_root\\\",\\\"name\\\": \\\"$BUILD_DIR\\\",\\\"type\\\": \\\"directory-remap\\\"}\"\n\ncat > \"$OBJROOT/bazel-out-overlay.yaml\" <<EOF\n{\"case-sensitive\": \"false\", \"fallthrough\": true, \"roots\": [$roots],\"version\": 0}\nEOF\n\ncd \"$SRCROOT\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  config=rules_xcodeproj_indexbuild\nelif [ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]; then\n  config=rules_xcodeproj_swiftuipreviews\nelse\n  config=rules_xcodeproj_build\nfi\n\ndate +%s > \"$INTERNAL_DIR/toplevel_cache_buster\"\n\nbuild_marker=\"$OBJROOT/bazel_build_start\"\ntouch \"$build_marker\"\n\nlog=$(mktemp)\n\"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py\" env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  \"${bazelrcs[@]}\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --config=$config \\\n  --color=yes \\\n  --experimental_convenience_symlinks=ignore \\\n  --symlink_prefix=/ \\\n  \"$output_groups_flag\" \\\n  //test/fixtures/macos_app:xcodeproj_bwb.generator \\\n  2>&1 | tee -i \"$log\"\n\nfor output_group in \"${output_groups[@]}\"; do\n  filelist=\"xcodeproj_bwb.generator-${output_group//\\//_}\"\n  filelist=\"${filelist/#/$output_path/darwin_x86_64-dbg-ST-1b9bd654f600/bin/test/fixtures/macos_app/}\"\n  filelist=\"${filelist/%/.filelist}\"\n  if [[ \"$filelist\" -ot \"$build_marker\" ]]; then\n    echo \"error: Bazel didn't generate the correct files (it should have generated outputs for output group \\\"$output_group\\\", but the timestamp for \\\"$filelist\\\" was from before the build). Please regenerate the project to fix this.\" >&2\n    echo \"error: If your bazel version is less than 5.2, you may need to \\`bazel clean\\` and/or \\`bazel shutdown\\` to work around a bug in project generation.\" >&2\n    echo \"error: If you are still getting this error after all of that, please file a bug report here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.\" >&2\n    exit 1\n  fi\ndone\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F94B766A6F00B6427D27F290 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E99AC4A22EBD2857E1B3BAB4 /* ContentView.swift in Sources */,
+				30C8A97AD6424D0CEE418C13 /* macOSApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		5F96E438EF4C12858E3D604D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = DDD61C8C1CFA249BBE0E369C /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		5AFD85147E5F7EEA259481C2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = BazelDependencies;
+			};
+			name = Debug;
+		};
+		B0892EE2AB907B40AA4EB960 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BAZEL_EXEC_ROOT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+				BAZEL_EXTERNAL = "bazel-output-base/external";
+				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
+				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
+				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
+				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
+				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
+				CC = "$(BAZEL_INTEGRATION_DIR)/cc.sh";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
+				COPY_PHASE_STRIP = NO;
+				CXX = "$(BAZEL_INTEGRATION_DIR)/cc.sh";
+				DEPLOYMENT_LOCATION = "$(INDEXING_DEPLOYMENT_LOCATION__$(INDEX_ENABLE_BUILD_ARENA)),";
+				DSTROOT = "$(PROJECT_TEMP_DIR)";
+				INDEXING_BUILT_PRODUCTS_DIR__ = "$(INDEXING_BUILT_PRODUCTS_DIR__NO)";
+				INDEXING_BUILT_PRODUCTS_DIR__NO = "$(BUILD_DIR)";
+				INDEXING_BUILT_PRODUCTS_DIR__YES = "$(CONFIGURATION_BUILD_DIR)";
+				INDEXING_DEPLOYMENT_LOCATION__ = "$(INDEXING_DEPLOYMENT_LOCATION__NO)";
+				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
+				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
+				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
+				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
+				LD = "$(BAZEL_INTEGRATION_DIR)/ld.sh";
+				LDPLUSPLUS = "$(BAZEL_INTEGRATION_DIR)/ld.sh";
+				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
+				LINKS_DIR = "$(INTERNAL_DIR)/links";
+				ONLY_ACTIVE_ARCH = YES;
+				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EXEC = "$(BAZEL_INTEGRATION_DIR)/swiftc.py";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_USE_INTEGRATED_DRIVER = NO;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+		ED022D7827FA072088152A34 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BAZEL_COMPILE_TARGET_ID = "//examples/macos_app/Example:Example.library macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
+				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c/bin/examples/macos_app/Example/Example.zip";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c/bin/examples/macos_app/Example";
+				BAZEL_TARGET_ID = "//examples/macos_app/Example:Example applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEPLOYMENT_LOCATION = NO;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = examples/macos_app/third_party;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c/bin/examples/macos_app/Example/rules_xcodeproj/Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c/examples/macos_app/Example/Example.link.params";
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=examples/macos_app/third_party/ExampleFramework.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexamples/macos_app/third_party -static";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
+				PRODUCT_MODULE_NAME = iOSApp;
+				PRODUCT_NAME = macOSApp;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = Example;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c/bin",
+				);
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4E80458017EA17FB5B672FEB /* Build configuration list for PBXNativeTarget "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ED022D7827FA072088152A34 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B0892EE2AB907B40AA4EB960 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5AFD85147E5F7EEA259481C2 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0805833D09730531AD081697 /* Project object */;
+}

--- a/test/fixtures/macos_app/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/macos_app/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -51,10 +51,10 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        # Xcode gets "stuck" in the `buildFiles` or `build` command for
-        # top-level targets, so we can't reliably change commands here. Leaving
-        # the code in place in case this is fixed in the future, or we want to
-        # do something similar in an XCBBuildService proxy.
+        # Xcode gets "suck" in the `buildFiles` or `build` command for top-level
+        # targets, so we can't reliably change commands here. Leaving the code
+        # in place in case this is fixed in the future, or we want to do
+        # something similar in an XCBBuildService proxy.
         #
         # command = (
         #     build_request.get("_buildCommand2", {}).get("command", "build")
@@ -197,7 +197,7 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
 
     if prefix == "i":
         # buildRequest for Index Build includes all targets, so we have to
-        # fall back to the scheme target ids (which are actually set by the
+        # fallback to the scheme target ids (which are actually set by the
         # "Copy Bazel Outputs" script)
         target_ids = scheme_target_ids
     else:

--- a/test/fixtures/macos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/macos_app/bwx.xcodeproj/project.pbxproj
@@ -1,0 +1,521 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		FE59281FE487F27A37DC2EE7 /* BazelDependencies */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
+			buildPhases = (
+				773C70B69E7F801B38FDC01C /* Generate Files */,
+				2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */,
+			);
+			dependencies = (
+			);
+			name = BazelDependencies;
+			productName = BazelDependencies;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		2A9C7B2694B074B34CE1622C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD45C53E5DCAC15BCF5764D /* ContentView.swift */; };
+		454667A16E391F68EFF5F703 /* ExampleFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 064F4BD4543FEAF27507ABED /* ExampleFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		54F6F91C757354B6B3A39639 /* macOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C68B74CE26786DEFFE645D3C /* macOSApp.swift */; };
+		59EE8266C2DE2B3FD22E2246 /* ExampleFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 064F4BD4543FEAF27507ABED /* ExampleFramework.framework */; };
+		AD0CF994A192837D1E79768B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AE97F6D6D5995C0DE3C23E17 /* Assets.xcassets */; };
+		BD77F248941C5014D3537699 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = EA136BCC5F8FF7F12B402D13 /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		DFB6B3D768109FDA95CBEF01 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		761DAAD429FC5A4C1EBD5270 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				454667A16E391F68EFF5F703 /* ExampleFramework.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		064F4BD4543FEAF27507ABED /* ExampleFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExampleFramework.framework; sourceTree = "<group>"; };
+		30C48FC7C131C94F65F8BC29 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		3DD45C53E5DCAC15BCF5764D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		4E0183A010067D0E90916009 /* macOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = macOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6A2956150DE5F0FBC62D9BE0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		AE97F6D6D5995C0DE3C23E17 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B941DEAA3E5A30BDF158E57F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		C68B74CE26786DEFFE645D3C /* macOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macOSApp.swift; sourceTree = "<group>"; };
+		CD1089FB595A4AE6D3F310D0 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		DEB253216085BA70FBA37EC3 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		EA136BCC5F8FF7F12B402D13 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		0BB138DF24439C6CB36F159F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				59EE8266C2DE2B3FD22E2246 /* ExampleFramework.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		03FB4F0C0D99EA8916C1A2EB /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				85D6459BA9D5556ACC88FCB9 /* rules_xcodeproj */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		34EEB3D407F10261A42BB9F7 /* fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				D33CCCCA9AB0590F674BE724 /* macos_app */,
+			);
+			path = fixtures;
+			sourceTree = "<group>";
+		};
+		355FA70F3D5E3216F351A4F0 /* macos_app */ = {
+			isa = PBXGroup;
+			children = (
+				81DF72949793AEFDD1B06BDD /* Example */,
+				5CBA2F9E44924729DFECF190 /* third_party */,
+			);
+			path = macos_app;
+			sourceTree = "<group>";
+		};
+		462C3519CA354BE1B04D4855 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4E0183A010067D0E90916009 /* macOSApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		5CBA2F9E44924729DFECF190 /* third_party */ = {
+			isa = PBXGroup;
+			children = (
+				DEB253216085BA70FBA37EC3 /* BUILD */,
+				064F4BD4543FEAF27507ABED /* ExampleFramework.framework */,
+			);
+			path = third_party;
+			sourceTree = "<group>";
+		};
+		6FAE58F334A8269E7C858347 /* macos_app */ = {
+			isa = PBXGroup;
+			children = (
+				03FB4F0C0D99EA8916C1A2EB /* Example */,
+			);
+			path = macos_app;
+			sourceTree = "<group>";
+		};
+		77E0714FDD425211EBA209DF = {
+			isa = PBXGroup;
+			children = (
+				86E3AA094AC3498BEDC1D673 /* examples */,
+				D2C8CC455B9D27F28D323622 /* test */,
+				A5A3DECCB7E56F0EA3676D12 /* Bazel Generated Files */,
+				462C3519CA354BE1B04D4855 /* Products */,
+				D9AAB93A5135F69103554470 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		81DF72949793AEFDD1B06BDD /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				D45747A50B9FCDA001D3AD4F /* PreviewContent */,
+				AE97F6D6D5995C0DE3C23E17 /* Assets.xcassets */,
+				30C48FC7C131C94F65F8BC29 /* BUILD */,
+				3DD45C53E5DCAC15BCF5764D /* ContentView.swift */,
+				B941DEAA3E5A30BDF158E57F /* Info.plist */,
+				C68B74CE26786DEFFE645D3C /* macOSApp.swift */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		85D6459BA9D5556ACC88FCB9 /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				8D2D3565CBDD344F2D1CE269 /* Example */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
+		86E3AA094AC3498BEDC1D673 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				355FA70F3D5E3216F351A4F0 /* macos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		8D2D3565CBDD344F2D1CE269 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				6A2956150DE5F0FBC62D9BE0 /* Info.plist */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		94D1B7341B8C79F3FB26AB46 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				6FAE58F334A8269E7C858347 /* macos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		A59C5D74181A3DDCE0ACFE7C /* applebin_macos-darwin_x86_64-dbg-ST-450091386d5c */ = {
+			isa = PBXGroup;
+			children = (
+				DAF4B76C7AB07061CFF42043 /* bin */,
+			);
+			path = "applebin_macos-darwin_x86_64-dbg-ST-450091386d5c";
+			sourceTree = "<group>";
+		};
+		A5A3DECCB7E56F0EA3676D12 /* Bazel Generated Files */ = {
+			isa = PBXGroup;
+			children = (
+				A59C5D74181A3DDCE0ACFE7C /* applebin_macos-darwin_x86_64-dbg-ST-450091386d5c */,
+			);
+			name = "Bazel Generated Files";
+			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+			sourceTree = "<group>";
+		};
+		D2C8CC455B9D27F28D323622 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				34EEB3D407F10261A42BB9F7 /* fixtures */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		D33CCCCA9AB0590F674BE724 /* macos_app */ = {
+			isa = PBXGroup;
+			children = (
+				CD1089FB595A4AE6D3F310D0 /* BUILD */,
+			);
+			path = macos_app;
+			sourceTree = "<group>";
+		};
+		D45747A50B9FCDA001D3AD4F /* PreviewContent */ = {
+			isa = PBXGroup;
+			children = (
+				EA136BCC5F8FF7F12B402D13 /* Preview Assets.xcassets */,
+			);
+			path = PreviewContent;
+			sourceTree = "<group>";
+		};
+		D9AAB93A5135F69103554470 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		DAF4B76C7AB07061CFF42043 /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				94D1B7341B8C79F3FB26AB46 /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9E46111B59CD5CC4865299C2 /* Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E6A9520E4E640351CDDD995F /* Build configuration list for PBXNativeTarget "Example" */;
+			buildPhases = (
+				B53A70A8850ED09CF7C2348A /* Create link.params */,
+				158225A69996B833609C215D /* Sources */,
+				0BB138DF24439C6CB36F159F /* Frameworks */,
+				EC82FDE86D73A4710E6DBDE5 /* Resources */,
+				761DAAD429FC5A4C1EBD5270 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AB1C3081B4C14FDC3D765DFD /* PBXTargetDependency */,
+			);
+			name = Example;
+			productName = macOSApp;
+			productReference = 4E0183A010067D0E90916009 /* macOSApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		36B5F79C7ED8B081842AF69D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
+				TargetAttributes = {
+					9E46111B59CD5CC4865299C2 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
+					FE59281FE487F27A37DC2EE7 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+				};
+			};
+			buildConfigurationList = 8C14447CB8BDD86ECF450932 /* Build configuration list for PBXProject "bwx" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 77E0714FDD425211EBA209DF;
+			productRefGroup = 462C3519CA354BE1B04D4855 /* Products */;
+			projectDirPath = ../../..;
+			projectRoot = "";
+			targets = (
+				FE59281FE487F27A37DC2EE7 /* BazelDependencies */,
+				9E46111B59CD5CC4865299C2 /* Example */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		EC82FDE86D73A4710E6DBDE5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AD0CF994A192837D1E79768B /* Assets.xcassets in Resources */,
+				BD77F248941C5014D3537699 /* Preview Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(OBJROOT)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		773C70B69E7F801B38FDC01C /* Generate Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate Files";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/generated.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -euo pipefail\n\n# In Xcode 14 the \"Index\" directory was renamed to \"Index.noindex\".\n# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can\n# use it to determine the name of the directory regardless of Xcode version.\nreadonly index_dir=\"${INDEX_DATA_STORE_DIR%/*}\"\nreadonly index_dir_name=\"${index_dir##*/}\"\n\n# Xcode doesn't adjust `$OBJROOT` in scheme action scripts when building for\n# previews. So we need to look in the non-preview build directory for this file.\nreadonly non_preview_objroot=\"${OBJROOT/\\/Intermediates.noindex\\/Previews\\/*//Intermediates.noindex}\"\nreadonly base_objroot=\"${non_preview_objroot/\\/$index_dir_name\\/Build\\/Intermediates.noindex//Build/Intermediates.noindex}\"\nreadonly scheme_target_ids_file=\"$non_preview_objroot/scheme_target_ids\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  readonly output_group_prefix=i\nelse\n  readonly output_group_prefix=g\nfi\n\n# We need to read from `$output_groups_file` as soon as possible, as concurrent\n# writes to it can happen during indexing, which breaks the off-by-one-by-design\n# nature of it\nIFS=$'\\n' read -r -d '' -a output_groups < \\\n  <( \"$CALCULATE_OUTPUT_GROUPS_SCRIPT\" \\\n       \"$non_preview_objroot\" \\\n       \"$base_objroot\" \\\n       \"$scheme_target_ids_file\" \\\n       $output_group_prefix \\\n       && printf '\\0' )\n\nif [ -z \"${output_groups:-}\" ]; then\n  if [ \"$ACTION\" == \"indexbuild\" ]; then\n    output_groups=(\"all_generated_inputs\")\n  else\n    echo \"error: BazelDependencies invoked without any output groups set. Please file a bug report here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.\" >&2\n    exit 1\n  fi\nfi\noutput_groups_flag=\"--output_groups=$(IFS=, ; echo \"${output_groups[*]}\")\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\nif [[ \"${COLOR_DIAGNOSTICS:-NO}\" == \"YES\" ]]; then\n  color=yes\nelse\n  color=no\nfi\n\nbazelrcs=(\n  --noworkspace_rc\n  \"--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc\"\n)\nif [[ -s \".bazelrc\" ]]; then\n  bazelrcs+=(\"--bazelrc=.bazelrc\")\nfi\nif [[ -s \"$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc\" ]]; then\n  bazelrcs+=(\"--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc\")\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  \"${bazelrcs[@]}\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --config=rules_xcodeproj_info \\\n  --color=\"$color\" \\\n  --experimental_convenience_symlinks=ignore \\\n  --symlink_prefix=/ \\\n  --bes_backend= \\\n  --bes_results_url= \\\n  output_path)\nexec_root=\"${output_path%/*}\"\n\nif [[ \"$ACTION\" != \"indexbuild\" && \"${ENABLE_PREVIEWS:-}\" != \"YES\" ]]; then\n  \"$BAZEL_INTEGRATION_DIR/create_lldbinit.sh\" \"$exec_root\"  > \"$BAZEL_LLDB_INIT\"\nfi\n\nif [[ \"${BAZEL_OUT:0:1}\" == '/' ]]; then\n  bazel_out_prefix=\nelse\n  bazel_out_prefix=\"$SRCROOT/\"\nfi\n\nabsolute_bazel_out=\"${bazel_out_prefix}$BAZEL_OUT\"\n\nif [[ \"$output_path\" != \"$absolute_bazel_out\" ]]; then\n  # Use current path for bazel-out\n  # This fixes Index Build to use its version of generated files\n  roots=\"{\\\"external-contents\\\": \\\"$output_path\\\",\\\"name\\\": \\\"$absolute_bazel_out\\\",\\\"type\\\": \\\"directory-remap\\\"}\"\nelse\n  roots=\nfi\n\ncat > \"$OBJROOT/bazel-out-overlay.yaml\" <<EOF\n{\"case-sensitive\": \"false\", \"fallthrough\": true, \"roots\": [$roots],\"version\": 0}\nEOF\n\n# Look up Swift generated headers in `$BUILD_DIR` first, then fall through to `$BAZEL_OUT`\ncat > \"$OBJROOT/xcode-overlay.yaml\" <<EOF\n{\"case-sensitive\": \"false\", \"fallthrough\": true, \"roots\": [],\"version\": 0}\nEOF\n\ncd \"$SRCROOT\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  config=rules_xcodeproj_indexbuild\nelif [ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]; then\n  config=rules_xcodeproj_swiftuipreviews\nelse\n  config=rules_xcodeproj_build\nfi\n\ndate +%s > \"$INTERNAL_DIR/toplevel_cache_buster\"\n\nbuild_marker=\"$OBJROOT/bazel_build_start\"\ntouch \"$build_marker\"\n\nlog=$(mktemp)\n\"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py\" env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  \"${bazelrcs[@]}\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --config=$config \\\n  --color=yes \\\n  --experimental_convenience_symlinks=ignore \\\n  --symlink_prefix=/ \\\n  \"$output_groups_flag\" \\\n  //test/fixtures/macos_app:xcodeproj_bwx.generator \\\n  2>&1 | tee -i \"$log\"\n\nfor output_group in \"${output_groups[@]}\"; do\n  filelist=\"xcodeproj_bwx.generator-${output_group//\\//_}\"\n  filelist=\"${filelist/#/$output_path/darwin_x86_64-dbg-ST-1b9bd654f600/bin/test/fixtures/macos_app/}\"\n  filelist=\"${filelist/%/.filelist}\"\n  if [[ \"$filelist\" -ot \"$build_marker\" ]]; then\n    echo \"error: Bazel didn't generate the correct files (it should have generated outputs for output group \\\"$output_group\\\", but the timestamp for \\\"$filelist\\\" was from before the build). Please regenerate the project to fix this.\" >&2\n    echo \"error: If your bazel version is less than 5.2, you may need to \\`bazel clean\\` and/or \\`bazel shutdown\\` to work around a bug in project generation.\" >&2\n    echo \"error: If you are still getting this error after all of that, please file a bug report here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.\" >&2\n    exit 1\n  fi\ndone\n";
+			showEnvVarsInLog = 0;
+		};
+		B53A70A8850ED09CF7C2348A /* Create link.params */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(LINK_PARAMS_FILE)",
+			);
+			name = "Create link.params";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/link.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		158225A69996B833609C215D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2A9C7B2694B074B34CE1622C /* ContentView.swift in Sources */,
+				54F6F91C757354B6B3A39639 /* macOSApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		AB1C3081B4C14FDC3D765DFD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = DFB6B3D768109FDA95CBEF01 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		67F44AB65FA7A2E38A56F5FB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = BazelDependencies;
+			};
+			name = Debug;
+		};
+		BE2CA0A20BAEAC56C4898C1A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BAZEL_COMPILE_TARGET_ID = "//examples/macos_app/Example:Example.library macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-450091386d5c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-450091386d5c/bin/examples/macos_app/Example";
+				BAZEL_TARGET_ID = "//examples/macos_app/Example:Example applebin_macos-darwin_x86_64-dbg-ST-450091386d5c";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEPLOYMENT_LOCATION = NO;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = examples/macos_app/third_party;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-450091386d5c/bin/examples/macos_app/Example/rules_xcodeproj/Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-450091386d5c/examples/macos_app/Example/Example.link.params";
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=examples/macos_app/third_party/ExampleFramework.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexamples/macos_app/third_party -static";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
+				PRODUCT_MODULE_NAME = iOSApp;
+				PRODUCT_NAME = macOSApp;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = Example;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-450091386d5c/bin",
+				);
+			};
+			name = Debug;
+		};
+		C221D886D6D02D33114D3473 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BAZEL_EXEC_ROOT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+				BAZEL_EXTERNAL = "bazel-output-base/external";
+				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
+				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
+				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
+				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
+				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
+				COPY_PHASE_STRIP = NO;
+				DEPLOYMENT_LOCATION = "$(INDEXING_DEPLOYMENT_LOCATION__$(INDEX_ENABLE_BUILD_ARENA)),";
+				DSTROOT = "$(PROJECT_TEMP_DIR)";
+				INDEXING_BUILT_PRODUCTS_DIR__ = "$(INDEXING_BUILT_PRODUCTS_DIR__NO)";
+				INDEXING_BUILT_PRODUCTS_DIR__NO = "$(BUILD_DIR)";
+				INDEXING_BUILT_PRODUCTS_DIR__YES = "$(CONFIGURATION_BUILD_DIR)";
+				INDEXING_DEPLOYMENT_LOCATION__ = "$(INDEXING_DEPLOYMENT_LOCATION__NO)";
+				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
+				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
+				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
+				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
+				LINKS_DIR = "$(INTERNAL_DIR)/links";
+				ONLY_ACTIVE_ARCH = YES;
+				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		8C14447CB8BDD86ECF450932 /* Build configuration list for PBXProject "bwx" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C221D886D6D02D33114D3473 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				67F44AB65FA7A2E38A56F5FB /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		E6A9520E4E640351CDDD995F /* Build configuration list for PBXNativeTarget "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BE2CA0A20BAEAC56C4898C1A /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 36B5F79C7ED8B081842AF69D /* Project object */;
+}

--- a/test/fixtures/macos_app/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/macos_app/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -51,10 +51,10 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        # Xcode gets "stuck" in the `buildFiles` or `build` command for
-        # top-level targets, so we can't reliably change commands here. Leaving
-        # the code in place in case this is fixed in the future, or we want to
-        # do something similar in an XCBBuildService proxy.
+        # Xcode gets "suck" in the `buildFiles` or `build` command for top-level
+        # targets, so we can't reliably change commands here. Leaving the code
+        # in place in case this is fixed in the future, or we want to do
+        # something similar in an XCBBuildService proxy.
         #
         # command = (
         #     build_request.get("_buildCommand2", {}).get("command", "build")
@@ -197,7 +197,7 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
 
     if prefix == "i":
         # buildRequest for Index Build includes all targets, so we have to
-        # fall back to the scheme target ids (which are actually set by the
+        # fallback to the scheme target ids (which are actually set by the
         # "Copy Bazel Outputs" script)
         target_ids = scheme_target_ids
     else:

--- a/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/project.pbxproj
@@ -3319,12 +3319,16 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/iOSApp:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/iOSApp:iOSApp.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0/bin/examples/multiplatform/iOSApp/iOSApp.ipa";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b/bin/examples/multiplatform/iOSApp/iOSApp.ipa";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0/bin/examples/multiplatform/iOSApp";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b/bin/examples/multiplatform/iOSApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0";
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				"CODE_SIGN_STYLE[sdk=iphoneos*]" = Automatic;
@@ -3406,6 +3410,7 @@
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-87378d9c7973/bin/examples/multiplatform/Lib";
 				BAZEL_TARGET_ID = "//examples/multiplatform/Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-461d90178fcd";
 				"BAZEL_TARGET_ID[sdk=watchos*]" = "//examples/multiplatform/Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-87378d9c7973";
+				"BAZEL_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -3450,6 +3455,9 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=watchos*]" = arm64_32;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-461d90178fcd";
+				"BAZEL_COMPILE_TARGET_ID[sdk=watchos*]" = "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension.library watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-87378d9c7973";
+				"BAZEL_COMPILE_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_HOST_TARGET_ID_0 = "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-03bb1c387590";
 				"BAZEL_HOST_TARGET_ID_0[sdk=watchos*]" = "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-9a4c12e75ccd";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-ST-461d90178fcd/bin/examples/multiplatform/watchOSAppExtension/watchOSAppExtension.zip";
@@ -3458,6 +3466,7 @@
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-87378d9c7973/bin/examples/multiplatform/watchOSAppExtension";
 				BAZEL_TARGET_ID = "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_x86_64-dbg-ST-461d90178fcd";
 				"BAZEL_TARGET_ID[sdk=watchos*]" = "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-ST-87378d9c7973";
+				"BAZEL_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				"CODE_SIGN_STYLE[sdk=watchos*]" = Automatic;
@@ -3522,12 +3531,16 @@
 				APPLETVSIMULATOR_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework";
 				ARCHS = x86_64;
 				"ARCHS[sdk=appletvos*]" = arm64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/tvOSApp/Source:tvOSApp.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvos*]" = "//examples/multiplatform/tvOSApp/Source:tvOSApp.library tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-357261695a5c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/multiplatform/tvOSApp/Source/tvOSApp.ipa";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-357261695a5c/bin/examples/multiplatform/tvOSApp/Source/tvOSApp.ipa";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/multiplatform/tvOSApp/Source";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-357261695a5c/bin/examples/multiplatform/tvOSApp/Source";
 				BAZEL_TARGET_ID = "//examples/multiplatform/tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
 				"BAZEL_TARGET_ID[sdk=appletvos*]" = "//examples/multiplatform/tvOSApp/Source:tvOSApp applebin_tvos-tvos_arm64-dbg-ST-357261695a5c";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				"CODE_SIGN_STYLE[sdk=appletvos*]" = Automatic;
@@ -3598,12 +3611,16 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/AppClip:AppClip.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/AppClip:AppClip.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0/bin/examples/multiplatform/AppClip/AppClip.ipa";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b/bin/examples/multiplatform/AppClip/AppClip.ipa";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0/bin/examples/multiplatform/AppClip";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b/bin/examples/multiplatform/AppClip";
 				BAZEL_TARGET_ID = "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0";
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_ENTITLEMENTS = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0/bin/examples/multiplatform/AppClip/Entitlements.withbundleid.plist";
 				"CODE_SIGN_ENTITLEMENTS[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b/bin/examples/multiplatform/AppClip/Entitlements.withbundleid.plist";
@@ -3668,9 +3685,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/tvOSApp/Test/UITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/multiplatform/tvOSApp/Test/UITests/ExampleUITests.__internal__.__test_bundle.zip";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/multiplatform/tvOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "//examples/multiplatform/tvOSApp/Test/UITests:ExampleUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_STYLE = Manual;
@@ -3707,9 +3727,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/Tool:Tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0ee56dce8f77";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-0ee56dce8f77/bin/examples/multiplatform/Tool/Tool";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-0ee56dce8f77/bin/examples/multiplatform/Tool";
 				BAZEL_TARGET_ID = "//examples/multiplatform/Tool:Tool applebin_macos-darwin_x86_64-dbg-ST-0ee56dce8f77";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_LOCATION = NO;
@@ -3754,6 +3777,7 @@
 				"BAZEL_TARGET_ID[sdk=appletvos*]" = "//examples/multiplatform/Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-357261695a5c";
 				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "//examples/multiplatform/Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -3817,9 +3841,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/tvOSApp/Test/UnitTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/multiplatform/tvOSApp/Test/UnitTests/ExampleTests.__internal__.__test_bundle.zip";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/multiplatform/tvOSApp/Test/UnitTests";
 				BAZEL_TARGET_ID = "//examples/multiplatform/tvOSApp/Test/UnitTests:ExampleTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Manual;
@@ -3861,10 +3888,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/iMessageApp:iMessageAppExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_HOST_TARGET_ID_0 = "//examples/multiplatform/iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0/bin/examples/multiplatform/iMessageApp/iMessageAppExtension.zip";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0/bin/examples/multiplatform/iMessageApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -3913,6 +3943,7 @@
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0/bin/examples/multiplatform/iMessageApp/iMessageApp.ipa";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0/bin/examples/multiplatform/iMessageApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -4002,6 +4033,9 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/WidgetExtension:WidgetExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/WidgetExtension:WidgetExtension.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_HOST_TARGET_ID_0 = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0";
 				"BAZEL_HOST_TARGET_ID_0[sdk=iphoneos*]" = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0/bin/examples/multiplatform/WidgetExtension/WidgetExtension.zip";
@@ -4010,6 +4044,7 @@
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b/bin/examples/multiplatform/WidgetExtension";
 				BAZEL_TARGET_ID = "//examples/multiplatform/WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-ST-f36cb6fd42a0";
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-ST-ec1fe2b9cd5b";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				"CODE_SIGN_STYLE[sdk=iphoneos*]" = Automatic;
@@ -4083,6 +4118,7 @@
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-9a4c12e75ccd/bin/examples/multiplatform/watchOSApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-03bb1c387590";
 				"BAZEL_TARGET_ID[sdk=watchos*]" = "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-9a4c12e75ccd";
+				"BAZEL_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				"CODE_SIGN_STYLE[sdk=watchos*]" = Automatic;
@@ -4129,9 +4165,12 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/macOSApp/Example:Example.library macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c/bin/examples/multiplatform/macOSApp/Example/Example.zip";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c/bin/examples/multiplatform/macOSApp/Example";
 				BAZEL_TARGET_ID = "//examples/multiplatform/macOSApp/Example:Example applebin_macos-darwin_x86_64-dbg-ST-e33b8db88e1c";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;

--- a/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/multiplatform/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/project.pbxproj
@@ -3288,6 +3288,7 @@
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-6ed25bb2f15f/bin/examples/multiplatform/watchOSApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-6c26b30d77f4";
 				"BAZEL_TARGET_ID[sdk=watchos*]" = "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-6ed25bb2f15f";
+				"BAZEL_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				"CODE_SIGN_STYLE[sdk=watchos*]" = Automatic;
@@ -3340,6 +3341,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-ST-132246d86df4/bin/examples/multiplatform/iMessageApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-ST-132246d86df4";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -3383,8 +3385,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/tvOSApp/Test/UnitTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/multiplatform/tvOSApp/Test/UnitTests";
 				BAZEL_TARGET_ID = "//examples/multiplatform/tvOSApp/Test/UnitTests:ExampleTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Manual;
@@ -3438,10 +3443,14 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/iOSApp:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-132246d86df4";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/iOSApp:iOSApp.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-1b4223f3338c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-132246d86df4/bin/examples/multiplatform/iOSApp";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-1b4223f3338c/bin/examples/multiplatform/iOSApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_x86_64-dbg-ST-132246d86df4";
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_arm64-dbg-ST-1b4223f3338c";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				"CODE_SIGN_STYLE[sdk=iphoneos*]" = Automatic;
@@ -3520,10 +3529,14 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/AppClip:AppClip.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-132246d86df4";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/AppClip:AppClip.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-1b4223f3338c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-132246d86df4/bin/examples/multiplatform/AppClip";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-1b4223f3338c/bin/examples/multiplatform/AppClip";
 				BAZEL_TARGET_ID = "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_x86_64-dbg-ST-132246d86df4";
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/AppClip:AppClip applebin_ios-ios_arm64-dbg-ST-1b4223f3338c";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-132246d86df4/bin/examples/multiplatform/AppClip/Entitlements.withbundleid.plist";
@@ -3592,10 +3605,14 @@
 				APPLETVSIMULATOR_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework";
 				ARCHS = x86_64;
 				"ARCHS[sdk=appletvos*]" = arm64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/tvOSApp/Source:tvOSApp.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvos*]" = "//examples/multiplatform/tvOSApp/Source:tvOSApp.library tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-7839a2751710";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/multiplatform/tvOSApp/Source";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-7839a2751710/bin/examples/multiplatform/tvOSApp/Source";
 				BAZEL_TARGET_ID = "//examples/multiplatform/tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
 				"BAZEL_TARGET_ID[sdk=appletvos*]" = "//examples/multiplatform/tvOSApp/Source:tvOSApp applebin_tvos-tvos_arm64-dbg-ST-7839a2751710";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				"CODE_SIGN_STYLE[sdk=appletvos*]" = Automatic;
@@ -3666,6 +3683,7 @@
 				"BAZEL_TARGET_ID[sdk=appletvos*]" = "//examples/multiplatform/Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-7839a2751710";
 				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "//examples/multiplatform/Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-1b4223f3338c";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -3735,6 +3753,7 @@
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-225f14c89e08/bin/examples/multiplatform/Lib";
 				BAZEL_TARGET_ID = "//examples/multiplatform/Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-29173b47b420";
 				"BAZEL_TARGET_ID[sdk=watchos*]" = "//examples/multiplatform/Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-225f14c89e08";
+				"BAZEL_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_TARGET_ID)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
@@ -3780,8 +3799,11 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/macOSApp/Example:Example.library macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-450091386d5c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min15.0-applebin_macos-darwin_x86_64-dbg-ST-450091386d5c/bin/examples/multiplatform/macOSApp/Example";
 				BAZEL_TARGET_ID = "//examples/multiplatform/macOSApp/Example:Example applebin_macos-darwin_x86_64-dbg-ST-450091386d5c";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -3861,8 +3883,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/Tool:Tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-8143dd6ed004";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-8143dd6ed004/bin/examples/multiplatform/Tool";
 				BAZEL_TARGET_ID = "//examples/multiplatform/Tool:Tool applebin_macos-darwin_x86_64-dbg-ST-8143dd6ed004";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_LOCATION = NO;
@@ -3896,12 +3921,16 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=watchos*]" = arm64_32;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-29173b47b420";
+				"BAZEL_COMPILE_TARGET_ID[sdk=watchos*]" = "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension.library watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-225f14c89e08";
+				"BAZEL_COMPILE_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_HOST_TARGET_ID_0 = "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-6c26b30d77f4";
 				"BAZEL_HOST_TARGET_ID_0[sdk=watchos*]" = "//examples/multiplatform/watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-6ed25bb2f15f";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-29173b47b420/bin/examples/multiplatform/watchOSAppExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-225f14c89e08/bin/examples/multiplatform/watchOSAppExtension";
 				BAZEL_TARGET_ID = "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_x86_64-dbg-ST-29173b47b420";
 				"BAZEL_TARGET_ID[sdk=watchos*]" = "//examples/multiplatform/watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-ST-225f14c89e08";
+				"BAZEL_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				"CODE_SIGN_STYLE[sdk=watchos*]" = Automatic;
@@ -3963,8 +3992,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/tvOSApp/Test/UITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/multiplatform/tvOSApp/Test/UITests";
 				BAZEL_TARGET_ID = "//examples/multiplatform/tvOSApp/Test/UITests:ExampleUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGNING_ALLOWED = YES;
 				CODE_SIGN_STYLE = Manual;
@@ -4002,12 +4034,16 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/WidgetExtension:WidgetExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-132246d86df4";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/WidgetExtension:WidgetExtension.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-1b4223f3338c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_HOST_TARGET_ID_0 = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_x86_64-dbg-ST-132246d86df4";
 				"BAZEL_HOST_TARGET_ID_0[sdk=iphoneos*]" = "//examples/multiplatform/iOSApp:iOSApp applebin_ios-ios_arm64-dbg-ST-1b4223f3338c";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-132246d86df4/bin/examples/multiplatform/WidgetExtension";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-1b4223f3338c/bin/examples/multiplatform/WidgetExtension";
 				BAZEL_TARGET_ID = "//examples/multiplatform/WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-ST-132246d86df4";
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//examples/multiplatform/WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-ST-1b4223f3338c";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				"CODE_SIGN_STYLE[sdk=iphoneos*]" = Automatic;
@@ -4071,9 +4107,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/multiplatform/iMessageApp:iMessageAppExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-132246d86df4";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_HOST_TARGET_ID_0 = "//examples/multiplatform/iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-ST-132246d86df4";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-132246d86df4/bin/examples/multiplatform/iMessageApp";
 				BAZEL_TARGET_ID = "//examples/multiplatform/iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-ST-132246d86df4";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CODE_SIGN_STYLE = Manual;
 				DEBUG_INFORMATION_FORMAT = dwarf;

--- a/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/multiplatform/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/test/fixtures/simple/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/simple/bwb.xcodeproj/project.pbxproj
@@ -267,6 +267,7 @@
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-aedfd39dd677/bin/examples/simple/SwiftBin";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-aedfd39dd677/bin/examples/simple";
 				BAZEL_TARGET_ID = "//examples/simple:SwiftBin darwin_x86_64-dbg-ST-aedfd39dd677";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_LOCATION = NO;

--- a/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/test/fixtures/simple/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/simple/bwx.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 				ARCHS = x86_64;
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a93f0e642138/bin/examples/simple";
 				BAZEL_TARGET_ID = "//examples/simple:SwiftBin darwin_x86_64-dbg-ST-a93f0e642138";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_LOCATION = NO;

--- a/test/fixtures/simple/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/simple/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -7,6 +7,21 @@ import sys
 import time
 import traceback
 
+# Ordered the same as we order platforms in the generated Xcode project, except
+# macOS is last
+_DEVICE_PLATFORMS = {
+    "iphoneos": None,
+    "appletvos": None,
+    "watchos": None,
+    "macosx": None,
+}
+_SIMULATOR_PLATFORMS = {
+    "iphonesimulator": None,
+    "appletvsimulator": None,
+    "watchsimulator": None,
+    "macosx": None,
+}
+
 def _calculate_build_request_file(objroot):
     build_description_cache = max(
         glob.iglob(f"{objroot}/XCBuildData/BuildDescriptionCacheIndex-*"),
@@ -36,9 +51,32 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        buildable_target_ids = []
+        # Xcode gets "stuck" in the `buildFiles` or `build` command for
+        # top-level targets, so we can't reliably change commands here. Leaving
+        # the code in place in case this is fixed in the future, or we want to
+        # do something similar in an XCBBuildService proxy.
+        #
+        # command = (
+        #     build_request.get("_buildCommand2", {}).get("command", "build")
+        # )
+        command = "build"
+        platform = (
+            build_request["parameters"]["activeRunDestination"]["platform"]
+        )
+
+        target_ids = []
         for target in build_request["configuredTargets"]:
-            buildable_target_ids.extend(guid_target_ids[target["guid"]])
+            full_target_target_ids = guid_target_ids[target["guid"]]
+            target_target_ids = (
+                full_target_target_ids.get(command) or
+                # Will only be `null` if `command == "buildFiles"`` and there
+                # isn't a different compile target id
+                full_target_target_ids["build"]
+            )
+            target_ids.append(_select_target_id(
+                target_target_ids,
+                platform,
+            ))
     except Exception as error:
         print(
             f"""\
@@ -51,13 +89,10 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
         )
         return scheme_target_ids
 
-    target_ids = set(buildable_target_ids).intersection(scheme_target_ids)
-
     if not target_ids:
         print(
             f"""\
-warning: Target ids from PIFCache ({buildable_target_ids}) \
-didn't match any scheme target ids ({scheme_target_ids}).
+warning: Couldn't deteremine target ids from PIFCache ({target_ids})
 
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
@@ -77,7 +112,7 @@ def _calculate_guid_target_ids(base_objroot):
 
     guid_target_ids_parent = f"{base_objroot}/guid_target_ids"
     guid_target_ids_path = f"""\
-{guid_target_ids_parent}/{os.path.basename(project_pif)}.json"""
+{guid_target_ids_parent}/{os.path.basename(project_pif)}_v2.json"""
 
     if os.path.exists(guid_target_ids_path):
         with open(guid_target_ids_path, encoding = "utf-8") as f:
@@ -96,19 +131,62 @@ def _calculate_guid_target_ids(base_objroot):
         with open(target_file, encoding = "utf-8") as f:
             target_pif = json.load(f)
 
-        guid = target_pif["guid"]
-        guid_target_ids[guid] = [
-            value
-            for configuration in target_pif["buildConfigurations"]
-            for key, value in configuration["buildSettings"].items()
-            if key.startswith("BAZEL_TARGET_ID")
-        ]
+        build_target_ids = {"key": "BAZEL_TARGET_ID"}
+        compile_target_ids = {"key": "BAZEL_COMPILE_TARGET_ID"}
+        for configuration in target_pif["buildConfigurations"]:
+            for key, value in configuration["buildSettings"].items():
+                if key.startswith("BAZEL_TARGET_ID"):
+                    build_target_ids[_platform_from_build_key(key)] = value
+                elif key.startswith("BAZEL_COMPILE_TARGET_ID"):
+                    compile_target_ids[_platform_from_compile_key(key)] = value
+
+        target_ids = {
+            "build": build_target_ids,
+        }
+        if len(compile_target_ids) > 1:
+            target_ids["buildFiles"] = compile_target_ids
+
+        guid_target_ids[target_pif["guid"]] = target_ids
 
     os.makedirs(guid_target_ids_parent, exist_ok = True)
     with open(guid_target_ids_path, "w", encoding = "utf-8") as f:
         json.dump(guid_target_ids, f)
 
     return guid_target_ids
+
+def _platform_from_build_key(key):
+    if key.startswith("BAZEL_TARGET_ID[sdk="):
+        return key[20:-2]
+    return ""
+
+def _platform_from_compile_key(key):
+    if key.startswith("BAZEL_COMPILE_TARGET_ID[sdk="):
+        return key[28:-2]
+    return ""
+
+def _select_target_id(target_ids, platform):
+    key = target_ids["key"]
+
+    platforms = {platform: None}
+
+    # We need to try other similar platforms (i.e. other simulator platforms if
+    # `platform`` is for a simulator). This is to support schemes with targets
+    # of multiple platforms in them. Because `dict` is insertion ordered,
+    # `platform` will be checked first.
+    platforms.update(_similar_platforms(platform))
+
+    for platform in platforms:
+        target_id = target_ids.get(platform)
+        if target_id:
+            if target_id == f"$({key})":
+                return target_ids[""]
+            return target_id
+    return target_ids[""]
+
+def _similar_platforms(platform):
+    if platform == "macosx" or "simulator" in platform:
+        return _SIMULATOR_PLATFORMS
+    return _DEVICE_PLATFORMS
 
 def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     if not os.path.exists(scheme_target_id_file):
@@ -117,28 +195,31 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
     with open(scheme_target_id_file, encoding = "utf-8") as f:
         scheme_target_ids = set(f.read().splitlines())
 
-    if not scheme_target_ids:
-        return
-
-    try:
-        build_request_file = _calculate_build_request_file(objroot)
-        guid_target_ids = _calculate_guid_target_ids(base_objroot)
-    except Exception:
-        print(
-            f"""\
+    if prefix == "i":
+        # buildRequest for Index Build includes all targets, so we have to
+        # fall back to the scheme target ids (which are actually set by the
+        # "Copy Bazel Outputs" script)
+        target_ids = scheme_target_ids
+    else:
+        try:
+            build_request_file = _calculate_build_request_file(objroot)
+            guid_target_ids = _calculate_guid_target_ids(base_objroot)
+        except Exception:
+            print(
+                f"""\
 warning: Failed to calculate target ids from PIFCache:
 {traceback.format_exc()}
 warning: Using scheme target ids as a fallback. Please file a bug report here: \
 https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.""",
-            file = sys.stderr,
-        )
-        target_ids = scheme_target_ids
-    else:
-        target_ids = _calculate_output_group_target_ids(
-            build_request_file,
-            scheme_target_ids,
-            guid_target_ids,
-        )
+                file = sys.stderr,
+            )
+            target_ids = scheme_target_ids
+        else:
+            target_ids = _calculate_output_group_target_ids(
+                build_request_file,
+                scheme_target_ids,
+                guid_target_ids,
+            )
 
     print("\n".join([f"{prefix} {id}" for id in target_ids]))
 

--- a/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/project.pbxproj
@@ -1,0 +1,894 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		7E7D155EBCA520F35DEA3571 /* BazelDependencies */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
+			buildPhases = (
+				9A630CF63C380FAE522825A9 /* Bazel Build */,
+				20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */,
+			);
+			dependencies = (
+			);
+			name = BazelDependencies;
+			productName = BazelDependencies;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		39BF0A575DB868D507469F87 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50D13467AC1061414CAD92AA /* ContentView.swift */; };
+		4B8F9453DB21BF522ED084F2 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E8EC5800B28DC7A5B63624 /* ExampleUITests.swift */; };
+		8247FC302A95B8C90FFAC948 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75AFCD0AE3F74ABC41475218 /* ExampleTests.swift */; };
+		AB903A67D5E295F09FE79F90 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0E59FF263E41FFE42D58A1 /* ExampleApp.swift */; };
+		B36065E1A4D78669F7CA6AD8 /* ExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD6FBABBE0C0A9D915CBF85B /* ExampleUITestsLaunchTests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		02A9E4CE2A3817364872DD5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
+		143B9C332C33613F47301BCA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DEF15AA97EC0FE28A9A97CAA;
+			remoteInfo = Example;
+		};
+		21804B34B29467B2C330177B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
+		C5DFA83DE27EDEFA7A3B6716 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DEF15AA97EC0FE28A9A97CAA;
+			remoteInfo = Example;
+		};
+		DDD61C8C1CFA249BBE0E369C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		01C4B223874C1C997C16920E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		1AD4E21BF05EA13F3C0E032B /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		311DCC867C94032A45629D52 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		386F24335E243DFFE5C69565 /* app.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = app.entitlements; sourceTree = "<group>"; };
+		39004B79217BED4A67CB9A93 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		44C19A56FE797949930D145D /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4E2E287D3B9BA9E6E4FC9C03 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		50D13467AC1061414CAD92AA /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		75AFCD0AE3F74ABC41475218 /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
+		8A36CA287ABB5359FEC0F830 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		AA8B40F3394AF193E0043C9C /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
+		AD6FBABBE0C0A9D915CBF85B /* ExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		D227CE711F51FF221F83B7EA /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6E8EC5800B28DC7A5B63624 /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
+		DB017F09DAA174C86C32DE47 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		E18F10CFF85D8830CA170107 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		E470DDDC0990D96A685DB11C /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4C7A4BB890E1C85A95001E8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		FA0E59FF263E41FFE42D58A1 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		1462C33E0E2DAA3B170477F7 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				C58654CF1F3C31244D4B1EBB /* rules_xcodeproj */,
+				386F24335E243DFFE5C69565 /* app.entitlements */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		1F75B84D472E4F903E58A310 /* apple */ = {
+			isa = PBXGroup;
+			children = (
+				B90C93321F57509ADC051F9E /* testing */,
+			);
+			path = apple;
+			sourceTree = "<group>";
+		};
+		2E6D9E4BA36A87B56922910C /* fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				8A867FE024EF721BBDC46736 /* tvos_app */,
+			);
+			path = fixtures;
+			sourceTree = "<group>";
+		};
+		3448A54BA8456B59D0977B66 /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				CA1D63B0158289668FEE7C69 /* rules_xcodeproj */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
+		3773BD242930877374A6A7F5 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				82808D3B34D8875263FAE129 /* tvos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		3BDEF3755B0C97BE442DCBE7 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				F4C7A4BB890E1C85A95001E8 /* Info.plist */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		3BF5FE1279B576AB4A8E47DD /* ExampleTests.__internal__.__test_bundle */ = {
+			isa = PBXGroup;
+			children = (
+				01C4B223874C1C997C16920E /* Info.plist */,
+			);
+			path = ExampleTests.__internal__.__test_bundle;
+			sourceTree = "<group>";
+		};
+		511045842CEF1A80349BDB87 /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				A07B0D2C612D407046C5064F /* rules_xcodeproj */,
+			);
+			path = ExampleUITests;
+			sourceTree = "<group>";
+		};
+		593E7C82FAAD94A7E6A04318 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D227CE711F51FF221F83B7EA /* Example.app */,
+				E470DDDC0990D96A685DB11C /* ExampleTests.xctest */,
+				44C19A56FE797949930D145D /* ExampleUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		68A1D737225E7A97337523DE /* test */ = {
+			isa = PBXGroup;
+			children = (
+				2E6D9E4BA36A87B56922910C /* fixtures */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		6954526F25178495F29471EA /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				3773BD242930877374A6A7F5 /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
+		82808D3B34D8875263FAE129 /* tvos_app */ = {
+			isa = PBXGroup;
+			children = (
+				1462C33E0E2DAA3B170477F7 /* Example */,
+				3448A54BA8456B59D0977B66 /* ExampleTests */,
+				511045842CEF1A80349BDB87 /* ExampleUITests */,
+			);
+			path = tvos_app;
+			sourceTree = "<group>";
+		};
+		8A4520AA26B6158FA29DFA58 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				4E2E287D3B9BA9E6E4FC9C03 /* Assets.xcassets */,
+				39004B79217BED4A67CB9A93 /* BUILD */,
+				50D13467AC1061414CAD92AA /* ContentView.swift */,
+				FA0E59FF263E41FFE42D58A1 /* ExampleApp.swift */,
+				DB017F09DAA174C86C32DE47 /* Info.plist */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		8A867FE024EF721BBDC46736 /* tvos_app */ = {
+			isa = PBXGroup;
+			children = (
+				E18F10CFF85D8830CA170107 /* BUILD */,
+			);
+			path = tvos_app;
+			sourceTree = "<group>";
+		};
+		8CED760FDF5D60548A6C1292 /* applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c */ = {
+			isa = PBXGroup;
+			children = (
+				6954526F25178495F29471EA /* bin */,
+			);
+			path = "applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+			sourceTree = "<group>";
+		};
+		962A94CEC4834EE66167AEEF /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				8A36CA287ABB5359FEC0F830 /* BUILD */,
+				75AFCD0AE3F74ABC41475218 /* ExampleTests.swift */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
+		9811D2ED915829A1A7881AFD /* Bazel External Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				DEDBB9862662A833DD5D663E /* build_bazel_rules_apple */,
+			);
+			name = "Bazel External Repositories";
+			path = "bazel-output-base/external";
+			sourceTree = "<group>";
+		};
+		A07B0D2C612D407046C5064F /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				DEB864BB2D578A3ADFE512D0 /* ExampleUITests.__internal__.__test_bundle */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
+		B90C93321F57509ADC051F9E /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				AA8B40F3394AF193E0043C9C /* DefaultTestBundle.plist */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
+		BB34C210E2A56E7B96B81F9A /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				FE08DC4FE2EB3C1D3FAC175F /* tvos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		C047AF1D451C7E165914273D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		C407A8E68D8C611448A3E699 /* Bazel Generated Files */ = {
+			isa = PBXGroup;
+			children = (
+				8CED760FDF5D60548A6C1292 /* applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c */,
+			);
+			name = "Bazel Generated Files";
+			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+			sourceTree = "<group>";
+		};
+		C58654CF1F3C31244D4B1EBB /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				3BDEF3755B0C97BE442DCBE7 /* Example */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
+		CA1D63B0158289668FEE7C69 /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				3BF5FE1279B576AB4A8E47DD /* ExampleTests.__internal__.__test_bundle */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
+		DEB864BB2D578A3ADFE512D0 /* ExampleUITests.__internal__.__test_bundle */ = {
+			isa = PBXGroup;
+			children = (
+				311DCC867C94032A45629D52 /* Info.plist */,
+			);
+			path = ExampleUITests.__internal__.__test_bundle;
+			sourceTree = "<group>";
+		};
+		DEDBB9862662A833DD5D663E /* build_bazel_rules_apple */ = {
+			isa = PBXGroup;
+			children = (
+				1F75B84D472E4F903E58A310 /* apple */,
+			);
+			path = build_bazel_rules_apple;
+			sourceTree = "<group>";
+		};
+		E3A32E13D18203BECE3A34CF /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				1AD4E21BF05EA13F3C0E032B /* BUILD */,
+				D6E8EC5800B28DC7A5B63624 /* ExampleUITests.swift */,
+				AD6FBABBE0C0A9D915CBF85B /* ExampleUITestsLaunchTests.swift */,
+			);
+			path = ExampleUITests;
+			sourceTree = "<group>";
+		};
+		EC6FEE5AC277A3FEEA95510A = {
+			isa = PBXGroup;
+			children = (
+				BB34C210E2A56E7B96B81F9A /* examples */,
+				68A1D737225E7A97337523DE /* test */,
+				9811D2ED915829A1A7881AFD /* Bazel External Repositories */,
+				C407A8E68D8C611448A3E699 /* Bazel Generated Files */,
+				593E7C82FAAD94A7E6A04318 /* Products */,
+				C047AF1D451C7E165914273D /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		FE08DC4FE2EB3C1D3FAC175F /* tvos_app */ = {
+			isa = PBXGroup;
+			children = (
+				8A4520AA26B6158FA29DFA58 /* Example */,
+				962A94CEC4834EE66167AEEF /* ExampleTests */,
+				E3A32E13D18203BECE3A34CF /* ExampleUITests */,
+			);
+			path = tvos_app;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1BE9F5CAE42CA37A7C4A53DB /* ExampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 529E9DE569B1F4ACD34C1EEC /* Build configuration list for PBXNativeTarget "ExampleUITests" */;
+			buildPhases = (
+				691585B0982F9A68358A02A1 /* Copy Bazel Outputs */,
+				4AFB1CCAF44E62E2758DDE1A /* Create link.params */,
+				4F9FE3B9695177163DF3F4F7 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DD37E6139BE33454F9BBB7C3 /* PBXTargetDependency */,
+				60A15C6742A5E861650F0705 /* PBXTargetDependency */,
+			);
+			name = ExampleUITests;
+			productName = ExampleUITests;
+			productReference = 44C19A56FE797949930D145D /* ExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		7A9D2A8E0409057861AEEA70 /* ExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0100CEFB31CE85C91D838A4D /* Build configuration list for PBXNativeTarget "ExampleTests" */;
+			buildPhases = (
+				765E1FE49C832E00D782BD54 /* Copy Bazel Outputs */,
+				F6321BA048CC586AD22757E7 /* Create link.params */,
+				64F0E9C37ADF426C760C0487 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				660083BC58282EABB2E2220A /* PBXTargetDependency */,
+				9EE143447B830CA252A7E7D4 /* PBXTargetDependency */,
+			);
+			name = ExampleTests;
+			productName = ExampleTests;
+			productReference = E470DDDC0990D96A685DB11C /* ExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		DEF15AA97EC0FE28A9A97CAA /* Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4E80458017EA17FB5B672FEB /* Build configuration list for PBXNativeTarget "Example" */;
+			buildPhases = (
+				91A249C04A86079A36A5303D /* Copy Bazel Outputs */,
+				3C5F7018A60EE40574F4CDA0 /* Create link.params */,
+				F94B766A6F00B6427D27F290 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5F96E438EF4C12858E3D604D /* PBXTargetDependency */,
+			);
+			name = Example;
+			productName = Example;
+			productReference = D227CE711F51FF221F83B7EA /* Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		0805833D09730531AD081697 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
+				TargetAttributes = {
+					1BE9F5CAE42CA37A7C4A53DB = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
+					};
+					7A9D2A8E0409057861AEEA70 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+						TestTargetID = DEF15AA97EC0FE28A9A97CAA;
+					};
+					7E7D155EBCA520F35DEA3571 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					DEF15AA97EC0FE28A9A97CAA = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
+				};
+			};
+			buildConfigurationList = 669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = EC6FEE5AC277A3FEEA95510A;
+			productRefGroup = 593E7C82FAAD94A7E6A04318 /* Products */;
+			projectDirPath = ../../..;
+			projectRoot = "";
+			targets = (
+				7E7D155EBCA520F35DEA3571 /* BazelDependencies */,
+				DEF15AA97EC0FE28A9A97CAA /* Example */,
+				7A9D2A8E0409057861AEEA70 /* ExampleTests */,
+				1BE9F5CAE42CA37A7C4A53DB /* ExampleUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(OBJROOT)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		3C5F7018A60EE40574F4CDA0 /* Create link.params */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(LINK_PARAMS_FILE)",
+			);
+			name = "Create link.params";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/link.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4AFB1CCAF44E62E2758DDE1A /* Create link.params */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(LINK_PARAMS_FILE)",
+			);
+			name = "Create link.params";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/link.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		691585B0982F9A68358A02A1 /* Copy Bazel Outputs */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Copy Bazel Outputs";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"ExampleUITests.xctest\" \\\n  \"\"\n";
+			showEnvVarsInLog = 0;
+		};
+		765E1FE49C832E00D782BD54 /* Copy Bazel Outputs */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Copy Bazel Outputs";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"ExampleTests.xctest\" \\\n  \"\"\n";
+			showEnvVarsInLog = 0;
+		};
+		91A249C04A86079A36A5303D /* Copy Bazel Outputs */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Copy Bazel Outputs";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"Example.app\" \\\n  \"$INTERNAL_DIR/app.exclude.rsynclist\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9A630CF63C380FAE522825A9 /* Bazel Build */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bazel Build";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/external.xcfilelist",
+				"$(INTERNAL_DIR)/generated.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -euo pipefail\n\n# In Xcode 14 the \"Index\" directory was renamed to \"Index.noindex\".\n# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can\n# use it to determine the name of the directory regardless of Xcode version.\nreadonly index_dir=\"${INDEX_DATA_STORE_DIR%/*}\"\nreadonly index_dir_name=\"${index_dir##*/}\"\n\n# Xcode doesn't adjust `$OBJROOT` in scheme action scripts when building for\n# previews. So we need to look in the non-preview build directory for this file.\nreadonly non_preview_objroot=\"${OBJROOT/\\/Intermediates.noindex\\/Previews\\/*//Intermediates.noindex}\"\nreadonly base_objroot=\"${non_preview_objroot/\\/$index_dir_name\\/Build\\/Intermediates.noindex//Build/Intermediates.noindex}\"\nreadonly scheme_target_ids_file=\"$non_preview_objroot/scheme_target_ids\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  readonly output_group_prefix=i\nelse\n  readonly output_group_prefix=b\nfi\n\n# We need to read from `$output_groups_file` as soon as possible, as concurrent\n# writes to it can happen during indexing, which breaks the off-by-one-by-design\n# nature of it\nIFS=$'\\n' read -r -d '' -a output_groups < \\\n  <( \"$CALCULATE_OUTPUT_GROUPS_SCRIPT\" \\\n       \"$non_preview_objroot\" \\\n       \"$base_objroot\" \\\n       \"$scheme_target_ids_file\" \\\n       $output_group_prefix \\\n       && printf '\\0' )\n\nif [ -z \"${output_groups:-}\" ]; then\n  if [ \"$ACTION\" == \"indexbuild\" ]; then\n    echo \"error: Can't yet determine Index Build output group. Next build should succeed. If not, please file a bug report here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.\" >&2\n    exit 1\n  else\n    echo \"error: BazelDependencies invoked without any output groups set. Please file a bug report here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.\" >&2\n    exit 1\n  fi\nfi\noutput_groups_flag=\"--output_groups=$(IFS=, ; echo \"${output_groups[*]}\")\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\nif [[ \"${COLOR_DIAGNOSTICS:-NO}\" == \"YES\" ]]; then\n  color=yes\nelse\n  color=no\nfi\n\nbazelrcs=(\n  --noworkspace_rc\n  \"--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc\"\n)\nif [[ -s \".bazelrc\" ]]; then\n  bazelrcs+=(\"--bazelrc=.bazelrc\")\nfi\nif [[ -s \"$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc\" ]]; then\n  bazelrcs+=(\"--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc\")\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  \"${bazelrcs[@]}\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --config=rules_xcodeproj_info \\\n  --color=\"$color\" \\\n  --experimental_convenience_symlinks=ignore \\\n  --symlink_prefix=/ \\\n  --bes_backend= \\\n  --bes_results_url= \\\n  output_path)\nexec_root=\"${output_path%/*}\"\n\nif [[ \"$ACTION\" != \"indexbuild\" && \"${ENABLE_PREVIEWS:-}\" != \"YES\" ]]; then\n  \"$BAZEL_INTEGRATION_DIR/create_lldbinit.sh\" \"$exec_root\"  > \"$BAZEL_LLDB_INIT\"\nfi\n\nif [[ \"${BAZEL_OUT:0:1}\" == '/' ]]; then\n  bazel_out_prefix=\nelse\n  bazel_out_prefix=\"$SRCROOT/\"\nfi\n\nabsolute_bazel_out=\"${bazel_out_prefix}$BAZEL_OUT\"\n\nif [[ \"$output_path\" != \"$absolute_bazel_out\" ]]; then\n  # Use current path for bazel-out\n  # This fixes Index Build to use its version of generated files\n  roots=\"{\\\"external-contents\\\": \\\"$output_path\\\",\\\"name\\\": \\\"$absolute_bazel_out\\\",\\\"type\\\": \\\"directory-remap\\\"}\"\nelse\n  roots=\nfi\n\n# Map `$BUILD_DIR` to execroot, to fix SwiftUI Previews and indexing edge cases\nroots=\"${roots:+${roots},}{\\\"external-contents\\\": \\\"$exec_root\\\",\\\"name\\\": \\\"$BUILD_DIR\\\",\\\"type\\\": \\\"directory-remap\\\"}\"\n\ncat > \"$OBJROOT/bazel-out-overlay.yaml\" <<EOF\n{\"case-sensitive\": \"false\", \"fallthrough\": true, \"roots\": [$roots],\"version\": 0}\nEOF\n\ncd \"$SRCROOT\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  config=rules_xcodeproj_indexbuild\nelif [ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]; then\n  config=rules_xcodeproj_swiftuipreviews\nelse\n  config=rules_xcodeproj_build\nfi\n\ndate +%s > \"$INTERNAL_DIR/toplevel_cache_buster\"\n\nbuild_marker=\"$OBJROOT/bazel_build_start\"\ntouch \"$build_marker\"\n\nlog=$(mktemp)\n\"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py\" env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  \"${bazelrcs[@]}\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --config=$config \\\n  --color=yes \\\n  --experimental_convenience_symlinks=ignore \\\n  --symlink_prefix=/ \\\n  \"$output_groups_flag\" \\\n  //test/fixtures/tvos_app:xcodeproj_bwb.generator \\\n  2>&1 | tee -i \"$log\"\n\nfor output_group in \"${output_groups[@]}\"; do\n  filelist=\"xcodeproj_bwb.generator-${output_group//\\//_}\"\n  filelist=\"${filelist/#/$output_path/darwin_x86_64-dbg-ST-1b9bd654f600/bin/test/fixtures/tvos_app/}\"\n  filelist=\"${filelist/%/.filelist}\"\n  if [[ \"$filelist\" -ot \"$build_marker\" ]]; then\n    echo \"error: Bazel didn't generate the correct files (it should have generated outputs for output group \\\"$output_group\\\", but the timestamp for \\\"$filelist\\\" was from before the build). Please regenerate the project to fix this.\" >&2\n    echo \"error: If your bazel version is less than 5.2, you may need to \\`bazel clean\\` and/or \\`bazel shutdown\\` to work around a bug in project generation.\" >&2\n    echo \"error: If you are still getting this error after all of that, please file a bug report here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.\" >&2\n    exit 1\n  fi\ndone\n";
+			showEnvVarsInLog = 0;
+		};
+		F6321BA048CC586AD22757E7 /* Create link.params */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(LINK_PARAMS_FILE)",
+			);
+			name = "Create link.params";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/link.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4F9FE3B9695177163DF3F4F7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4B8F9453DB21BF522ED084F2 /* ExampleUITests.swift in Sources */,
+				B36065E1A4D78669F7CA6AD8 /* ExampleUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		64F0E9C37ADF426C760C0487 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8247FC302A95B8C90FFAC948 /* ExampleTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F94B766A6F00B6427D27F290 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				39BF0A575DB868D507469F87 /* ContentView.swift in Sources */,
+				AB903A67D5E295F09FE79F90 /* ExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		5F96E438EF4C12858E3D604D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = DDD61C8C1CFA249BBE0E369C /* PBXContainerItemProxy */;
+		};
+		60A15C6742A5E861650F0705 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Example;
+			target = DEF15AA97EC0FE28A9A97CAA /* Example */;
+			targetProxy = C5DFA83DE27EDEFA7A3B6716 /* PBXContainerItemProxy */;
+		};
+		660083BC58282EABB2E2220A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = 02A9E4CE2A3817364872DD5B /* PBXContainerItemProxy */;
+		};
+		9EE143447B830CA252A7E7D4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Example;
+			target = DEF15AA97EC0FE28A9A97CAA /* Example */;
+			targetProxy = 143B9C332C33613F47301BCA /* PBXContainerItemProxy */;
+		};
+		DD37E6139BE33454F9BBB7C3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = 21804B34B29467B2C330177B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		5AFD85147E5F7EEA259481C2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = appletvsimulator;
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = BazelDependencies;
+			};
+			name = Debug;
+		};
+		7A9D355938686E9325E09855 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/tvos_app/ExampleUITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
+				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/ExampleUITests/ExampleUITests.__internal__.__test_bundle.zip";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/ExampleUITests";
+				BAZEL_TARGET_ID = "//examples/tvos_app/ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				CODE_SIGNING_ALLOWED = YES;
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEPLOYMENT_LOCATION = NO;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/ExampleUITests/rules_xcodeproj/ExampleUITests.__internal__.__test_bundle/Info.plist";
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/examples/tvos_app/ExampleUITests/ExampleUITests.link.params";
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.uitests;
+				PRODUCT_MODULE_NAME = ExampleUITests;
+				PRODUCT_NAME = ExampleUITests;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = appletvsimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = ExampleUITests;
+				TEST_TARGET_NAME = Example;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin",
+				);
+			};
+			name = Debug;
+		};
+		932B94637C866D029E72AD3A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/tvos_app/ExampleTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
+				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/ExampleTests/ExampleTests.__internal__.__test_bundle.zip";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/ExampleTests";
+				BAZEL_TARGET_ID = "//examples/tvos_app/ExampleTests:ExampleTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEPLOYMENT_LOCATION = NO;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/ExampleTests/rules_xcodeproj/ExampleTests.__internal__.__test_bundle/Info.plist";
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/examples/tvos_app/ExampleTests/ExampleTests.link.params";
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.tests;
+				PRODUCT_MODULE_NAME = ExampleTests;
+				PRODUCT_NAME = ExampleTests;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = appletvsimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/Example";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/Example$(TARGET_BUILD_SUBPATH)";
+				TARGET_NAME = ExampleTests;
+				TEST_HOST = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/Example/Example.app/Example";
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin",
+				);
+			};
+			name = Debug;
+		};
+		B0892EE2AB907B40AA4EB960 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BAZEL_EXEC_ROOT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+				BAZEL_EXTERNAL = "bazel-output-base/external";
+				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
+				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
+				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
+				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
+				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
+				CC = "$(BAZEL_INTEGRATION_DIR)/cc.sh";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CODE_SIGNING_ALLOWED = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
+				COPY_PHASE_STRIP = NO;
+				CXX = "$(BAZEL_INTEGRATION_DIR)/cc.sh";
+				DEPLOYMENT_LOCATION = "$(INDEXING_DEPLOYMENT_LOCATION__$(INDEX_ENABLE_BUILD_ARENA)),";
+				DSTROOT = "$(PROJECT_TEMP_DIR)";
+				INDEXING_BUILT_PRODUCTS_DIR__ = "$(INDEXING_BUILT_PRODUCTS_DIR__NO)";
+				INDEXING_BUILT_PRODUCTS_DIR__NO = "$(BUILD_DIR)";
+				INDEXING_BUILT_PRODUCTS_DIR__YES = "$(CONFIGURATION_BUILD_DIR)";
+				INDEXING_DEPLOYMENT_LOCATION__ = "$(INDEXING_DEPLOYMENT_LOCATION__NO)";
+				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
+				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
+				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
+				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
+				LD = "$(BAZEL_INTEGRATION_DIR)/ld.sh";
+				LDPLUSPLUS = "$(BAZEL_INTEGRATION_DIR)/ld.sh";
+				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
+				LINKS_DIR = "$(INTERNAL_DIR)/links";
+				ONLY_ACTIVE_ARCH = YES;
+				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_EXEC = "$(BAZEL_INTEGRATION_DIR)/swiftc.py";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_USE_INTEGRATED_DRIVER = NO;
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+		ED022D7827FA072088152A34 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				BAZEL_COMPILE_TARGET_ID = "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
+				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/Example/Example.ipa";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/Example";
+				BAZEL_TARGET_ID = "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				CODE_SIGN_ENTITLEMENTS = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/Example/app.entitlements";
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEPLOYMENT_LOCATION = NO;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin/examples/tvos_app/Example/rules_xcodeproj/Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/examples/tvos_app/Example/Example.link.params";
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
+				PRODUCT_MODULE_NAME = Example;
+				PRODUCT_NAME = Example;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = appletvsimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = Example;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-fc698be45e1c/bin",
+				);
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0100CEFB31CE85C91D838A4D /* Build configuration list for PBXNativeTarget "ExampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				932B94637C866D029E72AD3A /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		4E80458017EA17FB5B672FEB /* Build configuration list for PBXNativeTarget "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ED022D7827FA072088152A34 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		529E9DE569B1F4ACD34C1EEC /* Build configuration list for PBXNativeTarget "ExampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7A9D355938686E9325E09855 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B0892EE2AB907B40AA4EB960 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5AFD85147E5F7EEA259481C2 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 0805833D09730531AD081697 /* Project object */;
+}

--- a/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/tvos_app/bwb.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -51,10 +51,10 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        # Xcode gets "stuck" in the `buildFiles` or `build` command for
-        # top-level targets, so we can't reliably change commands here. Leaving
-        # the code in place in case this is fixed in the future, or we want to
-        # do something similar in an XCBBuildService proxy.
+        # Xcode gets "suck" in the `buildFiles` or `build` command for top-level
+        # targets, so we can't reliably change commands here. Leaving the code
+        # in place in case this is fixed in the future, or we want to do
+        # something similar in an XCBBuildService proxy.
         #
         # command = (
         #     build_request.get("_buildCommand2", {}).get("command", "build")
@@ -197,7 +197,7 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
 
     if prefix == "i":
         # buildRequest for Index Build includes all targets, so we have to
-        # fall back to the scheme target ids (which are actually set by the
+        # fallback to the scheme target ids (which are actually set by the
         # "Copy Bazel Outputs" script)
         target_ids = scheme_target_ids
     else:

--- a/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/project.pbxproj
@@ -1,0 +1,843 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		FE59281FE487F27A37DC2EE7 /* BazelDependencies */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
+			buildPhases = (
+				773C70B69E7F801B38FDC01C /* Generate Files */,
+				2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */,
+			);
+			dependencies = (
+			);
+			name = BazelDependencies;
+			productName = BazelDependencies;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		07F908DC176F821D2C7A2589 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCDCF5497AF5CB6FD82EB9AB /* ExampleTests.swift */; };
+		15290AABE3F18B7AA8B337A4 /* ExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6A6CF9C9CD7BEED9F65CA3 /* ExampleUITestsLaunchTests.swift */; };
+		5098BCCB1868B198F4419656 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99B15598E2A225AF0402DDCF /* ExampleApp.swift */; };
+		94614B984C53B88AC9ACC190 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 35BDF811504C7A1D635A8ED1 /* Assets.xcassets */; };
+		EB6A255551CEB04337D41DCB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BDA7F5F96E7A0A135F45B2 /* ContentView.swift */; };
+		FD42AA2BC37887E422B705F4 /* ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FB9EDA6F321B496D89ECD94 /* ExampleUITests.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0AD7BC763596B83B4C22F092 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9E46111B59CD5CC4865299C2;
+			remoteInfo = Example;
+		};
+		C741662DA9E8C325064CB18E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9E46111B59CD5CC4865299C2;
+			remoteInfo = Example;
+		};
+		DC6D5BCAEE6A6DF18BF02F7E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
+		DFB6B3D768109FDA95CBEF01 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
+		ED41EFD0264AD1C688EFC937 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		075CBE79402054D4E0D7FD2F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		122A98FA505350325F6740CA /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		1452248E39E2C6D3CB3559F0 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		1D174B1D4C25E9FD21719679 /* ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1E60F003F31713210E943417 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		35BDF811504C7A1D635A8ED1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		478967B39B54B9C2F93AD46B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		61BDA7F5F96E7A0A135F45B2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		6D716145772914014B1460C6 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		6FB9EDA6F321B496D89ECD94 /* ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITests.swift; sourceTree = "<group>"; };
+		7E6A6CF9C9CD7BEED9F65CA3 /* ExampleUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		99B15598E2A225AF0402DDCF /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
+		A8692825F3DA9302E3BED964 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		AE960EFF7013DD45F88383CC /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B69AF786B804E6CD15F61528 /* ExampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE5F89CF78F0E7C26F1539FC /* DefaultTestBundle.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = DefaultTestBundle.plist; sourceTree = "<group>"; };
+		CCDCF5497AF5CB6FD82EB9AB /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
+		D024F15DA31CEF6786E264C1 /* app.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = app.entitlements; sourceTree = "<group>"; };
+		DF91274AAE62325614655FBE /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+		04697D6283B6D52AAE90357D /* tvos_app */ = {
+			isa = PBXGroup;
+			children = (
+				DF91274AAE62325614655FBE /* BUILD */,
+			);
+			path = tvos_app;
+			sourceTree = "<group>";
+		};
+		04CC01BA1798E53DE0EC00C5 /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				FA54371A201B9A494B9AE76D /* rules_xcodeproj */,
+			);
+			path = ExampleUITests;
+			sourceTree = "<group>";
+		};
+		05BEA959EF732C9C423BF373 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				AEBE560571C3A313D062C6D2 /* rules_xcodeproj */,
+				D024F15DA31CEF6786E264C1 /* app.entitlements */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		1064E5B9DD0CD4D72A92A1E4 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				35BDF811504C7A1D635A8ED1 /* Assets.xcassets */,
+				1452248E39E2C6D3CB3559F0 /* BUILD */,
+				61BDA7F5F96E7A0A135F45B2 /* ContentView.swift */,
+				99B15598E2A225AF0402DDCF /* ExampleApp.swift */,
+				075CBE79402054D4E0D7FD2F /* Info.plist */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		273036962EC5C64F59C2ADF3 /* tvos_app */ = {
+			isa = PBXGroup;
+			children = (
+				1064E5B9DD0CD4D72A92A1E4 /* Example */,
+				BE32A3F8BF60AFC36D9ED0E7 /* ExampleTests */,
+				914F2AA1FC7CFD2BD3276037 /* ExampleUITests */,
+			);
+			path = tvos_app;
+			sourceTree = "<group>";
+		};
+		34EEB3D407F10261A42BB9F7 /* fixtures */ = {
+			isa = PBXGroup;
+			children = (
+				04697D6283B6D52AAE90357D /* tvos_app */,
+			);
+			path = fixtures;
+			sourceTree = "<group>";
+		};
+		38D97FD37FF97351A84386D5 /* build_bazel_rules_apple */ = {
+			isa = PBXGroup;
+			children = (
+				768C0B6FBEA15B86DF2C38DC /* apple */,
+			);
+			path = build_bazel_rules_apple;
+			sourceTree = "<group>";
+		};
+		39F4042FB42D4E462D0F86A7 /* testing */ = {
+			isa = PBXGroup;
+			children = (
+				BE5F89CF78F0E7C26F1539FC /* DefaultTestBundle.plist */,
+			);
+			path = testing;
+			sourceTree = "<group>";
+		};
+		462C3519CA354BE1B04D4855 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AE960EFF7013DD45F88383CC /* Example.app */,
+				B69AF786B804E6CD15F61528 /* ExampleTests.xctest */,
+				1D174B1D4C25E9FD21719679 /* ExampleUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4CA58148A4EACDFEE96A5A1D /* ExampleUITests.__internal__.__test_bundle */ = {
+			isa = PBXGroup;
+			children = (
+				A8692825F3DA9302E3BED964 /* Info.plist */,
+			);
+			path = ExampleUITests.__internal__.__test_bundle;
+			sourceTree = "<group>";
+		};
+		595054DB705A489256F447AD /* bin */ = {
+			isa = PBXGroup;
+			children = (
+				AF7F2159DC6DD82FAE3F03B9 /* examples */,
+			);
+			path = bin;
+			sourceTree = "<group>";
+		};
+		64DE93F52A753C0FEAEE07FA /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				CF8117A556BAAA88EF81BA07 /* ExampleTests.__internal__.__test_bundle */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
+		66F51077DF6129243F2D906D /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				64DE93F52A753C0FEAEE07FA /* rules_xcodeproj */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
+		768C0B6FBEA15B86DF2C38DC /* apple */ = {
+			isa = PBXGroup;
+			children = (
+				39F4042FB42D4E462D0F86A7 /* testing */,
+			);
+			path = apple;
+			sourceTree = "<group>";
+		};
+		77E0714FDD425211EBA209DF = {
+			isa = PBXGroup;
+			children = (
+				86E3AA094AC3498BEDC1D673 /* examples */,
+				D2C8CC455B9D27F28D323622 /* test */,
+				85F708DD1F5484A0D5558108 /* Bazel External Repositories */,
+				A5A3DECCB7E56F0EA3676D12 /* Bazel Generated Files */,
+				462C3519CA354BE1B04D4855 /* Products */,
+				D9AAB93A5135F69103554470 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		85F708DD1F5484A0D5558108 /* Bazel External Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				38D97FD37FF97351A84386D5 /* build_bazel_rules_apple */,
+			);
+			name = "Bazel External Repositories";
+			path = "bazel-output-base/external";
+			sourceTree = "<group>";
+		};
+		86E3AA094AC3498BEDC1D673 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				273036962EC5C64F59C2ADF3 /* tvos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		8C8F133759A9643C6958B72F /* applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb */ = {
+			isa = PBXGroup;
+			children = (
+				595054DB705A489256F447AD /* bin */,
+			);
+			path = "applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+			sourceTree = "<group>";
+		};
+		914F2AA1FC7CFD2BD3276037 /* ExampleUITests */ = {
+			isa = PBXGroup;
+			children = (
+				6D716145772914014B1460C6 /* BUILD */,
+				6FB9EDA6F321B496D89ECD94 /* ExampleUITests.swift */,
+				7E6A6CF9C9CD7BEED9F65CA3 /* ExampleUITestsLaunchTests.swift */,
+			);
+			path = ExampleUITests;
+			sourceTree = "<group>";
+		};
+		999234D1B8809D54001648F0 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				478967B39B54B9C2F93AD46B /* Info.plist */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		A5A3DECCB7E56F0EA3676D12 /* Bazel Generated Files */ = {
+			isa = PBXGroup;
+			children = (
+				8C8F133759A9643C6958B72F /* applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb */,
+			);
+			name = "Bazel Generated Files";
+			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+			sourceTree = "<group>";
+		};
+		AEBE560571C3A313D062C6D2 /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				999234D1B8809D54001648F0 /* Example */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
+		AF7F2159DC6DD82FAE3F03B9 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				B6B16A72C6CB15960EA6841F /* tvos_app */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		B6B16A72C6CB15960EA6841F /* tvos_app */ = {
+			isa = PBXGroup;
+			children = (
+				05BEA959EF732C9C423BF373 /* Example */,
+				66F51077DF6129243F2D906D /* ExampleTests */,
+				04CC01BA1798E53DE0EC00C5 /* ExampleUITests */,
+			);
+			path = tvos_app;
+			sourceTree = "<group>";
+		};
+		BE32A3F8BF60AFC36D9ED0E7 /* ExampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				122A98FA505350325F6740CA /* BUILD */,
+				CCDCF5497AF5CB6FD82EB9AB /* ExampleTests.swift */,
+			);
+			path = ExampleTests;
+			sourceTree = "<group>";
+		};
+		CF8117A556BAAA88EF81BA07 /* ExampleTests.__internal__.__test_bundle */ = {
+			isa = PBXGroup;
+			children = (
+				1E60F003F31713210E943417 /* Info.plist */,
+			);
+			path = ExampleTests.__internal__.__test_bundle;
+			sourceTree = "<group>";
+		};
+		D2C8CC455B9D27F28D323622 /* test */ = {
+			isa = PBXGroup;
+			children = (
+				34EEB3D407F10261A42BB9F7 /* fixtures */,
+			);
+			path = test;
+			sourceTree = "<group>";
+		};
+		D9AAB93A5135F69103554470 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		FA54371A201B9A494B9AE76D /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				4CA58148A4EACDFEE96A5A1D /* ExampleUITests.__internal__.__test_bundle */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		76739995B84B34D1F296EBE4 /* ExampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 61DE4199B1A5CD840CBE5936 /* Build configuration list for PBXNativeTarget "ExampleTests" */;
+			buildPhases = (
+				916375E568B5DCC38DE5B06C /* Create link.params */,
+				CB8AB7D1543020F00097DBF0 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F37E2647FBFBCE2913283992 /* PBXTargetDependency */,
+				BA1ED95209134FB8F05435AB /* PBXTargetDependency */,
+			);
+			name = ExampleTests;
+			productName = ExampleTests;
+			productReference = B69AF786B804E6CD15F61528 /* ExampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		9E46111B59CD5CC4865299C2 /* Example */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E6A9520E4E640351CDDD995F /* Build configuration list for PBXNativeTarget "Example" */;
+			buildPhases = (
+				B53A70A8850ED09CF7C2348A /* Create link.params */,
+				158225A69996B833609C215D /* Sources */,
+				EC82FDE86D73A4710E6DBDE5 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AB1C3081B4C14FDC3D765DFD /* PBXTargetDependency */,
+			);
+			name = Example;
+			productName = Example;
+			productReference = AE960EFF7013DD45F88383CC /* Example.app */;
+			productType = "com.apple.product-type.application";
+		};
+		9F806AD4E93B4D1D569E9D2B /* ExampleUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FB39583646574C3204F817B3 /* Build configuration list for PBXNativeTarget "ExampleUITests" */;
+			buildPhases = (
+				73D877B3DBEB236B190B36FB /* Create link.params */,
+				4FB0F65207D21A288CE24A4E /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CBC1C3C38884D04CA2FEF312 /* PBXTargetDependency */,
+				D953C022C6B9B2616735B46F /* PBXTargetDependency */,
+			);
+			name = ExampleUITests;
+			productName = ExampleUITests;
+			productReference = 1D174B1D4C25E9FD21719679 /* ExampleUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		36B5F79C7ED8B081842AF69D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 9999;
+				LastUpgradeCheck = 9999;
+				TargetAttributes = {
+					76739995B84B34D1F296EBE4 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+						TestTargetID = 9E46111B59CD5CC4865299C2;
+					};
+					9E46111B59CD5CC4865299C2 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
+					9F806AD4E93B4D1D569E9D2B = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+						TestTargetID = 9E46111B59CD5CC4865299C2;
+					};
+					FE59281FE487F27A37DC2EE7 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+				};
+			};
+			buildConfigurationList = 8C14447CB8BDD86ECF450932 /* Build configuration list for PBXProject "bwx" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 77E0714FDD425211EBA209DF;
+			productRefGroup = 462C3519CA354BE1B04D4855 /* Products */;
+			projectDirPath = ../../..;
+			projectRoot = "";
+			targets = (
+				FE59281FE487F27A37DC2EE7 /* BazelDependencies */,
+				9E46111B59CD5CC4865299C2 /* Example */,
+				76739995B84B34D1F296EBE4 /* ExampleTests */,
+				9F806AD4E93B4D1D569E9D2B /* ExampleUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		EC82FDE86D73A4710E6DBDE5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				94614B984C53B88AC9ACC190 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(INTERNAL_DIR)/swift_debug_settings.py",
+			);
+			name = "Create swift_debug_settings.py";
+			outputPaths = (
+				"$(OBJROOT)/swift_debug_settings.py",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		73D877B3DBEB236B190B36FB /* Create link.params */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(LINK_PARAMS_FILE)",
+			);
+			name = "Create link.params";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/link.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		773C70B69E7F801B38FDC01C /* Generate Files */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate Files";
+			outputFileListPaths = (
+				"$(INTERNAL_DIR)/external.xcfilelist",
+				"$(INTERNAL_DIR)/generated.xcfilelist",
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/bash;
+			shellScript = "set -euo pipefail\n\n# In Xcode 14 the \"Index\" directory was renamed to \"Index.noindex\".\n# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can\n# use it to determine the name of the directory regardless of Xcode version.\nreadonly index_dir=\"${INDEX_DATA_STORE_DIR%/*}\"\nreadonly index_dir_name=\"${index_dir##*/}\"\n\n# Xcode doesn't adjust `$OBJROOT` in scheme action scripts when building for\n# previews. So we need to look in the non-preview build directory for this file.\nreadonly non_preview_objroot=\"${OBJROOT/\\/Intermediates.noindex\\/Previews\\/*//Intermediates.noindex}\"\nreadonly base_objroot=\"${non_preview_objroot/\\/$index_dir_name\\/Build\\/Intermediates.noindex//Build/Intermediates.noindex}\"\nreadonly scheme_target_ids_file=\"$non_preview_objroot/scheme_target_ids\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  readonly output_group_prefix=i\nelse\n  readonly output_group_prefix=g\nfi\n\n# We need to read from `$output_groups_file` as soon as possible, as concurrent\n# writes to it can happen during indexing, which breaks the off-by-one-by-design\n# nature of it\nIFS=$'\\n' read -r -d '' -a output_groups < \\\n  <( \"$CALCULATE_OUTPUT_GROUPS_SCRIPT\" \\\n       \"$non_preview_objroot\" \\\n       \"$base_objroot\" \\\n       \"$scheme_target_ids_file\" \\\n       $output_group_prefix \\\n       && printf '\\0' )\n\nif [ -z \"${output_groups:-}\" ]; then\n  if [ \"$ACTION\" == \"indexbuild\" ]; then\n    output_groups=(\"all_generated_inputs\")\n  else\n    echo \"error: BazelDependencies invoked without any output groups set. Please file a bug report here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.\" >&2\n    exit 1\n  fi\nfi\noutput_groups_flag=\"--output_groups=$(IFS=, ; echo \"${output_groups[*]}\")\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  # We use a different output base for Index Build to prevent normal builds and\n  # indexing waiting on bazel locks from the other\n  output_base=\"$OBJROOT/bazel_output_base\"\nfi\n\nif [[ \"${COLOR_DIAGNOSTICS:-NO}\" == \"YES\" ]]; then\n  color=yes\nelse\n  color=no\nfi\n\nbazelrcs=(\n  --noworkspace_rc\n  \"--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc\"\n)\nif [[ -s \".bazelrc\" ]]; then\n  bazelrcs+=(\"--bazelrc=.bazelrc\")\nfi\nif [[ -s \"$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc\" ]]; then\n  bazelrcs+=(\"--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc\")\nfi\n\noutput_path=$(env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  \"${bazelrcs[@]}\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  info \\\n  --config=rules_xcodeproj_info \\\n  --color=\"$color\" \\\n  --experimental_convenience_symlinks=ignore \\\n  --symlink_prefix=/ \\\n  --bes_backend= \\\n  --bes_results_url= \\\n  output_path)\nexec_root=\"${output_path%/*}\"\n\nif [[ \"$ACTION\" != \"indexbuild\" && \"${ENABLE_PREVIEWS:-}\" != \"YES\" ]]; then\n  \"$BAZEL_INTEGRATION_DIR/create_lldbinit.sh\" \"$exec_root\"  > \"$BAZEL_LLDB_INIT\"\nfi\n\nif [[ \"${BAZEL_OUT:0:1}\" == '/' ]]; then\n  bazel_out_prefix=\nelse\n  bazel_out_prefix=\"$SRCROOT/\"\nfi\n\nabsolute_bazel_out=\"${bazel_out_prefix}$BAZEL_OUT\"\n\nif [[ \"$output_path\" != \"$absolute_bazel_out\" ]]; then\n  # Use current path for bazel-out\n  # This fixes Index Build to use its version of generated files\n  roots=\"{\\\"external-contents\\\": \\\"$output_path\\\",\\\"name\\\": \\\"$absolute_bazel_out\\\",\\\"type\\\": \\\"directory-remap\\\"}\"\nelse\n  roots=\nfi\n\ncat > \"$OBJROOT/bazel-out-overlay.yaml\" <<EOF\n{\"case-sensitive\": \"false\", \"fallthrough\": true, \"roots\": [$roots],\"version\": 0}\nEOF\n\n# Look up Swift generated headers in `$BUILD_DIR` first, then fall through to `$BAZEL_OUT`\ncat > \"$OBJROOT/xcode-overlay.yaml\" <<EOF\n{\"case-sensitive\": \"false\", \"fallthrough\": true, \"roots\": [],\"version\": 0}\nEOF\n\ncd \"$SRCROOT\"\n\nif [ \"$ACTION\" == \"indexbuild\" ]; then\n  config=rules_xcodeproj_indexbuild\nelif [ \"${ENABLE_PREVIEWS:-}\" == \"YES\" ]; then\n  config=rules_xcodeproj_swiftuipreviews\nelse\n  config=rules_xcodeproj_build\nfi\n\ndate +%s > \"$INTERNAL_DIR/toplevel_cache_buster\"\n\nbuild_marker=\"$OBJROOT/bazel_build_start\"\ntouch \"$build_marker\"\n\nlog=$(mktemp)\n\"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py\" env -i \\\n  DEVELOPER_DIR=\"$DEVELOPER_DIR\" \\\n  HOME=\"$HOME\" \\\n  PATH=\"/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin\" \\\n  USER=\"$USER\" \\\n  \"$BAZEL_PATH\" \\\n  \"${bazelrcs[@]}\" \\\n  ${output_base:+--output_base \"$output_base\"} \\\n  build \\\n  --config=$config \\\n  --color=yes \\\n  --experimental_convenience_symlinks=ignore \\\n  --symlink_prefix=/ \\\n  \"$output_groups_flag\" \\\n  //test/fixtures/tvos_app:xcodeproj_bwx.generator \\\n  2>&1 | tee -i \"$log\"\n\nfor output_group in \"${output_groups[@]}\"; do\n  filelist=\"xcodeproj_bwx.generator-${output_group//\\//_}\"\n  filelist=\"${filelist/#/$output_path/darwin_x86_64-dbg-ST-1b9bd654f600/bin/test/fixtures/tvos_app/}\"\n  filelist=\"${filelist/%/.filelist}\"\n  if [[ \"$filelist\" -ot \"$build_marker\" ]]; then\n    echo \"error: Bazel didn't generate the correct files (it should have generated outputs for output group \\\"$output_group\\\", but the timestamp for \\\"$filelist\\\" was from before the build). Please regenerate the project to fix this.\" >&2\n    echo \"error: If your bazel version is less than 5.2, you may need to \\`bazel clean\\` and/or \\`bazel shutdown\\` to work around a bug in project generation.\" >&2\n    echo \"error: If you are still getting this error after all of that, please file a bug report here: https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md.\" >&2\n    exit 1\n  fi\ndone\n";
+			showEnvVarsInLog = 0;
+		};
+		916375E568B5DCC38DE5B06C /* Create link.params */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(LINK_PARAMS_FILE)",
+			);
+			name = "Create link.params";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/link.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B53A70A8850ED09CF7C2348A /* Create link.params */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(LINK_PARAMS_FILE)",
+			);
+			name = "Create link.params";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/link.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		158225A69996B833609C215D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EB6A255551CEB04337D41DCB /* ContentView.swift in Sources */,
+				5098BCCB1868B198F4419656 /* ExampleApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4FB0F65207D21A288CE24A4E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FD42AA2BC37887E422B705F4 /* ExampleUITests.swift in Sources */,
+				15290AABE3F18B7AA8B337A4 /* ExampleUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB8AB7D1543020F00097DBF0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				07F908DC176F821D2C7A2589 /* ExampleTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		AB1C3081B4C14FDC3D765DFD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = DFB6B3D768109FDA95CBEF01 /* PBXContainerItemProxy */;
+		};
+		BA1ED95209134FB8F05435AB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Example;
+			target = 9E46111B59CD5CC4865299C2 /* Example */;
+			targetProxy = C741662DA9E8C325064CB18E /* PBXContainerItemProxy */;
+		};
+		CBC1C3C38884D04CA2FEF312 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = DC6D5BCAEE6A6DF18BF02F7E /* PBXContainerItemProxy */;
+		};
+		D953C022C6B9B2616735B46F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Example;
+			target = 9E46111B59CD5CC4865299C2 /* Example */;
+			targetProxy = 0AD7BC763596B83B4C22F092 /* PBXContainerItemProxy */;
+		};
+		F37E2647FBFBCE2913283992 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = ED41EFD0264AD1C688EFC937 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		5365217077C86993CCD43DFD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/tvos_app/ExampleTests:ExampleTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/tvos_app/ExampleTests";
+				BAZEL_TARGET_ID = "//examples/tvos_app/ExampleTests:ExampleTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEPLOYMENT_LOCATION = NO;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/tvos_app/ExampleTests/rules_xcodeproj/ExampleTests.__internal__.__test_bundle/Info.plist";
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/examples/tvos_app/ExampleTests/ExampleTests.link.params";
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.tests;
+				PRODUCT_MODULE_NAME = ExampleTests;
+				PRODUCT_NAME = ExampleTests;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = appletvsimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/tvos_app/Example";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_BUILD_DIR = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/tvos_app/Example$(TARGET_BUILD_SUBPATH)";
+				TARGET_NAME = ExampleTests;
+				TEST_HOST = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/tvos_app/Example/Example.app/Example";
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin",
+				);
+			};
+			name = Debug;
+		};
+		67F44AB65FA7A2E38A56F5FB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				SUPPORTED_PLATFORMS = appletvsimulator;
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = BazelDependencies;
+			};
+			name = Debug;
+		};
+		BE2CA0A20BAEAC56C4898C1A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				BAZEL_COMPILE_TARGET_ID = "//examples/tvos_app/Example:Example.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/tvos_app/Example";
+				BAZEL_TARGET_ID = "//examples/tvos_app/Example:Example applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/tvos_app/Example/app.entitlements";
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEPLOYMENT_LOCATION = NO;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/tvos_app/Example/rules_xcodeproj/Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/examples/tvos_app/Example/Example.link.params";
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
+				PRODUCT_MODULE_NAME = Example;
+				PRODUCT_NAME = Example;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = appletvsimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = Example;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin",
+				);
+			};
+			name = Debug;
+		};
+		C221D886D6D02D33114D3473 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BAZEL_EXEC_ROOT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+				BAZEL_EXTERNAL = "bazel-output-base/external";
+				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
+				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
+				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
+				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
+				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
+				COPY_PHASE_STRIP = NO;
+				DEPLOYMENT_LOCATION = "$(INDEXING_DEPLOYMENT_LOCATION__$(INDEX_ENABLE_BUILD_ARENA)),";
+				DSTROOT = "$(PROJECT_TEMP_DIR)";
+				INDEXING_BUILT_PRODUCTS_DIR__ = "$(INDEXING_BUILT_PRODUCTS_DIR__NO)";
+				INDEXING_BUILT_PRODUCTS_DIR__NO = "$(BUILD_DIR)";
+				INDEXING_BUILT_PRODUCTS_DIR__YES = "$(CONFIGURATION_BUILD_DIR)";
+				INDEXING_DEPLOYMENT_LOCATION__ = "$(INDEXING_DEPLOYMENT_LOCATION__NO)";
+				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
+				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
+				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
+				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
+				LINKS_DIR = "$(INTERNAL_DIR)/links";
+				ONLY_ACTIVE_ARCH = YES;
+				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+		E5BED42AB6E81139FC00F03C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//examples/tvos_app/ExampleUITests:ExampleUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/tvos_app/ExampleUITests";
+				BAZEL_TARGET_ID = "//examples/tvos_app/ExampleUITests:ExampleUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				CODE_SIGNING_ALLOWED = YES;
+				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEPLOYMENT_LOCATION = NO;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin/examples/tvos_app/ExampleUITests/rules_xcodeproj/ExampleUITests.__internal__.__test_bundle/Info.plist";
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/examples/tvos_app/ExampleUITests/ExampleUITests.link.params";
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.uitests;
+				PRODUCT_MODULE_NAME = ExampleUITests;
+				PRODUCT_NAME = ExampleUITests;
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = appletvsimulator;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				TARGET_NAME = ExampleUITests;
+				TEST_TARGET_NAME = Example;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-57405dc02cbb/bin",
+				);
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		61DE4199B1A5CD840CBE5936 /* Build configuration list for PBXNativeTarget "ExampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5365217077C86993CCD43DFD /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		8C14447CB8BDD86ECF450932 /* Build configuration list for PBXProject "bwx" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C221D886D6D02D33114D3473 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				67F44AB65FA7A2E38A56F5FB /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		E6A9520E4E640351CDDD995F /* Build configuration list for PBXNativeTarget "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BE2CA0A20BAEAC56C4898C1A /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		FB39583646574C3204F817B3 /* Build configuration list for PBXNativeTarget "ExampleUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E5BED42AB6E81139FC00F03C /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 36B5F79C7ED8B081842AF69D /* Project object */;
+}

--- a/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
+++ b/test/fixtures/tvos_app/bwx.xcodeproj/rules_xcodeproj/bazel/calculate_output_groups.py
@@ -51,10 +51,10 @@ def _calculate_output_group_target_ids(
             # Parse the build-request.json file
             build_request = json.load(f)
 
-        # Xcode gets "stuck" in the `buildFiles` or `build` command for
-        # top-level targets, so we can't reliably change commands here. Leaving
-        # the code in place in case this is fixed in the future, or we want to
-        # do something similar in an XCBBuildService proxy.
+        # Xcode gets "suck" in the `buildFiles` or `build` command for top-level
+        # targets, so we can't reliably change commands here. Leaving the code
+        # in place in case this is fixed in the future, or we want to do
+        # something similar in an XCBBuildService proxy.
         #
         # command = (
         #     build_request.get("_buildCommand2", {}).get("command", "build")
@@ -197,7 +197,7 @@ def _main(objroot, base_objroot, scheme_target_id_file, prefix):
 
     if prefix == "i":
         # buildRequest for Index Build includes all targets, so we have to
-        # fall back to the scheme target ids (which are actually set by the
+        # fallback to the scheme target ids (which are actually set by the
         # "Copy Bazel Outputs" script)
         target_ids = scheme_target_ids
     else:

--- a/tools/generator/src/DTO/Target.swift
+++ b/tools/generator/src/DTO/Target.swift
@@ -4,6 +4,7 @@ struct Target: Equatable {
     var name: String
     var label: BazelLabel
     let configuration: String
+    var compileTargetID: TargetID? = nil
     var packageBinDir: Path
     var platform: Platform
     let product: Product

--- a/tools/generator/src/Generator/ProcessTargetMerges.swift
+++ b/tools/generator/src/Generator/ProcessTargetMerges.swift
@@ -51,6 +51,9 @@ exist
 """)
                 }
 
+                // Set compile target id (used for "Compile File" command)
+                merged.compileTargetID = source
+
                 // Update Package Bin Dir
                 // We take on the libraries bazel-out directory to prevent
                 // issues with search paths that are calculated in Starlark.

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -2072,6 +2072,7 @@ perl -pe 's/^("?)(.*\$\(.*\).*?)("?)$/"$2"/ ; s/\$(\()?([a-zA-Z_]\w*)(?(1)\))/$E
                 "ARCHS": "arm64",
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/A 1",
                 "BAZEL_TARGET_ID": "A 1",
+                "BAZEL_TARGET_ID[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
                 "GENERATE_INFOPLIST_FILE": "YES",
                 "MACOSX_DEPLOYMENT_TARGET": "10.0",
                 "OTHER_SWIFT_FLAGS": #"""
@@ -2087,6 +2088,7 @@ perl -pe 's/^("?)(.*\$\(.*\).*?)("?)$/"$2"/ ; s/\$(\()?([a-zA-Z_]\w*)(?(1)\))/$E
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/A 2",
                 "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)",
                 "BAZEL_TARGET_ID": "A 2",
+                "BAZEL_TARGET_ID[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
                 "CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION": "YES",
                 "CODE_SIGN_ENTITLEMENTS": "app.entitlements",
                 "DEPLOYMENT_LOCATION": "NO",
@@ -2120,6 +2122,7 @@ $(INTERNAL_DIR)/targets/a1b2c/A 2/A.link.params
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/AC",
                 "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)",
                 "BAZEL_TARGET_ID": "AC",
+                "BAZEL_TARGET_ID[sdk=iphoneos*]": "$(BAZEL_TARGET_ID)",
                 "DEPLOYMENT_LOCATION": "NO",
                 "GENERATE_INFOPLIST_FILE": "YES",
                 "IPHONEOS_DEPLOYMENT_TARGET": "11.0",
@@ -2145,6 +2148,7 @@ $(INTERNAL_DIR)/targets/a1b2c/A 2/A.link.params
                 "ARCHS": "arm64",
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/B 1",
                 "BAZEL_TARGET_ID": "B 1",
+                "BAZEL_TARGET_ID[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
                 "GENERATE_INFOPLIST_FILE": "YES",
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
@@ -2165,6 +2169,7 @@ $(INTERNAL_DIR)/targets/a1b2c/A 2/A.link.params
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/B 2",
                 "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)",
                 "BAZEL_TARGET_ID": "B 2",
+                "BAZEL_TARGET_ID[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
                 "BUNDLE_LOADER": "$(TEST_HOST)",
                 "DEPLOYMENT_LOCATION": "NO",
                 "GENERATE_INFOPLIST_FILE": "YES",
@@ -2193,6 +2198,7 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2/A.app/A_ExecutableName
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/B 3",
                 "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)",
                 "BAZEL_TARGET_ID": "B 3",
+                "BAZEL_TARGET_ID[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
                 "CODE_SIGNING_ALLOWED": "YES",
                 "DEPLOYMENT_LOCATION": "NO",
                 "GENERATE_INFOPLIST_FILE": "YES",
@@ -2215,6 +2221,7 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2/A.app/A_ExecutableName
                 "ARCHS": "arm64",
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/C 1",
                 "BAZEL_TARGET_ID": "C 1",
+                "BAZEL_TARGET_ID[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
                 "EXECUTABLE_EXTENSION": "lo",
                 "GCC_PREFIX_HEADER": "a/b/c.pch",
                 "GENERATE_INFOPLIST_FILE": "YES",
@@ -2237,6 +2244,7 @@ $(BUILD_DIR)/bazel-out/a1b2c/bin/A 2/A.app/A_ExecutableName
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/C 2",
                 "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)",
                 "BAZEL_TARGET_ID": "C 2",
+                "BAZEL_TARGET_ID[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
                 "DEPLOYMENT_LOCATION": "NO",
                 "EXECUTABLE_EXTENSION": "",
                 "GENERATE_INFOPLIST_FILE": "YES",
@@ -2262,6 +2270,7 @@ $(INTERNAL_DIR)/targets/a1b2c/C 2/d.link.params
                 "ARCHS": "x86_64",
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/E1",
                 "BAZEL_TARGET_ID": "E1",
+                "BAZEL_TARGET_ID[sdk=watchos*]": "$(BAZEL_TARGET_ID)",
                 "GENERATE_INFOPLIST_FILE": "YES",
                 "OTHER_SWIFT_FLAGS": #"""
 -Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml \#
@@ -2280,6 +2289,7 @@ $(INTERNAL_DIR)/targets/a1b2c/C 2/d.link.params
                 "ARCHS": "arm64",
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/E2",
                 "BAZEL_TARGET_ID": "E2",
+                "BAZEL_TARGET_ID[sdk=appletvos*]": "$(BAZEL_TARGET_ID)",
                 "GENERATE_INFOPLIST_FILE": "YES",
                 "OTHER_SWIFT_FLAGS": #"""
 -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml
@@ -2295,6 +2305,7 @@ $(INTERNAL_DIR)/targets/a1b2c/C 2/d.link.params
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/I",
                 "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)",
                 "BAZEL_TARGET_ID": "I",
+                "BAZEL_TARGET_ID[sdk=iphoneos*]": "$(BAZEL_TARGET_ID)",
                 "DEPLOYMENT_LOCATION": "NO",
                 "FRAMEWORK_SEARCH_PATHS": """
 $(BAZEL_OUT)/some/framework/parent/dir
@@ -2334,6 +2345,7 @@ $(BAZEL_OUT)/some/quote/includes/parent/dir
                 "ARCHS": "arm64",
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/R 1",
                 "BAZEL_TARGET_ID": "R 1",
+                "BAZEL_TARGET_ID[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
                 "GENERATE_INFOPLIST_FILE": "YES",
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
@@ -2361,6 +2373,7 @@ bazel-out/a1b2c/bin/T 1
 bazel-out/a1b2c/bin/T 2
 """,
                 "BAZEL_TARGET_ID": "T 3",
+                "BAZEL_TARGET_ID[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
                 "BAZEL_TARGET_ID[sdk=iphoneos*]": "T 1",
                 "BAZEL_TARGET_ID[sdk=iphonesimulator*]": "T 2",
                 "EXCLUDED_SOURCE_FILE_NAMES": """
@@ -2402,6 +2415,7 @@ $(MACOSX_FILES)
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/W",
                 "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)",
                 "BAZEL_TARGET_ID": "W",
+                "BAZEL_TARGET_ID[sdk=watchos*]": "$(BAZEL_TARGET_ID)",
                 "BAZEL_HOST_TARGET_ID_0": "I",
                 "DEPLOYMENT_LOCATION": "NO",
                 "GENERATE_INFOPLIST_FILE": "YES",
@@ -2424,6 +2438,7 @@ $(MACOSX_FILES)
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/WDKE",
                 "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)",
                 "BAZEL_TARGET_ID": "WDKE",
+                "BAZEL_TARGET_ID[sdk=iphoneos*]": "$(BAZEL_TARGET_ID)",
                 "BAZEL_HOST_TARGET_ID_0": "I",
                 "DEPLOYMENT_LOCATION": "NO",
                 "GENERATE_INFOPLIST_FILE": "YES",
@@ -2452,6 +2467,7 @@ $(MACOSX_FILES)
                 "BAZEL_PACKAGE_BIN_DIR": "bazel-out/a1b2c/bin/WKE",
                 "BUILT_PRODUCTS_DIR": "$(CONFIGURATION_BUILD_DIR)",
                 "BAZEL_TARGET_ID": "WKE",
+                "BAZEL_TARGET_ID[sdk=watchos*]": "$(BAZEL_TARGET_ID)",
                 "BAZEL_HOST_TARGET_ID_0": "W",
                 "DEPLOYMENT_LOCATION": "NO",
                 "GENERATE_INFOPLIST_FILE": "YES",

--- a/tools/generator/test/ProcessTargetMergesTests.swift
+++ b/tools/generator/test/ProcessTargetMergesTests.swift
@@ -38,6 +38,7 @@ final class TargetMergingTests: XCTestCase {
         expectedTargets.removeValue(forKey: "A 1")
         expectedTargets.removeValue(forKey: "B 1")
         expectedTargets["A 2"] = Target.mock(
+            compileTargetID: "A 1",
             packageBinDir: targets["A 1"]!.packageBinDir,
             platform: targets["A 1"]!.platform,
             product: targets["A 2"]!.product,
@@ -68,6 +69,7 @@ final class TargetMergingTests: XCTestCase {
             outputs: targets["A 2"]!.outputs.merging(targets["A 1"]!.outputs)
         )
         expectedTargets["B 2"] = Target.mock(
+            compileTargetID: "B 1",
             packageBinDir: targets["B 1"]!.packageBinDir,
             platform: targets["B 1"]!.platform,
             product: targets["B 2"]!.product,
@@ -90,6 +92,7 @@ final class TargetMergingTests: XCTestCase {
             outputs: targets["B 2"]!.outputs.merging(targets["B 1"]!.outputs)
         )
         expectedTargets["B 3"] = Target.mock(
+            compileTargetID: "B 1",
             packageBinDir: targets["B 1"]!.packageBinDir,
             platform: targets["B 1"]!.platform,
             product: targets["B 3"]!.product,

--- a/tools/generator/test/SetTargetConfigurationsTests.swift
+++ b/tools/generator/test/SetTargetConfigurationsTests.swift
@@ -305,65 +305,101 @@ final class SetTargetConfigurationsTests: XCTestCase {
     func test_conditionals() throws {
         // Arrange
 
-        let key = "BAZEL_TARGET_ID"
+        let targetIDKey = "BAZEL_TARGET_ID"
+        let packageBinDirKey = "BAZEL_PACKAGE_BIN_DIR"
         let pbxProj = Fixtures.pbxProj()
 
         let (
             disambiguatedTargets,
             pbxTargets,
-            expectedSupportedPlatforms
+            expectedBuildSettings
         ) = Self.createFixtures([
             ([.macOS, .iOS, .tvOS, .watchOS], .staticLibrary,
              [
-                 key: "macOS-staticLibrary",
-                 "\(key)[sdk=iphoneos*]": "iOS-staticLibrary",
-                 "\(key)[sdk=appletvos*]": "tvOS-staticLibrary",
-                 "\(key)[sdk=watchos*]": "watchOS-staticLibrary",
+                targetIDKey: "macOS-staticLibrary",
+                "\(targetIDKey)[sdk=iphoneos*]": "iOS-staticLibrary",
+                "\(targetIDKey)[sdk=appletvos*]": "tvOS-staticLibrary",
+                "\(targetIDKey)[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
+                "\(targetIDKey)[sdk=watchos*]": "watchOS-staticLibrary",
+                packageBinDirKey: "b/macOS-staticLibrary",
+                "\(packageBinDirKey)[sdk=iphoneos*]": "b/iOS-staticLibrary",
+                "\(packageBinDirKey)[sdk=appletvos*]": "b/tvOS-staticLibrary",
+                "\(packageBinDirKey)[sdk=watchos*]": "b/watchOS-staticLibrary",
              ]),
             ([.macOS, .iOS], .staticLibrary, [
-                key: "macOS-staticLibrary",
-                "\(key)[sdk=iphoneos*]": "iOS-staticLibrary",
+                targetIDKey: "macOS-staticLibrary",
+                "\(targetIDKey)[sdk=iphoneos*]": "iOS-staticLibrary",
+                "\(targetIDKey)[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
+                packageBinDirKey: "b/macOS-staticLibrary",
+                "\(packageBinDirKey)[sdk=iphoneos*]": "b/iOS-staticLibrary",
             ]),
             ([.macOS, .tvOS], .staticLibrary, [
-                key: "macOS-staticLibrary",
-                "\(key)[sdk=appletvos*]": "tvOS-staticLibrary",
+                targetIDKey: "macOS-staticLibrary",
+                "\(targetIDKey)[sdk=appletvos*]": "tvOS-staticLibrary",
+                "\(targetIDKey)[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
+                packageBinDirKey: "b/macOS-staticLibrary",
+                "\(packageBinDirKey)[sdk=appletvos*]": "b/tvOS-staticLibrary",
             ]),
             ([.macOS, .watchOS], .staticLibrary, [
-                key: "macOS-staticLibrary",
-                "\(key)[sdk=watchos*]": "watchOS-staticLibrary",
+                targetIDKey: "macOS-staticLibrary",
+                "\(targetIDKey)[sdk=watchos*]": "watchOS-staticLibrary",
+                "\(targetIDKey)[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
+                packageBinDirKey: "b/macOS-staticLibrary",
+                "\(packageBinDirKey)[sdk=watchos*]": "b/watchOS-staticLibrary",
             ]),
             ([.macOS], .staticLibrary, [
-                key: "macOS-staticLibrary",
+                targetIDKey: "macOS-staticLibrary",
+                "\(targetIDKey)[sdk=macosx*]": "$(BAZEL_TARGET_ID)",
+                packageBinDirKey: "b/macOS-staticLibrary",
             ]),
 
             ([.iOS, .tvOS, .watchOS], .staticLibrary,
              [
-                 key: "iOS-staticLibrary",
-                 "\(key)[sdk=appletvos*]": "tvOS-staticLibrary",
-                 "\(key)[sdk=watchos*]": "watchOS-staticLibrary",
+                targetIDKey: "iOS-staticLibrary",
+                 "\(targetIDKey)[sdk=appletvos*]": "tvOS-staticLibrary",
+                "\(targetIDKey)[sdk=iphoneos*]": "$(BAZEL_TARGET_ID)",
+                 "\(targetIDKey)[sdk=watchos*]": "watchOS-staticLibrary",
+                packageBinDirKey: "b/iOS-staticLibrary",
+                 "\(packageBinDirKey)[sdk=appletvos*]": "b/tvOS-staticLibrary",
+                 "\(packageBinDirKey)[sdk=watchos*]": "b/watchOS-staticLibrary",
              ]),
             ([.iOS, .tvOS], .staticLibrary, [
-                key: "iOS-staticLibrary",
-                "\(key)[sdk=appletvos*]": "tvOS-staticLibrary",
+                targetIDKey: "iOS-staticLibrary",
+                "\(targetIDKey)[sdk=appletvos*]": "tvOS-staticLibrary",
+                "\(targetIDKey)[sdk=iphoneos*]": "$(BAZEL_TARGET_ID)",
+                packageBinDirKey: "b/iOS-staticLibrary",
+                "\(packageBinDirKey)[sdk=appletvos*]": "b/tvOS-staticLibrary",
             ]),
             ([.iOS, .watchOS], .staticLibrary, [
-                key: "iOS-staticLibrary",
-                "\(key)[sdk=watchos*]": "watchOS-staticLibrary",
+                targetIDKey: "iOS-staticLibrary",
+                "\(targetIDKey)[sdk=iphoneos*]": "$(BAZEL_TARGET_ID)",
+                "\(targetIDKey)[sdk=watchos*]": "watchOS-staticLibrary",
+                packageBinDirKey: "b/iOS-staticLibrary",
+                "\(packageBinDirKey)[sdk=watchos*]": "b/watchOS-staticLibrary",
             ]),
             ([.iOS], .staticLibrary, [
-                key: "iOS-staticLibrary",
+                targetIDKey: "iOS-staticLibrary",
+                "\(targetIDKey)[sdk=iphoneos*]": "$(BAZEL_TARGET_ID)",
+                packageBinDirKey: "b/iOS-staticLibrary",
             ]),
 
             ([.tvOS, .watchOS], .staticLibrary, [
-                key: "tvOS-staticLibrary",
-                "\(key)[sdk=watchos*]": "watchOS-staticLibrary",
+                targetIDKey: "tvOS-staticLibrary",
+                "\(targetIDKey)[sdk=appletvos*]": "$(BAZEL_TARGET_ID)",
+                "\(targetIDKey)[sdk=watchos*]": "watchOS-staticLibrary",
+                packageBinDirKey: "b/tvOS-staticLibrary",
+                "\(packageBinDirKey)[sdk=watchos*]": "b/watchOS-staticLibrary",
             ]),
             ([.tvOS], .staticLibrary, [
-                key: "tvOS-staticLibrary",
+                targetIDKey: "tvOS-staticLibrary",
+                "\(targetIDKey)[sdk=appletvos*]": "$(BAZEL_TARGET_ID)",
+                packageBinDirKey: "b/tvOS-staticLibrary",
             ]),
 
             ([.watchOS], .staticLibrary, [
-                key: "watchOS-staticLibrary",
+                targetIDKey: "watchOS-staticLibrary",
+                "\(targetIDKey)[sdk=watchos*]": "$(BAZEL_TARGET_ID)",
+                packageBinDirKey: "b/watchOS-staticLibrary",
             ]),
         ])
 
@@ -380,14 +416,19 @@ final class SetTargetConfigurationsTests: XCTestCase {
             filePathResolver: Self.filePathResolverFixture
         )
 
-        let supportedPlatforms: [ConsolidatedTarget.Key: [String: String]] =
-            try Self.getBuildSettings(key, from: pbxTargets)
+        var buildSettings: [ConsolidatedTarget.Key: [String: String]] = [:]
+        buildSettings.merge(
+            try Self.getBuildSettings(targetIDKey, from: pbxTargets)
+        ) { old, new in old.merging(new) { _, new in new } }
+        buildSettings.merge(
+            try Self.getBuildSettings(packageBinDirKey, from: pbxTargets)
+        ) { old, new in old.merging(new) { _, new in new } }
 
         // Assert
 
         XCTAssertNoDifference(
-            supportedPlatforms,
-            expectedSupportedPlatforms
+            buildSettings,
+            expectedBuildSettings
         )
     }
 
@@ -423,6 +464,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
                 }
 
                 let target = Target.mock(
+                    packageBinDir: Path("b/\(targetID.rawValue)"),
                     platform: .init(
                         os: os,
                         variant: variant,

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -9,6 +9,7 @@ extension Target {
     static func mock(
         label: BazelLabel? = nil,
         configuration: String = "a1b2c",
+        compileTargetID: TargetID? = nil,
         packageBinDir: Path = "bazel-out/a1b2c/some/package",
         platform: Platform? = nil,
         product: Product,
@@ -34,6 +35,7 @@ extension Target {
             name: product.name,
             label: label ?? .init(nilIfInvalid: "//some/package:\(product.name)")!,
             configuration: configuration,
+            compileTargetID: compileTargetID,
             packageBinDir: packageBinDir,
             platform: platform ?? .macOS(),
             product: product,


### PR DESCRIPTION
Fixes #931.

This PR changes how the `calculate_output_groups.py` script works, having it use knowledge of the destination platform to select the correct `BAZEL_TARGET_ID`s for all `configuredTargets`, and only using the scheme target ids as a backup.

It also has an unused implementation to pick the library target of a merged target. It's unused because Xcode doesn't update the `buildRequest` reliably for it, and we can get stuck building the wrong output group.