### PR TITLE
Add support for Bazel-built Swift index-while-building

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -26,11 +26,12 @@ if [ "$ACTION" == "indexbuild" ]; then
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-    # Inputs for compiling, inputs for linking
-    readonly output_group_prefixes="xc,xl"
+    # Inputs for compiling, inputs for linking, and index store data
+    readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules) and products (i.e. bundles)
-    readonly output_group_prefixes="bc,bp"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
+    # store data
+    readonly output_group_prefixes="bc,bp,bi"
   fi
 fi
 
@@ -189,10 +190,16 @@ touch "$build_marker"
   "$GENERATOR_LABEL" \
   2>&1
 
+indexstores_filelists=()
 for output_group in "${output_groups[@]}"; do
   filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
   filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
   filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
   if [[ "$filelist" -ot "$build_marker" ]]; then
     echo "error: Bazel didn't generate the correct files (it should have" \
 "generated outputs for output group \"$output_group\", but the timestamp for" \
@@ -208,3 +215,32 @@ for output_group in "${output_groups[@]}"; do
     exit 1
   fi
 done
+
+# Async actions
+#
+# For these commands to run in the background, both stdout and stderr need to be
+# redirected, otherwise Xcode will block the run script.
+
+log_dir="$OBJROOT/rules_xcodeproj_logs"
+mkdir -p "$log_dir"
+
+# Report errors from previous async actions
+shopt -s nullglob
+for log in "$log_dir"/*.async.log; do
+  if [[ -s "$log" ]]; then
+    command=$(basename "${log%.async.log}")
+    echo "warning: Previous run of \"$command\" had output:" >&2
+    sed "s|^|warning: |" "$log" >&2
+    echo "warning: If you believe this is a bug, please file a report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+  fi
+done
+
+# Import indexes
+if [ -n "${indexstores_filelists:-}" ]; then
+  "$BAZEL_INTEGRATION_DIR/import_indexstores.sh" \
+    "$execution_root" \
+    "${indexstores_filelists[@]}" \
+    >"$log_dir/import_indexstores.async.log" 2>&1 &
+fi

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly pidfile="$OBJROOT/import_indexstores.pid"
+readonly execution_root="$1"
+shift
+
+# Kill previously running import
+if [[ -s "$pidfile" ]]; then
+  pid=$(cat "$pidfile")
+  kill "$pid" 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null; do
+    sleep 1
+  done
+fi
+
+# Exit early if no indexstore filelists were provided
+if [ $# -eq 0 ]; then
+  exit
+fi
+
+# Set pid to allow cleanup later
+echo $$ > "$pidfile"
+trap 'rm "$pidfile" 2>/dev/null || true' EXIT
+
+# Merge all filelists into a single file
+filelist="$(mktemp)"
+sort -u "$@" | sed "s|^|$execution_root/|" > "$filelist"
+
+# Exit early if no indexstores were provided
+if [ ! -s "$filelist" ]; then
+  exit
+fi
+
+# Set remaps
+
+# Since users can override `--output_base`, all we know is that the
+# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
+readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+
+# We remove any `/private` prefix from the current execution_root, since it's
+# removed in the Project navigator.
+readonly xcode_execution_root="${execution_root#/private}"
+
+# The order of remaps is important. The first match is used. So we try the most
+# specific first. This also allows us to assume previous matches have taken care
+# of those types of files, so more general matches still work later.
+remaps=(
+  # Object files
+  #
+  # These currently come back relative, but we have the execution_root as an
+  # optional prefix in case this changes in the future. The path is based on
+  # rules_swift's current logic:
+  # https://github.com/bazelbuild/rules_swift/blob/6153a848f747e90248a8673869c49631f1323ff3/swift/internal/derived_files.bzl#L114-L119
+  # When we add support for C-based index imports we will have to use another
+  # pattern:
+  # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$PROJECT_TEMP_DIR/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+
+  # Generated sources and swiftmodules
+  #
+  # With object files taken care of, any other paths with `bazel-out/` as their
+  # prefix (relative to the execution_root) are assumed to be generated outputs.
+  # The two kinds of generated outputs used in the unit files are swiftmodule
+  # and source paths. So we map that, along with the `external/` prefix for
+  # external sources, to the current execution_root. Finally, currently these
+  # paths are returned as absolute, but a future change might make them
+  # relative, similar to the object files, so we have the execution_root as an
+  # optional prefix.
+  -remap "^(?:$execution_root_regex/)?bazel-out/=$xcode_execution_root/bazel-out/"
+
+  # External sources
+  #
+  # External sources need to be handled differently, since we use the
+  # non-symlinked version in Xcode.
+  -remap "^(?:$execution_root_regex/)?external/=${xcode_execution_root%/*/*}/external/"
+
+  # Project sources
+  #
+  # With the other source files and generated files taken care of, all other
+  # execution_root prefixed paths should be project sources.
+  -remap "^$execution_root_regex=$SRCROOT"
+
+  # Sysroot
+  #
+  # The only other type of path in the unit files are sysroot based. While
+  # these should always be Xcode.app relative, our regex supports command-line
+  # tools based paths as well.
+  -remap "^(?:.*?/[^/]+/Contents/Developer|/Library/Developer/CommandLineTools).*?/SDKs/([^\\d.]+)=$DEVELOPER_DIR/Platforms/\$1.platform/Developer/SDKs/\$1"
+)
+
+# Import
+
+mkdir -p "$INDEX_DATA_STORE_DIR"
+
+"$INDEX_IMPORT" \
+    -undo-rules_swift-renames \
+    "${remaps[@]}" \
+    -incremental \
+    @"$filelist" \
+    "$INDEX_DATA_STORE_DIR"
+
+# Unit files are created fresh, but record files are copied from `bazel-out/`,
+# which are read-only. We need to adjust their permissions.
+# TODO: Do this in `index-import`
+chmod -R u+w "$INDEX_DATA_STORE_DIR"

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -35,6 +35,16 @@ build:rules_xcodeproj --features=relative_ast_path
 # this in `swift_debug_settings.py`, so debugging still works.
 build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 
+# `swift.index-while-building` passes `-index-store-path` to `swiftc`, which
+# generates index store data. We enable this globally, and don't disable it in
+# `rules_xcodeproj_indexbuild`, even though we only need it for the normal
+# build, because it's better to get cache hits between normal and Index Build
+# builds than it is to save some time in an uncached Index Build build. We only
+# download the outputs in the normal build though, saving some bandwidth/disk
+# space.
+build:rules_xcodeproj --features=swift.index_while_building
+build:rules_xcodeproj --features=swift.use_global_index_store
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
@@ -72,6 +82,10 @@ build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
+
+# Unset `swift.index-while-building` since we don't need index store data, and
+# we already have cache misses from the `swiftc` flags above
+build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -26,11 +26,12 @@ if [ "$ACTION" == "indexbuild" ]; then
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-    # Inputs for compiling, inputs for linking
-    readonly output_group_prefixes="xc,xl"
+    # Inputs for compiling, inputs for linking, and index store data
+    readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules) and products (i.e. bundles)
-    readonly output_group_prefixes="bc,bp"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
+    # store data
+    readonly output_group_prefixes="bc,bp,bi"
   fi
 fi
 
@@ -189,10 +190,16 @@ touch "$build_marker"
   "$GENERATOR_LABEL" \
   2>&1
 
+indexstores_filelists=()
 for output_group in "${output_groups[@]}"; do
   filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
   filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
   filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
   if [[ "$filelist" -ot "$build_marker" ]]; then
     echo "error: Bazel didn't generate the correct files (it should have" \
 "generated outputs for output group \"$output_group\", but the timestamp for" \
@@ -208,3 +215,32 @@ for output_group in "${output_groups[@]}"; do
     exit 1
   fi
 done
+
+# Async actions
+#
+# For these commands to run in the background, both stdout and stderr need to be
+# redirected, otherwise Xcode will block the run script.
+
+log_dir="$OBJROOT/rules_xcodeproj_logs"
+mkdir -p "$log_dir"
+
+# Report errors from previous async actions
+shopt -s nullglob
+for log in "$log_dir"/*.async.log; do
+  if [[ -s "$log" ]]; then
+    command=$(basename "${log%.async.log}")
+    echo "warning: Previous run of \"$command\" had output:" >&2
+    sed "s|^|warning: |" "$log" >&2
+    echo "warning: If you believe this is a bug, please file a report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+  fi
+done
+
+# Import indexes
+if [ -n "${indexstores_filelists:-}" ]; then
+  "$BAZEL_INTEGRATION_DIR/import_indexstores.sh" \
+    "$execution_root" \
+    "${indexstores_filelists[@]}" \
+    >"$log_dir/import_indexstores.async.log" 2>&1 &
+fi

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -35,6 +35,16 @@ build:rules_xcodeproj --features=relative_ast_path
 # this in `swift_debug_settings.py`, so debugging still works.
 build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 
+# `swift.index-while-building` passes `-index-store-path` to `swiftc`, which
+# generates index store data. We enable this globally, and don't disable it in
+# `rules_xcodeproj_indexbuild`, even though we only need it for the normal
+# build, because it's better to get cache hits between normal and Index Build
+# builds than it is to save some time in an uncached Index Build build. We only
+# download the outputs in the normal build though, saving some bandwidth/disk
+# space.
+build:rules_xcodeproj --features=swift.index_while_building
+build:rules_xcodeproj --features=swift.use_global_index_store
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
@@ -72,6 +82,10 @@ build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
+
+# Unset `swift.index-while-building` since we don't need index store data, and
+# we already have cache misses from the `swiftc` flags above
+build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/examples/cc/test/fixtures/bwx_spec.json
+++ b/examples/cc/test/fixtures/bwx_spec.json
@@ -25,6 +25,10 @@
         "test/fixtures/BUILD"
     ],
     "force_bazel_dependencies": false,
+    "index_import": {
+        "t": "g",
+        "_": "darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import"
+    },
     "label": "//test/fixtures:xcodeproj_bwx.generator",
     "name": "bwx",
     "replacement_labels": [],

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -4926,6 +4926,7 @@
 				GENERATOR_PACKAGE_BIN_DIR = "darwin_x86_64-dbg-ST-14942f8a2d44/bin/test/fixtures";
 				GENERATOR_TARGET_NAME = xcodeproj_bwb.generator;
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
+				INDEX_IMPORT = "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import";
 				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SUPPORTED_PLATFORMS = macosx;

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -26,11 +26,12 @@ if [ "$ACTION" == "indexbuild" ]; then
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-    # Inputs for compiling, inputs for linking
-    readonly output_group_prefixes="xc,xl"
+    # Inputs for compiling, inputs for linking, and index store data
+    readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules) and products (i.e. bundles)
-    readonly output_group_prefixes="bc,bp"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
+    # store data
+    readonly output_group_prefixes="bc,bp,bi"
   fi
 fi
 
@@ -189,10 +190,16 @@ touch "$build_marker"
   "$GENERATOR_LABEL" \
   2>&1
 
+indexstores_filelists=()
 for output_group in "${output_groups[@]}"; do
   filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
   filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
   filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
   if [[ "$filelist" -ot "$build_marker" ]]; then
     echo "error: Bazel didn't generate the correct files (it should have" \
 "generated outputs for output group \"$output_group\", but the timestamp for" \
@@ -208,3 +215,32 @@ for output_group in "${output_groups[@]}"; do
     exit 1
   fi
 done
+
+# Async actions
+#
+# For these commands to run in the background, both stdout and stderr need to be
+# redirected, otherwise Xcode will block the run script.
+
+log_dir="$OBJROOT/rules_xcodeproj_logs"
+mkdir -p "$log_dir"
+
+# Report errors from previous async actions
+shopt -s nullglob
+for log in "$log_dir"/*.async.log; do
+  if [[ -s "$log" ]]; then
+    command=$(basename "${log%.async.log}")
+    echo "warning: Previous run of \"$command\" had output:" >&2
+    sed "s|^|warning: |" "$log" >&2
+    echo "warning: If you believe this is a bug, please file a report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+  fi
+done
+
+# Import indexes
+if [ -n "${indexstores_filelists:-}" ]; then
+  "$BAZEL_INTEGRATION_DIR/import_indexstores.sh" \
+    "$execution_root" \
+    "${indexstores_filelists[@]}" \
+    >"$log_dir/import_indexstores.async.log" 2>&1 &
+fi

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly pidfile="$OBJROOT/import_indexstores.pid"
+readonly execution_root="$1"
+shift
+
+# Kill previously running import
+if [[ -s "$pidfile" ]]; then
+  pid=$(cat "$pidfile")
+  kill "$pid" 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null; do
+    sleep 1
+  done
+fi
+
+# Exit early if no indexstore filelists were provided
+if [ $# -eq 0 ]; then
+  exit
+fi
+
+# Set pid to allow cleanup later
+echo $$ > "$pidfile"
+trap 'rm "$pidfile" 2>/dev/null || true' EXIT
+
+# Merge all filelists into a single file
+filelist="$(mktemp)"
+sort -u "$@" | sed "s|^|$execution_root/|" > "$filelist"
+
+# Exit early if no indexstores were provided
+if [ ! -s "$filelist" ]; then
+  exit
+fi
+
+# Set remaps
+
+# Since users can override `--output_base`, all we know is that the
+# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
+readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+
+# We remove any `/private` prefix from the current execution_root, since it's
+# removed in the Project navigator.
+readonly xcode_execution_root="${execution_root#/private}"
+
+# The order of remaps is important. The first match is used. So we try the most
+# specific first. This also allows us to assume previous matches have taken care
+# of those types of files, so more general matches still work later.
+remaps=(
+  # Object files
+  #
+  # These currently come back relative, but we have the execution_root as an
+  # optional prefix in case this changes in the future. The path is based on
+  # rules_swift's current logic:
+  # https://github.com/bazelbuild/rules_swift/blob/6153a848f747e90248a8673869c49631f1323ff3/swift/internal/derived_files.bzl#L114-L119
+  # When we add support for C-based index imports we will have to use another
+  # pattern:
+  # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$PROJECT_TEMP_DIR/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+
+  # Generated sources and swiftmodules
+  #
+  # With object files taken care of, any other paths with `bazel-out/` as their
+  # prefix (relative to the execution_root) are assumed to be generated outputs.
+  # The two kinds of generated outputs used in the unit files are swiftmodule
+  # and source paths. So we map that, along with the `external/` prefix for
+  # external sources, to the current execution_root. Finally, currently these
+  # paths are returned as absolute, but a future change might make them
+  # relative, similar to the object files, so we have the execution_root as an
+  # optional prefix.
+  -remap "^(?:$execution_root_regex/)?bazel-out/=$xcode_execution_root/bazel-out/"
+
+  # External sources
+  #
+  # External sources need to be handled differently, since we use the
+  # non-symlinked version in Xcode.
+  -remap "^(?:$execution_root_regex/)?external/=${xcode_execution_root%/*/*}/external/"
+
+  # Project sources
+  #
+  # With the other source files and generated files taken care of, all other
+  # execution_root prefixed paths should be project sources.
+  -remap "^$execution_root_regex=$SRCROOT"
+
+  # Sysroot
+  #
+  # The only other type of path in the unit files are sysroot based. While
+  # these should always be Xcode.app relative, our regex supports command-line
+  # tools based paths as well.
+  -remap "^(?:.*?/[^/]+/Contents/Developer|/Library/Developer/CommandLineTools).*?/SDKs/([^\\d.]+)=$DEVELOPER_DIR/Platforms/\$1.platform/Developer/SDKs/\$1"
+)
+
+# Import
+
+mkdir -p "$INDEX_DATA_STORE_DIR"
+
+"$INDEX_IMPORT" \
+    -undo-rules_swift-renames \
+    "${remaps[@]}" \
+    -incremental \
+    @"$filelist" \
+    "$INDEX_DATA_STORE_DIR"
+
+# Unit files are created fresh, but record files are copied from `bazel-out/`,
+# which are read-only. We need to adjust their permissions.
+# TODO: Do this in `index-import`
+chmod -R u+w "$INDEX_DATA_STORE_DIR"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -35,6 +35,16 @@ build:rules_xcodeproj --features=relative_ast_path
 # this in `swift_debug_settings.py`, so debugging still works.
 build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 
+# `swift.index-while-building` passes `-index-store-path` to `swiftc`, which
+# generates index store data. We enable this globally, and don't disable it in
+# `rules_xcodeproj_indexbuild`, even though we only need it for the normal
+# build, because it's better to get cache hits between normal and Index Build
+# builds than it is to save some time in an uncached Index Build build. We only
+# download the outputs in the normal build though, saving some bandwidth/disk
+# space.
+build:rules_xcodeproj --features=swift.index_while_building
+build:rules_xcodeproj --features=swift.use_global_index_store
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
@@ -72,6 +82,10 @@ build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
+
+# Unset `swift.index-while-building` since we don't need index store data, and
+# we already have cache misses from the `swiftc` flags above
+build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -328,6 +328,10 @@
         "test/fixtures/BUILD"
     ],
     "force_bazel_dependencies": true,
+    "index_import": {
+        "t": "g",
+        "_": "darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import"
+    },
     "label": "//test/fixtures:xcodeproj_bwb.generator",
     "name": "bwb",
     "replacement_labels": [

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -4740,6 +4740,7 @@
 				GENERATOR_PACKAGE_BIN_DIR = "darwin_x86_64-dbg-ST-14942f8a2d44/bin/test/fixtures";
 				GENERATOR_TARGET_NAME = xcodeproj_bwx.generator;
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
+				INDEX_IMPORT = "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import";
 				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SUPPORTED_PLATFORMS = macosx;

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -26,11 +26,12 @@ if [ "$ACTION" == "indexbuild" ]; then
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-    # Inputs for compiling, inputs for linking
-    readonly output_group_prefixes="xc,xl"
+    # Inputs for compiling, inputs for linking, and index store data
+    readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules) and products (i.e. bundles)
-    readonly output_group_prefixes="bc,bp"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
+    # store data
+    readonly output_group_prefixes="bc,bp,bi"
   fi
 fi
 
@@ -189,10 +190,16 @@ touch "$build_marker"
   "$GENERATOR_LABEL" \
   2>&1
 
+indexstores_filelists=()
 for output_group in "${output_groups[@]}"; do
   filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
   filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
   filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
   if [[ "$filelist" -ot "$build_marker" ]]; then
     echo "error: Bazel didn't generate the correct files (it should have" \
 "generated outputs for output group \"$output_group\", but the timestamp for" \
@@ -208,3 +215,32 @@ for output_group in "${output_groups[@]}"; do
     exit 1
   fi
 done
+
+# Async actions
+#
+# For these commands to run in the background, both stdout and stderr need to be
+# redirected, otherwise Xcode will block the run script.
+
+log_dir="$OBJROOT/rules_xcodeproj_logs"
+mkdir -p "$log_dir"
+
+# Report errors from previous async actions
+shopt -s nullglob
+for log in "$log_dir"/*.async.log; do
+  if [[ -s "$log" ]]; then
+    command=$(basename "${log%.async.log}")
+    echo "warning: Previous run of \"$command\" had output:" >&2
+    sed "s|^|warning: |" "$log" >&2
+    echo "warning: If you believe this is a bug, please file a report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+  fi
+done
+
+# Import indexes
+if [ -n "${indexstores_filelists:-}" ]; then
+  "$BAZEL_INTEGRATION_DIR/import_indexstores.sh" \
+    "$execution_root" \
+    "${indexstores_filelists[@]}" \
+    >"$log_dir/import_indexstores.async.log" 2>&1 &
+fi

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -35,6 +35,16 @@ build:rules_xcodeproj --features=relative_ast_path
 # this in `swift_debug_settings.py`, so debugging still works.
 build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 
+# `swift.index-while-building` passes `-index-store-path` to `swiftc`, which
+# generates index store data. We enable this globally, and don't disable it in
+# `rules_xcodeproj_indexbuild`, even though we only need it for the normal
+# build, because it's better to get cache hits between normal and Index Build
+# builds than it is to save some time in an uncached Index Build build. We only
+# download the outputs in the normal build though, saving some bandwidth/disk
+# space.
+build:rules_xcodeproj --features=swift.index_while_building
+build:rules_xcodeproj --features=swift.use_global_index_store
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
@@ -72,6 +82,10 @@ build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
+
+# Unset `swift.index-while-building` since we don't need index store data, and
+# we already have cache misses from the `swiftc` flags above
+build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -256,6 +256,10 @@
         "test/fixtures/BUILD"
     ],
     "force_bazel_dependencies": true,
+    "index_import": {
+        "t": "g",
+        "_": "darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import"
+    },
     "label": "//test/fixtures:xcodeproj_bwx.generator",
     "name": "bwx",
     "replacement_labels": [

--- a/examples/simple/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 				GENERATOR_PACKAGE_BIN_DIR = "darwin_x86_64-dbg-ST-14942f8a2d44/bin/test/fixtures";
 				GENERATOR_TARGET_NAME = xcodeproj_bwb.generator;
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
+				INDEX_IMPORT = "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import";
 				RESOLVED_EXTERNAL_REPOSITORIES = "";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SUPPORTED_PLATFORMS = macosx;

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -26,11 +26,12 @@ if [ "$ACTION" == "indexbuild" ]; then
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-    # Inputs for compiling, inputs for linking
-    readonly output_group_prefixes="xc,xl"
+    # Inputs for compiling, inputs for linking, and index store data
+    readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules) and products (i.e. bundles)
-    readonly output_group_prefixes="bc,bp"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
+    # store data
+    readonly output_group_prefixes="bc,bp,bi"
   fi
 fi
 
@@ -189,10 +190,16 @@ touch "$build_marker"
   "$GENERATOR_LABEL" \
   2>&1
 
+indexstores_filelists=()
 for output_group in "${output_groups[@]}"; do
   filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
   filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
   filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
   if [[ "$filelist" -ot "$build_marker" ]]; then
     echo "error: Bazel didn't generate the correct files (it should have" \
 "generated outputs for output group \"$output_group\", but the timestamp for" \
@@ -208,3 +215,32 @@ for output_group in "${output_groups[@]}"; do
     exit 1
   fi
 done
+
+# Async actions
+#
+# For these commands to run in the background, both stdout and stderr need to be
+# redirected, otherwise Xcode will block the run script.
+
+log_dir="$OBJROOT/rules_xcodeproj_logs"
+mkdir -p "$log_dir"
+
+# Report errors from previous async actions
+shopt -s nullglob
+for log in "$log_dir"/*.async.log; do
+  if [[ -s "$log" ]]; then
+    command=$(basename "${log%.async.log}")
+    echo "warning: Previous run of \"$command\" had output:" >&2
+    sed "s|^|warning: |" "$log" >&2
+    echo "warning: If you believe this is a bug, please file a report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+  fi
+done
+
+# Import indexes
+if [ -n "${indexstores_filelists:-}" ]; then
+  "$BAZEL_INTEGRATION_DIR/import_indexstores.sh" \
+    "$execution_root" \
+    "${indexstores_filelists[@]}" \
+    >"$log_dir/import_indexstores.async.log" 2>&1 &
+fi

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly pidfile="$OBJROOT/import_indexstores.pid"
+readonly execution_root="$1"
+shift
+
+# Kill previously running import
+if [[ -s "$pidfile" ]]; then
+  pid=$(cat "$pidfile")
+  kill "$pid" 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null; do
+    sleep 1
+  done
+fi
+
+# Exit early if no indexstore filelists were provided
+if [ $# -eq 0 ]; then
+  exit
+fi
+
+# Set pid to allow cleanup later
+echo $$ > "$pidfile"
+trap 'rm "$pidfile" 2>/dev/null || true' EXIT
+
+# Merge all filelists into a single file
+filelist="$(mktemp)"
+sort -u "$@" | sed "s|^|$execution_root/|" > "$filelist"
+
+# Exit early if no indexstores were provided
+if [ ! -s "$filelist" ]; then
+  exit
+fi
+
+# Set remaps
+
+# Since users can override `--output_base`, all we know is that the
+# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
+readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+
+# We remove any `/private` prefix from the current execution_root, since it's
+# removed in the Project navigator.
+readonly xcode_execution_root="${execution_root#/private}"
+
+# The order of remaps is important. The first match is used. So we try the most
+# specific first. This also allows us to assume previous matches have taken care
+# of those types of files, so more general matches still work later.
+remaps=(
+  # Object files
+  #
+  # These currently come back relative, but we have the execution_root as an
+  # optional prefix in case this changes in the future. The path is based on
+  # rules_swift's current logic:
+  # https://github.com/bazelbuild/rules_swift/blob/6153a848f747e90248a8673869c49631f1323ff3/swift/internal/derived_files.bzl#L114-L119
+  # When we add support for C-based index imports we will have to use another
+  # pattern:
+  # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$PROJECT_TEMP_DIR/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+
+  # Generated sources and swiftmodules
+  #
+  # With object files taken care of, any other paths with `bazel-out/` as their
+  # prefix (relative to the execution_root) are assumed to be generated outputs.
+  # The two kinds of generated outputs used in the unit files are swiftmodule
+  # and source paths. So we map that, along with the `external/` prefix for
+  # external sources, to the current execution_root. Finally, currently these
+  # paths are returned as absolute, but a future change might make them
+  # relative, similar to the object files, so we have the execution_root as an
+  # optional prefix.
+  -remap "^(?:$execution_root_regex/)?bazel-out/=$xcode_execution_root/bazel-out/"
+
+  # External sources
+  #
+  # External sources need to be handled differently, since we use the
+  # non-symlinked version in Xcode.
+  -remap "^(?:$execution_root_regex/)?external/=${xcode_execution_root%/*/*}/external/"
+
+  # Project sources
+  #
+  # With the other source files and generated files taken care of, all other
+  # execution_root prefixed paths should be project sources.
+  -remap "^$execution_root_regex=$SRCROOT"
+
+  # Sysroot
+  #
+  # The only other type of path in the unit files are sysroot based. While
+  # these should always be Xcode.app relative, our regex supports command-line
+  # tools based paths as well.
+  -remap "^(?:.*?/[^/]+/Contents/Developer|/Library/Developer/CommandLineTools).*?/SDKs/([^\\d.]+)=$DEVELOPER_DIR/Platforms/\$1.platform/Developer/SDKs/\$1"
+)
+
+# Import
+
+mkdir -p "$INDEX_DATA_STORE_DIR"
+
+"$INDEX_IMPORT" \
+    -undo-rules_swift-renames \
+    "${remaps[@]}" \
+    -incremental \
+    @"$filelist" \
+    "$INDEX_DATA_STORE_DIR"
+
+# Unit files are created fresh, but record files are copied from `bazel-out/`,
+# which are read-only. We need to adjust their permissions.
+# TODO: Do this in `index-import`
+chmod -R u+w "$INDEX_DATA_STORE_DIR"

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -35,6 +35,16 @@ build:rules_xcodeproj --features=relative_ast_path
 # this in `swift_debug_settings.py`, so debugging still works.
 build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 
+# `swift.index-while-building` passes `-index-store-path` to `swiftc`, which
+# generates index store data. We enable this globally, and don't disable it in
+# `rules_xcodeproj_indexbuild`, even though we only need it for the normal
+# build, because it's better to get cache hits between normal and Index Build
+# builds than it is to save some time in an uncached Index Build build. We only
+# download the outputs in the normal build though, saving some bandwidth/disk
+# space.
+build:rules_xcodeproj --features=swift.index_while_building
+build:rules_xcodeproj --features=swift.use_global_index_store
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
@@ -72,6 +82,10 @@ build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
+
+# Unset `swift.index-while-building` since we don't need index store data, and
+# we already have cache misses from the `swiftc` flags above
+build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/examples/simple/test/fixtures/bwb_spec.json
+++ b/examples/simple/test/fixtures/bwb_spec.json
@@ -18,6 +18,10 @@
         "test/fixtures/BUILD"
     ],
     "force_bazel_dependencies": false,
+    "index_import": {
+        "t": "g",
+        "_": "darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import"
+    },
     "label": "//test/fixtures:xcodeproj_bwb.generator",
     "name": "bwb",
     "replacement_labels": [],

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -26,11 +26,12 @@ if [ "$ACTION" == "indexbuild" ]; then
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-    # Inputs for compiling, inputs for linking
-    readonly output_group_prefixes="xc,xl"
+    # Inputs for compiling, inputs for linking, and index store data
+    readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules) and products (i.e. bundles)
-    readonly output_group_prefixes="bc,bp"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
+    # store data
+    readonly output_group_prefixes="bc,bp,bi"
   fi
 fi
 
@@ -189,10 +190,16 @@ touch "$build_marker"
   "$GENERATOR_LABEL" \
   2>&1
 
+indexstores_filelists=()
 for output_group in "${output_groups[@]}"; do
   filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
   filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
   filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
   if [[ "$filelist" -ot "$build_marker" ]]; then
     echo "error: Bazel didn't generate the correct files (it should have" \
 "generated outputs for output group \"$output_group\", but the timestamp for" \
@@ -208,3 +215,32 @@ for output_group in "${output_groups[@]}"; do
     exit 1
   fi
 done
+
+# Async actions
+#
+# For these commands to run in the background, both stdout and stderr need to be
+# redirected, otherwise Xcode will block the run script.
+
+log_dir="$OBJROOT/rules_xcodeproj_logs"
+mkdir -p "$log_dir"
+
+# Report errors from previous async actions
+shopt -s nullglob
+for log in "$log_dir"/*.async.log; do
+  if [[ -s "$log" ]]; then
+    command=$(basename "${log%.async.log}")
+    echo "warning: Previous run of \"$command\" had output:" >&2
+    sed "s|^|warning: |" "$log" >&2
+    echo "warning: If you believe this is a bug, please file a report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+  fi
+done
+
+# Import indexes
+if [ -n "${indexstores_filelists:-}" ]; then
+  "$BAZEL_INTEGRATION_DIR/import_indexstores.sh" \
+    "$execution_root" \
+    "${indexstores_filelists[@]}" \
+    >"$log_dir/import_indexstores.async.log" 2>&1 &
+fi

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -35,6 +35,16 @@ build:rules_xcodeproj --features=relative_ast_path
 # this in `swift_debug_settings.py`, so debugging still works.
 build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 
+# `swift.index-while-building` passes `-index-store-path` to `swiftc`, which
+# generates index store data. We enable this globally, and don't disable it in
+# `rules_xcodeproj_indexbuild`, even though we only need it for the normal
+# build, because it's better to get cache hits between normal and Index Build
+# builds than it is to save some time in an uncached Index Build build. We only
+# download the outputs in the normal build though, saving some bandwidth/disk
+# space.
+build:rules_xcodeproj --features=swift.index_while_building
+build:rules_xcodeproj --features=swift.use_global_index_store
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
@@ -72,6 +82,10 @@ build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
+
+# Unset `swift.index-while-building` since we don't need index store data, and
+# we already have cache misses from the `swiftc` flags above
+build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/examples/simple/test/fixtures/bwx_spec.json
+++ b/examples/simple/test/fixtures/bwx_spec.json
@@ -18,6 +18,10 @@
         "test/fixtures/BUILD"
     ],
     "force_bazel_dependencies": false,
+    "index_import": {
+        "t": "g",
+        "_": "darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import"
+    },
     "label": "//test/fixtures:xcodeproj_bwx.generator",
     "name": "bwx",
     "replacement_labels": [],

--- a/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwb.xcodeproj/project.pbxproj
@@ -22,35 +22,28 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		47A652C93D0ED0E4B3D9E7CF /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 48A78400BB5E1C20A3299A42 /* main.c */; };
-		80A6741D0B0D88FD1395524A /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = BF6AED364F6BEC4B651A5032 /* lib.c */; };
-		9639B0DDE138496A9E661EEE /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = A2B55BE680D0A09636C9B2B8 /* lib.c */; };
+		CD2AA10AC79D5924E155E574 /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = FB80EF95C89684721EBBDC35 /* lib.c */; };
+		CFDEFD32F9576B104A39894D /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 9411DCDC5C6F92122299107F /* main.c */; };
 		D8961DA25CBC1AF0367FBA37 /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 26866FEDF67CD3FA66FFAB17 /* lib.c */; };
+		FC39DB0614B0AB5B5A2DF90E /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = FB0F020B344E60F89B31265D /* lib.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		138D72E83A5A533D00999AB1 /* PBXContainerItemProxy */ = {
+		1AB65E1F649B115C62DA830F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
+			remoteGlobalIDString = E180851AE3E1EEC8C4944F10;
+			remoteInfo = "//examples/cc/lib:lib_impl";
 		};
-		1D339408DBF7C3E910376D67 /* PBXContainerItemProxy */ = {
+		20B4384B1C553426B14F3544 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = E97BB4F5E7A1A5667030D4C5;
-			remoteInfo = "//lib2:lib_impl";
+			remoteGlobalIDString = 373A62571D2CA8826AD4F92C;
+			remoteInfo = "//examples/cc/lib2:lib_impl";
 		};
 		222EDD9A43AD7060E37D98C1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
-		230C74027CF49296E318C22E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -64,14 +57,21 @@
 			remoteGlobalIDString = 0CEAA3455274D4DE9B4B82BF;
 			remoteInfo = "@examples_cc_external//:lib_impl";
 		};
-		4747345E3F51DB581B6B4D58 /* PBXContainerItemProxy */ = {
+		4EE0B41522461A6BD9642C81 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = DA1CC6F7CBE8BEA35178CDF1;
-			remoteInfo = "//lib:lib_impl";
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
 		};
-		4EE0B41522461A6BD9642C81 /* PBXContainerItemProxy */ = {
+		B8A90ED069A5C28768A4173B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
+		E602DA48799768752E79F6E5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
@@ -81,34 +81,26 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		1B6E86525CF42B0DBC06EF8C /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
-		252388815FC72D44B8FB5A71 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
-		268081BB1DF68D819337131E /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
+		1FA9CAC061B4F491CEBDF60A /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		26866FEDF67CD3FA66FFAB17 /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
-		295286D1006239978AF51215 /* liblib_impl.lo */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.lo; path = "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib/liblib_impl.lo"; sourceTree = BUILT_PRODUCTS_DIR; };
+		295286D1006239978AF51215 /* liblib_impl.lo */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.lo; path = "bazel-out/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib/liblib_impl.lo"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2F2B12BDC30B75C3CD2012BD /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		3C80F439DD6B6A9F76C8BCC6 /* private.inc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.inc; sourceTree = "<group>"; };
-		3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		48A78400BB5E1C20A3299A42 /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
-		89E36EEAF8D2A80B9CFBF60D /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib2/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		43CB090CE80B33F7C6C1C7F6 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
+		5F5A15B1B3110ED9696BD6FB /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		82E8E5D354CD9B769C1DD508 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
+		8D73636373B8CDD4BE62C0A5 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
 		8EEF31F83F9AF990435CC135 /* tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tool; sourceTree = BUILT_PRODUCTS_DIR; };
-		A2B55BE680D0A09636C9B2B8 /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
-		BF6AED364F6BEC4B651A5032 /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
-		CDA701F96A5177E4188BEA69 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E4FF1C5D081F72C452F9B333 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
-		E5D5198F6B5B74FA95B386A5 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
-		E8EC0FBB4B1FC3CF8BF27BFD /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		9411DCDC5C6F92122299107F /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		CDA701F96A5177E4188BEA69 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/examples_cc_external/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E179886B32A8D20BA0FD517F /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		F360F9D030E464AA774319E0 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
+		FB0F020B344E60F89B31265D /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
+		FB80EF95C89684721EBBDC35 /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
-		07FAB588F8230EA3664E958C /* private */ = {
-			isa = PBXGroup;
-			children = (
-				E4FF1C5D081F72C452F9B333 /* private.h */,
-			);
-			path = private;
-			sourceTree = "<group>";
-		};
 		2D3DFF4472B24F4AD7FC4D86 /* examples_cc_external */ = {
 			isa = PBXGroup;
 			children = (
@@ -117,25 +109,41 @@
 				F360F9D030E464AA774319E0 /* lib.h */,
 			);
 			name = examples_cc_external;
-			path = external;
+			path = examples/cc/external;
 			sourceTree = SOURCE_ROOT;
 		};
 		2E6D9E4BA36A87B56922910C /* fixtures */ = {
 			isa = PBXGroup;
 			children = (
-				1B6E86525CF42B0DBC06EF8C /* BUILD */,
+				396C9D84AEFF8EDCE2CB9D82 /* cc */,
 			);
 			path = fixtures;
 			sourceTree = "<group>";
 		};
-		4CDF54236E377AE02D7E7A7F /* lib2 */ = {
+		396C9D84AEFF8EDCE2CB9D82 /* cc */ = {
 			isa = PBXGroup;
 			children = (
-				BC9D41B5104B7D51C3B01915 /* includes */,
-				89E36EEAF8D2A80B9CFBF60D /* BUILD */,
-				A2B55BE680D0A09636C9B2B8 /* lib.c */,
+				5F5A15B1B3110ED9696BD6FB /* BUILD */,
 			);
-			path = lib2;
+			path = cc;
+			sourceTree = "<group>";
+		};
+		538988851287F65BCA835B1D /* cc */ = {
+			isa = PBXGroup;
+			children = (
+				FDC330C37DD1DC9F623083BB /* lib */,
+				DF54345C65AB17E1D19AD454 /* lib2 */,
+				B81CB5A85E717306A9EDAE07 /* tool */,
+			);
+			path = cc;
+			sourceTree = "<group>";
+		};
+		579D7C5094A2D9E435BA8012 /* private */ = {
+			isa = PBXGroup;
+			children = (
+				8D73636373B8CDD4BE62C0A5 /* private.h */,
+			);
+			path = private;
 			sourceTree = "<group>";
 		};
 		593E7C82FAAD94A7E6A04318 /* Products */ = {
@@ -157,15 +165,6 @@
 			path = test;
 			sourceTree = "<group>";
 		};
-		7FAE228BE16508FE1557CD57 /* tool */ = {
-			isa = PBXGroup;
-			children = (
-				E8EC0FBB4B1FC3CF8BF27BFD /* BUILD */,
-				48A78400BB5E1C20A3299A42 /* main.c */,
-			);
-			path = tool;
-			sourceTree = "<group>";
-		};
 		9811D2ED915829A1A7881AFD /* Bazel External Repositories */ = {
 			isa = PBXGroup;
 			children = (
@@ -175,12 +174,21 @@
 			path = "bazel-output-base/external";
 			sourceTree = "<group>";
 		};
-		BC9D41B5104B7D51C3B01915 /* includes */ = {
+		B81CB5A85E717306A9EDAE07 /* tool */ = {
 			isa = PBXGroup;
 			children = (
-				268081BB1DF68D819337131E /* lib.h */,
+				2F2B12BDC30B75C3CD2012BD /* BUILD */,
+				9411DCDC5C6F92122299107F /* main.c */,
 			);
-			path = includes;
+			path = tool;
+			sourceTree = "<group>";
+		};
+		BB34C210E2A56E7B96B81F9A /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				538988851287F65BCA835B1D /* cc */,
+			);
+			path = examples;
 			sourceTree = "<group>";
 		};
 		C047AF1D451C7E165914273D /* Frameworks */ = {
@@ -188,6 +196,16 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		DF54345C65AB17E1D19AD454 /* lib2 */ = {
+			isa = PBXGroup;
+			children = (
+				EA59CE4984D207D31CCFF180 /* includes */,
+				E179886B32A8D20BA0FD517F /* BUILD */,
+				FB0F020B344E60F89B31265D /* lib.c */,
+			);
+			path = lib2;
 			sourceTree = "<group>";
 		};
 		E612587DC09602FB8217B300 /* private */ = {
@@ -198,28 +216,34 @@
 			path = private;
 			sourceTree = "<group>";
 		};
-		EA3CABF95B96FD404760D6F1 /* lib */ = {
+		EA59CE4984D207D31CCFF180 /* includes */ = {
 			isa = PBXGroup;
 			children = (
-				07FAB588F8230EA3664E958C /* private */,
-				252388815FC72D44B8FB5A71 /* BUILD */,
-				BF6AED364F6BEC4B651A5032 /* lib.c */,
-				E5D5198F6B5B74FA95B386A5 /* lib.h */,
+				43CB090CE80B33F7C6C1C7F6 /* lib.h */,
 			);
-			path = lib;
+			path = includes;
 			sourceTree = "<group>";
 		};
 		EC6FEE5AC277A3FEEA95510A = {
 			isa = PBXGroup;
 			children = (
-				EA3CABF95B96FD404760D6F1 /* lib */,
-				4CDF54236E377AE02D7E7A7F /* lib2 */,
+				BB34C210E2A56E7B96B81F9A /* examples */,
 				68A1D737225E7A97337523DE /* test */,
-				7FAE228BE16508FE1557CD57 /* tool */,
 				9811D2ED915829A1A7881AFD /* Bazel External Repositories */,
 				593E7C82FAAD94A7E6A04318 /* Products */,
 				C047AF1D451C7E165914273D /* Frameworks */,
 			);
+			sourceTree = "<group>";
+		};
+		FDC330C37DD1DC9F623083BB /* lib */ = {
+			isa = PBXGroup;
+			children = (
+				579D7C5094A2D9E435BA8012 /* private */,
+				1FA9CAC061B4F491CEBDF60A /* BUILD */,
+				FB80EF95C89684721EBBDC35 /* lib.c */,
+				82E8E5D354CD9B769C1DD508 /* lib.h */,
+			);
+			path = lib;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -253,41 +277,41 @@
 			dependencies = (
 				7176C357250A109C7B9B42E1 /* PBXTargetDependency */,
 				09E3E376134BB6CCC0CBAD31 /* PBXTargetDependency */,
-				4D16E1442BB4054D34F691C4 /* PBXTargetDependency */,
-				3A2CA71B65BCAEF5539BE49D /* PBXTargetDependency */,
+				7B9C45B4ECC722806B78A989 /* PBXTargetDependency */,
+				5072A54D92BD54F162C06B45 /* PBXTargetDependency */,
 			);
 			name = tool;
 			productName = tool;
 			productReference = 8EEF31F83F9AF990435CC135 /* tool */;
 			productType = "com.apple.product-type.tool";
 		};
-		DA1CC6F7CBE8BEA35178CDF1 /* //lib:lib_impl */ = {
+		373A62571D2CA8826AD4F92C /* //examples/cc/lib2:lib_impl */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 03537C1ECF5000F9C19E0A95 /* Build configuration list for PBXNativeTarget "//lib:lib_impl" */;
+			buildConfigurationList = CC32E30C4447E4F98912299A /* Build configuration list for PBXNativeTarget "//examples/cc/lib2:lib_impl" */;
 			buildPhases = (
-				042395F96E1CF85EECBB3A6F /* Sources */,
+				31E865B4B67E6E7FC42468E1 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				5298EC7D24D5D6C536E99722 /* PBXTargetDependency */,
+				1312633D03938D4760FD58AE /* PBXTargetDependency */,
 			);
-			name = "//lib:lib_impl";
+			name = "//examples/cc/lib2:lib_impl";
 			productName = lib_impl;
 			productType = "com.apple.product-type.library.static";
 		};
-		E97BB4F5E7A1A5667030D4C5 /* //lib2:lib_impl */ = {
+		E180851AE3E1EEC8C4944F10 /* //examples/cc/lib:lib_impl */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = BAF5CB3FC59AE25AA03E4FDE /* Build configuration list for PBXNativeTarget "//lib2:lib_impl" */;
+			buildConfigurationList = 52314820FE23152C79C94D1E /* Build configuration list for PBXNativeTarget "//examples/cc/lib:lib_impl" */;
 			buildPhases = (
-				FD466E179925521F063E6736 /* Sources */,
+				5F6E740F936730CFEDAF6F7E /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				86FC71DA204ADE2206CFECF7 /* PBXTargetDependency */,
+				EA85858C8C7FFB7F3791E220 /* PBXTargetDependency */,
 			);
-			name = "//lib2:lib_impl";
+			name = "//examples/cc/lib:lib_impl";
 			productName = lib_impl;
 			productType = "com.apple.product-type.library.static";
 		};
@@ -309,14 +333,14 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
 					};
-					7E7D155EBCA520F35DEA3571 = {
-						CreatedOnToolsVersion = 13.2.1;
-					};
-					DA1CC6F7CBE8BEA35178CDF1 = {
+					373A62571D2CA8826AD4F92C = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
 					};
-					E97BB4F5E7A1A5667030D4C5 = {
+					7E7D155EBCA520F35DEA3571 = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					E180851AE3E1EEC8C4944F10 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
 					};
@@ -332,13 +356,13 @@
 			);
 			mainGroup = EC6FEE5AC277A3FEEA95510A;
 			productRefGroup = 593E7C82FAAD94A7E6A04318 /* Products */;
-			projectDirPath = ../..;
+			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
 				7E7D155EBCA520F35DEA3571 /* BazelDependencies */,
 				0CEAA3455274D4DE9B4B82BF /* @examples_cc_external//:lib_impl */,
-				DA1CC6F7CBE8BEA35178CDF1 /* //lib:lib_impl */,
-				E97BB4F5E7A1A5667030D4C5 /* //lib2:lib_impl */,
+				E180851AE3E1EEC8C4944F10 /* //examples/cc/lib:lib_impl */,
+				373A62571D2CA8826AD4F92C /* //examples/cc/lib2:lib_impl */,
 				27EDD304E889980DC176FF62 /* tool */,
 			);
 		};
@@ -425,11 +449,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		042395F96E1CF85EECBB3A6F /* Sources */ = {
+		31E865B4B67E6E7FC42468E1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				80A6741D0B0D88FD1395524A /* lib.c in Sources */,
+				FC39DB0614B0AB5B5A2DF90E /* lib.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5F6E740F936730CFEDAF6F7E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CD2AA10AC79D5924E155E574 /* lib.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -437,15 +469,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				47A652C93D0ED0E4B3D9E7CF /* main.c in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FD466E179925521F063E6736 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				9639B0DDE138496A9E661EEE /* lib.c in Sources */,
+				CFDEFD32F9576B104A39894D /* main.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -458,11 +482,11 @@
 			target = 0CEAA3455274D4DE9B4B82BF /* @examples_cc_external//:lib_impl */;
 			targetProxy = 2D50AC8D57F94038C0E530C9 /* PBXContainerItemProxy */;
 		};
-		3A2CA71B65BCAEF5539BE49D /* PBXTargetDependency */ = {
+		1312633D03938D4760FD58AE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "//lib2:lib_impl";
-			target = E97BB4F5E7A1A5667030D4C5 /* //lib2:lib_impl */;
-			targetProxy = 1D339408DBF7C3E910376D67 /* PBXContainerItemProxy */;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = B8A90ED069A5C28768A4173B /* PBXContainerItemProxy */;
 		};
 		43831FD0645D4D31D8BF9F3C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -470,17 +494,11 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 222EDD9A43AD7060E37D98C1 /* PBXContainerItemProxy */;
 		};
-		4D16E1442BB4054D34F691C4 /* PBXTargetDependency */ = {
+		5072A54D92BD54F162C06B45 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "//lib:lib_impl";
-			target = DA1CC6F7CBE8BEA35178CDF1 /* //lib:lib_impl */;
-			targetProxy = 4747345E3F51DB581B6B4D58 /* PBXContainerItemProxy */;
-		};
-		5298EC7D24D5D6C536E99722 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = 230C74027CF49296E318C22E /* PBXContainerItemProxy */;
+			name = "//examples/cc/lib2:lib_impl";
+			target = 373A62571D2CA8826AD4F92C /* //examples/cc/lib2:lib_impl */;
+			targetProxy = 20B4384B1C553426B14F3544 /* PBXContainerItemProxy */;
 		};
 		7176C357250A109C7B9B42E1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -488,11 +506,17 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 4EE0B41522461A6BD9642C81 /* PBXContainerItemProxy */;
 		};
-		86FC71DA204ADE2206CFECF7 /* PBXTargetDependency */ = {
+		7B9C45B4ECC722806B78A989 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "//examples/cc/lib:lib_impl";
+			target = E180851AE3E1EEC8C4944F10 /* //examples/cc/lib:lib_impl */;
+			targetProxy = 1AB65E1F649B115C62DA830F /* PBXContainerItemProxy */;
+		};
+		EA85858C8C7FFB7F3791E220 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = 138D72E83A5A533D00999AB1 /* PBXContainerItemProxy */;
+			targetProxy = E602DA48799768752E79F6E5 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -501,8 +525,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external";
-				BAZEL_TARGET_ID = "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/examples_cc_external";
+				BAZEL_TARGET_ID = "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-0e5ef877669f";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				COMPILE_TARGET_NAME = lib_impl;
@@ -518,7 +542,7 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/examples_cc_external/private",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external/private",
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/examples_cc_external/private",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_CFLAGS = (
@@ -556,19 +580,19 @@
 				TARGET_NAME = lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/examples_cc_external",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external",
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/examples_cc_external",
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin",
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin",
 				);
 			};
 			name = Debug;
 		};
-		33E2D0F5AC3B2BC775FF1871 /* Debug */ = {
+		06F3B47FD3F55150815C937C /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib";
-				BAZEL_TARGET_ID = "//lib:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib";
+				BAZEL_TARGET_ID = "//examples/cc/lib:lib_impl darwin_x86_64-dbg-ST-0e5ef877669f";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				COMPILE_TARGET_NAME = lib_impl;
@@ -584,8 +608,8 @@
 					"SECRET_3=\\\"Hello\\\"",
 				);
 				HEADER_SEARCH_PATHS = (
-					lib/private,
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib/private",
+					examples/cc/lib/private,
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib/private",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_CFLAGS = (
@@ -623,7 +647,7 @@
 				TARGET_NAME = lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin",
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin",
 				);
 			};
 			name = Debug;
@@ -634,12 +658,12 @@
 				BAZEL_CONFIG = rules_xcodeproj;
 				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
-				GENERATOR_LABEL = "//test/fixtures:xcodeproj_bwb.generator";
-				GENERATOR_PACKAGE_BIN_DIR = "darwin_x86_64-dbg-ST-14942f8a2d44/bin/test/fixtures";
+				GENERATOR_LABEL = "//test/fixtures/cc:xcodeproj_bwb.generator";
+				GENERATOR_PACKAGE_BIN_DIR = "darwin_x86_64-dbg-ST-14942f8a2d44/bin/test/fixtures/cc";
 				GENERATOR_TARGET_NAME = xcodeproj_bwb.generator;
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
-				INDEX_IMPORT = "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import";
-				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_cc_external\" \"$(SRCROOT)/external\"";
+				INDEX_IMPORT = "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/build_bazel_rules_swift_index_import/index-import";
+				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_cc_external\" \"$(SRCROOT)/examples/cc/external\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SUPPORTED_PLATFORMS = macosx;
 				SUPPORTS_MACCATALYST = YES;
@@ -651,9 +675,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin/tool/rules_xcodeproj/tool/tool";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/tool";
-				BAZEL_TARGET_ID = "//tool:tool darwin_x86_64-dbg-ST-a9822d5480e1";
+				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/tool/rules_xcodeproj/tool/tool";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/tool";
+				BAZEL_TARGET_ID = "//examples/cc/tool:tool darwin_x86_64-dbg-ST-0e5ef877669f";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
@@ -671,7 +695,7 @@
 					"SECRET_2=\\\"World!\\\"",
 					"EXTERNAL_SECRET_2=\\\"World?\\\"",
 				);
-				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-a9822d5480e1/tool/tool.link.params";
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-0e5ef877669f/examples/cc/tool/tool.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
@@ -707,17 +731,80 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				SYSTEM_HEADER_SEARCH_PATHS = (
-					lib2/includes,
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/includes",
+					examples/cc/lib2/includes,
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib2/includes",
 				);
 				TARGET_NAME = tool;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin",
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin",
 					"$(BAZEL_EXTERNAL)/examples_cc_external",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external",
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/examples_cc_external",
 					"$(BAZEL_EXTERNAL)/bazel_tools",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/bazel_tools",
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/bazel_tools",
+				);
+			};
+			name = Debug;
+		};
+		AAB27910AD69F396275140DA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib2";
+				BAZEL_TARGET_ID = "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-0e5ef877669f";
+				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				COMPILE_TARGET_NAME = lib_impl;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					"__DATE__=\"redacted\"",
+					"__TIMESTAMP__=\"redacted\"",
+					"__TIME__=\"redacted\"",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
+				OTHER_CFLAGS = (
+					"-ivfsoverlay",
+					"$(OBJROOT)/bazel-out-overlay.yaml",
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-ivfsoverlay",
+					"$(OBJROOT)/bazel-out-overlay.yaml",
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-no-canonical-prefixes",
+					"-pthread",
+					"-no-canonical-prefixes",
+					"-Wno-builtin-macro-redefined",
+				);
+				PRODUCT_NAME = lib_impl;
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5;
+				SYSTEM_HEADER_SEARCH_PATHS = (
+					examples/cc/lib2/includes,
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib2/includes",
+				);
+				TARGET_NAME = lib_impl;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-0e5ef877669f/bin",
 				);
 			};
 			name = Debug;
@@ -726,11 +813,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "bazel-output-base/execroot/__main__";
+				BAZEL_EXEC_ROOT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
 				BAZEL_EXTERNAL = "bazel-output-base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "bazel-output-base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";
@@ -769,76 +856,13 @@
 			};
 			name = Debug;
 		};
-		D09084456B2A974B7CAAF4F6 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2";
-				BAZEL_TARGET_ID = "//lib2:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1";
-				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				COMPILE_TARGET_NAME = lib_impl;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_BITCODE = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"_FORTIFY_SOURCE=1",
-					"__DATE__=\"redacted\"",
-					"__TIMESTAMP__=\"redacted\"",
-					"__TIME__=\"redacted\"",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				OTHER_CFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-					"-fstack-protector",
-					"-Wall",
-					"-Wthread-safety",
-					"-Wself-assign",
-					"-fno-omit-frame-pointer",
-					"-no-canonical-prefixes",
-					"-pthread",
-					"-no-canonical-prefixes",
-					"-Wno-builtin-macro-redefined",
-				);
-				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-					"-fstack-protector",
-					"-Wall",
-					"-Wthread-safety",
-					"-Wself-assign",
-					"-fno-omit-frame-pointer",
-					"-no-canonical-prefixes",
-					"-pthread",
-					"-no-canonical-prefixes",
-					"-Wno-builtin-macro-redefined",
-				);
-				PRODUCT_NAME = lib_impl;
-				SDKROOT = macosx;
-				SUPPORTED_PLATFORMS = macosx;
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5;
-				SYSTEM_HEADER_SEARCH_PATHS = (
-					lib2/includes,
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/includes",
-				);
-				TARGET_NAME = lib_impl;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-a9822d5480e1/bin",
-				);
-			};
-			name = Debug;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		03537C1ECF5000F9C19E0A95 /* Build configuration list for PBXNativeTarget "//lib:lib_impl" */ = {
+		52314820FE23152C79C94D1E /* Build configuration list for PBXNativeTarget "//examples/cc/lib:lib_impl" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				33E2D0F5AC3B2BC775FF1871 /* Debug */,
+				06F3B47FD3F55150815C937C /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -867,10 +891,10 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		BAF5CB3FC59AE25AA03E4FDE /* Build configuration list for PBXNativeTarget "//lib2:lib_impl" */ = {
+		CC32E30C4447E4F98912299A /* Build configuration list for PBXNativeTarget "//examples/cc/lib2:lib_impl" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D09084456B2A974B7CAAF4F6 /* Debug */,
+				AAB27910AD69F396275140DA /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -111,7 +111,14 @@ else
 fi
 
 output_path=$("${bazel_cmd[@]}" \
-  info --config="${BAZEL_CONFIG}_info" --color="$color" output_path)
+  info \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$color" \
+  --experimental_convenience_symlinks=ignore \
+  --symlink_prefix=/ \
+  --bes_backend= \
+  --bes_results_url= \
+  output_path)
 execution_root="${output_path%/*}"
 
 # Create `bazel.lldbinit``
@@ -169,7 +176,7 @@ if [ "$ACTION" == "indexbuild" ]; then
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 else
-  config="_${BAZEL_CONFIG}_build"
+  config="${BAZEL_CONFIG}_build"
 fi
 
 mkdir -p /tmp/rules_xcodeproj

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly pidfile="$OBJROOT/import_indexstores.pid"
+readonly execution_root="$1"
+shift
+
+# Kill previously running import
+if [[ -s "$pidfile" ]]; then
+  pid=$(cat "$pidfile")
+  kill "$pid" 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null; do
+    sleep 1
+  done
+fi
+
+# Exit early if no indexstore filelists were provided
+if [ $# -eq 0 ]; then
+  exit
+fi
+
+# Set pid to allow cleanup later
+echo $$ > "$pidfile"
+trap 'rm "$pidfile" 2>/dev/null || true' EXIT
+
+# Merge all filelists into a single file
+filelist="$(mktemp)"
+sort -u "$@" | sed "s|^|$execution_root/|" > "$filelist"
+
+# Exit early if no indexstores were provided
+if [ ! -s "$filelist" ]; then
+  exit
+fi
+
+# Set remaps
+
+# Since users can override `--output_base`, all we know if that the
+# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
+readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+
+# We remove any `/private` prefix from the current execution_root, since it's
+# removed in the Project navigator.
+readonly xcode_execution_root="${execution_root#/private}"
+
+# The order of remaps is important. The first match is used. So we try the most
+# specific first. This also allows us to assume previous matches have taken care
+# of those types of files, so more general matches still work later.
+remaps=(
+  # Object files
+  #
+  # These currently come back relative, but we have the execution_root as an
+  # optional prefix in case this changes in the future. The path is based on
+  # rules_swift's current logic:
+  # https://github.com/bazelbuild/rules_swift/blob/6153a848f747e90248a8673869c49631f1323ff3/swift/internal/derived_files.bzl#L114-L119
+  # When we add support for C-based index imports we will have to use another
+  # pattern:
+  # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$PROJECT_TEMP_DIR/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+
+  # Generated sources and swiftmodules
+  #
+  # With object files taken care of, any other paths with `bazel-out/` as their
+  # prefix (relative to the execution_root) are assumed to be generated outputs.
+  # The two kinds of generated outputs used in the unit files are swiftmodule
+  # and source paths. So we map that, along with the `external/` prefix for
+  # external sources, to the current execution_root. Finally, currently these
+  # paths are returned as absolute, but a future change might make them
+  # relative, similar to the object files, so we have the execution_root as an
+  # optional prefix.
+  -remap "^(?:$execution_root_regex/)?bazel-out/=$xcode_execution_root/bazel-out/"
+
+  # External sources
+  #
+  # External sources need to be handled differently, since we use the
+  # non-symlinked version in Xcode.
+  -remap "^(?:$execution_root_regex/)?external/=${xcode_execution_root%/*/*}/external/"
+
+  # Project sources
+  #
+  # With the other source files and generated files taken care of, all other
+  # execution_root prefixed paths should be project sources.
+  -remap "^$execution_root_regex=$SRCROOT"
+
+  # Sysroot
+  #
+  # The only other type of path in the unit files are sysroot based. While
+  # these should always be Xcode.app relative, our regex supports command-line
+  # tools based paths as well.
+  -remap "^(?:.*?/[^/]+/Contents/Developer|/Library/Developer/CommandLineTools).*?/SDKs/([^\\d.]+)=$DEVELOPER_DIR/Platforms/\$1.platform/Developer/SDKs/\$1"
+)
+
+# Import
+
+mkdir -p "$INDEX_DATA_STORE_DIR"
+
+"$INDEX_IMPORT" \
+    "${remaps[@]}" \
+    -incremental \
+    @"$filelist" \
+    "$INDEX_DATA_STORE_DIR"
+
+# Unit files are created fresh, but record files are copied from `bazel-out/`,
+# which are read-only. We need to adjust their permissions.
+# TODO: Do this in `index-import`
+chmod -R u+w "$INDEX_DATA_STORE_DIR"

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -1,16 +1,15 @@
 ### `--config=rules_xcodeproj`
 #
-# Used directly when doing a normal build, but it is also the base config of all
-# the `rules_xcodeproj_*` configs. Adjust this config if you want something to
-# apply to all builds (which should be most settings).
+# `rules_xcodeproj` is the base config of `rules_xcodeproj_*` configs.
+# Add to this config if you want something to apply to all builds (which should
+# be most settings), as the various configs (e.g. `rules_xcodeproj_indexbuild`)
+# don't inherit from `rules_xcodeproj_build`. This allows
+# `rules_xcodeproj_build` to strictly apply to the normal build.
 
 common:rules_xcodeproj --verbose_failures
 
 # We default to `dbg` since debugging is broken otherwise
 build:rules_xcodeproj --compilation_mode=dbg
-
-# Xcode builds shouldn't mess with the workspace's symlinks
-build:rules_xcodeproj --experimental_convenience_symlinks=ignore
 
 # Not using `--define=apple.experimental.tree_artifact_outputs=1` is slow (we
 # have to unzip an archive on each build). If this doesn't work for your
@@ -36,10 +35,10 @@ build:rules_xcodeproj --features=relative_ast_path
 build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 
 # `swift.index-while-building` passes `-index-store-path` to `swiftc`, which
-# generates index store data. We enable this globally, and don't disable it in
-# `rules_xcodeproj_indexbuild`, even though we only need it for the normal
-# build, because it's better to get cache hits between normal and Index Build
-# builds than it is to save some time in an uncached Index Build build. We only
+# generates index store data. We enable this globally, even though we only need
+# it for the normal build, since it's better to get cache hits between normal
+# and Index Build builds than it is to save some time in an uncached Index Store
+# build. It also makes it easier to disable in your `.bazelrc` files. We only
 # download the outputs in the normal build though, saving some bandwidth/disk
 # space.
 build:rules_xcodeproj --features=swift.index_while_building
@@ -63,9 +62,15 @@ info:rules_xcodeproj_info --config=rules_xcodeproj
 # Filter out extra noise
 info:rules_xcodeproj_info --ui_event_filters=-INFO,-WARNING
 
+### `--config=rules_xcodeproj_build`
+#
+# Used when doing a normal build.
+
+build:rules_xcodeproj_build --config=rules_xcodeproj
+
 ### `--config=rules_xcodeproj_indexbuild`
 #
-# Used when doing an Index Build.
+# Used when doing an Index build.
 
 build:rules_xcodeproj_indexbuild --config=rules_xcodeproj
 
@@ -87,15 +92,7 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=_rules_xcodeproj_build`
-#
-# Private implementation detail. Don't adjust this config, adjust
-# `rules_xcodeproj` instead. This config exists solely to allow project-level
-# configs to work correctly.
-
-build:_rules_xcodeproj_build --config=rules_xcodeproj
-
 ### Project specific configs
-%project_configs%
+
 # Import `xcodeproj.bazelrc` if it exists
 try-import %workspace%/xcodeproj.bazelrc

--- a/test/fixtures/cc/bwb_spec.json
+++ b/test/fixtures/cc/bwb_spec.json
@@ -1,6 +1,6 @@
 {
     "bazel_config": "rules_xcodeproj",
-    "bazel_workspace_name": "__main__",
+    "bazel_workspace_name": "com_github_buildbuddy_io_rules_xcodeproj",
     "build_settings": {
         "ALWAYS_SEARCH_USER_PATHS": false,
         "BAZEL_PATH": "bazel",
@@ -14,29 +14,29 @@
     "configuration": "darwin_x86_64-dbg-ST-14942f8a2d44",
     "custom_xcode_schemes": [],
     "extra_files": [
-        "lib/BUILD",
-        "lib/lib.h",
-        "lib2/BUILD",
+        "examples/cc/lib/BUILD",
+        "examples/cc/lib/lib.h",
+        "examples/cc/lib2/BUILD",
         {
             "_": "examples_cc_external/lib.h",
             "t": "e"
         },
-        "tool/BUILD",
-        "test/fixtures/BUILD"
+        "examples/cc/tool/BUILD",
+        "test/fixtures/cc/BUILD"
     ],
     "force_bazel_dependencies": false,
     "index_import": {
         "t": "g",
-        "_": "darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import"
+        "_": "darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/build_bazel_rules_swift_index_import/index-import"
     },
-    "label": "//test/fixtures:xcodeproj_bwb.generator",
+    "label": "//test/fixtures/cc:xcodeproj_bwb.generator",
     "name": "bwb",
     "replacement_labels": [],
     "scheme_autogeneration_mode": "auto",
     "target_hosts": [],
     "target_merges": [],
     "targets": [
-        "//lib2:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1",
+        "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-0e5ef877669f",
         {
             "build_settings": {
                 "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
@@ -75,19 +75,19 @@
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
-            "configuration": "darwin_x86_64-dbg-ST-a9822d5480e1",
+            "configuration": "darwin_x86_64-dbg-ST-0e5ef877669f",
             "inputs": {
                 "hdrs": [
-                    "lib2/includes/lib.h"
+                    "examples/cc/lib2/includes/lib.h"
                 ],
                 "srcs": [
-                    "lib2/lib.c"
+                    "examples/cc/lib2/lib.c"
                 ]
             },
             "is_swift": false,
-            "label": "//lib2:lib_impl",
+            "label": "//examples/cc/lib2:lib_impl",
             "name": "lib_impl",
-            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2",
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib2",
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "12.0",
@@ -98,7 +98,7 @@
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
-                    "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/liblib_impl.a",
+                    "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib2/liblib_impl.a",
                     "t": "g"
                 },
                 "type": "com.apple.product-type.library.static"
@@ -107,20 +107,20 @@
                 "quote_includes": [
                     ".",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin",
                         "t": "g"
                     }
                 ],
                 "system_includes": [
-                    "lib2/includes",
+                    "examples/cc/lib2/includes",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/includes",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib2/includes",
                         "t": "g"
                     }
                 ]
             }
         },
-        "//lib:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1",
+        "//examples/cc/lib:lib_impl darwin_x86_64-dbg-ST-0e5ef877669f",
         {
             "build_settings": {
                 "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
@@ -160,17 +160,17 @@
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
-            "configuration": "darwin_x86_64-dbg-ST-a9822d5480e1",
+            "configuration": "darwin_x86_64-dbg-ST-0e5ef877669f",
             "inputs": {
                 "srcs": [
-                    "lib/lib.c",
-                    "lib/private/private.h"
+                    "examples/cc/lib/lib.c",
+                    "examples/cc/lib/private/private.h"
                 ]
             },
             "is_swift": false,
-            "label": "//lib:lib_impl",
+            "label": "//examples/cc/lib:lib_impl",
             "name": "lib_impl",
-            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib",
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib",
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "12.0",
@@ -181,29 +181,29 @@
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
-                    "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib/liblib_impl.lo",
+                    "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib/liblib_impl.lo",
                     "t": "g"
                 },
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {
                 "includes": [
-                    "lib/private",
+                    "examples/cc/lib/private",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib/private",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib/private",
                         "t": "g"
                     }
                 ],
                 "quote_includes": [
                     ".",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin",
                         "t": "g"
                     }
                 ]
             }
         },
-        "//tool:tool darwin_x86_64-dbg-ST-a9822d5480e1",
+        "//examples/cc/tool:tool darwin_x86_64-dbg-ST-0e5ef877669f",
         {
             "build_settings": {
                 "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
@@ -244,23 +244,23 @@
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
-            "configuration": "darwin_x86_64-dbg-ST-a9822d5480e1",
+            "configuration": "darwin_x86_64-dbg-ST-0e5ef877669f",
             "dependencies": [
-                "//lib:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1",
-                "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1",
-                "//lib2:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1"
+                "//examples/cc/lib:lib_impl darwin_x86_64-dbg-ST-0e5ef877669f",
+                "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-0e5ef877669f",
+                "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-0e5ef877669f"
             ],
             "inputs": {
                 "srcs": [
-                    "tool/main.c"
+                    "examples/cc/tool/main.c"
                 ]
             },
             "is_swift": false,
-            "label": "//tool:tool",
+            "label": "//examples/cc/tool:tool",
             "linker_inputs": {
                 "force_load": [
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib/liblib_impl.lo",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib/liblib_impl.lo",
                         "t": "g"
                     }
                 ],
@@ -271,11 +271,11 @@
                 ],
                 "static_libraries": [
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/liblib_impl.a",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib2/liblib_impl.a",
                         "t": "g"
                     },
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external/liblib_impl.a",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/examples_cc_external/liblib_impl.a",
                         "t": "g"
                     }
                 ]
@@ -283,11 +283,11 @@
             "name": "tool",
             "outputs": {
                 "p": {
-                    "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/tool/rules_xcodeproj/tool/tool",
+                    "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/tool/rules_xcodeproj/tool/tool",
                     "t": "g"
                 }
             },
-            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/tool",
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/tool",
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "12.0",
@@ -298,7 +298,7 @@
                 "executable_name": "tool",
                 "name": "tool",
                 "path": {
-                    "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/tool/rules_xcodeproj/tool/tool",
+                    "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/tool/rules_xcodeproj/tool/tool",
                     "t": "g"
                 },
                 "type": "com.apple.product-type.tool"
@@ -307,7 +307,7 @@
                 "quote_includes": [
                     ".",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin",
                         "t": "g"
                     },
                     {
@@ -315,7 +315,7 @@
                         "t": "e"
                     },
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/examples_cc_external",
                         "t": "g"
                     },
                     {
@@ -323,20 +323,20 @@
                         "t": "e"
                     },
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/bazel_tools",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/bazel_tools",
                         "t": "g"
                     }
                 ],
                 "system_includes": [
-                    "lib2/includes",
+                    "examples/cc/lib2/includes",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/includes",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/examples/cc/lib2/includes",
                         "t": "g"
                     }
                 ]
             }
         },
-        "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1",
+        "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-0e5ef877669f",
         {
             "build_settings": {
                 "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
@@ -376,7 +376,7 @@
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
-            "configuration": "darwin_x86_64-dbg-ST-a9822d5480e1",
+            "configuration": "darwin_x86_64-dbg-ST-0e5ef877669f",
             "inputs": {
                 "hdrs": [
                     {
@@ -398,7 +398,7 @@
             "is_swift": false,
             "label": "@examples_cc_external//:lib_impl",
             "name": "lib_impl",
-            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external",
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/examples_cc_external",
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "12.0",
@@ -409,7 +409,7 @@
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
-                    "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external/liblib_impl.a",
+                    "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/examples_cc_external/liblib_impl.a",
                     "t": "g"
                 },
                 "type": "com.apple.product-type.library.static"
@@ -421,7 +421,7 @@
                         "t": "e"
                     },
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external/private",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/examples_cc_external/private",
                         "t": "g"
                     }
                 ],
@@ -431,12 +431,12 @@
                         "t": "e"
                     },
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin/external/examples_cc_external",
                         "t": "g"
                     },
                     ".",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin",
+                        "_": "darwin_x86_64-dbg-ST-0e5ef877669f/bin",
                         "t": "g"
                     }
                 ]

--- a/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/cc/bwx.xcodeproj/project.pbxproj
@@ -23,32 +23,18 @@
 
 /* Begin PBXBuildFile section */
 		051B8A7BC0F5DBB11025923F /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 0282BFF13FDF4BED1663D2AF /* lib.c */; };
-		865464E17E0679228DB59369 /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 48913068AF40B3160BE92F17 /* lib.c */; };
-		86F794CE905D2C30B1209936 /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = E63B352CAB2E709CD65F0205 /* lib.c */; };
-		ED57A6A6DAC99D03BBA410CA /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = C6EE2567643A48ED61BC352B /* main.c */; };
+		27F99F3C7155CD79101A4A0F /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = BD77ACEF34FC7AFD41A09A4A /* main.c */; };
+		376A1C58A742EDEA9540B257 /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 4C8095547A55E1C477C2E094 /* lib.c */; };
+		6487CF8827955B8B86C59E14 /* lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 72DD4925E3FB6AE32B7ACADA /* lib.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		3AB864198F725791FCF5CBA3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
-		};
 		42025A1CD8FA6A1FEB112EA2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
-		};
-		452AA7B3D50C2DC7F0847760 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 27B7D45BB593CAD8F52196C6;
-			remoteInfo = "//lib:lib_impl";
 		};
 		59511478AA09290DC3C73AC2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -57,6 +43,20 @@
 			remoteGlobalIDString = 9DF8EA4260F38FC7243F6241;
 			remoteInfo = "@examples_cc_external//:lib_impl";
 		};
+		8323E2CE960EF05475B43F52 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
+		8698CD4A6028A873CA99945C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BCD9FA95C7CBE2A799AC3DF9;
+			remoteInfo = "//examples/cc/lib:lib_impl";
+		};
 		880FFE0FA4EE63FB2C4847F8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -64,77 +64,67 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		A25925C5CC812849E4CBC4BB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 60E60B1F2298FD94DC0C0352;
-			remoteInfo = "//lib2:lib_impl";
-		};
-		D84F676F7E7882F03DB781DC /* PBXContainerItemProxy */ = {
+		928A63C7A3B638688471026B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
+		E2C8E26DA4198C7C2B9239BD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B2EDA6BA27C01B7B8423DADB;
+			remoteInfo = "//examples/cc/lib2:lib_impl";
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		0282BFF13FDF4BED1663D2AF /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
+		054732C7DCF543EED5337D81 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
+		19B81294B60CEC2BA6843380 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
 		1E24825205C7C82ED0184DEA /* tool */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tool; sourceTree = BUILT_PRODUCTS_DIR; };
-		43EFFA16783121B68B512943 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
+		31620B8F4712C7D8A23356B9 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		473752B2F4FD8D5B513230B3 /* private.inc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.inc; sourceTree = "<group>"; };
-		48913068AF40B3160BE92F17 /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
-		5E2BDA2783889EAED806599E /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
-		5F3A14AEA59ECEA61E71A226 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
-		61D4E93D586B426B1BE67C73 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8C467A9CF11D6BFFA7FEE894 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C8095547A55E1C477C2E094 /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
+		61D4E93D586B426B1BE67C73 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib2/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		72DD4925E3FB6AE32B7ACADA /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
+		887E70CEDC5A85E62FB23126 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
+		8C467A9CF11D6BFFA7FEE894 /* liblib_impl.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.a; path = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		921187174A58741CF8ADCCD9 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
-		97ADB761BAE21D828622D393 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
-		ADBBAFDAD596ED7AA10266FB /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
-		B4FF189F9C254729E69ECA06 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
-		C6EE2567643A48ED61BC352B /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
-		C92ECF666C8BB9EC4D328562 /* private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = private.h; sourceTree = "<group>"; };
-		E63B352CAB2E709CD65F0205 /* lib.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = lib.c; sourceTree = "<group>"; };
-		EA9A40D0AB233B5E56E5E050 /* liblib_impl.lo */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.lo; path = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo"; sourceTree = BUILT_PRODUCTS_DIR; };
+		BD77ACEF34FC7AFD41A09A4A /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
+		C0FE22BC231A9DB0A7E546A8 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		DD6E27CD14BF041559DD9225 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		EA9A40D0AB233B5E56E5E050 /* liblib_impl.lo */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_impl.lo; path = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib/liblib_impl.lo"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F836536D759D1084EDC9B80D /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
-		0A7CC0BBB482E97546BD601E /* lib */ = {
+		084CF4A865BD4A03FD909037 /* lib2 */ = {
 			isa = PBXGroup;
 			children = (
-				EA5AC2528D794AAC3861ECB2 /* private */,
-				B4FF189F9C254729E69ECA06 /* BUILD */,
-				48913068AF40B3160BE92F17 /* lib.c */,
-				43EFFA16783121B68B512943 /* lib.h */,
+				0DEDF63103D0E79BA0A649F1 /* includes */,
+				DD6E27CD14BF041559DD9225 /* BUILD */,
+				4C8095547A55E1C477C2E094 /* lib.c */,
 			);
-			path = lib;
+			path = lib2;
 			sourceTree = "<group>";
 		};
-		167FA20BD7021B6B13B88366 /* tool */ = {
+		0DEDF63103D0E79BA0A649F1 /* includes */ = {
 			isa = PBXGroup;
 			children = (
-				ADBBAFDAD596ED7AA10266FB /* BUILD */,
-				C6EE2567643A48ED61BC352B /* main.c */,
+				19B81294B60CEC2BA6843380 /* lib.h */,
 			);
-			path = tool;
+			path = includes;
 			sourceTree = "<group>";
 		};
 		34EEB3D407F10261A42BB9F7 /* fixtures */ = {
 			isa = PBXGroup;
 			children = (
-				97ADB761BAE21D828622D393 /* BUILD */,
+				70DC9256243D9E106213838F /* cc */,
 			);
 			path = fixtures;
-			sourceTree = "<group>";
-		};
-		3960A5CA7808F67CA20756A0 /* includes */ = {
-			isa = PBXGroup;
-			children = (
-				5E2BDA2783889EAED806599E /* lib.h */,
-			);
-			path = includes;
 			sourceTree = "<group>";
 		};
 		462C3519CA354BE1B04D4855 /* Products */ = {
@@ -148,23 +138,28 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		647FBC2D7EC5AB1E47C84723 /* lib2 */ = {
+		5D2B88303984EDAE376A8A42 /* tool */ = {
 			isa = PBXGroup;
 			children = (
-				3960A5CA7808F67CA20756A0 /* includes */,
-				5F3A14AEA59ECEA61E71A226 /* BUILD */,
-				E63B352CAB2E709CD65F0205 /* lib.c */,
+				31620B8F4712C7D8A23356B9 /* BUILD */,
+				BD77ACEF34FC7AFD41A09A4A /* main.c */,
 			);
-			path = lib2;
+			path = tool;
+			sourceTree = "<group>";
+		};
+		70DC9256243D9E106213838F /* cc */ = {
+			isa = PBXGroup;
+			children = (
+				C0FE22BC231A9DB0A7E546A8 /* BUILD */,
+			);
+			path = cc;
 			sourceTree = "<group>";
 		};
 		77E0714FDD425211EBA209DF = {
 			isa = PBXGroup;
 			children = (
-				0A7CC0BBB482E97546BD601E /* lib */,
-				647FBC2D7EC5AB1E47C84723 /* lib2 */,
+				86E3AA094AC3498BEDC1D673 /* examples */,
 				D2C8CC455B9D27F28D323622 /* test */,
-				167FA20BD7021B6B13B88366 /* tool */,
 				85F708DD1F5484A0D5558108 /* Bazel External Repositories */,
 				462C3519CA354BE1B04D4855 /* Products */,
 				D9AAB93A5135F69103554470 /* Frameworks */,
@@ -180,6 +175,33 @@
 			path = "bazel-output-base/external";
 			sourceTree = "<group>";
 		};
+		86E3AA094AC3498BEDC1D673 /* examples */ = {
+			isa = PBXGroup;
+			children = (
+				F3DF213D7DA809F2C6035D8E /* cc */,
+			);
+			path = examples;
+			sourceTree = "<group>";
+		};
+		9EE678F46B9B0B1005378325 /* lib */ = {
+			isa = PBXGroup;
+			children = (
+				BE21FCC0C62FE17028698925 /* private */,
+				F836536D759D1084EDC9B80D /* BUILD */,
+				72DD4925E3FB6AE32B7ACADA /* lib.c */,
+				887E70CEDC5A85E62FB23126 /* lib.h */,
+			);
+			path = lib;
+			sourceTree = "<group>";
+		};
+		BE21FCC0C62FE17028698925 /* private */ = {
+			isa = PBXGroup;
+			children = (
+				054732C7DCF543EED5337D81 /* private.h */,
+			);
+			path = private;
+			sourceTree = "<group>";
+		};
 		C0094871AF8AEE1DBE5F47F3 /* examples_cc_external */ = {
 			isa = PBXGroup;
 			children = (
@@ -188,7 +210,7 @@
 				921187174A58741CF8ADCCD9 /* lib.h */,
 			);
 			name = examples_cc_external;
-			path = external;
+			path = examples/cc/external;
 			sourceTree = SOURCE_ROOT;
 		};
 		D2C8CC455B9D27F28D323622 /* test */ = {
@@ -206,14 +228,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		EA5AC2528D794AAC3861ECB2 /* private */ = {
-			isa = PBXGroup;
-			children = (
-				C92ECF666C8BB9EC4D328562 /* private.h */,
-			);
-			path = private;
-			sourceTree = "<group>";
-		};
 		EF589287E599D540537F7FDF /* private */ = {
 			isa = PBXGroup;
 			children = (
@@ -222,39 +236,19 @@
 			path = private;
 			sourceTree = "<group>";
 		};
+		F3DF213D7DA809F2C6035D8E /* cc */ = {
+			isa = PBXGroup;
+			children = (
+				9EE678F46B9B0B1005378325 /* lib */,
+				084CF4A865BD4A03FD909037 /* lib2 */,
+				5D2B88303984EDAE376A8A42 /* tool */,
+			);
+			path = cc;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		27B7D45BB593CAD8F52196C6 /* //lib:lib_impl */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8F144B3A4BA088394957B74A /* Build configuration list for PBXNativeTarget "//lib:lib_impl" */;
-			buildPhases = (
-				BB974C61B608B2287A43A2A9 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				48E3E6F91A68A97C56484D10 /* PBXTargetDependency */,
-			);
-			name = "//lib:lib_impl";
-			productName = lib_impl;
-			productType = "com.apple.product-type.library.static";
-		};
-		60E60B1F2298FD94DC0C0352 /* //lib2:lib_impl */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 913A85F38FB54FD89B673741 /* Build configuration list for PBXNativeTarget "//lib2:lib_impl" */;
-			buildPhases = (
-				03C989EFFCB845CC3833188A /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				E3342E5867EF38BF0B0CE0A0 /* PBXTargetDependency */,
-			);
-			name = "//lib2:lib_impl";
-			productName = lib_impl;
-			productType = "com.apple.product-type.library.static";
-		};
 		9DF8EA4260F38FC7243F6241 /* @examples_cc_external//:lib_impl */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FA7CA526EED1582756E3E941 /* Build configuration list for PBXNativeTarget "@examples_cc_external//:lib_impl" */;
@@ -270,6 +264,36 @@
 			productName = lib_impl;
 			productType = "com.apple.product-type.library.static";
 		};
+		B2EDA6BA27C01B7B8423DADB /* //examples/cc/lib2:lib_impl */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1DD860963E9CFCDCE0CE985C /* Build configuration list for PBXNativeTarget "//examples/cc/lib2:lib_impl" */;
+			buildPhases = (
+				626D87EA37F5C2B81559DE3F /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3812C1780716CAECFF2F902E /* PBXTargetDependency */,
+			);
+			name = "//examples/cc/lib2:lib_impl";
+			productName = lib_impl;
+			productType = "com.apple.product-type.library.static";
+		};
+		BCD9FA95C7CBE2A799AC3DF9 /* //examples/cc/lib:lib_impl */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A2FAA47B02D787D062553D79 /* Build configuration list for PBXNativeTarget "//examples/cc/lib:lib_impl" */;
+			buildPhases = (
+				A0F9AA66ADF43CE37FF948A8 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				533771049510B162334158B1 /* PBXTargetDependency */,
+			);
+			name = "//examples/cc/lib:lib_impl";
+			productName = lib_impl;
+			productType = "com.apple.product-type.library.static";
+		};
 		EC6A68AC956C60AA25485960 /* tool */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 85DAE5AD4B16C63749019BBB /* Build configuration list for PBXNativeTarget "tool" */;
@@ -282,8 +306,8 @@
 			dependencies = (
 				C7CE0C2F304E0B02B1E4E5A4 /* PBXTargetDependency */,
 				59AC8FC7ED45C65DBD76BA41 /* PBXTargetDependency */,
-				1E3E25F21FFFBE97D34A142E /* PBXTargetDependency */,
-				A54AEFAAFCE346283DA915AF /* PBXTargetDependency */,
+				1122A5CB331663C0EE9EAB7D /* PBXTargetDependency */,
+				42759F6FCC327FD82603CB04 /* PBXTargetDependency */,
 			);
 			name = tool;
 			productName = tool;
@@ -300,15 +324,15 @@
 				LastSwiftUpdateCheck = 9999;
 				LastUpgradeCheck = 9999;
 				TargetAttributes = {
-					27B7D45BB593CAD8F52196C6 = {
-						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 9999;
-					};
-					60E60B1F2298FD94DC0C0352 = {
-						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 9999;
-					};
 					9DF8EA4260F38FC7243F6241 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
+					B2EDA6BA27C01B7B8423DADB = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
+					BCD9FA95C7CBE2A799AC3DF9 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
 					};
@@ -331,13 +355,13 @@
 			);
 			mainGroup = 77E0714FDD425211EBA209DF;
 			productRefGroup = 462C3519CA354BE1B04D4855 /* Products */;
-			projectDirPath = ../..;
+			projectDirPath = ../../..;
 			projectRoot = "";
 			targets = (
 				FE59281FE487F27A37DC2EE7 /* BazelDependencies */,
 				9DF8EA4260F38FC7243F6241 /* @examples_cc_external//:lib_impl */,
-				27B7D45BB593CAD8F52196C6 /* //lib:lib_impl */,
-				60E60B1F2298FD94DC0C0352 /* //lib2:lib_impl */,
+				BCD9FA95C7CBE2A799AC3DF9 /* //examples/cc/lib:lib_impl */,
+				B2EDA6BA27C01B7B8423DADB /* //examples/cc/lib2:lib_impl */,
 				EC6A68AC956C60AA25485960 /* tool */,
 			);
 		};
@@ -400,27 +424,27 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		03C989EFFCB845CC3833188A /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				86F794CE905D2C30B1209936 /* lib.c in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		5070903440E6C33AE9B061E6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				ED57A6A6DAC99D03BBA410CA /* main.c in Sources */,
+				27F99F3C7155CD79101A4A0F /* main.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BB974C61B608B2287A43A2A9 /* Sources */ = {
+		626D87EA37F5C2B81559DE3F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				865464E17E0679228DB59369 /* lib.c in Sources */,
+				376A1C58A742EDEA9540B257 /* lib.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A0F9AA66ADF43CE37FF948A8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6487CF8827955B8B86C59E14 /* lib.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -435,11 +459,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		1E3E25F21FFFBE97D34A142E /* PBXTargetDependency */ = {
+		1122A5CB331663C0EE9EAB7D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "//lib:lib_impl";
-			target = 27B7D45BB593CAD8F52196C6 /* //lib:lib_impl */;
-			targetProxy = 452AA7B3D50C2DC7F0847760 /* PBXContainerItemProxy */;
+			name = "//examples/cc/lib:lib_impl";
+			target = BCD9FA95C7CBE2A799AC3DF9 /* //examples/cc/lib:lib_impl */;
+			targetProxy = 8698CD4A6028A873CA99945C /* PBXContainerItemProxy */;
 		};
 		285FA061754C2107327A45D8 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -447,11 +471,23 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 42025A1CD8FA6A1FEB112EA2 /* PBXContainerItemProxy */;
 		};
-		48E3E6F91A68A97C56484D10 /* PBXTargetDependency */ = {
+		3812C1780716CAECFF2F902E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = 3AB864198F725791FCF5CBA3 /* PBXContainerItemProxy */;
+			targetProxy = 928A63C7A3B638688471026B /* PBXContainerItemProxy */;
+		};
+		42759F6FCC327FD82603CB04 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "//examples/cc/lib2:lib_impl";
+			target = B2EDA6BA27C01B7B8423DADB /* //examples/cc/lib2:lib_impl */;
+			targetProxy = E2C8E26DA4198C7C2B9239BD /* PBXContainerItemProxy */;
+		};
+		533771049510B162334158B1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = 8323E2CE960EF05475B43F52 /* PBXContainerItemProxy */;
 		};
 		59AC8FC7ED45C65DBD76BA41 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -459,52 +495,21 @@
 			target = 9DF8EA4260F38FC7243F6241 /* @examples_cc_external//:lib_impl */;
 			targetProxy = 59511478AA09290DC3C73AC2 /* PBXContainerItemProxy */;
 		};
-		A54AEFAAFCE346283DA915AF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "//lib2:lib_impl";
-			target = 60E60B1F2298FD94DC0C0352 /* //lib2:lib_impl */;
-			targetProxy = A25925C5CC812849E4CBC4BB /* PBXContainerItemProxy */;
-		};
 		C7CE0C2F304E0B02B1E4E5A4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 880FFE0FA4EE63FB2C4847F8 /* PBXContainerItemProxy */;
 		};
-		E3342E5867EF38BF0B0CE0A0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = D84F676F7E7882F03DB781DC /* PBXContainerItemProxy */;
-		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		67F44AB65FA7A2E38A56F5FB /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BAZEL_CONFIG = rules_xcodeproj;
-				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
-				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
-				GENERATOR_LABEL = "//test/fixtures:xcodeproj_bwx.generator";
-				GENERATOR_PACKAGE_BIN_DIR = "darwin_x86_64-dbg-ST-14942f8a2d44/bin/test/fixtures";
-				GENERATOR_TARGET_NAME = xcodeproj_bwx.generator;
-				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
-				INDEX_IMPORT = "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import";
-				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_cc_external\" \"$(SRCROOT)/external\"";
-				RULES_XCODEPROJ_BUILD_MODE = xcode;
-				SUPPORTED_PLATFORMS = macosx;
-				SUPPORTS_MACCATALYST = YES;
-				TARGET_NAME = BazelDependencies;
-			};
-			name = Debug;
-		};
-		A1A1448FC50C1E6FAD40CA08 /* Debug */ = {
+		3C4E7D66EF31F8A2E1312361 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib";
-				BAZEL_TARGET_ID = "//lib:lib_impl darwin_x86_64-dbg-ST-3688109ddba2";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib";
+				BAZEL_TARGET_ID = "//examples/cc/lib:lib_impl darwin_x86_64-dbg-ST-3688109ddba2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				COMPILE_TARGET_NAME = lib_impl;
@@ -521,8 +526,8 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				HEADER_SEARCH_PATHS = (
-					lib/private,
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/private",
+					examples/cc/lib/private,
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib/private",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_CFLAGS = (
@@ -569,12 +574,70 @@
 			};
 			name = Debug;
 		};
-		B43F155CDA3E79C52FA58839 /* Debug */ = {
+		67F44AB65FA7A2E38A56F5FB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BAZEL_CONFIG = rules_xcodeproj;
+				BAZEL_PACKAGE_BIN_DIR = rules_xcodeproj;
+				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
+				GENERATOR_LABEL = "//test/fixtures/cc:xcodeproj_bwx.generator";
+				GENERATOR_PACKAGE_BIN_DIR = "darwin_x86_64-dbg-ST-14942f8a2d44/bin/test/fixtures/cc";
+				GENERATOR_TARGET_NAME = xcodeproj_bwx.generator;
+				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
+				INDEX_IMPORT = "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/build_bazel_rules_swift_index_import/index-import";
+				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_cc_external\" \"$(SRCROOT)/examples/cc/external\"";
+				RULES_XCODEPROJ_BUILD_MODE = xcode;
+				SUPPORTED_PLATFORMS = macosx;
+				SUPPORTS_MACCATALYST = YES;
+				TARGET_NAME = BazelDependencies;
+			};
+			name = Debug;
+		};
+		C221D886D6D02D33114D3473 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BAZEL_EXEC_ROOT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+				BAZEL_EXTERNAL = "bazel-output-base/external";
+				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
+				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
+				BAZEL_OUT = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+				BAZEL_PATH = bazel;
+				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
+				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";
+				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
+				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
+				COPY_PHASE_STRIP = NO;
+				DEPLOYMENT_LOCATION = "$(INDEXING_DEPLOYMENT_LOCATION__$(INDEX_ENABLE_BUILD_ARENA)),";
+				DSTROOT = "$(PROJECT_TEMP_DIR)";
+				INDEXING_BUILT_PRODUCTS_DIR__ = "$(INDEXING_BUILT_PRODUCTS_DIR__NO)";
+				INDEXING_BUILT_PRODUCTS_DIR__NO = "$(BUILD_DIR)";
+				INDEXING_BUILT_PRODUCTS_DIR__YES = "$(CONFIGURATION_BUILD_DIR)";
+				INDEXING_DEPLOYMENT_LOCATION__ = "$(INDEXING_DEPLOYMENT_LOCATION__NO)";
+				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
+				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
+				INDEX_FORCE_SCRIPT_EXECUTION = YES;
+				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
+				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
+				LINKS_DIR = "$(INTERNAL_DIR)/links";
+				ONLY_ACTIVE_ARCH = YES;
+				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)";
+				USE_HEADERMAP = NO;
+				VALIDATE_WORKSPACE = NO;
+			};
+			name = Debug;
+		};
+		CF6609A15495C44CBDB37C68 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2";
-				BAZEL_TARGET_ID = "//lib2:lib_impl darwin_x86_64-dbg-ST-3688109ddba2";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib2";
+				BAZEL_TARGET_ID = "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-3688109ddba2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				COMPILE_TARGET_NAME = lib_impl;
@@ -626,8 +689,8 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				SYSTEM_HEADER_SEARCH_PATHS = (
-					lib2/includes,
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/includes",
+					examples/cc/lib2/includes,
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib2/includes",
 				);
 				TARGET_NAME = lib_impl;
 				USER_HEADER_SEARCH_PATHS = (
@@ -637,51 +700,12 @@
 			};
 			name = Debug;
 		};
-		C221D886D6D02D33114D3473 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "bazel-output-base/execroot/__main__";
-				BAZEL_EXTERNAL = "bazel-output-base/external";
-				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
-				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "bazel-output-base/execroot/__main__/bazel-out";
-				BAZEL_PATH = bazel;
-				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
-				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";
-				BUILT_PRODUCTS_DIR = "$(INDEXING_BUILT_PRODUCTS_DIR__$(INDEX_ENABLE_BUILD_ARENA))";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_MODULES_AUTOLINK = NO;
-				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(BAZEL_PACKAGE_BIN_DIR)";
-				COPY_PHASE_STRIP = NO;
-				DEPLOYMENT_LOCATION = "$(INDEXING_DEPLOYMENT_LOCATION__$(INDEX_ENABLE_BUILD_ARENA)),";
-				DSTROOT = "$(PROJECT_TEMP_DIR)";
-				INDEXING_BUILT_PRODUCTS_DIR__ = "$(INDEXING_BUILT_PRODUCTS_DIR__NO)";
-				INDEXING_BUILT_PRODUCTS_DIR__NO = "$(BUILD_DIR)";
-				INDEXING_BUILT_PRODUCTS_DIR__YES = "$(CONFIGURATION_BUILD_DIR)";
-				INDEXING_DEPLOYMENT_LOCATION__ = "$(INDEXING_DEPLOYMENT_LOCATION__NO)";
-				INDEXING_DEPLOYMENT_LOCATION__NO = YES;
-				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
-				INDEX_FORCE_SCRIPT_EXECUTION = YES;
-				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
-				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";
-				LINKS_DIR = "$(INTERNAL_DIR)/links";
-				ONLY_ACTIVE_ARCH = YES;
-				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)";
-				USE_HEADERMAP = NO;
-				VALIDATE_WORKSPACE = NO;
-			};
-			name = Debug;
-		};
 		DE39562D4492E281F18A3205 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/tool";
-				BAZEL_TARGET_ID = "//tool:tool darwin_x86_64-dbg-ST-3688109ddba2";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/tool";
+				BAZEL_TARGET_ID = "//examples/cc/tool:tool darwin_x86_64-dbg-ST-3688109ddba2";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
@@ -700,7 +724,7 @@
 					"EXTERNAL_SECRET_2=\\\"World?\\\"",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
-				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-3688109ddba2/tool/tool.link.params";
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/darwin_x86_64-dbg-ST-3688109ddba2/examples/cc/tool/tool.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
@@ -740,8 +764,8 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5;
 				SYSTEM_HEADER_SEARCH_PATHS = (
-					lib2/includes,
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/includes",
+					examples/cc/lib2/includes,
+					"$(BAZEL_OUT)/darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib2/includes",
 				);
 				TARGET_NAME = tool;
 				USER_HEADER_SEARCH_PATHS = (
@@ -829,6 +853,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1DD860963E9CFCDCE0CE985C /* Build configuration list for PBXNativeTarget "//examples/cc/lib2:lib_impl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CF6609A15495C44CBDB37C68 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		85DAE5AD4B16C63749019BBB /* Build configuration list for PBXNativeTarget "tool" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -845,18 +877,10 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		8F144B3A4BA088394957B74A /* Build configuration list for PBXNativeTarget "//lib:lib_impl" */ = {
+		A2FAA47B02D787D062553D79 /* Build configuration list for PBXNativeTarget "//examples/cc/lib:lib_impl" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A1A1448FC50C1E6FAD40CA08 /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		913A85F38FB54FD89B673741 /* Build configuration list for PBXNativeTarget "//lib2:lib_impl" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				B43F155CDA3E79C52FA58839 /* Debug */,
+				3C4E7D66EF31F8A2E1312361 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -111,7 +111,14 @@ else
 fi
 
 output_path=$("${bazel_cmd[@]}" \
-  info --config="${BAZEL_CONFIG}_info" --color="$color" output_path)
+  info \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$color" \
+  --experimental_convenience_symlinks=ignore \
+  --symlink_prefix=/ \
+  --bes_backend= \
+  --bes_results_url= \
+  output_path)
 execution_root="${output_path%/*}"
 
 # Create `bazel.lldbinit``
@@ -169,7 +176,7 @@ if [ "$ACTION" == "indexbuild" ]; then
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 else
-  config="_${BAZEL_CONFIG}_build"
+  config="${BAZEL_CONFIG}_build"
 fi
 
 mkdir -p /tmp/rules_xcodeproj

--- a/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -1,16 +1,15 @@
 ### `--config=rules_xcodeproj`
 #
-# Used directly when doing a normal build, but it is also the base config of all
-# the `rules_xcodeproj_*` configs. Adjust this config if you want something to
-# apply to all builds (which should be most settings).
+# `rules_xcodeproj` is the base config of `rules_xcodeproj_*` configs.
+# Add to this config if you want something to apply to all builds (which should
+# be most settings), as the various configs (e.g. `rules_xcodeproj_indexbuild`)
+# don't inherit from `rules_xcodeproj_build`. This allows
+# `rules_xcodeproj_build` to strictly apply to the normal build.
 
 common:rules_xcodeproj --verbose_failures
 
 # We default to `dbg` since debugging is broken otherwise
 build:rules_xcodeproj --compilation_mode=dbg
-
-# Xcode builds shouldn't mess with the workspace's symlinks
-build:rules_xcodeproj --experimental_convenience_symlinks=ignore
 
 # Not using `--define=apple.experimental.tree_artifact_outputs=1` is slow (we
 # have to unzip an archive on each build). If this doesn't work for your
@@ -36,10 +35,10 @@ build:rules_xcodeproj --features=relative_ast_path
 build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 
 # `swift.index-while-building` passes `-index-store-path` to `swiftc`, which
-# generates index store data. We enable this globally, and don't disable it in
-# `rules_xcodeproj_indexbuild`, even though we only need it for the normal
-# build, because it's better to get cache hits between normal and Index Build
-# builds than it is to save some time in an uncached Index Build build. We only
+# generates index store data. We enable this globally, even though we only need
+# it for the normal build, since it's better to get cache hits between normal
+# and Index Build builds than it is to save some time in an uncached Index Store
+# build. It also makes it easier to disable in your `.bazelrc` files. We only
 # download the outputs in the normal build though, saving some bandwidth/disk
 # space.
 build:rules_xcodeproj --features=swift.index_while_building
@@ -63,9 +62,15 @@ info:rules_xcodeproj_info --config=rules_xcodeproj
 # Filter out extra noise
 info:rules_xcodeproj_info --ui_event_filters=-INFO,-WARNING
 
+### `--config=rules_xcodeproj_build`
+#
+# Used when doing a normal build.
+
+build:rules_xcodeproj_build --config=rules_xcodeproj
+
 ### `--config=rules_xcodeproj_indexbuild`
 #
-# Used when doing an Index Build.
+# Used when doing an Index build.
 
 build:rules_xcodeproj_indexbuild --config=rules_xcodeproj
 
@@ -87,15 +92,7 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=_rules_xcodeproj_build`
-#
-# Private implementation detail. Don't adjust this config, adjust
-# `rules_xcodeproj` instead. This config exists solely to allow project-level
-# configs to work correctly.
-
-build:_rules_xcodeproj_build --config=rules_xcodeproj
-
 ### Project specific configs
-%project_configs%
+
 # Import `xcodeproj.bazelrc` if it exists
 try-import %workspace%/xcodeproj.bazelrc

--- a/test/fixtures/cc/bwx_spec.json
+++ b/test/fixtures/cc/bwx_spec.json
@@ -1,6 +1,6 @@
 {
     "bazel_config": "rules_xcodeproj",
-    "bazel_workspace_name": "__main__",
+    "bazel_workspace_name": "com_github_buildbuddy_io_rules_xcodeproj",
     "build_settings": {
         "ALWAYS_SEARCH_USER_PATHS": false,
         "BAZEL_PATH": "bazel",
@@ -14,29 +14,29 @@
     "configuration": "darwin_x86_64-dbg-ST-14942f8a2d44",
     "custom_xcode_schemes": [],
     "extra_files": [
-        "lib/BUILD",
-        "lib/lib.h",
-        "lib2/BUILD",
+        "examples/cc/lib/BUILD",
+        "examples/cc/lib/lib.h",
+        "examples/cc/lib2/BUILD",
         {
             "_": "examples_cc_external/lib.h",
             "t": "e"
         },
-        "tool/BUILD",
-        "test/fixtures/BUILD"
+        "examples/cc/tool/BUILD",
+        "test/fixtures/cc/BUILD"
     ],
     "force_bazel_dependencies": false,
     "index_import": {
         "t": "g",
-        "_": "darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import"
+        "_": "darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/build_bazel_rules_swift_index_import/index-import"
     },
-    "label": "//test/fixtures:xcodeproj_bwb.generator",
-    "name": "bwb",
+    "label": "//test/fixtures/cc:xcodeproj_bwx.generator",
+    "name": "bwx",
     "replacement_labels": [],
     "scheme_autogeneration_mode": "auto",
     "target_hosts": [],
     "target_merges": [],
     "targets": [
-        "//lib2:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1",
+        "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-3688109ddba2",
         {
             "build_settings": {
                 "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
@@ -75,19 +75,19 @@
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
-            "configuration": "darwin_x86_64-dbg-ST-a9822d5480e1",
+            "configuration": "darwin_x86_64-dbg-ST-3688109ddba2",
             "inputs": {
                 "hdrs": [
-                    "lib2/includes/lib.h"
+                    "examples/cc/lib2/includes/lib.h"
                 ],
                 "srcs": [
-                    "lib2/lib.c"
+                    "examples/cc/lib2/lib.c"
                 ]
             },
             "is_swift": false,
-            "label": "//lib2:lib_impl",
+            "label": "//examples/cc/lib2:lib_impl",
             "name": "lib_impl",
-            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2",
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib2",
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "12.0",
@@ -98,7 +98,7 @@
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
-                    "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/liblib_impl.a",
+                    "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib2/liblib_impl.a",
                     "t": "g"
                 },
                 "type": "com.apple.product-type.library.static"
@@ -107,20 +107,20 @@
                 "quote_includes": [
                     ".",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin",
                         "t": "g"
                     }
                 ],
                 "system_includes": [
-                    "lib2/includes",
+                    "examples/cc/lib2/includes",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/includes",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib2/includes",
                         "t": "g"
                     }
                 ]
             }
         },
-        "//lib:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1",
+        "//examples/cc/lib:lib_impl darwin_x86_64-dbg-ST-3688109ddba2",
         {
             "build_settings": {
                 "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
@@ -160,17 +160,17 @@
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
-            "configuration": "darwin_x86_64-dbg-ST-a9822d5480e1",
+            "configuration": "darwin_x86_64-dbg-ST-3688109ddba2",
             "inputs": {
                 "srcs": [
-                    "lib/lib.c",
-                    "lib/private/private.h"
+                    "examples/cc/lib/lib.c",
+                    "examples/cc/lib/private/private.h"
                 ]
             },
             "is_swift": false,
-            "label": "//lib:lib_impl",
+            "label": "//examples/cc/lib:lib_impl",
             "name": "lib_impl",
-            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib",
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib",
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "12.0",
@@ -181,29 +181,29 @@
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
-                    "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib/liblib_impl.lo",
+                    "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib/liblib_impl.lo",
                     "t": "g"
                 },
                 "type": "com.apple.product-type.library.static"
             },
             "search_paths": {
                 "includes": [
-                    "lib/private",
+                    "examples/cc/lib/private",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib/private",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib/private",
                         "t": "g"
                     }
                 ],
                 "quote_includes": [
                     ".",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin",
                         "t": "g"
                     }
                 ]
             }
         },
-        "//tool:tool darwin_x86_64-dbg-ST-a9822d5480e1",
+        "//examples/cc/tool:tool darwin_x86_64-dbg-ST-3688109ddba2",
         {
             "build_settings": {
                 "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
@@ -244,23 +244,23 @@
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
-            "configuration": "darwin_x86_64-dbg-ST-a9822d5480e1",
+            "configuration": "darwin_x86_64-dbg-ST-3688109ddba2",
             "dependencies": [
-                "//lib:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1",
-                "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1",
-                "//lib2:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1"
+                "//examples/cc/lib:lib_impl darwin_x86_64-dbg-ST-3688109ddba2",
+                "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-3688109ddba2",
+                "//examples/cc/lib2:lib_impl darwin_x86_64-dbg-ST-3688109ddba2"
             ],
             "inputs": {
                 "srcs": [
-                    "tool/main.c"
+                    "examples/cc/tool/main.c"
                 ]
             },
             "is_swift": false,
-            "label": "//tool:tool",
+            "label": "//examples/cc/tool:tool",
             "linker_inputs": {
                 "force_load": [
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib/liblib_impl.lo",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib/liblib_impl.lo",
                         "t": "g"
                     }
                 ],
@@ -271,11 +271,11 @@
                 ],
                 "static_libraries": [
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/liblib_impl.a",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib2/liblib_impl.a",
                         "t": "g"
                     },
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external/liblib_impl.a",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a",
                         "t": "g"
                     }
                 ]
@@ -283,11 +283,11 @@
             "name": "tool",
             "outputs": {
                 "p": {
-                    "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/tool/rules_xcodeproj/tool/tool",
+                    "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/tool/rules_xcodeproj/tool/tool",
                     "t": "g"
                 }
             },
-            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/tool",
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/tool",
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "12.0",
@@ -298,7 +298,7 @@
                 "executable_name": "tool",
                 "name": "tool",
                 "path": {
-                    "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/tool/rules_xcodeproj/tool/tool",
+                    "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/tool/rules_xcodeproj/tool/tool",
                     "t": "g"
                 },
                 "type": "com.apple.product-type.tool"
@@ -307,7 +307,7 @@
                 "quote_includes": [
                     ".",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin",
                         "t": "g"
                     },
                     {
@@ -315,7 +315,7 @@
                         "t": "e"
                     },
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external",
                         "t": "g"
                     },
                     {
@@ -323,20 +323,20 @@
                         "t": "e"
                     },
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/bazel_tools",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/external/bazel_tools",
                         "t": "g"
                     }
                 ],
                 "system_includes": [
-                    "lib2/includes",
+                    "examples/cc/lib2/includes",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/includes",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/examples/cc/lib2/includes",
                         "t": "g"
                     }
                 ]
             }
         },
-        "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-a9822d5480e1",
+        "@examples_cc_external//:lib_impl darwin_x86_64-dbg-ST-3688109ddba2",
         {
             "build_settings": {
                 "CLANG_CXX_LANGUAGE_STANDARD": "c++0x",
@@ -376,7 +376,7 @@
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
                 "SWIFT_VERSION": "5"
             },
-            "configuration": "darwin_x86_64-dbg-ST-a9822d5480e1",
+            "configuration": "darwin_x86_64-dbg-ST-3688109ddba2",
             "inputs": {
                 "hdrs": [
                     {
@@ -398,7 +398,7 @@
             "is_swift": false,
             "label": "@examples_cc_external//:lib_impl",
             "name": "lib_impl",
-            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external",
+            "package_bin_dir": "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external",
             "platform": {
                 "arch": "x86_64",
                 "minimum_os_version": "12.0",
@@ -409,7 +409,7 @@
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
-                    "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external/liblib_impl.a",
+                    "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a",
                     "t": "g"
                 },
                 "type": "com.apple.product-type.library.static"
@@ -421,7 +421,7 @@
                         "t": "e"
                     },
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external/private",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/private",
                         "t": "g"
                     }
                 ],
@@ -431,12 +431,12 @@
                         "t": "e"
                     },
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external",
                         "t": "g"
                     },
                     ".",
                     {
-                        "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin",
+                        "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin",
                         "t": "g"
                     }
                 ]

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -2445,6 +2445,7 @@
 				GENERATOR_PACKAGE_BIN_DIR = "darwin_x86_64-dbg-ST-14942f8a2d44/bin/test/fixtures/generator";
 				GENERATOR_TARGET_NAME = xcodeproj_bwb.generator;
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
+				INDEX_IMPORT = "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import";
 				RESOLVED_EXTERNAL_REPOSITORIES = "";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SUPPORTED_PLATFORMS = macosx;

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -26,11 +26,12 @@ if [ "$ACTION" == "indexbuild" ]; then
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-    # Inputs for compiling, inputs for linking
-    readonly output_group_prefixes="xc,xl"
+    # Inputs for compiling, inputs for linking, and index store data
+    readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules) and products (i.e. bundles)
-    readonly output_group_prefixes="bc,bp"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
+    # store data
+    readonly output_group_prefixes="bc,bp,bi"
   fi
 fi
 
@@ -189,10 +190,16 @@ touch "$build_marker"
   "$GENERATOR_LABEL" \
   2>&1
 
+indexstores_filelists=()
 for output_group in "${output_groups[@]}"; do
   filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
   filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
   filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
   if [[ "$filelist" -ot "$build_marker" ]]; then
     echo "error: Bazel didn't generate the correct files (it should have" \
 "generated outputs for output group \"$output_group\", but the timestamp for" \
@@ -208,3 +215,32 @@ for output_group in "${output_groups[@]}"; do
     exit 1
   fi
 done
+
+# Async actions
+#
+# For these commands to run in the background, both stdout and stderr need to be
+# redirected, otherwise Xcode will block the run script.
+
+log_dir="$OBJROOT/rules_xcodeproj_logs"
+mkdir -p "$log_dir"
+
+# Report errors from previous async actions
+shopt -s nullglob
+for log in "$log_dir"/*.async.log; do
+  if [[ -s "$log" ]]; then
+    command=$(basename "${log%.async.log}")
+    echo "warning: Previous run of \"$command\" had output:" >&2
+    sed "s|^|warning: |" "$log" >&2
+    echo "warning: If you believe this is a bug, please file a report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+  fi
+done
+
+# Import indexes
+if [ -n "${indexstores_filelists:-}" ]; then
+  "$BAZEL_INTEGRATION_DIR/import_indexstores.sh" \
+    "$execution_root" \
+    "${indexstores_filelists[@]}" \
+    >"$log_dir/import_indexstores.async.log" 2>&1 &
+fi

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly pidfile="$OBJROOT/import_indexstores.pid"
+readonly execution_root="$1"
+shift
+
+# Kill previously running import
+if [[ -s "$pidfile" ]]; then
+  pid=$(cat "$pidfile")
+  kill "$pid" 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null; do
+    sleep 1
+  done
+fi
+
+# Exit early if no indexstore filelists were provided
+if [ $# -eq 0 ]; then
+  exit
+fi
+
+# Set pid to allow cleanup later
+echo $$ > "$pidfile"
+trap 'rm "$pidfile" 2>/dev/null || true' EXIT
+
+# Merge all filelists into a single file
+filelist="$(mktemp)"
+sort -u "$@" | sed "s|^|$execution_root/|" > "$filelist"
+
+# Exit early if no indexstores were provided
+if [ ! -s "$filelist" ]; then
+  exit
+fi
+
+# Set remaps
+
+# Since users can override `--output_base`, all we know is that the
+# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
+readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+
+# We remove any `/private` prefix from the current execution_root, since it's
+# removed in the Project navigator.
+readonly xcode_execution_root="${execution_root#/private}"
+
+# The order of remaps is important. The first match is used. So we try the most
+# specific first. This also allows us to assume previous matches have taken care
+# of those types of files, so more general matches still work later.
+remaps=(
+  # Object files
+  #
+  # These currently come back relative, but we have the execution_root as an
+  # optional prefix in case this changes in the future. The path is based on
+  # rules_swift's current logic:
+  # https://github.com/bazelbuild/rules_swift/blob/6153a848f747e90248a8673869c49631f1323ff3/swift/internal/derived_files.bzl#L114-L119
+  # When we add support for C-based index imports we will have to use another
+  # pattern:
+  # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$PROJECT_TEMP_DIR/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+
+  # Generated sources and swiftmodules
+  #
+  # With object files taken care of, any other paths with `bazel-out/` as their
+  # prefix (relative to the execution_root) are assumed to be generated outputs.
+  # The two kinds of generated outputs used in the unit files are swiftmodule
+  # and source paths. So we map that, along with the `external/` prefix for
+  # external sources, to the current execution_root. Finally, currently these
+  # paths are returned as absolute, but a future change might make them
+  # relative, similar to the object files, so we have the execution_root as an
+  # optional prefix.
+  -remap "^(?:$execution_root_regex/)?bazel-out/=$xcode_execution_root/bazel-out/"
+
+  # External sources
+  #
+  # External sources need to be handled differently, since we use the
+  # non-symlinked version in Xcode.
+  -remap "^(?:$execution_root_regex/)?external/=${xcode_execution_root%/*/*}/external/"
+
+  # Project sources
+  #
+  # With the other source files and generated files taken care of, all other
+  # execution_root prefixed paths should be project sources.
+  -remap "^$execution_root_regex=$SRCROOT"
+
+  # Sysroot
+  #
+  # The only other type of path in the unit files are sysroot based. While
+  # these should always be Xcode.app relative, our regex supports command-line
+  # tools based paths as well.
+  -remap "^(?:.*?/[^/]+/Contents/Developer|/Library/Developer/CommandLineTools).*?/SDKs/([^\\d.]+)=$DEVELOPER_DIR/Platforms/\$1.platform/Developer/SDKs/\$1"
+)
+
+# Import
+
+mkdir -p "$INDEX_DATA_STORE_DIR"
+
+"$INDEX_IMPORT" \
+    -undo-rules_swift-renames \
+    "${remaps[@]}" \
+    -incremental \
+    @"$filelist" \
+    "$INDEX_DATA_STORE_DIR"
+
+# Unit files are created fresh, but record files are copied from `bazel-out/`,
+# which are read-only. We need to adjust their permissions.
+# TODO: Do this in `index-import`
+chmod -R u+w "$INDEX_DATA_STORE_DIR"

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -35,6 +35,16 @@ build:rules_xcodeproj --features=relative_ast_path
 # this in `swift_debug_settings.py`, so debugging still works.
 build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 
+# `swift.index-while-building` passes `-index-store-path` to `swiftc`, which
+# generates index store data. We enable this globally, and don't disable it in
+# `rules_xcodeproj_indexbuild`, even though we only need it for the normal
+# build, because it's better to get cache hits between normal and Index Build
+# builds than it is to save some time in an uncached Index Build build. We only
+# download the outputs in the normal build though, saving some bandwidth/disk
+# space.
+build:rules_xcodeproj --features=swift.index_while_building
+build:rules_xcodeproj --features=swift.use_global_index_store
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
@@ -72,6 +82,10 @@ build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
+
+# Unset `swift.index-while-building` since we don't need index store data, and
+# we already have cache misses from the `swiftc` flags above
+build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -74,6 +74,10 @@
         "test/fixtures/generator/BUILD"
     ],
     "force_bazel_dependencies": true,
+    "index_import": {
+        "t": "g",
+        "_": "darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import"
+    },
     "label": "//test/fixtures/generator:xcodeproj_bwb.generator",
     "name": "bwb",
     "replacement_labels": [

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -2418,6 +2418,7 @@
 				GENERATOR_PACKAGE_BIN_DIR = "darwin_x86_64-dbg-ST-14942f8a2d44/bin/test/fixtures/generator";
 				GENERATOR_TARGET_NAME = xcodeproj_bwx.generator;
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
+				INDEX_IMPORT = "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import";
 				RESOLVED_EXTERNAL_REPOSITORIES = "";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SUPPORTED_PLATFORMS = macosx;

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -26,11 +26,12 @@ if [ "$ACTION" == "indexbuild" ]; then
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-    # Inputs for compiling, inputs for linking
-    readonly output_group_prefixes="xc,xl"
+    # Inputs for compiling, inputs for linking, and index store data
+    readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules) and products (i.e. bundles)
-    readonly output_group_prefixes="bc,bp"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
+    # store data
+    readonly output_group_prefixes="bc,bp,bi"
   fi
 fi
 
@@ -189,10 +190,16 @@ touch "$build_marker"
   "$GENERATOR_LABEL" \
   2>&1
 
+indexstores_filelists=()
 for output_group in "${output_groups[@]}"; do
   filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
   filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
   filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
   if [[ "$filelist" -ot "$build_marker" ]]; then
     echo "error: Bazel didn't generate the correct files (it should have" \
 "generated outputs for output group \"$output_group\", but the timestamp for" \
@@ -208,3 +215,32 @@ for output_group in "${output_groups[@]}"; do
     exit 1
   fi
 done
+
+# Async actions
+#
+# For these commands to run in the background, both stdout and stderr need to be
+# redirected, otherwise Xcode will block the run script.
+
+log_dir="$OBJROOT/rules_xcodeproj_logs"
+mkdir -p "$log_dir"
+
+# Report errors from previous async actions
+shopt -s nullglob
+for log in "$log_dir"/*.async.log; do
+  if [[ -s "$log" ]]; then
+    command=$(basename "${log%.async.log}")
+    echo "warning: Previous run of \"$command\" had output:" >&2
+    sed "s|^|warning: |" "$log" >&2
+    echo "warning: If you believe this is a bug, please file a report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+  fi
+done
+
+# Import indexes
+if [ -n "${indexstores_filelists:-}" ]; then
+  "$BAZEL_INTEGRATION_DIR/import_indexstores.sh" \
+    "$execution_root" \
+    "${indexstores_filelists[@]}" \
+    >"$log_dir/import_indexstores.async.log" 2>&1 &
+fi

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -35,6 +35,16 @@ build:rules_xcodeproj --features=relative_ast_path
 # this in `swift_debug_settings.py`, so debugging still works.
 build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 
+# `swift.index-while-building` passes `-index-store-path` to `swiftc`, which
+# generates index store data. We enable this globally, and don't disable it in
+# `rules_xcodeproj_indexbuild`, even though we only need it for the normal
+# build, because it's better to get cache hits between normal and Index Build
+# builds than it is to save some time in an uncached Index Build build. We only
+# download the outputs in the normal build though, saving some bandwidth/disk
+# space.
+build:rules_xcodeproj --features=swift.index_while_building
+build:rules_xcodeproj --features=swift.use_global_index_store
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
@@ -72,6 +82,10 @@ build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
+
+# Unset `swift.index-while-building` since we don't need index store data, and
+# we already have cache misses from the `swiftc` flags above
+build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -74,6 +74,10 @@
         "test/fixtures/generator/BUILD"
     ],
     "force_bazel_dependencies": true,
+    "index_import": {
+        "t": "g",
+        "_": "darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import"
+    },
     "label": "//test/fixtures/generator:xcodeproj_bwx.generator",
     "name": "bwx",
     "replacement_labels": [

--- a/tools/generator/src/DTO/Project.swift
+++ b/tools/generator/src/DTO/Project.swift
@@ -13,4 +13,5 @@ struct Project: Equatable, Decodable {
     let schemeAutogenerationMode: SchemeAutogenerationMode
     let customXcodeSchemes: [XcodeScheme]
     let forceBazelDependencies: Bool
+    let indexImport: FilePath
 }

--- a/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
+++ b/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
@@ -22,6 +22,7 @@ extension Generator {
         in pbxProj: PBXProj,
         buildMode: BuildMode,
         forceBazelDependencies: Bool,
+        indexImport: FilePath,
         files: [FilePath: File],
         filePathResolver: FilePathResolver,
         resolvedExternalRepositories: [(Path, Path)],
@@ -61,6 +62,8 @@ $(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py
 """,
                 "GENERATOR_TARGET_NAME": xcodeprojBazelLabel.name,
                 "INDEX_DATA_STORE_DIR": "$(INDEX_DATA_STORE_DIR)",
+                "INDEX_IMPORT":try filePathResolver
+                    .resolve(indexImport, useBazelOut: true).string,
                 "RESOLVED_EXTERNAL_REPOSITORIES": resolvedExternalRepositories
                     // Sorted by length to ensure that subdirectories are listed first
                     .sorted { $0.0.string.count > $1.0.string.count }

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -64,6 +64,7 @@ struct Environment {
         _ pbxProj: PBXProj,
         _ buildMode: BuildMode,
         _ forceBazelDependencies: Bool,
+        _ indexImport: FilePath,
         _ files: [FilePath: File],
         _ filePathResolver: FilePathResolver,
         _ resolvedExternalRepositories: [(Path, Path)],

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -126,6 +126,7 @@ class Generator {
             pbxProj,
             buildMode,
             project.forceBazelDependencies,
+            project.indexImport,
             files,
             filePathResolver,
             resolvedExternalRepositories,

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -35,7 +35,8 @@ enum Fixtures {
         ],
         schemeAutogenerationMode: .auto,
         customXcodeSchemes: [],
-        forceBazelDependencies: false
+        forceBazelDependencies: false,
+        indexImport: "/tmp/index-import"
     )
 
     static let extensionPointIdentifiers: [TargetID: ExtensionPointIdentifier] = [

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -25,7 +25,8 @@ final class GeneratorTests: XCTestCase {
             extraFiles: [],
             schemeAutogenerationMode: .auto,
             customXcodeSchemes: [],
-            forceBazelDependencies: false
+            forceBazelDependencies: false,
+            indexImport: "/tmp/index-import"
         )
         let xccurrentversions: [XCCurrentVersion] = [
             .init(container: "Ex/M.xcdatamodeld", version: "M2.xcdatamodel"),
@@ -465,6 +466,7 @@ final class GeneratorTests: XCTestCase {
             let pbxProj: PBXProj
             let buildMode: BuildMode
             let forceBazelDependencies: Bool
+            let indexImport: FilePath
             let files: [FilePath: File]
             let filePathResolver: FilePathResolver
             let bazelConfig: String
@@ -479,6 +481,7 @@ final class GeneratorTests: XCTestCase {
             in pbxProj: PBXProj,
             buildMode: BuildMode,
             forceBazelDependencies: Bool,
+            indexImport: FilePath,
             files: [FilePath: File],
             filePathResolver: FilePathResolver,
             resolvedExternalRepositories: [(Path, Path)],
@@ -491,6 +494,7 @@ final class GeneratorTests: XCTestCase {
                 pbxProj: pbxProj,
                 buildMode: buildMode,
                 forceBazelDependencies: forceBazelDependencies,
+                indexImport: indexImport,
                 files: files,
                 filePathResolver: filePathResolver,
                 bazelConfig: bazelConfig,
@@ -506,6 +510,7 @@ final class GeneratorTests: XCTestCase {
                 pbxProj: pbxProj,
                 buildMode: buildMode,
                 forceBazelDependencies: project.forceBazelDependencies,
+                indexImport: project.indexImport,
                 files: files,
                 filePathResolver: filePathResolver,
                 bazelConfig: project.bazelConfig,

--- a/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
+++ b/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly pidfile="$OBJROOT/import_indexstores.pid"
+readonly execution_root="$1"
+shift
+
+# Kill previously running import
+if [[ -s "$pidfile" ]]; then
+  pid=$(cat "$pidfile")
+  kill "$pid" 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null; do
+    sleep 1
+  done
+fi
+
+# Exit early if no indexstore filelists were provided
+if [ $# -eq 0 ]; then
+  exit
+fi
+
+# Set pid to allow cleanup later
+echo $$ > "$pidfile"
+trap 'rm "$pidfile" 2>/dev/null || true' EXIT
+
+# Merge all filelists into a single file
+filelist="$(mktemp)"
+sort -u "$@" | sed "s|^|$execution_root/|" > "$filelist"
+
+# Exit early if no indexstores were provided
+if [ ! -s "$filelist" ]; then
+  exit
+fi
+
+# Set remaps
+
+# Since users can override `--output_base`, all we know is that the
+# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
+readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+
+# We remove any `/private` prefix from the current execution_root, since it's
+# removed in the Project navigator.
+readonly xcode_execution_root="${execution_root#/private}"
+
+# The order of remaps is important. The first match is used. So we try the most
+# specific first. This also allows us to assume previous matches have taken care
+# of those types of files, so more general matches still work later.
+remaps=(
+  # Object files
+  #
+  # These currently come back relative, but we have the execution_root as an
+  # optional prefix in case this changes in the future. The path is based on
+  # rules_swift's current logic:
+  # https://github.com/bazelbuild/rules_swift/blob/6153a848f747e90248a8673869c49631f1323ff3/swift/internal/derived_files.bzl#L114-L119
+  # When we add support for C-based index imports we will have to use another
+  # pattern:
+  # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$PROJECT_TEMP_DIR/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+
+  # Generated sources and swiftmodules
+  #
+  # With object files taken care of, any other paths with `bazel-out/` as their
+  # prefix (relative to the execution_root) are assumed to be generated outputs.
+  # The two kinds of generated outputs used in the unit files are swiftmodule
+  # and source paths. So we map that, along with the `external/` prefix for
+  # external sources, to the current execution_root. Finally, currently these
+  # paths are returned as absolute, but a future change might make them
+  # relative, similar to the object files, so we have the execution_root as an
+  # optional prefix.
+  -remap "^(?:$execution_root_regex/)?bazel-out/=$xcode_execution_root/bazel-out/"
+
+  # External sources
+  #
+  # External sources need to be handled differently, since we use the
+  # non-symlinked version in Xcode.
+  -remap "^(?:$execution_root_regex/)?external/=${xcode_execution_root%/*/*}/external/"
+
+  # Project sources
+  #
+  # With the other source files and generated files taken care of, all other
+  # execution_root prefixed paths should be project sources.
+  -remap "^$execution_root_regex=$SRCROOT"
+
+  # Sysroot
+  #
+  # The only other type of path in the unit files are sysroot based. While
+  # these should always be Xcode.app relative, our regex supports command-line
+  # tools based paths as well.
+  -remap "^(?:.*?/[^/]+/Contents/Developer|/Library/Developer/CommandLineTools).*?/SDKs/([^\\d.]+)=$DEVELOPER_DIR/Platforms/\$1.platform/Developer/SDKs/\$1"
+)
+
+# Import
+
+mkdir -p "$INDEX_DATA_STORE_DIR"
+
+"$INDEX_IMPORT" \
+    -undo-rules_swift-renames \
+    "${remaps[@]}" \
+    -incremental \
+    @"$filelist" \
+    "$INDEX_DATA_STORE_DIR"
+
+# Unit files are created fresh, but record files are copied from `bazel-out/`,
+# which are read-only. We need to adjust their permissions.
+# TODO: Do this in `index-import`
+chmod -R u+w "$INDEX_DATA_STORE_DIR"

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -17,7 +17,7 @@ load(
     "parsed_file_path",
 )
 load(":linker_input_files.bzl", "linker_input_files")
-load(":output_files.bzl", "parse_swift_info_module", "swift_to_list")
+load(":output_files.bzl", "parse_swift_info_module", "swift_to_outputs")
 load(":output_group_map.bzl", "output_group_map")
 load(":providers.bzl", "XcodeProjInfo")
 load(":resources.bzl", "collect_resources")
@@ -357,6 +357,7 @@ def _collect(
         ))
 
     # Collect unfocused target info
+    indexstores = []
     unfocused_libraries = None
     if should_include_non_xcode_outputs(ctx = ctx):
         if unfocused == None:
@@ -413,7 +414,12 @@ def _collect(
                 ],
             )
         for module in non_target_swift_info_modules.to_list():
-            generated.extend(swift_to_list(parse_swift_info_module(module)))
+            compiled, indexstore = swift_to_outputs(
+                parse_swift_info_module(module),
+            )
+            generated.extend(compiled)
+            if indexstore:
+                indexstores.append(indexstore)
 
         if is_swift:
             unfocused_swift_info_modules = target[SwiftInfo].transitive_modules
@@ -421,18 +427,29 @@ def _collect(
             unfocused_swift_info_modules = non_target_swift_info_modules
 
         unfocused_generated_compiling = []
+        unfocused_generated_indexstores = []
         for module in unfocused_swift_info_modules.to_list():
-            unfocused_generated_compiling.extend(
-                swift_to_list(parse_swift_info_module(module)),
+            compiled, indexstore = swift_to_outputs(
+                parse_swift_info_module(module),
             )
+            unfocused_generated_compiling.extend(compiled)
+            if indexstore:
+                unfocused_generated_indexstores.append(indexstore)
 
         if unfocused_generated_compiling:
             unfocused_generated_compiling = tuple(unfocused_generated_compiling)
         else:
             unfocused_generated_compiling = None
+        if unfocused_generated_indexstores:
+            unfocused_generated_indexstores = tuple(
+                unfocused_generated_indexstores,
+            )
+        else:
+            unfocused_generated_indexstores = None
     else:
         non_target_swift_info_modules = depset()
         unfocused_generated_compiling = None
+        unfocused_generated_indexstores = None
         unfocused_generated_linking = None
 
     important_generated = [
@@ -450,16 +467,28 @@ def _collect(
                 automatic_target_info.xcode_targets.get(attr, [None]))
         ],
     )
+    indexstores_depset = depset(
+        indexstores if indexstores else None,
+        transitive = [
+            info.inputs.indexstores
+            for attr, info in transitive_infos
+            if (info.target_type in
+                automatic_target_info.xcode_targets.get(attr, [None]))
+        ],
+    )
 
     if id:
         compiling_output_group_name = "xc {}".format(id)
+        indexstores_output_group_name = "xi {}".format(id)
         linking_output_group_name = "xl {}".format(id)
         direct_group_list = [
             (compiling_output_group_name, generated_depset),
+            (indexstores_output_group_name, indexstores_depset),
             (linking_output_group_name, depset()),
         ]
     else:
         compiling_output_group_name = None
+        indexstores_output_group_name = None
         linking_output_group_name = None
         direct_group_list = None
 
@@ -599,6 +628,7 @@ def _collect(
             ],
         ),
         unfocused_generated_compiling = unfocused_generated_compiling,
+        unfocused_generated_indexstores = unfocused_generated_indexstores,
         unfocused_generated_linking = unfocused_generated_linking,
         has_generated_files = bool(generated) or bool([
             True
@@ -607,6 +637,7 @@ def _collect(
                 (info.target_type in
                  automatic_target_info.xcode_targets.get(attr, [None])))
         ]),
+        indexstores = indexstores_depset,
         extra_files = depset(
             [(id, tuple(extra_files))] if (id and extra_files) else None,
             transitive = [
@@ -627,6 +658,7 @@ def _collect(
         ),
         unfocused_libraries = unfocused_libraries,
         compiling_output_group_name = compiling_output_group_name,
+        indexstores_output_group_name = indexstores_output_group_name,
         linking_output_group_name = linking_output_group_name,
     )
 
@@ -650,11 +682,15 @@ def _from_resource_bundle(bundle):
         xccurrentversions = depset(),
         generated = depset(),
         important_generated = depset(),
-        unfocused_generated = None,
+        unfocused_generated_compiling = None,
+        unfocused_generated_indexstores = None,
+        unfocused_generated_linking = None,
+        indexstores = depset(),
         extra_files = depset(),
         uncategorized = depset(),
         unfocused_libraries = depset(),
         compiling_output_group_name = None,
+        indexstores_output_group_name = None,
         linking_output_group_name = None,
     )
 
@@ -740,12 +776,20 @@ def _merge(*, transitive_infos, extra_generated = None):
                 for _, info in transitive_infos
             ],
         ),
-        unfocused_generated = None,
+        unfocused_generated_compiling = None,
+        unfocused_generated_indexstores = None,
+        unfocused_generated_linking = None,
         has_generated_files = bool([
             True
             for _, info in transitive_infos
             if info.inputs.has_generated_files
         ]),
+        indexstores = depset(
+            transitive = [
+                info.inputs.indexstores
+                for _, info in transitive_infos
+            ],
+        ),
         extra_files = depset(
             transitive = [
                 info.inputs.extra_files
@@ -765,6 +809,7 @@ def _merge(*, transitive_infos, extra_generated = None):
             ],
         ),
         compiling_output_group_name = None,
+        indexstores_output_group_name = None,
         linking_output_group_name = None,
     )
 
@@ -830,7 +875,7 @@ def _to_output_groups_fields(
         ctx,
         inputs,
         additional_generated = {},
-        top_level_cache_buster):
+        additional_output_map_inputs):
     """Generates a dictionary to be splatted into `OutputGroupInfo`.
 
     Args:
@@ -839,10 +884,11 @@ def _to_output_groups_fields(
         additional_generated: A `dict` that maps the output group name of
             targets to a `list` of `depset`s of `File`s that should be merged
             into the output group map for that output group name.
-        top_level_cache_buster: A `File` that changes with each build, and is
-            used as an input to the output map generation, to ensure that
-            the files references by the output map are always downloaded from
-            the remote cache, even when using `--remote_download_toplevel`.
+        additional_output_map_inputs: A `list` of `File`s that are used as
+            additional inputs to the output map generation. Minimally contains a
+            `File` that changes with each build, to ensure that the files
+            references by the output map are always downloaded from the remote
+            cache, even when using `--remote_download_toplevel`.
 
     Returns:
         A `dict` where the keys are output group names and the values are
@@ -862,7 +908,7 @@ def _to_output_groups_fields(
             ctx = ctx,
             name = name.replace("/", "_"),
             files = files,
-            top_level_cache_buster = top_level_cache_buster,
+            additional_inputs = additional_output_map_inputs,
         )])
         for name, files in all_files.items()
     }
@@ -876,7 +922,19 @@ def _to_output_groups_fields(
                 if name.startswith("xc")
             ],
         ),
-        top_level_cache_buster = top_level_cache_buster,
+        additional_inputs = additional_output_map_inputs,
+    )])
+    output_groups["all_xi"] = depset([output_group_map.write_map(
+        ctx = ctx,
+        name = "all_xi",
+        files = depset(
+            transitive = [
+                files
+                for name, files in all_files.items()
+                if name.startswith("xi")
+            ],
+        ),
+        additional_inputs = additional_output_map_inputs,
     )])
     output_groups["all_xl"] = depset([output_group_map.write_map(
         ctx = ctx,
@@ -888,7 +946,7 @@ def _to_output_groups_fields(
                 if name.startswith("xl")
             ],
         ),
-        top_level_cache_buster = top_level_cache_buster,
+        additional_inputs = additional_output_map_inputs,
     )])
 
     return output_groups

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -37,6 +37,8 @@ _SWIFTC_SKIP_OPTS = {
     "-enable-batch-mode": 1,
     # TODO: See if we need to support this
     "-gline-tables-only": 1,
+    "-index-ignore-system-modules": 1,
+    "-index-store-path": 2,
     "-module-name": 2,
     "-num-threads": 2,
     "-output-file-map": 2,

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -37,6 +37,7 @@ def _create(
     """
     direct_products = []
     direct_compiles = []
+    indexstore = None
 
     if infoplist:
         direct_products.append(infoplist)
@@ -44,7 +45,8 @@ def _create(
     if direct_outputs:
         swift = direct_outputs.swift
         if swift:
-            direct_compiles.extend(swift_to_list(swift))
+            compiles, indexstore = swift_to_outputs(swift)
+            direct_compiles.extend(compiles)
 
         if direct_outputs.product:
             direct_products.append(direct_outputs.product)
@@ -55,6 +57,18 @@ def _create(
         direct_compiles if direct_compiles else None,
         transitive = [
             info.outputs._transitive_compiles
+            for attr, info in transitive_infos
+            if (not automatic_target_info or
+                info.target_type in automatic_target_info.xcode_targets.get(
+                    attr,
+                    [None],
+                ))
+        ],
+    )
+    transitive_indexestores = depset(
+        [indexstore] if indexstore else None,
+        transitive = [
+            info.outputs._transitive_indexestores
             for attr, info in transitive_infos
             if (not automatic_target_info or
                 info.target_type in automatic_target_info.xcode_targets.get(
@@ -92,6 +106,7 @@ def _create(
         products_output_group_name = "bp {}".format(direct_outputs.id)
         direct_group_list = [
             ("bc {}".format(direct_outputs.id), transitive_compiles),
+            ("bi {}".format(direct_outputs.id), transitive_indexestores),
             (products_output_group_name, transitive_products),
         ]
     else:
@@ -115,6 +130,7 @@ def _create(
         _direct_outputs = direct_outputs if should_produce_dto else None,
         _output_group_list = output_group_list,
         _transitive_compiles = transitive_compiles,
+        _transitive_indexestores = transitive_indexestores,
         _transitive_products = transitive_products,
         _transitive_swift = transitive_swift,
         products_output_group_name = products_output_group_name,
@@ -273,7 +289,7 @@ def _to_output_groups_fields(
         ctx,
         outputs,
         additional_outputs = {},
-        top_level_cache_buster):
+        additional_output_map_inputs):
     """Generates a dictionary to be splatted into `OutputGroupInfo`.
 
     Args:
@@ -282,10 +298,11 @@ def _to_output_groups_fields(
         additional_outputs: A `dict` that maps the output group name of
             targets to a `list` of `depset`s of `File`s that should be merged
             into the output group map for that output group name.
-        top_level_cache_buster: A `File` that changes with each build, and is
-            used as an input to the output map generation, to ensure that
-            the files references by the output map are always downloaded from
-            the remote cache, even when using `--remote_download_toplevel`.
+        additional_output_map_inputs: A `list` of `File`s that are used as
+            additional inputs to the output map generation. Minimally contains a
+            `File` that changes with each build, to ensure that the files
+            references by the output map are always downloaded from the remote
+            cache, even when using `--remote_download_toplevel`.
 
     Returns:
         A `dict` where the keys are output group names and the values are
@@ -305,7 +322,7 @@ def _to_output_groups_fields(
             ctx = ctx,
             name = name.replace("/", "_"),
             files = files,
-            top_level_cache_buster = top_level_cache_buster,
+            additional_inputs = additional_output_map_inputs,
         )])
         for name, files in all_files.items()
     }
@@ -313,7 +330,7 @@ def _to_output_groups_fields(
         ctx = ctx,
         name = "all_b",
         files = depset(transitive = all_files.values()),
-        top_level_cache_buster = top_level_cache_buster,
+        additional_inputs = additional_output_map_inputs,
     )])
 
     return output_groups
@@ -348,31 +365,33 @@ def parse_swift_info_module(module):
         generated_header = generated_header,
     )
 
-def swift_to_list(swift):
-    """Converts a Swift output struct to a list of `File`s.
+def swift_to_outputs(swift):
+    """Converts a Swift output struct to more easily consumable outputs.
 
     Args:
         swift: A value returned from `parse_swift_info_module`.
 
     Returns:
-        A `list` of `File`s.
-    """
-    ret = []
+        A `tuple` containing two elements:
 
+        *   A `list` of `File`s that can be used for future compiles (e.g.
+            `.swiftmodule`, `-Swift.h`).
+        *   A `File`s that represent generated index store data, or `None`.
+    """
     if not swift:
-        return ret
+        return ([], None)
 
     module = swift.module
-    ret.append(module.swiftdoc)
-    ret.append(module.swiftmodule)
-    if module.swiftsourceinfo:
-        ret.append(module.swiftsourceinfo)
-    if module.swiftinterface:
-        ret.append(module.swiftinterface)
-    if swift.generated_header:
-        ret.append(swift.generated_header)
 
-    return ret
+    compiles = [module.swiftdoc, module.swiftmodule]
+    if module.swiftsourceinfo:
+        compiles.append(module.swiftsourceinfo)
+    if module.swiftinterface:
+        compiles.append(module.swiftinterface)
+    if swift.generated_header:
+        compiles.append(swift.generated_header)
+
+    return (compiles, getattr(module, "indexstore", None))
 
 output_files = struct(
     collect = _collect,

--- a/xcodeproj/internal/output_group_map.bzl
+++ b/xcodeproj/internal/output_group_map.bzl
@@ -10,7 +10,7 @@
 # TODO: Use a different value for different types of outputs.
 _SHARD_SIZE = 75
 
-def _write_sharded_maps(*, ctx, name, files, top_level_cache_buster):
+def _write_sharded_maps(*, ctx, name, files, additional_inputs):
     files_list = files.to_list()
     length = len(files_list)
     shard_count = length // _SHARD_SIZE
@@ -25,7 +25,7 @@ def _write_sharded_maps(*, ctx, name, files, top_level_cache_buster):
                 shard = None,
                 shard_count = 1,
                 files = files,
-                top_level_cache_buster = top_level_cache_buster,
+                additional_inputs = additional_inputs,
             ),
         ]
 
@@ -41,7 +41,7 @@ def _write_sharded_maps(*, ctx, name, files, top_level_cache_buster):
                 shard = shard + 1,
                 shard_count = shard_count,
                 files = sharded_inputs,
-                top_level_cache_buster = top_level_cache_buster,
+                additional_inputs = additional_inputs,
             ),
         )
 
@@ -54,7 +54,7 @@ def _write_sharded_map(
         shard,
         shard_count,
         files,
-        top_level_cache_buster):
+        additional_inputs):
     args = ctx.actions.args()
     args.use_param_file("%s", use_always = True)
     args.set_param_file_format("multiline")
@@ -96,7 +96,7 @@ fi
         ],
         # Include files as inputs to cause them to be built or downloaded,
         # even if they aren't top level targets
-        inputs = depset([top_level_cache_buster], transitive = [files]),
+        inputs = depset(additional_inputs, transitive = [files]),
         mnemonic = "XcodeProjOutputMap",
         progress_message = progress_message,
         outputs = [output],
@@ -113,7 +113,7 @@ fi
 
     return output
 
-def _write_map(*, ctx, name, files, top_level_cache_buster):
+def _write_map(*, ctx, name, files, additional_inputs):
     if files == None:
         files = depset()
 
@@ -121,7 +121,7 @@ def _write_map(*, ctx, name, files, top_level_cache_buster):
         ctx = ctx,
         name = name,
         files = files,
-        top_level_cache_buster = top_level_cache_buster,
+        additional_inputs = additional_inputs,
     )
     if len(files_list) == 1:
         # If only one shared output map was generated, we use it as is
@@ -148,7 +148,7 @@ cat "$@" > "$output"
         ],
         # Include files as inputs to cause them to be built or downloaded,
         # even if they aren't top level targets
-        inputs = depset([top_level_cache_buster], transitive = [files]),
+        inputs = depset(additional_inputs, transitive = [files]),
         mnemonic = "XcodeProjOutputMapMerge",
         progress_message = "Merging '{}-{}' output map".format(
             ctx.attr.name,

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -147,6 +147,7 @@ targets.
     additional_outputs = {}
     for xcode_target in focused_targets:
         additional_compiling_files = []
+        additional_indexstores_files = []
         additional_linking_files = []
         for dependency in xcode_target.transitive_dependencies.to_list():
             unfocused_dependency = unfocused_dependencies.get(dependency)
@@ -155,12 +156,19 @@ targets.
             unfocused_compiling_files = (
                 unfocused_dependency.inputs.unfocused_generated_compiling
             )
+            unfocused_indexstores_files = (
+                unfocused_dependency.inputs.unfocused_generated_indexstores
+            )
             unfocused_linking_files = (
                 unfocused_dependency.inputs.unfocused_generated_linking
             )
             if unfocused_compiling_files:
                 additional_compiling_files.append(
                     depset(unfocused_compiling_files),
+                )
+            if unfocused_indexstores_files:
+                additional_indexstores_files.append(
+                    depset(unfocused_indexstores_files),
                 )
             if unfocused_linking_files:
                 additional_linking_files.append(
@@ -170,11 +178,20 @@ targets.
         compiling_output_group_name = (
             xcode_target.inputs.compiling_output_group_name
         )
+        indexstores_output_group_name = (
+            xcode_target.inputs.indexstores_output_group_name
+        )
         if compiling_output_group_name:
             set_if_true(
                 additional_generated,
                 compiling_output_group_name,
                 additional_compiling_files,
+            )
+        if indexstores_output_group_name:
+            set_if_true(
+                additional_generated,
+                indexstores_output_group_name,
+                additional_indexstores_files,
             )
 
         label = replacement_labels.get(
@@ -337,6 +354,7 @@ def _write_json_spec(
 "custom_xcode_schemes":{custom_xcode_schemes},\
 "extra_files":{extra_files},\
 "force_bazel_dependencies":{force_bazel_dependencies},\
+"index_import":{index_import},\
 "label":"{label}",\
 "name":"{name}",\
 "replacement_labels":{replacement_labels},\
@@ -354,6 +372,9 @@ def _write_json_spec(
         extra_files = json.encode(extra_files_dto),
         force_bazel_dependencies = json.encode(
             has_focused_targets or inputs.has_generated_files,
+        ),
+        index_import = file_path_to_dto(
+            file_path(ctx.executable._index_import),
         ),
         label = ctx.label,
         name = project_name,
@@ -518,6 +539,7 @@ def _write_xcodeproj(
             extensionpointidentifiers_file,
         ] + bazel_integration_files,
         outputs = [xcodeproj],
+        tools = [ctx.attr._index_import[DefaultInfo].files_to_run],
         execution_requirements = {
             # Projects can be rather large, and take almost no time to generate
             # This also works around any RBC tree artifact issues
@@ -723,18 +745,25 @@ def _xcodeproj_impl(ctx):
         ctx = ctx,
         inputs = inputs,
         additional_generated = additional_generated,
-        top_level_cache_buster = ctx.file._top_level_cache_buster,
+        additional_output_map_inputs = [
+            ctx.file._top_level_cache_buster,
+            ctx.executable._index_import,
+        ],
     )
     output_files_output_groups = output_files.to_output_groups_fields(
         ctx = ctx,
         outputs = outputs,
         additional_outputs = additional_outputs,
-        top_level_cache_buster = ctx.file._top_level_cache_buster,
+        additional_output_map_inputs = [
+            ctx.file._top_level_cache_buster,
+            ctx.executable._index_import,
+        ],
     )
 
     if build_mode == "xcode":
         all_targets_files = [
             input_files_output_groups["all_xc"],
+            input_files_output_groups["all_xi"],
             input_files_output_groups["all_xl"],
         ]
     else:
@@ -966,6 +995,11 @@ transitive dependencies of the targets specified in the
         "_generator": attr.label(
             cfg = "exec",
             default = Label("//tools/generator:universal_generator"),
+            executable = True,
+        ),
+        "_index_import": attr.label(
+            cfg = "exec",
+            default = Label("@rules_xcodeproj_index_import//:index_import"),
             executable = True,
         ),
         "_install_path": attr.label(

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -81,6 +81,29 @@ def xcodeproj_rules_dependencies(
         ignore_version_differences = ignore_version_differences,
     )
 
+    # `rules_swift` depends on `build_bazel_rules_swift_index_import`, and we
+    # also need to use `index-import`, so we could declare the same dependency
+    # here in order to reuse it, and in case `rules_swift` stops depending on it
+    # in the future. We don't though, because we need 5.5.3.1 or higher, and the
+    # currently lowest version of rules_swift we support uses 5.3.2.6.
+    _maybe(
+        http_archive,
+        name = "rules_xcodeproj_index_import",
+        build_file_content = """\
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+native_binary(
+    name = "index_import",
+    src = "index-import",
+    out = "index-import",
+    visibility = ["//visibility:public"],
+)
+""",
+        url = "https://github.com/MobileNativeFoundation/index-import/releases/download/5.5.3.1/index-import.tar.gz",
+        sha256 = "176ec3bf1e7ea4a0f5e320fc2fc666f4c736fb51d21a99a8ef134e19ed51ef5f",
+        ignore_version_differences = ignore_version_differences,
+    )
+
     _maybe(
         http_archive,
         name = "build_bazel_rules_apple",


### PR DESCRIPTION
Now `Bazel Build` will produce index store data for Swift targets similar to Xcode-built target. This speeds up Xcode getting to a state where it returns proper indexing data.

This is necessary, but not sufficient, to fix indexing of unfocused targets.