### PR TITLE
Use `--override_repository` for `top_level_cache_buster`

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -185,7 +185,10 @@ else
   config="_${BAZEL_CONFIG}_build"
 fi
 
+# Ensure that our top-level cache buster `override_repository` is valid
 mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
 date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -45,6 +45,11 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# We use `--override_repository` instead of adjusting the
+# `top_level_cache_buster` file in the repository itself, to ensure that it
+# continues to work with `--noexperimental_check_external_repository_files`
+common:rules_xcodeproj --override_repository=rules_xcodeproj_top_level_cache_buster=/tmp/rules_xcodeproj
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -185,7 +185,10 @@ else
   config="_${BAZEL_CONFIG}_build"
 fi
 
+# Ensure that our top-level cache buster `override_repository` is valid
 mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
 date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -45,6 +45,11 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# We use `--override_repository` instead of adjusting the
+# `top_level_cache_buster` file in the repository itself, to ensure that it
+# continues to work with `--noexperimental_check_external_repository_files`
+common:rules_xcodeproj --override_repository=rules_xcodeproj_top_level_cache_buster=/tmp/rules_xcodeproj
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -185,7 +185,10 @@ else
   config="_${BAZEL_CONFIG}_build"
 fi
 
+# Ensure that our top-level cache buster `override_repository` is valid
 mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
 date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -45,6 +45,11 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# We use `--override_repository` instead of adjusting the
+# `top_level_cache_buster` file in the repository itself, to ensure that it
+# continues to work with `--noexperimental_check_external_repository_files`
+common:rules_xcodeproj --override_repository=rules_xcodeproj_top_level_cache_buster=/tmp/rules_xcodeproj
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -185,7 +185,10 @@ else
   config="_${BAZEL_CONFIG}_build"
 fi
 
+# Ensure that our top-level cache buster `override_repository` is valid
 mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
 date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -45,6 +45,11 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# We use `--override_repository` instead of adjusting the
+# `top_level_cache_buster` file in the repository itself, to ensure that it
+# continues to work with `--noexperimental_check_external_repository_files`
+common:rules_xcodeproj --override_repository=rules_xcodeproj_top_level_cache_buster=/tmp/rules_xcodeproj
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -185,7 +185,10 @@ else
   config="_${BAZEL_CONFIG}_build"
 fi
 
+# Ensure that our top-level cache buster `override_repository` is valid
 mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
 date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -45,6 +45,11 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# We use `--override_repository` instead of adjusting the
+# `top_level_cache_buster` file in the repository itself, to ensure that it
+# continues to work with `--noexperimental_check_external_repository_files`
+common:rules_xcodeproj --override_repository=rules_xcodeproj_top_level_cache_buster=/tmp/rules_xcodeproj
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -185,7 +185,10 @@ else
   config="_${BAZEL_CONFIG}_build"
 fi
 
+# Ensure that our top-level cache buster `override_repository` is valid
 mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
 date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -45,6 +45,11 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# We use `--override_repository` instead of adjusting the
+# `top_level_cache_buster` file in the repository itself, to ensure that it
+# continues to work with `--noexperimental_check_external_repository_files`
+common:rules_xcodeproj --override_repository=rules_xcodeproj_top_level_cache_buster=/tmp/rules_xcodeproj
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -185,7 +185,10 @@ else
   config="_${BAZEL_CONFIG}_build"
 fi
 
+# Ensure that our top-level cache buster `override_repository` is valid
 mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
 date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -45,6 +45,11 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# We use `--override_repository` instead of adjusting the
+# `top_level_cache_buster` file in the repository itself, to ensure that it
+# continues to work with `--noexperimental_check_external_repository_files`
+common:rules_xcodeproj --override_repository=rules_xcodeproj_top_level_cache_buster=/tmp/rules_xcodeproj
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -185,7 +185,10 @@ else
   config="_${BAZEL_CONFIG}_build"
 fi
 
+# Ensure that our top-level cache buster `override_repository` is valid
 mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
 date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -45,6 +45,11 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# We use `--override_repository` instead of adjusting the
+# `top_level_cache_buster` file in the repository itself, to ensure that it
+# continues to work with `--noexperimental_check_external_repository_files`
+common:rules_xcodeproj --override_repository=rules_xcodeproj_top_level_cache_buster=/tmp/rules_xcodeproj
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -185,7 +185,10 @@ else
   config="_${BAZEL_CONFIG}_build"
 fi
 
+# Ensure that our top-level cache buster `override_repository` is valid
 mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
 date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 build_marker="$OBJROOT/bazel_build_start"

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -60,8 +60,10 @@ pre_config_flags=(
   "--repo_env=USE_CLANG_CL=$xcode_build_version"
 )
 
-# Ensure that our top-level cache buster `new_local_repository` is valid
+# Ensure that our top-level cache buster `override_repository` is valid
 mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
 date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
 
 if [[ -z "${build_output_groups:-}" ]]; then

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -45,6 +45,11 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# We use `--override_repository` instead of adjusting the
+# `top_level_cache_buster` file in the repository itself, to ensure that it
+# continues to work with `--noexperimental_check_external_repository_files`
+common:rules_xcodeproj --override_repository=rules_xcodeproj_top_level_cache_buster=/tmp/rules_xcodeproj
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.

--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -254,9 +254,8 @@ in your `.bazelrc` or `xcodeproj.bazelrc` file.""")
 
     tags = kwargs.pop("tags", [])
 
-    # The runner needs to ensure that the
-    # `rules_xcodeproj_top_level_cache_buster` repository is properly created,
-    # so don't allow people to accidentally try to build the generator.
+    # The generator should always have its config applied, so add `manual` to
+    # the tag to prevent accidental building with `//...`
     generator_tags = list(tags)
     if "manual" not in generator_tags:
         generator_tags.append("manual")

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -776,23 +776,22 @@ def _xcodeproj_impl(ctx):
         xcodeproj = xcodeproj,
     )
 
+    additional_output_map_inputs = [
+        ctx.file._top_level_cache_buster,
+        ctx.executable._index_import,
+    ]
+
     input_files_output_groups = input_files.to_output_groups_fields(
         ctx = ctx,
         inputs = inputs,
         additional_generated = additional_generated,
-        additional_output_map_inputs = [
-            ctx.file._top_level_cache_buster,
-            ctx.executable._index_import,
-        ],
+        additional_output_map_inputs = additional_output_map_inputs,
     )
     output_files_output_groups = output_files.to_output_groups_fields(
         ctx = ctx,
         outputs = outputs,
         additional_outputs = additional_outputs,
-        additional_output_map_inputs = [
-            ctx.file._top_level_cache_buster,
-            ctx.executable._index_import,
-        ],
+        additional_output_map_inputs = additional_output_map_inputs,
     )
 
     if build_mode == "xcode":

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -212,10 +212,16 @@ swift_library(
         ignore_version_differences = ignore_version_differences,
     )
 
-    native.new_local_repository(
+    _cache_buster_repository(
         name = "rules_xcodeproj_top_level_cache_buster",
-        build_file_content = """\
-exports_files(["top_level_cache_buster"])
-""",
-        path = "/tmp/rules_xcodeproj",
     )
+
+def _cache_buster_repository_impl(repository_ctx):
+    repository_ctx.file("BUILD", """\
+exports_files(["top_level_cache_buster"])
+""")
+    repository_ctx.file("top_level_cache_buster", "")
+
+_cache_buster_repository = repository_rule(
+    implementation = _cache_buster_repository_impl,
+)


### PR DESCRIPTION
Before this change `bazel query 'deps(...)'` could fail because our `rules_xcodeproj_top_level_cache_buster` wasn't set up properly. Now we have a minimal custom repository rule to ensure that always works. We could modify the file inside of the rule, but that won't get picked up if `--noexperimental_check_external_repository_files` is used, so we use `--override_repository` to work around that.