### PR TITLE
Remove `{un,}focus_schemes` from `xcode_schemes` module

### DIFF
--- a/doc/rules-xcodeproj.md
+++ b/doc/rules-xcodeproj.md
@@ -267,58 +267,6 @@ Constructs a launch action for an Xcode scheme.
 A `struct` representing a launch action.
 
 
-<a id="xcode_schemes.focus_schemes"></a>
-
-## xcode_schemes.focus_schemes
-
-<pre>
-xcode_schemes.focus_schemes(<a href="#xcode_schemes.focus_schemes-schemes">schemes</a>, <a href="#xcode_schemes.focus_schemes-focused_targets">focused_targets</a>)
-</pre>
-
-Filter/adjust a `sequence` of schemes to only include focused targets.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="xcode_schemes.focus_schemes-schemes"></a>schemes |  A <code>sequence</code> of values returned by <code>xcode_schemes.scheme</code>.   |  none |
-| <a id="xcode_schemes.focus_schemes-focused_targets"></a>focused_targets |  A <code>sequence</code> of <code>string</code> values representing Bazel labels of focused targets.   |  none |
-
-**RETURNS**
-
-A `sequence` of values returned by `xcode_schemes.scheme`.
-  Will only include schemes that have at least one target in
-  `focused_targets`. Some actions might be removed if they reference
-  unfocused targets.
-
-
-<a id="xcode_schemes.unfocus_schemes"></a>
-
-## xcode_schemes.unfocus_schemes
-
-<pre>
-xcode_schemes.unfocus_schemes(<a href="#xcode_schemes.unfocus_schemes-schemes">schemes</a>, <a href="#xcode_schemes.unfocus_schemes-unfocused_targets">unfocused_targets</a>)
-</pre>
-
-Filter/adjust a `sequence` of schemes to exclude unfocused targets.
-
-**PARAMETERS**
-
-
-| Name  | Description | Default Value |
-| :------------- | :------------- | :------------- |
-| <a id="xcode_schemes.unfocus_schemes-schemes"></a>schemes |  A <code>sequence</code> of values returned by <code>xcode_schemes.scheme</code>.   |  none |
-| <a id="xcode_schemes.unfocus_schemes-unfocused_targets"></a>unfocused_targets |  A <code>sequence</code> of <code>string</code> values representing Bazel labels of unfocused targets.   |  none |
-
-**RETURNS**
-
-A `sequence` of values returned by `xcode_schemes.scheme`.
-  Will only include schemes that have at least one target not in
-  `unfocused_targets`. Some actions might be removed if they reference
-  unfocused targets.
-
-
 <a id="xcodeproj"></a>
 
 ## xcodeproj

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -6,7 +6,7 @@ load(":xcode_schemes_internal.bzl", "xcode_schemes_internal")
 
 _DEFAULT_BUILD_CONFIGURATION_NAME = "Debug"
 
-def _focus_schemes(schemes, focused_targets):
+def focus_schemes(schemes, focused_targets):
     """Filter/adjust a `sequence` of schemes to only include focused targets.
 
     Args:
@@ -77,7 +77,7 @@ def _focus_schemes(schemes, focused_targets):
 
     return focused_schemes
 
-def _unfocus_schemes(schemes, unfocused_targets):
+def unfocus_schemes(schemes, unfocused_targets):
     """Filter/adjust a `sequence` of schemes to exclude unfocused targets.
 
     Args:
@@ -154,7 +154,7 @@ def make_xcode_schemes(bazel_labels):
         bazel_labels: A `bazel_labels` module.
 
     Returns:
-        A `struct` that can be used as a `bazel_labels` module.
+        A `struct` that can be used as a `xcode_schemes` module.
     """
 
     def _build_action(targets):
@@ -271,8 +271,6 @@ def make_xcode_schemes(bazel_labels):
         build_for_values = xcode_schemes_internal.build_for_values,
         test_action = _test_action,
         launch_action = _launch_action,
-        focus_schemes = _focus_schemes,
-        unfocus_schemes = _unfocus_schemes,
         DEFAULT_BUILD_CONFIGURATION_NAME = _DEFAULT_BUILD_CONFIGURATION_NAME,
         BUILD_FOR_ALL_ENABLED = xcode_schemes_internal.BUILD_FOR_ALL_ENABLED,
     )

--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -4,7 +4,7 @@ load("@bazel_skylib//lib:sets.bzl", "sets")
 load(":bazel_labels.bzl", "bazel_labels")
 load(":logging.bzl", "warn")
 load(":top_level_target.bzl", "top_level_target")
-load(":xcode_schemes.bzl", "xcode_schemes")
+load(":xcode_schemes.bzl", "focus_schemes", "unfocus_schemes")
 load(":xcodeproj_rule.bzl", _xcodeproj = "xcodeproj")
 load(":xcodeproj_runner.bzl", "xcodeproj_runner")
 
@@ -223,12 +223,12 @@ in your `.bazelrc` or `xcodeproj.bazelrc` file.""")
     schemes_json = None
     if schemes:
         if unfocused_targets:
-            schemes = xcode_schemes.unfocus_schemes(
+            schemes = unfocus_schemes(
                 schemes = schemes,
                 unfocused_targets = unfocused_targets,
             )
         if focused_targets:
-            schemes = xcode_schemes.focus_schemes(
+            schemes = focus_schemes(
                 schemes = schemes,
                 focused_targets = focused_targets,
             )


### PR DESCRIPTION
These shouldn't have been public API, and are now properly private.