### PR TITLE
Disable codesigning for bundles in BwX

### DIFF
--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -4636,6 +4636,7 @@
 				BAZEL_TARGET_ID = "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353";
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd";
 				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
+				CODE_SIGNING_ALLOWED = NO;
 				COMPILE_TARGET_NAME = ExampleNestedResources;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
@@ -4710,6 +4711,7 @@
 				BAZEL_TARGET_ID = "//iOSApp/Resources/ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353";
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//iOSApp/Resources/ExampleResources:ExampleResources ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd";
 				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
+				CODE_SIGNING_ALLOWED = NO;
 				COMPILE_TARGET_NAME = ExampleResources;
 				EXCLUDED_SOURCE_FILE_NAMES = "$(IPHONEOS_FILES) $(IPHONESIMULATOR_FILES)";
 				GENERATE_INFOPLIST_FILE = YES;

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -358,11 +358,8 @@ $(CONFIGURATION_BUILD_DIR)
             )
         }
         
-        if buildMode == .xcode && target.platform.os == .iOS {
-            // Xcode 14 defaults this value to YES, and iOS bundles do not need to be signed
-            if target.product.type == .bundle {
-                buildSettings["CODE_SIGNING_ALLOWED"] = false
-            }
+        if buildMode == .xcode && target.shouldDisableCodeSigning {
+           buildSettings["CODE_SIGNING_ALLOWED"] = false
         }
         
         // Set VFS overlays
@@ -631,6 +628,11 @@ extension Target {
 
     func linkParamsFilePath() throws -> FilePath {
         return try .internal(internalTargetFilesPath() + "\(name).link.params")
+    }
+    
+    // Used to work around CODE_SIGNING_ENABLED = YES in Xcode 14
+    var shouldDisableCodeSigning: Bool {
+        return platform.os == .iOS && product.type == .bundle
     }
 }
 

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -357,6 +357,11 @@ $(CONFIGURATION_BUILD_DIR)
                 to: ldRunpathSearchPaths
             )
         }
+        
+        // Xcode 14 defaults this value to YES, and iOS bundles do not need to be signed
+        if target.product.type == .bundle {
+            buildSettings["CODE_SIGNING_ALLOWED"] = false
+        }
 
         // Set VFS overlays
 

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -358,11 +358,13 @@ $(CONFIGURATION_BUILD_DIR)
             )
         }
         
-        // Xcode 14 defaults this value to YES, and iOS bundles do not need to be signed
-        if target.product.type == .bundle {
-            buildSettings["CODE_SIGNING_ALLOWED"] = false
+        if buildMode == .xcode && target.platform.os == .iOS {
+            // Xcode 14 defaults this value to YES, and iOS bundles do not need to be signed
+            if target.product.type == .bundle {
+                buildSettings["CODE_SIGNING_ALLOWED"] = false
+            }
         }
-
+        
         // Set VFS overlays
 
         if hasBazelDependencies {


### PR DESCRIPTION
Fixes #1123.

It appears the default `CODE_SIGNING_ALLOWED` changed in Xcode 14

https://developer.apple.com/forums/thread/708659