### PR TITLE
Add tsan config

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -181,6 +181,8 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,6 +92,13 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -181,6 +181,8 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,6 +92,13 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/app.exclude.rsynclist
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/app.exclude.rsynclist
@@ -1,3 +1,4 @@
+/*.app/Frameworks/libclang_rt.tsan*.dylib
 /*.app/Frameworks/libXCTestBundleInject.dylib
 /*.app/Frameworks/libXCTestSwiftSupport.dylib
 /*.app/Frameworks/XCTAutomationSupport.framework

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -181,6 +181,8 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,6 +92,13 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust
@@ -115,6 +122,8 @@ info:rules_xcodeproj_integration_info --config=rules_xcodeproj_info
 info:rules_xcodeproj_integration_info --config=rules_xcodeproj_integration
 build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_swiftuipreviews
 build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_integration
+build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_tsan
+build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_integration
 
 # Private implementation detail. Don't adjust this config, adjust
 # `rules_xcodeproj_integration` instead.

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -181,6 +181,8 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,6 +92,13 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust
@@ -115,6 +122,8 @@ info:rules_xcodeproj_integration_info --config=rules_xcodeproj_info
 info:rules_xcodeproj_integration_info --config=rules_xcodeproj_integration
 build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_swiftuipreviews
 build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_integration
+build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_tsan
+build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_integration
 
 # Private implementation detail. Don't adjust this config, adjust
 # `rules_xcodeproj_integration` instead.

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -181,6 +181,8 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,6 +92,13 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -181,6 +181,8 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,6 +92,13 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -181,6 +181,8 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,6 +92,13 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -181,6 +181,8 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,6 +92,13 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -563,6 +563,7 @@ extension Generator {
         {
             files[.internal(appRsyncExcludeFileListPath)] =
                 .nonReferencedContent(#"""
+/*.app/Frameworks/libclang_rt.tsan*.dylib
 /*.app/Frameworks/libXCTestBundleInject.dylib
 /*.app/Frameworks/libXCTestSwiftSupport.dylib
 /*.app/Frameworks/XCTAutomationSupport.framework

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -181,6 +181,8 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -92,6 +92,13 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/xcodeproj/internal/xcodeproj_runner.bzl
+++ b/xcodeproj/internal/xcodeproj_runner.bzl
@@ -28,6 +28,8 @@ info:{config}_info --config=rules_xcodeproj_info
 info:{config}_info --config={config}
 build:{config}_swiftuipreviews --config=rules_xcodeproj_swiftuipreviews
 build:{config}_swiftuipreviews --config={config}
+build:{config}_tsan --config=rules_xcodeproj_tsan
+build:{config}_tsan --config={config}
 
 # Private implementation detail. Don't adjust this config, adjust
 # `{config}` instead.


### PR DESCRIPTION
Related to the Base PR: https://github.com/buildbuddy-io/rules_xcodeproj/pull/1127

- Adds `/*.app/Frameworks/libclang_rt.tsan*.dylib` to the exclude list. It's a wildcard because clang has different dylib per target os and target architecture. 
- This also requires passing --features=tsan to make it fully work and hence the bazelrc was modified and a new config build:rules_xcodeproj_tsan was added to address this.


What will be covered in the next PR(s)?
- Symlinking of the lib directory. (context: https://github.com/buildbuddy-io/rules_xcodeproj/pull/1127)