### PR TITLE
Use an external repository for top_level_cache_buster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 
 **/*.xcodeproj/xcuserdata/*
 **/*.xcodeproj/project.xcworkspace/xcuserdata/*
-**/*.xcodeproj/rules_xcodeproj/toplevel_cache_buster
 **/*.xcodeproj/*
 
 user.bazelrc

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -166,7 +166,8 @@ else
   config=rules_xcodeproj_build
 fi
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"
 touch "$build_marker"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -166,7 +166,8 @@ else
   config=rules_xcodeproj_build
 fi
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"
 touch "$build_marker"

--- a/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/ios_app/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -166,7 +166,8 @@ else
   config=rules_xcodeproj_build
 fi
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"
 touch "$build_marker"

--- a/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/ios_app/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -166,7 +166,8 @@ else
   config=rules_xcodeproj_build
 fi
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"
 touch "$build_marker"

--- a/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/cc/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -166,7 +166,8 @@ else
   config=rules_xcodeproj_build
 fi
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"
 touch "$build_marker"

--- a/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/cc/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -166,7 +166,8 @@ else
   config=rules_xcodeproj_build
 fi
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"
 touch "$build_marker"

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -166,7 +166,8 @@ else
   config=rules_xcodeproj_build
 fi
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"
 touch "$build_marker"

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -166,7 +166,8 @@ else
   config=rules_xcodeproj_build
 fi
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"
 touch "$build_marker"

--- a/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/simple/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -166,7 +166,8 @@ else
   config=rules_xcodeproj_build
 fi
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"
 touch "$build_marker"

--- a/test/fixtures/simple/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/simple/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -166,7 +166,8 @@ else
   config=rules_xcodeproj_build
 fi
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"
 touch "$build_marker"

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1469,7 +1469,8 @@ done
 
 cd "$SRCROOT"
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 env -i \
   DEVELOPER_DIR="$DEVELOPER_DIR" \

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -166,7 +166,8 @@ else
   config=rules_xcodeproj_build
 fi
 
-date +%s > "$INTERNAL_DIR/toplevel_cache_buster"
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"
 touch "$build_marker"

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -830,7 +830,7 @@ def _to_output_groups_fields(
         ctx,
         inputs,
         additional_generated = {},
-        toplevel_cache_buster):
+        top_level_cache_buster):
     """Generates a dictionary to be splatted into `OutputGroupInfo`.
 
     Args:
@@ -839,8 +839,8 @@ def _to_output_groups_fields(
         additional_generated: A `dict` that maps the output group name of
             targets to a `list` of `depset`s of `File`s that should be merged
             into the output group map for that output group name.
-        toplevel_cache_buster: A `list` of `File`s that change with each build,
-            and are used as inputs to the output map generation, to ensure that
+        top_level_cache_buster: A `File` that changes with each build, and is
+            used as an input to the output map generation, to ensure that
             the files references by the output map are always downloaded from
             the remote cache, even when using `--remote_download_toplevel`.
 
@@ -862,7 +862,7 @@ def _to_output_groups_fields(
             ctx = ctx,
             name = name.replace("/", "_"),
             files = files,
-            toplevel_cache_buster = toplevel_cache_buster,
+            top_level_cache_buster = top_level_cache_buster,
         )])
         for name, files in all_files.items()
     }
@@ -876,7 +876,7 @@ def _to_output_groups_fields(
                 if name.startswith("xc")
             ],
         ),
-        toplevel_cache_buster = toplevel_cache_buster,
+        top_level_cache_buster = top_level_cache_buster,
     )])
     output_groups["all_xl"] = depset([output_group_map.write_map(
         ctx = ctx,
@@ -888,7 +888,7 @@ def _to_output_groups_fields(
                 if name.startswith("xl")
             ],
         ),
-        toplevel_cache_buster = toplevel_cache_buster,
+        top_level_cache_buster = top_level_cache_buster,
     )])
 
     return output_groups

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -309,7 +309,7 @@ def _to_output_groups_fields(
         ctx,
         outputs,
         additional_outputs = {},
-        toplevel_cache_buster):
+        top_level_cache_buster):
     """Generates a dictionary to be splatted into `OutputGroupInfo`.
 
     Args:
@@ -318,8 +318,8 @@ def _to_output_groups_fields(
         additional_outputs: A `dict` that maps the output group name of
             targets to a `list` of `depset`s of `File`s that should be merged
             into the output group map for that output group name.
-        toplevel_cache_buster: A `list` of `File`s that change with each build,
-            and are used as inputs to the output map generation, to ensure that
+        top_level_cache_buster: A `File` that changes with each build, and is
+            used as an input to the output map generation, to ensure that
             the files references by the output map are always downloaded from
             the remote cache, even when using `--remote_download_toplevel`.
 
@@ -341,7 +341,7 @@ def _to_output_groups_fields(
             ctx = ctx,
             name = name.replace("/", "_"),
             files = files,
-            toplevel_cache_buster = toplevel_cache_buster,
+            top_level_cache_buster = top_level_cache_buster,
         )])
         for name, files in all_files.items()
     }
@@ -349,7 +349,7 @@ def _to_output_groups_fields(
         ctx = ctx,
         name = "all_b",
         files = depset(transitive = all_files.values()),
-        toplevel_cache_buster = toplevel_cache_buster,
+        top_level_cache_buster = top_level_cache_buster,
     )])
 
     return output_groups

--- a/xcodeproj/internal/output_group_map.bzl
+++ b/xcodeproj/internal/output_group_map.bzl
@@ -10,7 +10,7 @@
 # TODO: Use a different value for different types of outputs.
 _SHARD_SIZE = 75
 
-def _write_sharded_maps(*, ctx, name, files, toplevel_cache_buster):
+def _write_sharded_maps(*, ctx, name, files, top_level_cache_buster):
     files_list = files.to_list()
     length = len(files_list)
     shard_count = length // _SHARD_SIZE
@@ -25,7 +25,7 @@ def _write_sharded_maps(*, ctx, name, files, toplevel_cache_buster):
                 shard = None,
                 shard_count = 1,
                 files = files,
-                toplevel_cache_buster = toplevel_cache_buster,
+                top_level_cache_buster = top_level_cache_buster,
             ),
         ]
 
@@ -41,7 +41,7 @@ def _write_sharded_maps(*, ctx, name, files, toplevel_cache_buster):
                 shard = shard + 1,
                 shard_count = shard_count,
                 files = sharded_inputs,
-                toplevel_cache_buster = toplevel_cache_buster,
+                top_level_cache_buster = top_level_cache_buster,
             ),
         )
 
@@ -54,7 +54,7 @@ def _write_sharded_map(
         shard,
         shard_count,
         files,
-        toplevel_cache_buster):
+        top_level_cache_buster):
     args = ctx.actions.args()
     args.use_param_file("%s", use_always = True)
     args.set_param_file_format("multiline")
@@ -96,7 +96,7 @@ fi
         ],
         # Include files as inputs to cause them to be built or downloaded,
         # even if they aren't top level targets
-        inputs = depset(toplevel_cache_buster, transitive = [files]),
+        inputs = depset([top_level_cache_buster], transitive = [files]),
         mnemonic = "XcodeProjOutputMap",
         progress_message = progress_message,
         outputs = [output],
@@ -113,7 +113,7 @@ fi
 
     return output
 
-def _write_map(*, ctx, name, files, toplevel_cache_buster):
+def _write_map(*, ctx, name, files, top_level_cache_buster):
     if files == None:
         files = depset()
 
@@ -121,7 +121,7 @@ def _write_map(*, ctx, name, files, toplevel_cache_buster):
         ctx = ctx,
         name = name,
         files = files,
-        toplevel_cache_buster = toplevel_cache_buster,
+        top_level_cache_buster = top_level_cache_buster,
     )
     if len(files_list) == 1:
         # If only one shared output map was generated, we use it as is
@@ -148,7 +148,7 @@ cat "$@" > "$output"
         ],
         # Include files as inputs to cause them to be built or downloaded,
         # even if they aren't top level targets
-        inputs = depset(toplevel_cache_buster, transitive = [files]),
+        inputs = depset([top_level_cache_buster], transitive = [files]),
         mnemonic = "XcodeProjOutputMapMerge",
         progress_message = "Merging '{}-{}' output map".format(
             ctx.attr.name,

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -50,6 +50,10 @@ if [[ -s "$extra_flags_bazelrc" ]]; then
   bazelrcs+=("--bazelrc=$extra_flags_bazelrc")
 fi
 
+# Ensure that our top-level cache buster `new_local_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
 if [[ -z "${build_output_groups:-}" ]]; then
   echo
   echo 'Generating "%project_name%.xcodeproj"'

--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -208,28 +208,15 @@ in your `.bazelrc` or `xcodeproj.bazelrc` file.""")
             )
         schemes_json = json.encode(schemes)
 
-    if kwargs.get("toplevel_cache_buster"):
-        fail("`toplevel_cache_buster` is for internal use only")
-
-    # We control an input file to force downloading of top-level outputs,
-    # without having them be declared as the exact top level outputs. This makes
-    # the BEP a lot smaller and the UI output cleaner.
-    # See `//xcodeproj/internal:output_files.bzl` for more details.
-    toplevel_cache_buster = native.glob(
-        [
-            "{}.xcodeproj/rules_xcodeproj/toplevel_cache_buster".format(
-                project_name,
-            ),
-        ],
-        allow_empty = True,
-    )
-
     generator_name = "{}.generator".format(name)
 
     xcodeproj_rule = kwargs.pop("xcodeproj_rule", _xcodeproj)
 
     tags = kwargs.pop("tags", [])
 
+    # The runner needs to ensure that the
+    # `rules_xcodeproj_top_level_cache_buster` repository is properly created,
+    # so don't allow people to accidentally try to build the generator.
     generator_tags = list(tags)
     if "manual" not in generator_tags:
         generator_tags.append("manual")
@@ -248,7 +235,6 @@ in your `.bazelrc` or `xcodeproj.bazelrc` file.""")
         testonly = testonly,
         top_level_device_targets = top_level_device_targets,
         top_level_simulator_targets = top_level_simulator_targets,
-        toplevel_cache_buster = toplevel_cache_buster,
         tvos_device_cpus = tvos_device_cpus,
         tvos_simulator_cpus = tvos_simulator_cpus,
         unfocused_targets = unfocused_targets,

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -715,13 +715,13 @@ def _xcodeproj_impl(ctx):
         ctx = ctx,
         inputs = inputs,
         additional_generated = additional_generated,
-        toplevel_cache_buster = ctx.files.toplevel_cache_buster,
+        top_level_cache_buster = ctx.file._top_level_cache_buster,
     )
     output_files_output_groups = output_files.to_output_groups_fields(
         ctx = ctx,
         outputs = outputs,
         additional_outputs = additional_outputs,
-        toplevel_cache_buster = ctx.files.toplevel_cache_buster,
+        top_level_cache_buster = ctx.file._top_level_cache_buster,
     )
 
     if build_mode == "xcode":
@@ -849,11 +849,6 @@ as two separate but similar Xcode targets.
             aspects = [xcodeproj_aspect],
             providers = [XcodeProjInfo],
         ),
-        "toplevel_cache_buster": attr.label_list(
-            doc = "For internal use only. Do not set this value yourself.",
-            allow_empty = True,
-            allow_files = True,
-        ),
         "unfocused_targets": attr.string_list(
             doc = """\
 A `list` of target labels as `string` values. Any targets in the transitive
@@ -969,6 +964,19 @@ transitive dependencies of the targets specified in the
         "_installer_template": attr.label(
             allow_single_file = True,
             default = Label("//xcodeproj/internal:installer.template.sh"),
+        ),
+        "_top_level_cache_buster": attr.label(
+            doc = """\
+We control an input file to force downloading of top-level outputs, without
+having them be declared as the exact top level outputs. This makes the BEP a lot
+smaller and the UI output cleaner.
+
+See `//xcodeproj/internal:output_files.bzl` for more details.
+""",
+            allow_single_file = True,
+            default = Label(
+                "@rules_xcodeproj_top_level_cache_buster//:top_level_cache_buster",
+            ),
         ),
         "_xccurrentversions_parser": attr.label(
             cfg = "exec",

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -48,6 +48,7 @@ pass `ignore_version_differences = True` to `xcodeproj_rules_dependencies()`.
 
     repo_rule(name = name, **kwargs)
 
+# buildifier: disable=unnamed-macro
 def xcodeproj_rules_dependencies(
         ignore_version_differences = False,
         use_dev_patches = False):
@@ -186,4 +187,12 @@ swift_library(
         strip_prefix = "swift-collections-1.0.2",
         url = "https://github.com/apple/swift-collections/archive/refs/tags/1.0.2.tar.gz",
         ignore_version_differences = ignore_version_differences,
+    )
+
+    native.new_local_repository(
+        name = "rules_xcodeproj_top_level_cache_buster",
+        build_file_content = """\
+exports_files(["top_level_cache_buster"])
+""",
+        path = "/tmp/rules_xcodeproj",
     )


### PR DESCRIPTION
Fixes #1029.

We use a `new_local_repository` to ensure this continues to work with `--noexperimental_check_external_repository_files`.