### PR TITLE
Update `generator` launch arguments

### DIFF
--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -159,15 +159,15 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_root_dirs"
+            argument = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_xccurrentversions"
+            argument = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_extensionpointidentifiers"
+            argument = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -31,9 +31,9 @@
             "launch_action": {
                 "args": [
                     "/tmp/spec.json",
-                    "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_root_dirs",
-                    "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_xccurrentversions",
-                    "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_extensionpointidentifiers",
+                    "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
+                    "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
+                    "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
                     "xcodeproj/internal/bazel_integration_files",
                     "/tmp/out.xcodeproj",
                     "/tmp/out.final.xcodeproj",

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -149,15 +149,15 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_root_dirs"
+            argument = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_xccurrentversions"
+            argument = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_extensionpointidentifiers"
+            argument = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -31,9 +31,9 @@
             "launch_action": {
                 "args": [
                     "/tmp/spec.json",
-                    "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_root_dirs",
-                    "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_xccurrentversions",
-                    "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_extensionpointidentifiers",
+                    "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
+                    "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
+                    "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
                     "xcodeproj/internal/bazel_integration_files",
                     "/tmp/out.xcodeproj",
                     "/tmp/out.final.xcodeproj",

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -47,9 +47,9 @@ def get_xcode_schemes():
                 _APP_TARGET,
                 args = [
                     "/tmp/spec.json",
-                    "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_root_dirs",
-                    "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_xccurrentversions",
-                    "bazel-out/darwin_arm64-fastbuild/bin/tools/generator/xcodeproj_extensionpointidentifiers",
+                    "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
+                    "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
+                    "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
                     "xcodeproj/internal/bazel_integration_files",
                     "/tmp/out.xcodeproj",
                     "/tmp/out.final.xcodeproj",


### PR DESCRIPTION
These now work again (on my machine 😉) with the removal of the Bazel convenience symlinks.