### PR TITLE
Track when products have more than out bazel output path

### DIFF
--- a/examples/cc/test/fixtures/bwb_spec.json
+++ b/examples/cc/test/fixtures/bwb_spec.json
@@ -97,6 +97,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
@@ -180,6 +181,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
@@ -297,6 +299,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tool",
                 "name": "tool",
                 "path": {
@@ -408,6 +411,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {

--- a/examples/cc/test/fixtures/bwx_spec.json
+++ b/examples/cc/test/fixtures/bwx_spec.json
@@ -97,6 +97,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
@@ -180,6 +181,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
@@ -297,6 +299,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tool",
                 "name": "tool",
                 "path": {
@@ -408,6 +411,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -616,6 +616,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "AppClip",
                 "name": "AppClip",
                 "path": {
@@ -798,6 +799,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "AppClip",
                 "name": "AppClip",
                 "path": {
@@ -886,6 +888,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "AppClip.library",
                 "path": {
@@ -980,6 +983,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "AppClip.library",
                 "path": {
@@ -1201,6 +1205,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "CommandLineTool",
                 "name": "CommandLineTool",
                 "path": {
@@ -1335,6 +1340,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tool.library",
                 "path": {
@@ -1462,6 +1468,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
@@ -1555,6 +1562,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "lib_swift",
                 "path": {
@@ -1652,6 +1660,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "private_lib",
                 "path": {
@@ -1716,6 +1725,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "private_swift_lib",
                 "path": {
@@ -1803,6 +1813,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "CommandLineLibSwiftTestsLib",
                 "path": {
@@ -2068,6 +2079,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "CommandLineToolTests",
                 "name": "CommandLineToolTests",
                 "path": {
@@ -2163,6 +2175,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "c_lib",
                 "path": {
@@ -2236,6 +2249,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -2323,6 +2337,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -2410,6 +2425,7 @@
                 "variant": "appletvos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -2497,6 +2513,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -2584,6 +2601,7 @@
                 "variant": "watchos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -2671,6 +2689,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -2758,6 +2777,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -2851,6 +2871,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -2944,6 +2965,7 @@
                 "variant": "appletvos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -3037,6 +3059,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -3130,6 +3153,7 @@
                 "variant": "watchos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -3223,6 +3247,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -3405,6 +3430,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "WidgetExtension",
                 "name": "WidgetExtension",
                 "path": {
@@ -3580,6 +3606,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "WidgetExtension",
                 "name": "WidgetExtension",
                 "path": {
@@ -3671,6 +3698,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "WidgetExtension.library",
                 "path": {
@@ -3768,6 +3796,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "WidgetExtension.library",
                 "path": {
@@ -3855,6 +3884,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "iMessageApp",
                 "name": "iMessageApp",
                 "path": {
@@ -4016,6 +4046,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "iMessageAppExtension",
                 "name": "iMessageAppExtension",
                 "path": {
@@ -4103,6 +4134,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "iMessageAppExtension.library",
                 "path": {
@@ -4391,6 +4423,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "iOSApp_ExecutableName",
                 "name": "iOSApp",
                 "path": {
@@ -4693,6 +4726,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "iOSApp_ExecutableName",
                 "name": "iOSApp",
                 "path": {
@@ -4813,6 +4847,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "iOSApp.library",
                 "path": {
@@ -4942,6 +4977,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "iOSApp.library",
                 "path": {
@@ -5088,6 +5124,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "macOSApp",
                 "name": "macOSApp",
                 "path": {
@@ -5163,6 +5200,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "macOSApp.library",
                 "path": {
@@ -5261,6 +5299,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "macOSAppUITests",
                 "name": "macOSAppUITests",
                 "path": {
@@ -5328,6 +5367,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "macOSAppUITests.library",
                 "path": {
@@ -5527,6 +5567,7 @@
                 "variant": "appletvos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tvOSApp",
                 "name": "tvOSApp",
                 "path": {
@@ -5739,6 +5780,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tvOSApp",
                 "name": "tvOSApp",
                 "path": {
@@ -5826,6 +5868,7 @@
                 "variant": "appletvos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tvOSApp.library",
                 "path": {
@@ -5923,6 +5966,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tvOSApp.library",
                 "path": {
@@ -6042,6 +6086,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tvOSAppUITests",
                 "name": "tvOSAppUITests",
                 "path": {
@@ -6109,6 +6154,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tvOSAppUITests.library",
                 "path": {
@@ -6328,6 +6374,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tvOSAppUnitTests",
                 "name": "tvOSAppUnitTests",
                 "path": {
@@ -6417,6 +6464,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tvOSAppUnitTests.library",
                 "path": {
@@ -6540,6 +6588,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSAppUITests",
                 "name": "watchOSAppUITests",
                 "path": {
@@ -6607,6 +6656,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "watchOSAppUITests.library",
                 "path": {
@@ -6674,6 +6724,7 @@
                 "variant": "watchos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSApp",
                 "name": "watchOSApp",
                 "path": {
@@ -6740,6 +6791,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSApp",
                 "name": "watchOSApp",
                 "path": {
@@ -6940,6 +6992,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSAppExtensionUnitTests",
                 "name": "watchOSAppExtensionUnitTests",
                 "path": {
@@ -7028,6 +7081,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "watchOSAppExtensionUnitTests.library",
                 "path": {
@@ -7251,6 +7305,7 @@
                 "variant": "watchos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSAppExtension",
                 "name": "watchOSAppExtension",
                 "path": {
@@ -7463,6 +7518,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSAppExtension",
                 "name": "watchOSAppExtension",
                 "path": {
@@ -7550,6 +7606,7 @@
                 "variant": "watchos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "watchOSAppExtension.library",
                 "path": {
@@ -7647,6 +7704,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "watchOSAppExtension.library",
                 "path": {

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -475,6 +475,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "AppClip",
                 "name": "AppClip",
                 "path": {
@@ -587,6 +588,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "AppClip",
                 "name": "AppClip",
                 "path": {
@@ -675,6 +677,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "AppClip.library",
                 "path": {
@@ -769,6 +772,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "AppClip.library",
                 "path": {
@@ -915,6 +919,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "CommandLineTool",
                 "name": "CommandLineTool",
                 "path": {
@@ -1049,6 +1054,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tool.library",
                 "path": {
@@ -1176,6 +1182,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "lib_impl",
                 "path": {
@@ -1269,6 +1276,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "lib_swift",
                 "path": {
@@ -1366,6 +1374,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "private_lib",
                 "path": {
@@ -1430,6 +1439,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "private_swift_lib",
                 "path": {
@@ -1517,6 +1527,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "CommandLineLibSwiftTestsLib",
                 "path": {
@@ -1659,6 +1670,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "CommandLineToolTests",
                 "name": "CommandLineToolTests",
                 "path": {
@@ -1754,6 +1766,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "c_lib",
                 "path": {
@@ -1827,6 +1840,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -1914,6 +1928,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -2001,6 +2016,7 @@
                 "variant": "appletvos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -2088,6 +2104,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -2175,6 +2192,7 @@
                 "variant": "watchos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -2262,6 +2280,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "Lib",
                 "path": {
@@ -2349,6 +2368,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -2442,6 +2462,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -2535,6 +2556,7 @@
                 "variant": "appletvos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -2628,6 +2650,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -2721,6 +2744,7 @@
                 "variant": "watchos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -2814,6 +2838,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "UI",
                 "path": {
@@ -2927,6 +2952,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "WidgetExtension",
                 "name": "WidgetExtension",
                 "path": {
@@ -3033,6 +3059,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "WidgetExtension",
                 "name": "WidgetExtension",
                 "path": {
@@ -3124,6 +3151,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "WidgetExtension.library",
                 "path": {
@@ -3221,6 +3249,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "WidgetExtension.library",
                 "path": {
@@ -3313,6 +3342,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "iMessageApp",
                 "name": "iMessageApp",
                 "path": {
@@ -3406,6 +3436,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "iMessageAppExtension",
                 "name": "iMessageAppExtension",
                 "path": {
@@ -3493,6 +3524,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "iMessageAppExtension.library",
                 "path": {
@@ -3566,6 +3598,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "ExampleNestedResources",
                 "path": {
@@ -3610,6 +3643,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "ExampleNestedResources",
                 "path": {
@@ -3655,6 +3689,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "ExampleResources",
                 "path": {
@@ -3703,6 +3738,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "ExampleResources",
                 "path": {
@@ -3850,6 +3886,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "iOSApp_ExecutableName",
                 "name": "iOSApp",
                 "path": {
@@ -4041,6 +4078,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "iOSApp_ExecutableName",
                 "name": "iOSApp",
                 "path": {
@@ -4165,6 +4203,7 @@
                 "variant": "iphoneos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "iOSApp.library",
                 "path": {
@@ -4294,6 +4333,7 @@
                 "variant": "iphonesimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "iOSApp.library",
                 "path": {
@@ -4421,6 +4461,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "macOSApp",
                 "name": "macOSApp",
                 "path": {
@@ -4496,6 +4537,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "macOSApp.library",
                 "path": {
@@ -4575,6 +4617,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "macOSAppUITests",
                 "name": "macOSAppUITests",
                 "path": {
@@ -4642,6 +4685,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "macOSAppUITests.library",
                 "path": {
@@ -4740,6 +4784,7 @@
                 "variant": "appletvos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tvOSApp",
                 "name": "tvOSApp",
                 "path": {
@@ -4851,6 +4896,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tvOSApp",
                 "name": "tvOSApp",
                 "path": {
@@ -4938,6 +4984,7 @@
                 "variant": "appletvos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tvOSApp.library",
                 "path": {
@@ -5035,6 +5082,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tvOSApp.library",
                 "path": {
@@ -5135,6 +5183,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tvOSAppUITests",
                 "name": "tvOSAppUITests",
                 "path": {
@@ -5202,6 +5251,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tvOSAppUITests.library",
                 "path": {
@@ -5281,6 +5331,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tvOSAppUnitTests",
                 "name": "tvOSAppUnitTests",
                 "path": {
@@ -5370,6 +5421,7 @@
                 "variant": "appletvsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tvOSAppUnitTests.library",
                 "path": {
@@ -5474,6 +5526,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSAppUITests",
                 "name": "watchOSAppUITests",
                 "path": {
@@ -5541,6 +5594,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "watchOSAppUITests.library",
                 "path": {
@@ -5613,6 +5667,7 @@
                 "variant": "watchos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSApp",
                 "name": "watchOSApp",
                 "path": {
@@ -5684,6 +5739,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSApp",
                 "name": "watchOSApp",
                 "path": {
@@ -5777,6 +5833,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSAppExtensionUnitTests",
                 "name": "watchOSAppExtensionUnitTests",
                 "path": {
@@ -5865,6 +5922,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "watchOSAppExtensionUnitTests.library",
                 "path": {
@@ -5986,6 +6044,7 @@
                 "variant": "watchos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSAppExtension",
                 "name": "watchOSAppExtension",
                 "path": {
@@ -6096,6 +6155,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "watchOSAppExtension",
                 "name": "watchOSAppExtension",
                 "path": {
@@ -6183,6 +6243,7 @@
                 "variant": "watchos"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "watchOSAppExtension.library",
                 "path": {
@@ -6280,6 +6341,7 @@
                 "variant": "watchsimulator"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "watchOSAppExtension.library",
                 "path": {

--- a/examples/simple/test/fixtures/bwb_spec.json
+++ b/examples/simple/test/fixtures/bwb_spec.json
@@ -93,6 +93,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "SwiftBin",
                 "name": "SwiftBin",
                 "path": {

--- a/examples/simple/test/fixtures/bwx_spec.json
+++ b/examples/simple/test/fixtures/bwx_spec.json
@@ -74,6 +74,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "SwiftBin",
                 "name": "SwiftBin",
                 "path": {

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -355,6 +355,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tests",
                 "name": "tests",
                 "path": {
@@ -473,6 +474,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tests.library",
                 "path": {
@@ -687,6 +689,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "generator",
                 "name": "generator",
                 "path": {
@@ -826,6 +829,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "generator.library",
                 "path": {
@@ -1107,6 +1111,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "OrderedCollections",
                 "path": {
@@ -1174,6 +1179,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "PathKit",
                 "path": {
@@ -1340,6 +1346,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "CustomDump",
                 "path": {
@@ -1413,6 +1420,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "XCTestDynamicOverlay",
                 "path": {
@@ -1859,6 +1867,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "XcodeProj",
                 "path": {

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -355,6 +355,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "tests",
                 "name": "tests",
                 "path": {
@@ -473,6 +474,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "tests.library",
                 "path": {
@@ -687,6 +689,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": "generator",
                 "name": "generator",
                 "path": {
@@ -826,6 +829,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "generator.library",
                 "path": {
@@ -1107,6 +1111,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "OrderedCollections",
                 "path": {
@@ -1174,6 +1179,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "PathKit",
                 "path": {
@@ -1340,6 +1346,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "CustomDump",
                 "path": {
@@ -1413,6 +1420,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "XCTestDynamicOverlay",
                 "path": {
@@ -1859,6 +1867,7 @@
                 "variant": "macosx"
             },
             "product": {
+                "additional_paths": [],
                 "executable_name": null,
                 "name": "XcodeProj",
                 "path": {

--- a/tools/generator/src/DTO/Product.swift
+++ b/tools/generator/src/DTO/Product.swift
@@ -1,8 +1,66 @@
+import PathKit
 import XcodeProj
 
 struct Product: Equatable, Decodable {
     let type: PBXProductType
     let name: String
-    let path: FilePath
+    var path: FilePath
+    var additionalPaths: [FilePath]
     let executableName: String?
+
+    /// Custom initializer for easier testing.
+    init(
+        type: PBXProductType,
+        name: String,
+        path: FilePath,
+        additionalPaths: [FilePath] = [],
+        executableName: String? = nil
+    ) {
+        self.type = type
+        self.name = name
+        self.path = path
+        self.additionalPaths = additionalPaths
+        self.executableName = executableName
+    }
+}
+
+extension Product {
+    mutating func merge(oldPackageBinDir: Path, newPackageBinDir: Path) {
+        let oldPath = path
+        path.replacePackageBinDir(old: oldPackageBinDir, new: newPackageBinDir)
+
+        if oldPath != path {
+            additionalPaths.append(oldPath)
+        }
+    }
+
+    func merging(oldPackageBinDir: Path, newPackageBinDir: Path) -> Product {
+        var product = self
+        product.merge(
+            oldPackageBinDir: oldPackageBinDir,
+            newPackageBinDir: newPackageBinDir
+        )
+        return product
+    }
+}
+
+private extension FilePath {
+    mutating func replacePackageBinDir(old: Path, new: Path) {
+        guard type == .generated else {
+            return
+        }
+
+        // Remove `bazel-out/` from path
+        let old = old.string.dropFirst(10)
+
+        let pathString = path.string
+        guard pathString.hasPrefix(old) else {
+            return
+        }
+
+        // Remove `bazel-out/` from path
+        let new = new.string.dropFirst(10)
+
+        path = Path("\(new)\(pathString.dropFirst(old.count))")
+    }
 }

--- a/tools/generator/src/DTO/Target+LinkerFlags.swift
+++ b/tools/generator/src/DTO/Target+LinkerFlags.swift
@@ -9,7 +9,7 @@ extension Target {
     }
 
     func allLinkerFlags(
-        xcodeGeneratedFiles: Set<FilePath>,
+        xcodeGeneratedFiles: [FilePath: FilePath],
         filePathResolver: FilePathResolver
     ) throws -> [String] {
         var flags = try processLinkopts(
@@ -24,7 +24,8 @@ extension Target {
                 return try filePathResolver
                     .resolve(
                         filePath,
-                        useBazelOut: !xcodeGeneratedFiles.contains(filePath)
+                        useBazelOut: !xcodeGeneratedFiles.keys
+                            .contains(filePath)
                     )
                     .string.quoted
             }
@@ -37,7 +38,8 @@ extension Target {
                     try filePathResolver
                         .resolve(
                             filePath,
-                            useBazelOut: !xcodeGeneratedFiles.contains(filePath)
+                            useBazelOut: !xcodeGeneratedFiles.keys
+                                .contains(filePath)
                         )
                         .string.quoted,
                 ]
@@ -60,7 +62,7 @@ extension Target {
 private func processLinkopts(
     _ linkopts: [String],
     swiftTriple: String,
-    xcodeGeneratedFiles: Set<FilePath>,
+    xcodeGeneratedFiles: [FilePath: FilePath],
     filePathResolver: FilePathResolver
 ) throws -> [String] {
     return try linkopts
@@ -77,7 +79,7 @@ private func processLinkopts(
 private func processLinkopt(
     _ linkopt: String,
     swiftTriple: String,
-    xcodeGeneratedFiles: Set<FilePath>,
+    xcodeGeneratedFiles: [FilePath: FilePath],
     filePathResolver: FilePathResolver
 ) throws -> String {
     return try linkopt
@@ -97,7 +99,7 @@ private func processLinkopt(
 private func processLinkoptComponent(
     _ opt: String,
     swiftTriple: String,
-    xcodeGeneratedFiles: Set<FilePath>,
+    xcodeGeneratedFiles: [FilePath: FilePath],
     filePathResolver: FilePathResolver
 ) throws -> String {
     let extracted = extractOptValue(opt)
@@ -117,7 +119,7 @@ private func processLinkoptComponent(
     }
 
     if var filePath = filePath {
-        let xcodeGenerated = xcodeGeneratedFiles.contains(filePath)
+        let xcodeGenerated = xcodeGeneratedFiles.keys.contains(filePath)
 
         if xcodeGenerated {
             if let `extension` = filePath.path.extension,

--- a/tools/generator/src/DTO/Target.swift
+++ b/tools/generator/src/DTO/Target.swift
@@ -7,7 +7,7 @@ struct Target: Equatable {
     var compileTarget: CompileTarget? = nil
     var packageBinDir: Path
     var platform: Platform
-    let product: Product
+    var product: Product
     var isTestonly: Bool
     var isSwift: Bool
     let testHost: TargetID?

--- a/tools/generator/src/Generator/ConsolidateTargets.swift
+++ b/tools/generator/src/Generator/ConsolidateTargets.swift
@@ -323,7 +323,9 @@ extension ConsolidatedTarget {
             name: aTarget.product.name,
             type: aTarget.product.type,
             basename: aTarget.product.path.path.lastComponent,
-            paths: Set(targets.values.map(\.product.path))
+            paths: Set(targets.values.flatMap { target in
+                return [target.product.path] + target.product.additionalPaths
+            })
         )
         isSwift = aTarget.isSwift
 

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -40,7 +40,7 @@ struct Environment {
     ) throws -> (
         files: [FilePath: File],
         rootElements: [PBXFileElement],
-        xcodeGeneratedFiles: Set<FilePath>,
+        xcodeGeneratedFiles: [FilePath: FilePath],
         resolvedExternalRepositories: [(Path, Path)]
     )
 
@@ -94,7 +94,7 @@ struct Environment {
         _ pbxTargets: [ConsolidatedTarget.Key: PBXTarget],
         _ hostIDs: [TargetID: [TargetID]],
         _ hasBazelDependencies: Bool,
-        _ xcodeGeneratedFiles: Set<FilePath>,
+        _ xcodeGeneratedFiles: [FilePath: FilePath],
         _ filePathResolver: FilePathResolver
     ) throws -> Void
 

--- a/tools/generator/src/Generator/ProcessTargetMerges.swift
+++ b/tools/generator/src/Generator/ProcessTargetMerges.swift
@@ -47,6 +47,12 @@ exist
                 // Set compile target id (used for "Compile File" command)
                 merged.compileTarget = .init(id: source, name: merging.name)
 
+                // Update product
+                merged.product.merge(
+                    oldPackageBinDir: merged.packageBinDir,
+                    newPackageBinDir: merging.packageBinDir
+                )
+
                 // Update Package Bin Dir
                 // We take on the libraries bazel-out directory to prevent
                 // issues with search paths that are calculated in Starlark.

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -16,7 +16,7 @@ extension Generator {
         pbxTargets: [ConsolidatedTarget.Key: PBXTarget],
         hostIDs: [TargetID: [TargetID]],
         hasBazelDependencies: Bool,
-        xcodeGeneratedFiles: Set<FilePath>,
+        xcodeGeneratedFiles: [FilePath: FilePath],
         filePathResolver: FilePathResolver
     ) throws {
         for (key, disambiguatedTarget) in disambiguatedTargets.targets {
@@ -76,7 +76,7 @@ Target "\(key)" not found in `pbxTargets`
         targets: [TargetID: Target],
         hostIDs: [TargetID: [TargetID]],
         hasBazelDependencies: Bool,
-        xcodeGeneratedFiles: Set<FilePath>,
+        xcodeGeneratedFiles: [FilePath: FilePath],
         filePathResolver: FilePathResolver
     ) throws -> [BuildSettingConditional: [String: BuildSetting]] {
         var anyBuildSettings: [String: BuildSetting] = [:]
@@ -156,7 +156,7 @@ Target with id "\(id)" not found in `consolidatedTarget.uniqueFiles`
         hostIDs: [TargetID],
         buildMode: BuildMode,
         hasBazelDependencies: Bool,
-        xcodeGeneratedFiles: Set<FilePath>,
+        xcodeGeneratedFiles: [FilePath: FilePath],
         filePathResolver: FilePathResolver
     ) throws -> [String: BuildSetting] {
         var buildSettings = target.buildSettings
@@ -339,12 +339,11 @@ $(CONFIGURATION_BUILD_DIR)
         if !swiftmodules.isEmpty {
             let includePaths = try swiftmodules
                 .map { filePath -> String in
-                    var dir = filePath
-                    dir.path = dir.path.parent().normalize()
                     return try filePathResolver
                         .resolve(
-                            dir,
-                            useBazelOut: !xcodeGeneratedFiles.contains(filePath)
+                            filePath.parent(),
+                            useBazelOut: !xcodeGeneratedFiles.keys
+                                .contains(filePath)
                         )
                         .string.quoted
                 }

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -428,7 +428,7 @@ enum Fixtures {
     ) -> (
         files: [FilePath: File],
         elements: [FilePath: PBXFileElement],
-        xcodeGeneratedFiles: Set<FilePath>,
+        xcodeGeneratedFiles: [FilePath: FilePath],
         resolvedExternalRepositories: [(Path, Path)]
     ) {
         var elements: [FilePath: PBXFileElement] = [:]
@@ -1162,26 +1162,26 @@ class StopHook:
 
         // `xcodegeneratedfiles`
 
-        let xcodeGeneratedFiles: Set<FilePath> = [
-            .generated("z/A.a"),
-            .generated("x/y.swiftmodule"),
-            .generated("z/A.app"),
-            .generated("z/AC.app"),
-            .generated("a/b.framework"),
-            .generated("B.xctest"),
-            .generated("B3.xctest"),
-            .generated("a/c.lo"),
-            .generated("d"),
-            .generated("e1/E.a"),
-            .generated("e2/E.a"),
-            .generated("z/I.app"),
-            .generated("r1/R1.bundle"),
-            .generated("T/T 1/T.a"),
-            .generated("T/T 2/T.a"),
-            .generated("T/T 3/T.a"),
-            .generated("z/W.app"),
-            .generated("z/WDK.appex"),
-            .generated("z/WK.appex"),
+        let xcodeGeneratedFiles: [FilePath: FilePath] = [
+            .generated("z/A.a"): .generated("z/A.a"),
+            .generated("x/y.swiftmodule"): .generated("x/y.swiftmodule"),
+            .generated("z/A.app"): .generated("z/A.app"),
+            .generated("z/AC.app"): .generated("z/AC.app"),
+            .generated("a/b.framework"): .generated("a/b.framework"),
+            .generated("B.xctest"): .generated("B.xctest"),
+            .generated("B3.xctest"): .generated("B3.xctest"),
+            .generated("a/c.lo"): .generated("a/c.lo"),
+            .generated("d"): .generated("d"),
+            .generated("e1/E.a"): .generated("e1/E.a"),
+            .generated("e2/E.a"): .generated("e2/E.a"),
+            .generated("z/I.app"): .generated("z/I.app"),
+            .generated("r1/R1.bundle"): .generated("r1/R1.bundle"),
+            .generated("T/T 1/T.a"): .generated("T/T 1/T.a"),
+            .generated("T/T 2/T.a"): .generated("T/T 2/T.a"),
+            .generated("T/T 3/T.a"): .generated("T/T 3/T.a"),
+            .generated("z/W.app"): .generated("z/W.app"),
+            .generated("z/WDK.appex"): .generated("z/WDK.appex"),
+            .generated("z/WK.appex"): .generated("z/WK.appex"),
         ]
 
         return (files, elements, xcodeGeneratedFiles, [])
@@ -2013,7 +2013,7 @@ perl -pe 's/^("?)(.*\$\(.*\).*?)("?)$/"$2"/ ; s/\$(\()?([a-zA-Z_]\w*)(?(1)\))/$E
     ) -> (
         [ConsolidatedTarget.Key: PBXTarget],
         DisambiguatedTargets,
-        Set<FilePath>
+        [FilePath: FilePath]
     ) {
         let pbxProject = pbxProj.rootObject!
         let mainGroup = pbxProject.mainGroup!

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -357,7 +357,7 @@ final class GeneratorTests: XCTestCase {
         ) -> (
             files: [FilePath: File],
             rootElements: [PBXFileElement],
-            xcodeGeneratedFiles: Set<FilePath>,
+            xcodeGeneratedFiles: [FilePath: FilePath],
             resolvedExternalRepositories: [(Path, Path)]
         ) {
             createFilesAndGroupsCalled.append(.init(
@@ -584,7 +584,7 @@ final class GeneratorTests: XCTestCase {
             let pbxTargets: [ConsolidatedTarget.Key: PBXTarget]
             let hostIDs: [TargetID: [TargetID]]
             let hasBazelDependencies: Bool
-            let xcodeGeneratedFiles: Set<FilePath>
+            let xcodeGeneratedFiles: [FilePath: FilePath]
             let filePathResolver: FilePathResolver
         }
 
@@ -597,7 +597,7 @@ final class GeneratorTests: XCTestCase {
             pbxTargets: [ConsolidatedTarget.Key: PBXTarget],
             hostIDs: [TargetID: [TargetID]],
             hasBazelDependencies: Bool,
-            xcodeGeneratedFiles: Set<FilePath>,
+            xcodeGeneratedFiles: [FilePath: FilePath],
             filePathResolver: FilePathResolver
         ) {
             setTargetConfigurationsCalled.append(.init(

--- a/tools/generator/test/SetTargetConfigurationsTests.swift
+++ b/tools/generator/test/SetTargetConfigurationsTests.swift
@@ -183,7 +183,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: [:],
             hasBazelDependencies: false,
-            xcodeGeneratedFiles: [],
+            xcodeGeneratedFiles: [:],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -236,7 +236,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: [:],
             hasBazelDependencies: false,
-            xcodeGeneratedFiles: [],
+            xcodeGeneratedFiles: [:],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -291,7 +291,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: [:],
             hasBazelDependencies: false,
-            xcodeGeneratedFiles: [],
+            xcodeGeneratedFiles: [:],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -417,7 +417,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: [:],
             hasBazelDependencies: false,
-            xcodeGeneratedFiles: [],
+            xcodeGeneratedFiles: [:],
             filePathResolver: Self.filePathResolverFixture
         )
 

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -118,12 +118,6 @@ extension Platform {
     }
 }
 
-extension Product {
-    init(type: PBXProductType, name: String, path: FilePath) {
-        self.init(type: type, name: name, path: path, executableName: nil)
-    }
-}
-
 extension ConsolidatedTargets {
     init(targets: [TargetID: Target]) {
         var keys: [TargetID: ConsolidatedTarget.Key] = [:]


### PR DESCRIPTION
Bazel can refer to binaries of frameworks in one location (pre-bundle) and the finished bundle in another location. We also weren't handling merged targets perfectly, which could have issues for unfocused test hosts (I need to look into this and apply a separate fix after this).