### PR TITLE
Add `all_targets` output group

### DIFF
--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -311,15 +311,28 @@ def _to_output_groups_fields(*, ctx, outputs, toplevel_cache_buster):
         A `dict` where the keys are output group names and the values are
         `depset` of `File`s.
     """
-    return {
+    all_files = {
+        name: files
+        for name, files in outputs._output_group_list.to_list()
+    }
+
+    output_groups = {
         name: depset([output_group_map.write_map(
             ctx = ctx,
             name = name.replace("/", "_"),
             files = files,
             toplevel_cache_buster = toplevel_cache_buster,
         )])
-        for name, files in outputs._output_group_list.to_list()
+        for name, files in all_files.items()
     }
+    output_groups["all_output_files"] = depset([output_group_map.write_map(
+        ctx = ctx,
+        name = "all_output_files",
+        files = depset(transitive = all_files.values()),
+        toplevel_cache_buster = toplevel_cache_buster,
+    )])
+
+    return output_groups
 
 def parse_swift_info_module(module):
     """Collects outputs from a rules_swift module.

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -610,6 +610,23 @@ def _xcodeproj_impl(ctx):
         xcodeproj = xcodeproj,
     )
 
+    input_files_output_groups = input_files.to_output_groups_fields(
+        ctx = ctx,
+        inputs = inputs,
+        additional_generated = additional_generated,
+        toplevel_cache_buster = ctx.files.toplevel_cache_buster,
+    )
+    output_files_output_groups = output_files.to_output_groups_fields(
+        ctx = ctx,
+        outputs = outputs,
+        toplevel_cache_buster = ctx.files.toplevel_cache_buster,
+    )
+
+    if build_mode == "xcode":
+        all_targets_files = input_files_output_groups["all_generated_inputs"]
+    else:
+        all_targets_files = output_files_output_groups["all_output_files"]
+
     return [
         DefaultInfo(
             executable = installer,
@@ -620,18 +637,10 @@ def _xcodeproj_impl(ctx):
             runfiles = ctx.runfiles(files = [xcodeproj]),
         ),
         OutputGroupInfo(
+            all_targets = all_targets_files,
             **dicts.add(
-                input_files.to_output_groups_fields(
-                    ctx = ctx,
-                    inputs = inputs,
-                    additional_generated = additional_generated,
-                    toplevel_cache_buster = ctx.files.toplevel_cache_buster,
-                ),
-                output_files.to_output_groups_fields(
-                    ctx = ctx,
-                    outputs = outputs,
-                    toplevel_cache_buster = ctx.files.toplevel_cache_buster,
-                ),
+                input_files_output_groups,
+                output_files_output_groups,
             )
         ),
     ]


### PR DESCRIPTION
This allows building all of the bazel-generated files of a project with a single output group. The main use for this is populating a Remote Build Cache with artifacts for developers.