### PR TITLE
Improve readability of installer output

### DIFF
--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -54,6 +54,7 @@ if [[ -s "$extra_flags_bazelrc" ]]; then
 fi
 
 if [[ -z "${build_output_groups:-}" ]]; then
+  echo
   echo 'Generating "%project_name%.xcodeproj"'
 
   "%bazel_path%" \


### PR DESCRIPTION
Now that the runner being built has bazel output, and the generator being built has bazel output, adding this simple blank line really helps with readability.

New output:
```console
$ bazel run --config=cache //tools/generator:xcodeproj
INFO: Invocation ID: a1c9163b-bce2-4594-b773-65f56d79d83f
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/a1c9163b-bce2-4594-b773-65f56d79d83f
INFO: Analyzed target //tools/generator:xcodeproj (1 packages loaded, 1 target configured).
INFO: Found 1 target...
Target //tools/generator:xcodeproj up-to-date:
  bazel-bin/tools/generator/xcodeproj-runner.sh
INFO: Elapsed time: 0.225s, Critical Path: 0.00s
INFO: 2 processes: 2 internal.
INFO: Running command line: bazel-bin/tools/generator/xcodeproj-runner.sh
INFO: Streaming build results to: https://app.buildbuddy.io/invocation/a1c9163b-bce2-4594-b773-65f56d79d83f
INFO: Build completed successfully, 2 total actions

Generating "generator.xcodeproj"
INFO: Invocation ID: 6ff6f616-544b-46b1-8789-517c91aca1d1
INFO: Analyzed target //tools/generator:xcodeproj.generator (1 packages loaded, 77 targets configured).
INFO: Found 1 target...
INFO: Elapsed time: 0.256s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/tools/generator/xcodeproj.generator-installer.sh --extra_flags_bazelrc /private/var/tmp/_bazel_brentley/3d5821071b04bd5519a8cc5bb33889a1/execroot/com_github_buildbuddy_io_rules_xcodeproj
INFO: Build completed successfully, 1 total action
Updated project at "tools/generator/generator.xcodeproj"
```