### PR TITLE
Fix error when merging `XcodeProjInfo` with `deps_attr`

### DIFF
--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -421,6 +421,7 @@ def merge_xcodeprojinfos(infos):
     info_fields = _skip_target(
         target = None,
         deps = [],
+        deps_attrs = [],
         transitive_infos = [(None, info) for info in infos],
     )
     return XcodeProjInfo(


### PR DESCRIPTION
After https://github.com/buildbuddy-io/rules_xcodeproj/pull/1004, when using a `device_and_simulator` rule, the project generation fails with the following error:
```bash
ERROR: .../xcodeproj/BUILD.bazel:53:21: in device_and_simulator rule //bazel/xcodeproj:targets:
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_patrickb/9c146a5e97098b318f66f519df2b642d/external/com_github_buildbuddy_io_rules_xcodeproj/xcodeproj/internal/device_and_simulator_rule.bzl", line 89, column 29, in _device_and_simulator_impl
		merge_xcodeprojinfos([
	File "/private/var/tmp/_bazel_patrickb/9c146a5e97098b318f66f519df2b642d/external/com_github_buildbuddy_io_rules_xcodeproj/xcodeproj/internal/xcodeprojinfo.bzl", line 421, column 31, in merge_xcodeprojinfos
		info_fields = _skip_target(
	File "/private/var/tmp/_bazel_patrickb/9c146a5e97098b318f66f519df2b642d/external/com_github_buildbuddy_io_rules_xcodeproj/xcodeproj/internal/xcodeprojinfo.bzl", line 135, column 5, in _skip_target
		def _skip_target(*, target, deps, deps_attrs, transitive_infos):
Error: _skip_target() missing 1 required keyword-only argument: deps_attrs
```

This PR fixes the issue for me.