### PR TITLE
Make the docs `diff_test` manual

### DIFF
--- a/docs/BUILD.bazel
+++ b/docs/BUILD.bazel
@@ -51,6 +51,7 @@ diff_test(
     failure_message = "\nPlease update the docs by running\n    bazel run //docs:update",
     file1 = "bazel.generated.md",
     file2 = "bazel.md",
+    tags = ["manual"],
 )
 
 # Updating


### PR DESCRIPTION
This makes it so only the `Docs` Workflow fails when there are docs issues.