### PR TITLE
Add ability to build output groups from command-line

### DIFF
--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -2,8 +2,43 @@
 
 set -euo pipefail
 
+
+# Functions
+
+# Echos the provided message to stderr and exits with an error (1)
+fail() {
+  local msg="${1:-}"
+  shift 1
+  while (("$#")); do
+    msg="${msg:-}"$'\n'"${1}"
+    shift 1
+  done
+  echo >&2 "${msg}"
+  exit 1
+}
+
+# Process Args
+
 readonly bazelrc="$PWD/%bazelrc%"
 readonly extra_flags_bazelrc="$PWD/%extra_flags_bazelrc%"
+
+installer_flags=(--extra_flags_bazelrc "$extra_flags_bazelrc")
+
+while (("$#")); do
+  case "${1}" in
+    "--build_output_groups")
+      build_output_groups="${2}"
+      shift 2
+      ;;
+    "--destination")
+      installer_flags+=(--destination "${2}")
+      shift 2
+      ;;
+    *)
+      fail "Unrecognized argument: ${1}"
+      ;;
+  esac
+done
 
 cd "$BUILD_WORKSPACE_DIRECTORY"
 
@@ -18,13 +53,23 @@ if [[ -s "$extra_flags_bazelrc" ]]; then
   bazelrcs+=("--bazelrc=$extra_flags_bazelrc")
 fi
 
-echo 'Generating "%project_name%.xcodeproj"'
+if [[ -z "${build_output_groups:-}" ]]; then
+  echo 'Generating "%project_name%.xcodeproj"'
 
-"%bazel_path%" \
-  "${bazelrcs[@]}" \
-  run \
-  --config=rules_xcodeproj_generator \
-  %extra_generator_flags% \
-  "%generator_label%" \
-  -- "$@" \
-  --extra_flags_bazelrc "$extra_flags_bazelrc"
+  "%bazel_path%" \
+    "${bazelrcs[@]}" \
+    run \
+    --config=rules_xcodeproj_generator \
+    %extra_generator_flags% \
+    "%generator_label%" \
+    -- "${installer_flags[@]}"
+else
+  echo "Building \"%generator_label% --output_groups=$build_output_groups\""
+
+  "%bazel_path%" \
+    "${bazelrcs[@]}" \
+    build \
+    --config=rules_xcodeproj_build \
+    --output_groups="$build_output_groups" \
+    "%generator_label%"
+fi


### PR DESCRIPTION
Before adding the abstraction of a runner it was relatively “easy” to build output groups yourself outside of Xcode. But now that there is a lot of ceremony handled by the runner, it's not so easy. This change makes it so you can add `--build_output_groups output_groups,here` to have the runner build those output groups instead of generate the project. The end result is that a command like the following:

```
bazel run //tools/generator:xcodeproj -- --build_output_groups some_output_group
```

will execute a command like this:

```
bazel --noworkspace_rc --bazelrc=tools/generator/generator.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc --bazelrc=.bazelrc build --config=rules_xcodeproj_build //tools/generator:xcodeproj.generator --output_groups=some_output_group
```