### PR TITLE
Revert runner set `--xcode_version`

### DIFF
--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -54,9 +54,6 @@ fi
 
 xcode_build_version=$(/usr/bin/xcodebuild -version | tail -1 | cut -d " " -f3)
 pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$xcode_build_version"
-
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version


### PR DESCRIPTION
While `bazel_build.sh` should still have `--xcode_version`, to ensure that Bazel uses the version of Xcode you are building inside of, setting `--xcode_version` based on `xcode-select` can counter-act some people's use of `--xcode_config`. We leave the `--repo_env` though to at least try to fix https://github.com/bazelbuild/bazel/issues/8902.