### PR TITLE
Mark fixtures as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Mark fixtures as generated
+test/fixtures/*/*.xcodeproj/** linguist-generated
+test/fixtures/*/*_spec.json linguist-generated
+examples/*/test/fixtures/*.xcodeproj/** linguist-generated
+examples/*/test/fixtures/*_spec.json linguist-generated


### PR DESCRIPTION
This will collapse them by default in PRs and remove the files from language statistics. Reviewers can still check the diffs in the PR as needed.

<img width="1097" alt="CleanShot 2022-08-31 at 15 38 13@2x" src="https://user-images.githubusercontent.com/158658/187777414-6142398a-d1f9-485d-a3eb-93232532260e.png">