### PR TITLE
Remove README WORKSPACE snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,56 +58,11 @@ rules.
 More versions of these tools and rulesets might be supported, but these are the
 ones we've officially tested with.
 
-## Quick setup
+## Installation
 
-Add the following to your `WORKSPACE` file to add the external repositories,
-replacing the version number in the `url` attribute with the version of the
-rules you wish to depend on:
-
-```python
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "com_github_buildbuddy_io_rules_xcodeproj",
-    sha256 = "a647ad9ee6664a78377cf5707331966b6788be09d1fea48045a61bc450c8f1b1",
-    url = "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/0.7.0/release.tar.gz",
-)
-
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:repositories.bzl",
-    "xcodeproj_rules_dependencies",
-)
-
-xcodeproj_rules_dependencies()
-
-load(
-    "@build_bazel_rules_apple//apple:repositories.bzl",
-    "apple_rules_dependencies",
-)
-
-apple_rules_dependencies()
-
-load(
-    "@build_bazel_rules_swift//swift:repositories.bzl",
-    "swift_rules_dependencies",
-)
-
-swift_rules_dependencies()
-
-load(
-    "@build_bazel_rules_swift//swift:extras.bzl",
-    "swift_rules_extra_dependencies",
-)
-
-swift_rules_extra_dependencies()
-
-load(
-    "@build_bazel_apple_support//lib:repositories.bzl",
-    "apple_support_dependencies",
-)
-
-apple_support_dependencies()
-```
+From the
+[release you wish to use](https://github.com/buildbuddy-io/rules_xcodeproj/releases),
+copy the WORKSPACE snippet into your `WORKSPACE` file.
 
 ## Examples
 


### PR DESCRIPTION
We already include it in the release notes, and this is one less piece of information that can be stale (and look, it was stale right now!).