### PR TITLE
Move public rules and macros to `xcodeproj/defs.bzl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ load(
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "top_level_target",
     "xcodeproj",
 )

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -3,14 +3,14 @@
 ### Usage
 
 To use these rules and macros in your `BUILD` files, `load` them from
-`xcodeproj/xcodeproj.bzl`.
+`xcodeproj/defs.bzl`.
 
 For example, to use the [`xcodeproj`](#xcodeproj) rule, you would need to use
 this `load` statement:
 
 ```starlark
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcodeproj",
 )
 ```
@@ -125,11 +125,11 @@ A `struct` containing fields for the provided arguments.
 # Custom Xcode schemes
 
 To use these functions, `load` the `xcode_schemes` module from
-`xcodeproj/xcodeproj.bzl`:
+`xcodeproj/defs.bzl`:
 
 ```starlark
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_schemes",
 )
 ```

--- a/docs/design/custom-xcode-schemes.md
+++ b/docs/design/custom-xcode-schemes.md
@@ -68,7 +68,7 @@ targets, `//Sources/Foo` and `//Tests/FooTests`.
 
 ```python
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_schemes",
     "xcodeproj",
 )
@@ -111,7 +111,7 @@ to the mix.
 #   //Sources/AppUITests = ios_ui_test
 
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_schemes",
     "xcodeproj",
 )
@@ -159,7 +159,7 @@ accomplished by specifying them as parameters to the
 #   //Sources/AppUITests = ios_ui_test
 
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_schemes",
     "xcodeproj",
 )
@@ -400,7 +400,7 @@ following shows an example.
 
 ```python
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_schemes",
     "xcodeproj",
 )
@@ -437,7 +437,7 @@ targets.
 #   //Sources/AppUITests = ios_ui_test
 
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_schemes",
     "xcodeproj",
 )

--- a/examples/cc/BUILD
+++ b/examples/cc/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcodeproj",
 )
 load(":xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")

--- a/examples/integration/AppClip/BUILD
+++ b/examples/integration/AppClip/BUILD
@@ -3,7 +3,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_app_clip")
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_provisioning_profile",
 )
 load(

--- a/examples/integration/BUILD
+++ b/examples/integration/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcodeproj",
 )
 load(

--- a/examples/integration/WidgetExtension/BUILD
+++ b/examples/integration/WidgetExtension/BUILD
@@ -7,7 +7,7 @@ load(
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_provisioning_profile",
 )
 load(

--- a/examples/integration/iOSApp/Source/BUILD
+++ b/examples/integration/iOSApp/Source/BUILD
@@ -3,7 +3,7 @@ load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_provisioning_profile",
 )
 load(

--- a/examples/integration/tvOSApp/Source/BUILD
+++ b/examples/integration/tvOSApp/Source/BUILD
@@ -2,7 +2,7 @@ load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
 load("@build_bazel_rules_apple//apple:tvos.bzl", "tvos_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_provisioning_profile",
 )
 load(

--- a/examples/integration/watchOSApp/BUILD
+++ b/examples/integration/watchOSApp/BUILD
@@ -1,7 +1,7 @@
 load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
 load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_application")
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_provisioning_profile",
 )
 load(

--- a/examples/integration/watchOSAppExtension/BUILD
+++ b/examples/integration/watchOSAppExtension/BUILD
@@ -3,7 +3,7 @@ load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
 load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_extension")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_provisioning_profile",
 )
 load(

--- a/examples/integration/xcodeproj_targets.bzl
+++ b/examples/integration/xcodeproj_targets.bzl
@@ -1,7 +1,7 @@
 """Exposes targets used by `xcodeproj` to allow use in fixture tests."""
 
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "top_level_target",
 )
 

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -1,6 +1,6 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcodeproj",
 )
 load(":xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")

--- a/tools/generator/BUILD
+++ b/tools/generator/BUILD
@@ -8,7 +8,7 @@ load(
     "swift_binary",
     "swift_library",
 )
-load("//xcodeproj:xcodeproj.bzl", "xcodeproj")
+load("//xcodeproj:defs.bzl", "xcodeproj")
 load(
     ":xcodeproj_targets.bzl",
     "SCHEME_AUTOGENERATION_MODE",

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -1,6 +1,6 @@
 """Exposes targets used by `xcodeproj` to allow use in fixture tests."""
 
-load("//xcodeproj:xcodeproj.bzl", "xcode_schemes")
+load("//xcodeproj:defs.bzl", "xcode_schemes")
 
 UNFOCUSED_TARGETS = [
     "@com_github_tadija_aexml//:AEXML",

--- a/xcodeproj/BUILD
+++ b/xcodeproj/BUILD
@@ -24,13 +24,6 @@ string_flag(
     visibility = ["//visibility:public"],
 )
 
-# Required for stardoc integration
-
-exports_files([
-    "experimental.doc.bzl",
-    "xcodeproj.bzl",
-])
-
 # Release
 
 filegroup(

--- a/xcodeproj/defs.bzl
+++ b/xcodeproj/defs.bzl
@@ -1,0 +1,32 @@
+"""Public rules, macros, and libraries."""
+
+load(
+    "//xcodeproj/internal:top_level_target.bzl",
+    _top_level_target = "top_level_target",
+)
+load(
+    "//xcodeproj/internal:providers.bzl",
+    _XcodeProjAutomaticTargetProcessingInfo = "XcodeProjAutomaticTargetProcessingInfo",
+    _XcodeProjInfo = "XcodeProjInfo",
+)
+load(
+    "//xcodeproj/internal:xcode_provisioning_profile.bzl",
+    _xcode_provisioning_profile = "xcode_provisioning_profile",
+)
+load("//xcodeproj/internal:xcode_schemes.bzl", _xcode_schemes = "xcode_schemes")
+load(
+    "//xcodeproj/internal:xcodeproj_macro.bzl",
+    _xcodeproj = "xcodeproj",
+)
+
+# Re-exporting providers
+XcodeProjAutomaticTargetProcessingInfo = _XcodeProjAutomaticTargetProcessingInfo
+XcodeProjInfo = _XcodeProjInfo
+
+# Re-exporting rules
+top_level_target = _top_level_target
+xcodeproj = _xcodeproj
+xcode_provisioning_profile = _xcode_provisioning_profile
+
+# Re-exporting APIs
+xcode_schemes = _xcode_schemes

--- a/xcodeproj/experimental.bzl
+++ b/xcodeproj/experimental.bzl
@@ -14,6 +14,6 @@ device_and_simulator = _device_and_simulator
 def xcode_provisioning_profile(**kwargs):
     fail("""\
 The `xcode_provisioning_profile` rule has moved to \
-`@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl`. Please \
-update your `load` statements to use the new path.
+`@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl`. Please update \
+your `load` statements to use the new path.
 """)

--- a/xcodeproj/internal/docs/bazel.header.md
+++ b/xcodeproj/internal/docs/bazel.header.md
@@ -3,14 +3,14 @@
 ### Usage
 
 To use these rules and macros in your `BUILD` files, `load` them from
-`xcodeproj/xcodeproj.bzl`.
+`xcodeproj/defs.bzl`.
 
 For example, to use the [`xcodeproj`](#xcodeproj) rule, you would need to use
 this `load` statement:
 
 ```starlark
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcodeproj",
 )
 ```

--- a/xcodeproj/internal/docs/xcode_schemes.bzl
+++ b/xcodeproj/internal/docs/xcode_schemes.bzl
@@ -1,11 +1,11 @@
 """# Custom Xcode schemes
 
 To use these functions, `load` the `xcode_schemes` module from
-`xcodeproj/xcodeproj.bzl`:
+`xcodeproj/defs.bzl`:
 
 ```starlark
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:xcodeproj.bzl",
+    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
     "xcode_schemes",
 )
 ```

--- a/xcodeproj/xcodeproj.bzl
+++ b/xcodeproj/xcodeproj.bzl
@@ -1,32 +1,45 @@
-"""Public rules, macros, and libraries."""
+""""""
 
-load(
-    "//xcodeproj/internal:top_level_target.bzl",
-    _top_level_target = "top_level_target",
-)
-load(
-    "//xcodeproj/internal:providers.bzl",
-    _XcodeProjAutomaticTargetProcessingInfo = "XcodeProjAutomaticTargetProcessingInfo",
-    _XcodeProjInfo = "XcodeProjInfo",
-)
-load(
-    "//xcodeproj/internal:xcode_provisioning_profile.bzl",
-    _xcode_provisioning_profile = "xcode_provisioning_profile",
-)
-load("//xcodeproj/internal:xcode_schemes.bzl", _xcode_schemes = "xcode_schemes")
-load(
-    "//xcodeproj/internal:xcodeproj_macro.bzl",
-    _xcodeproj = "xcodeproj",
-)
+# TODO: Remove these by the 1.0 release
 
-# Re-exporting providers
-XcodeProjAutomaticTargetProcessingInfo = _XcodeProjAutomaticTargetProcessingInfo
-XcodeProjInfo = _XcodeProjInfo
+def _moved(name, type):
+    fail("""\
+The `{name}` {type} has moved to \
+`@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl`. Please update \
+your `load` statements to use the new path.
+""".format(name = name, type = type))
 
-# Re-exporting rules
-top_level_target = _top_level_target
-xcodeproj = _xcodeproj
-xcode_provisioning_profile = _xcode_provisioning_profile
+# buildifier: disable=unused-variable
+def top_level_target(**kwargs):
+    _moved(name = "top_level_target", type = "function")
 
-# Re-exporting APIs
-xcode_schemes = _xcode_schemes
+# buildifier: disable=unused-variable
+def xcodeproj(**kwargs):
+    _moved(name = "xcodeproj", type = "rule")
+
+# buildifier: disable=unused-variable
+def xcode_provisioning_profile(**kwargs):
+    _moved(name = "xcode_provisioning_profile", type = "rule")
+
+# buildifier: disable=unused-variable
+def XcodeProjAutomaticTargetProcessingInfo(**kwargs):
+    _moved(name = "XcodeProjAutomaticTargetProcessingInfo", type = "provider")
+
+# buildifier: disable=unused-variable
+def XcodeProjInfo(**kwargs):
+    _moved(name = "XcodeProjInfo", type = "provider")
+
+# buildifier: disable=unused-variable
+def _xcode_schemes_function(**kwargs):
+    _moved(name = "xcode_schemes", type = "module")
+
+xcode_schemes = struct(
+    scheme = _xcode_schemes_function,
+    build_action = _xcode_schemes_function,
+    build_target = _xcode_schemes_function,
+    build_for = _xcode_schemes_function,
+    build_for_values = _xcode_schemes_function,
+    launch_action = _xcode_schemes_function,
+    test_action = _xcode_schemes_function,
+    pre_post_action = _xcode_schemes_function,
+)


### PR DESCRIPTION
As recommend by best practices, and followed by more modern rulesets:
- https://bazel.build/rules/deploying#rules
- https://github.com/bazel-contrib/rules-template/blob/main/mylang/defs.bzl
- https://github.com/bazelbuild/rules_jvm_external/blob/00ddb84c67b58d52c89b659cf9fcceea16995a32/defs.bzl
- https://github.com/bazelbuild/rules_python/blob/a364fcac97b7ccadb5c5a703ec8ce2f2ecef0d97/python/defs.bzl
- https://github.com/bazelbuild/rules_java/blob/07691fb9cb85bfa5dd03e3361db9810dbac44c36/java/defs.bzl