### PR TITLE
Fix path for `create_xcode_overlay.sh`

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -153,7 +153,7 @@ cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
 EOF
 
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh"
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
 fi
 
 # Build

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -153,7 +153,7 @@ cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
 EOF
 
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh"
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
 fi
 
 # Build

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -153,7 +153,7 @@ cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
 EOF
 
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh"
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
 fi
 
 # Build

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -153,7 +153,7 @@ cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
 EOF
 
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh"
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
 fi
 
 # Build

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -153,7 +153,7 @@ cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
 EOF
 
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh"
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
 fi
 
 # Build

--- a/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -153,7 +153,7 @@ cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
 EOF
 
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh"
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
 fi
 
 # Build

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -153,7 +153,7 @@ cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
 EOF
 
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh"
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
 fi
 
 # Build

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -153,7 +153,7 @@ cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
 EOF
 
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh"
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
 fi
 
 # Build

--- a/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -153,7 +153,7 @@ cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
 EOF
 
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh"
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
 fi
 
 # Build

--- a/test/fixtures/simple/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/simple/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -153,7 +153,7 @@ cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
 EOF
 
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh"
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
 fi
 
 # Build

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -153,7 +153,7 @@ cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
 EOF
 
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$BAZEL_INTEGRATION_DIR/create_xcode_overlay.sh"
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
 fi
 
 # Build


### PR DESCRIPTION
Typo in f32a22ceeab5d97c6bdcc39bcf5508f3f57e62b1.