### PR TITLE
Add version handling in the clang stub

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
@@ -17,6 +17,7 @@ do
     break
     ;;
   -v)
+    # TODO: Make this work with custom toolchains
     DEV_DIR_PREFIX=$(awk '{ sub(/.*-isysroot /, ""); sub(/.Contents\/Developer.*/, ""); print}' <<< "${@:1}")
     clang="$DEV_DIR_PREFIX/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
     "$clang" "${@:1}"

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
@@ -16,6 +16,12 @@ do
   *.o)
     break
     ;;
+  -v)
+    DEV_DIR_PREFIX=$(awk '{ sub(/.*-isysroot /, ""); sub(/.Contents\/Developer.*/, ""); print}' <<< "${@:1}")
+    clang="$DEV_DIR_PREFIX/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+    "$clang" "${@:1}"
+    break
+    ;;
   esac
 
   shift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
@@ -17,6 +17,7 @@ do
     break
     ;;
   -v)
+    # TODO: Make this work with custom toolchains
     DEV_DIR_PREFIX=$(awk '{ sub(/.*-isysroot /, ""); sub(/.Contents\/Developer.*/, ""); print}' <<< "${@:1}")
     clang="$DEV_DIR_PREFIX/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
     "$clang" "${@:1}"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
@@ -16,6 +16,12 @@ do
   *.o)
     break
     ;;
+  -v)
+    DEV_DIR_PREFIX=$(awk '{ sub(/.*-isysroot /, ""); sub(/.Contents\/Developer.*/, ""); print}' <<< "${@:1}")
+    clang="$DEV_DIR_PREFIX/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+    "$clang" "${@:1}"
+    break
+    ;;
   esac
 
   shift

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
@@ -17,6 +17,7 @@ do
     break
     ;;
   -v)
+    # TODO: Make this work with custom toolchains
     DEV_DIR_PREFIX=$(awk '{ sub(/.*-isysroot /, ""); sub(/.Contents\/Developer.*/, ""); print}' <<< "${@:1}")
     clang="$DEV_DIR_PREFIX/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
     "$clang" "${@:1}"

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
@@ -16,6 +16,12 @@ do
   *.o)
     break
     ;;
+  -v)
+    DEV_DIR_PREFIX=$(awk '{ sub(/.*-isysroot /, ""); sub(/.Contents\/Developer.*/, ""); print}' <<< "${@:1}")
+    clang="$DEV_DIR_PREFIX/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+    "$clang" "${@:1}"
+    break
+    ;;
   esac
 
   shift

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
@@ -17,6 +17,7 @@ do
     break
     ;;
   -v)
+    # TODO: Make this work with custom toolchains
     DEV_DIR_PREFIX=$(awk '{ sub(/.*-isysroot /, ""); sub(/.Contents\/Developer.*/, ""); print}' <<< "${@:1}")
     clang="$DEV_DIR_PREFIX/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
     "$clang" "${@:1}"

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/clang.sh
@@ -16,6 +16,12 @@ do
   *.o)
     break
     ;;
+  -v)
+    DEV_DIR_PREFIX=$(awk '{ sub(/.*-isysroot /, ""); sub(/.Contents\/Developer.*/, ""); print}' <<< "${@:1}")
+    clang="$DEV_DIR_PREFIX/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+    "$clang" "${@:1}"
+    break
+    ;;
   esac
 
   shift

--- a/xcodeproj/internal/bazel_integration_files/clang.sh
+++ b/xcodeproj/internal/bazel_integration_files/clang.sh
@@ -17,6 +17,7 @@ do
     break
     ;;
   -v)
+    # TODO: Make this work with custom toolchains
     DEV_DIR_PREFIX=$(awk '{ sub(/.*-isysroot /, ""); sub(/.Contents\/Developer.*/, ""); print}' <<< "${@:1}")
     clang="$DEV_DIR_PREFIX/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
     "$clang" "${@:1}"

--- a/xcodeproj/internal/bazel_integration_files/clang.sh
+++ b/xcodeproj/internal/bazel_integration_files/clang.sh
@@ -16,6 +16,12 @@ do
   *.o)
     break
     ;;
+  -v)
+    DEV_DIR_PREFIX=$(awk '{ sub(/.*-isysroot /, ""); sub(/.Contents\/Developer.*/, ""); print}' <<< "${@:1}")
+    clang="$DEV_DIR_PREFIX/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+    "$clang" "${@:1}"
+    break
+    ;;
   esac
 
   shift


### PR DESCRIPTION
This PR updates the clang stub to handle version argument.

Xcode invokes the stub with the following arguments:
`-v -E -dM -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator16.0.sdk -x c -c /dev/null
`

This support is required to implement Thread sanitizer (and other sanitizers) covered in https://github.com/buildbuddy-io/rules_xcodeproj/pull/1127.
