### PR TITLE
Re-enable `working_directory` for `launch_action`

### DIFF
--- a/doc/rules-xcodeproj.md
+++ b/doc/rules-xcodeproj.md
@@ -247,7 +247,7 @@ A `struct` representing a test action.
 ## xcode_schemes.launch_action
 
 <pre>
-xcode_schemes.launch_action(<a href="#xcode_schemes.launch_action-target">target</a>, <a href="#xcode_schemes.launch_action-args">args</a>, <a href="#xcode_schemes.launch_action-env">env</a>)
+xcode_schemes.launch_action(<a href="#xcode_schemes.launch_action-target">target</a>, <a href="#xcode_schemes.launch_action-args">args</a>, <a href="#xcode_schemes.launch_action-env">env</a>, <a href="#xcode_schemes.launch_action-working_directory">working_directory</a>)
 </pre>
 
 Constructs a launch action for an Xcode scheme.
@@ -260,6 +260,7 @@ Constructs a launch action for an Xcode scheme.
 | <a id="xcode_schemes.launch_action-target"></a>target |  A target label as a <code>string</code> value.   |  none |
 | <a id="xcode_schemes.launch_action-args"></a>args |  Optional. A <code>list</code> of <code>string</code> arguments that should be passed to the target when executed.   |  <code>None</code> |
 | <a id="xcode_schemes.launch_action-env"></a>env |  Optional. A <code>dict</code> of <code>string</code> values that will be set as environment variables when the target is executed.   |  <code>None</code> |
+| <a id="xcode_schemes.launch_action-working_directory"></a>working_directory |  Optional. A <code>string</code> that will be set as the custom working directory in the Xcode scheme's launch action.   |  <code>None</code> |
 
 **RETURNS**
 

--- a/doc/rules-xcodeproj.md
+++ b/doc/rules-xcodeproj.md
@@ -260,7 +260,7 @@ Constructs a launch action for an Xcode scheme.
 | <a id="xcode_schemes.launch_action-target"></a>target |  A target label as a <code>string</code> value.   |  none |
 | <a id="xcode_schemes.launch_action-args"></a>args |  Optional. A <code>list</code> of <code>string</code> arguments that should be passed to the target when executed.   |  <code>None</code> |
 | <a id="xcode_schemes.launch_action-env"></a>env |  Optional. A <code>dict</code> of <code>string</code> values that will be set as environment variables when the target is executed.   |  <code>None</code> |
-| <a id="xcode_schemes.launch_action-working_directory"></a>working_directory |  Optional. A <code>string</code> that will be set as the custom working directory in the Xcode scheme's launch action.   |  <code>None</code> |
+| <a id="xcode_schemes.launch_action-working_directory"></a>working_directory |  Optional. A <code>string</code> that will be set as the custom working directory in the Xcode scheme's launch action. Relative paths will be relative to value of BUILT_PRODUCTS_DIRECTORY.   |  <code>None</code> |
 
 **RETURNS**
 

--- a/doc/rules-xcodeproj.md
+++ b/doc/rules-xcodeproj.md
@@ -260,7 +260,7 @@ Constructs a launch action for an Xcode scheme.
 | <a id="xcode_schemes.launch_action-target"></a>target |  A target label as a <code>string</code> value.   |  none |
 | <a id="xcode_schemes.launch_action-args"></a>args |  Optional. A <code>list</code> of <code>string</code> arguments that should be passed to the target when executed.   |  <code>None</code> |
 | <a id="xcode_schemes.launch_action-env"></a>env |  Optional. A <code>dict</code> of <code>string</code> values that will be set as environment variables when the target is executed.   |  <code>None</code> |
-| <a id="xcode_schemes.launch_action-working_directory"></a>working_directory |  Optional. A <code>string</code> that will be set as the custom working directory in the Xcode scheme's launch action. Relative paths will be relative to value of BUILT_PRODUCTS_DIRECTORY.   |  <code>None</code> |
+| <a id="xcode_schemes.launch_action-working_directory"></a>working_directory |  Optional. A <code>string</code> that will be set as the custom working directory in the Xcode scheme's launch action. Relative paths will be relative to the value of <code>target</code>'s <code>BUILT_PRODUCTS_DIR</code>, which is unique to it.   |  <code>None</code> |
 
 **RETURNS**
 

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -44,7 +44,7 @@
                     "CUSTOM_ENV_VAR": "hello"
                 },
                 "target": "//tools/generator:generator",
-                "working_directory": null
+                "working_directory": "$BUILD_WORKSPACE_DIRECTORY"
             },
             "name": "generator",
             "test_action": {

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -44,7 +44,7 @@
                     "CUSTOM_ENV_VAR": "hello"
                 },
                 "target": "//tools/generator:generator",
-                "working_directory": null
+                "working_directory": "$BUILD_WORKSPACE_DIRECTORY"
             },
             "name": "generator",
             "test_action": {

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -58,8 +58,7 @@ def get_xcode_schemes():
                 # This is not necessary for the generator. It is here to help
                 # verify that custom environment variables are passed along.
                 env = {"CUSTOM_ENV_VAR": "hello"},
-                working_directory = "$BUILD_WORKSPACE_DIRECTORY"
-
+                working_directory = "$BUILD_WORKSPACE_DIRECTORY",
             ),
             test_action = xcode_schemes.test_action(
                 [_TEST_TARGET],

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -58,6 +58,8 @@ def get_xcode_schemes():
                 # This is not necessary for the generator. It is here to help
                 # verify that custom environment variables are passed along.
                 env = {"CUSTOM_ENV_VAR": "hello"},
+                working_directory = "$BUILD_WORKSPACE_DIRECTORY"
+
             ),
             test_action = xcode_schemes.test_action(
                 [_TEST_TARGET],

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -258,7 +258,7 @@ def make_xcode_schemes(bazel_labels):
             target = bazel_labels.normalize(target),
             args = args,
             env = env,
-            working_directory = working_directory
+            working_directory = working_directory,
         )
 
     return struct(

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -249,7 +249,8 @@ def make_xcode_schemes(bazel_labels):
                 environment variables when the target is executed.
             working_directory: Optional. A `string` that will be set as the custom
                  working directory in the Xcode scheme's launch action. Relative
-                 paths will be relative to value of BUILT_PRODUCTS_DIRECTORY.
+                 paths will be relative to the value of `target`'s
+                 `BUILT_PRODUCTS_DIR`, which is unique to it.
 
         Returns:
             A `struct` representing a launch action.

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -237,7 +237,8 @@ def make_xcode_schemes(bazel_labels):
     def _launch_action(
             target,
             args = None,
-            env = None):
+            env = None,
+            working_directory = None):
         """Constructs a launch action for an Xcode scheme.
 
         Args:
@@ -246,6 +247,8 @@ def make_xcode_schemes(bazel_labels):
                 the target when executed.
             env: Optional. A `dict` of `string` values that will be set as
                 environment variables when the target is executed.
+            working_directory: Optional. A `string` that will be set as the custom
+                 working directory in the Xcode scheme's launch action.
 
         Returns:
             A `struct` representing a launch action.
@@ -255,6 +258,7 @@ def make_xcode_schemes(bazel_labels):
             target = bazel_labels.normalize(target),
             args = args,
             env = env,
+            working_directory = working_directory
         )
 
     return struct(

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -248,7 +248,8 @@ def make_xcode_schemes(bazel_labels):
             env: Optional. A `dict` of `string` values that will be set as
                 environment variables when the target is executed.
             working_directory: Optional. A `string` that will be set as the custom
-                 working directory in the Xcode scheme's launch action.
+                 working directory in the Xcode scheme's launch action. Relative
+                 paths will be relative to value of BUILT_PRODUCTS_DIRECTORY.
 
         Returns:
             A `struct` representing a launch action.


### PR DESCRIPTION
Resolves #933.

Now that we have updated xcodeproj to contain https://github.com/tuist/XcodeProj/pull/720 we can set the value of the custom working
directory for LaunchActions