### PR TITLE
Rename variable to match bazel terminology

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -113,14 +113,14 @@ output_path=$("${bazel_cmd[@]}" \
   --bes_backend= \
   --bes_results_url= \
   output_path)
-exec_root="${output_path%/*}"
+execution_root="${output_path%/*}"
 
 # Create `bazel.lldbinit``
 
 if [[ "$ACTION" != "indexbuild" && "${ENABLE_PREVIEWS:-}" != "YES" ]]; then
   # shellcheck disable=SC2046
   "$BAZEL_INTEGRATION_DIR/create_lldbinit.sh" \
-    "$exec_root" \
+    "$execution_root" \
     $(xargs -n1 <<< "${RESOLVED_EXTERNAL_REPOSITORIES:-}") \
     > "$BAZEL_LLDB_INIT"
 fi
@@ -143,9 +143,9 @@ else
   roots=
 fi
 if [[ "$RULES_XCODEPROJ_BUILD_MODE" != "xcode" ]]; then
-  # Map `$BUILD_DIR` to execroot, to fix SwiftUI Previews and indexing edge
-  # cases
-  roots="${roots:+${roots},}{\"external-contents\": \"$exec_root\",\"name\": \"$BUILD_DIR\",\"type\": \"directory-remap\"}"
+  # Map `$BUILD_DIR` to execution_root, to fix SwiftUI Previews and indexing
+  # edge cases
+  roots="${roots:+${roots},}{\"external-contents\": \"$execution_root\",\"name\": \"$BUILD_DIR\",\"type\": \"directory-remap\"}"
 fi
 
 cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF

--- a/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
+++ b/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
@@ -2,11 +2,11 @@
 
 set -euo pipefail
 
-readonly exec_root="$1"
+readonly execution_root="$1"
 shift
 
-readonly output_base="${exec_root%/*/*}"
-readonly build_bazel_out="$exec_root/bazel-out"
+readonly output_base="${execution_root%/*/*}"
+readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
 # In Xcode 14 the "Index" directory was renamed to "Index.noindex".
@@ -16,22 +16,22 @@ readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
 readonly index_dir_name="${index_dir##*/}"
 
 readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
-readonly workspace_name="${exec_root##*/}"
-readonly index_exec_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly workspace_name="${execution_root##*/}"
+readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
 
-readonly index_bazel_out="$index_exec_root/bazel-out"
-readonly index_external="$index_exec_root/external"
+readonly index_bazel_out="$index_execution_root/bazel-out"
+readonly index_external="$index_execution_root/external"
 
 # Load ~/.lldbinit if it exists
 if [[ -f "$HOME/.lldbinit" ]]; then
   echo "command source ~/.lldbinit"
 fi
 
-# Set `CWD` to `$exec_root` so relative paths in binaries work
+# Set `CWD` to `$execution_root` so relative paths in binaries work
 #
 # This is needed because we use the `oso_prefix_is_pwd` feature, which makes the
 # paths to archives relative to the exec root.
-echo "platform settings -w \"$exec_root\""
+echo "platform settings -w \"$execution_root\""
 
 mkdir -p "$index_bazel_out"
 mkdir -p "$index_external"
@@ -39,9 +39,10 @@ mkdir -p "$index_external"
 # "Undo" `-debug-prefix-map` for breakpoints
 #
 # This needs to cause the files to match exactly what Xcode set for breakpoints,
-# which is why we don't use `$exec_root` here. Xcode will set the path based
-# on the way you opened a file. If you open a file via the Project navigator,
-# or indexing (e.g. Jump to Definition), it will use the paths specified below.
+# which is why we don't use `$execution_root` here. Xcode will set the path
+# based on the way you opened a file. If you open a file via the Project
+# navigator, or indexing (e.g. Jump to Definition), it will use the paths
+# specified below.
 
 if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
     absolute_bazel_out="$BAZEL_OUT"


### PR DESCRIPTION
Bazel uses both `execroot` and `execution_root`, and they mean different things. Our `exec_root` was meaning to match `bazel info execution_root`, so I've renamed the variable to be clear. `execroot` is actually an intermediate parent directory of `execution_root`.