### PR TITLE
Remove swiftlint from pre-build script

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -66,10 +66,3 @@ buildifier(
     mode = "fix",
     tags = ["manual"],
 )
-
-# IDE Tools
-
-exports_files([
-    "swiftformat",
-    "swiftlint",
-])

--- a/test/fixtures/generator/BUILD
+++ b/test/fixtures/generator/BUILD
@@ -1,6 +1,5 @@
 load(
     "//tools/generator:xcodeproj_targets.bzl",
-    "PRE_BUILD",
     "SCHEME_AUTOGENERATION_MODE",
     "TOP_LEVEL_TARGETS",
     "UNFOCUSED_TARGETS",
@@ -9,7 +8,6 @@ load(
 load("//xcodeproj:testing.bzl", "xcodeproj_fixture")
 
 xcodeproj_fixture(
-    pre_build = PRE_BUILD,
     scheme_autogeneration_mode = SCHEME_AUTOGENERATION_MODE,
     schemes = get_xcode_schemes(),
     top_level_targets = TOP_LEVEL_TARGETS,

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 			isa = PBXAggregateTarget;
 			buildConfigurationList = 914277EC9F57B808A8817CF5 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
-				922073A986018654923053B1 /* Pre-build Run Script */,
 				9A630CF63C380FAE522825A9 /* Bazel Build */,
 				20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */,
 			);
@@ -1872,21 +1871,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libOrderedCollections.a\" \\\n  \"\"\n";
-			showEnvVarsInLog = 0;
-		};
-		922073A986018654923053B1 /* Pre-build Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Pre-build Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$PROJECT_DIR/swiftlint\"";
 			showEnvVarsInLog = 0;
 		};
 		9A630CF63C380FAE522825A9 /* Bazel Build */ = {

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -95,7 +95,7 @@
     "label": "//test/fixtures/generator:xcodeproj_bwb.generator",
     "name": "bwb",
     "post_build_script": null,
-    "pre_build_script": "swiftlint",
+    "pre_build_script": null,
     "replacement_labels": [
         "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000",
         "//tools/generator/test:tests"

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 			isa = PBXAggregateTarget;
 			buildConfigurationList = A4C19F2824EAB3EBB5D7EE24 /* Build configuration list for PBXAggregateTarget "BazelDependencies" */;
 			buildPhases = (
-				6405D59516D4825C839B80EC /* Pre-build Run Script */,
 				773C70B69E7F801B38FDC01C /* Generate Files */,
 				2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */,
 			);
@@ -1783,21 +1782,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6405D59516D4825C839B80EC /* Pre-build Run Script */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Pre-build Run Script";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$PROJECT_DIR/swiftlint\"";
 			showEnvVarsInLog = 0;
 		};
 		70EEEFD103E781D8A11D78F7 /* Create linking dependencies */ = {

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -95,7 +95,7 @@
     "label": "//test/fixtures/generator:xcodeproj_bwx.generator",
     "name": "bwx",
     "post_build_script": null,
-    "pre_build_script": "swiftlint",
+    "pre_build_script": null,
     "replacement_labels": [
         "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889",
         "//tools/generator/test:tests"

--- a/tools/generator/BUILD
+++ b/tools/generator/BUILD
@@ -11,7 +11,6 @@ load(
 load("//xcodeproj:defs.bzl", "xcodeproj")
 load(
     ":xcodeproj_targets.bzl",
-    "PRE_BUILD",
     "SCHEME_AUTOGENERATION_MODE",
     "TOP_LEVEL_TARGETS",
     "UNFOCUSED_TARGETS",
@@ -63,7 +62,6 @@ apple_universal_binary(
 
 xcodeproj(
     name = "xcodeproj",
-    pre_build = PRE_BUILD,
     project_name = "generator",
     scheme_autogeneration_mode = SCHEME_AUTOGENERATION_MODE,
     schemes = get_xcode_schemes(),

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -2,8 +2,6 @@
 
 load("//xcodeproj:defs.bzl", "xcode_schemes")
 
-PRE_BUILD = "//:swiftlint"
-
 UNFOCUSED_TARGETS = [
     "@com_github_tadija_aexml//:AEXML",
 ]


### PR DESCRIPTION
`./swiftlint` attempts to call globally installed binary but it work only on a specific environment as Xcode runs pre-build script in a limited PATH, so for now removing swiftlint script from xcodeproj of generator.
`//example/simple:xcodeproj` is still available as an example of `xcodeproj-pre_build` usage and for an integration test.