### PR TITLE
Fix BwX unfocused target linking

### DIFF
--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -134,8 +134,8 @@ targets.
                 additional_compiling_files.append(
                     depset(unfocused_compiling_files),
                 )
-            if additional_linking_files:
-                additional_compiling_files.append(
+            if unfocused_linking_files:
+                additional_linking_files.append(
                     depset(unfocused_linking_files),
                 )
 


### PR DESCRIPTION
Typo in cd98712b7bb7e69f52f7fd836d3da10ac63d1fd6.