### PR TITLE
Copy dependent frameworks for BwB framework SwiftUI Previews

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -56,6 +56,22 @@ else
       --out-format="%n%L" \
       "$product_basename" \
       "$TARGET_BUILD_DIR"
+
+    # SwiftUI Previews has a hard time finding frameworks (`@rpath`) when using
+    # framework schemes, so let's copy them to `$BUILD_DIR`
+    if [[ "${ENABLE_PREVIEWS:-}" == "YES" && \
+          -n "${PREVIEW_FRAMEWORK_PATHS:-}" ]]; then
+      # shellcheck disable=SC2046
+      rsync \
+        --copy-links \
+        --recursive \
+        --times \
+        --delete \
+        --chmod=u+w \
+        --out-format="%n%L" \
+        $(xargs -n1 <<< "${PREVIEW_FRAMEWORK_PATHS:-}") \
+        "$BUILD_DIR"
+    fi
   fi
 fi
 

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -69,7 +69,7 @@ else
         --delete \
         --chmod=u+w \
         --out-format="%n%L" \
-        $(xargs -n1 <<< "${PREVIEW_FRAMEWORK_PATHS:-}") \
+        $(xargs -n1 <<< "$PREVIEW_FRAMEWORK_PATHS") \
         "$BUILD_DIR"
     fi
   fi

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -56,6 +56,22 @@ else
       --out-format="%n%L" \
       "$product_basename" \
       "$TARGET_BUILD_DIR"
+
+    # SwiftUI Previews has a hard time finding frameworks (`@rpath`) when using
+    # framework schemes, so let's copy them to `$BUILD_DIR`
+    if [[ "${ENABLE_PREVIEWS:-}" == "YES" && \
+          -n "${PREVIEW_FRAMEWORK_PATHS:-}" ]]; then
+      # shellcheck disable=SC2046
+      rsync \
+        --copy-links \
+        --recursive \
+        --times \
+        --delete \
+        --chmod=u+w \
+        --out-format="%n%L" \
+        $(xargs -n1 <<< "${PREVIEW_FRAMEWORK_PATHS:-}") \
+        "$BUILD_DIR"
+    fi
   fi
 fi
 

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -69,7 +69,7 @@ else
         --delete \
         --chmod=u+w \
         --out-format="%n%L" \
-        $(xargs -n1 <<< "${PREVIEW_FRAMEWORK_PATHS:-}") \
+        $(xargs -n1 <<< "$PREVIEW_FRAMEWORK_PATHS") \
         "$BUILD_DIR"
     fi
   fi

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -56,6 +56,22 @@ else
       --out-format="%n%L" \
       "$product_basename" \
       "$TARGET_BUILD_DIR"
+
+    # SwiftUI Previews has a hard time finding frameworks (`@rpath`) when using
+    # framework schemes, so let's copy them to `$BUILD_DIR`
+    if [[ "${ENABLE_PREVIEWS:-}" == "YES" && \
+          -n "${PREVIEW_FRAMEWORK_PATHS:-}" ]]; then
+      # shellcheck disable=SC2046
+      rsync \
+        --copy-links \
+        --recursive \
+        --times \
+        --delete \
+        --chmod=u+w \
+        --out-format="%n%L" \
+        $(xargs -n1 <<< "${PREVIEW_FRAMEWORK_PATHS:-}") \
+        "$BUILD_DIR"
+    fi
   fi
 fi
 

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -69,7 +69,7 @@ else
         --delete \
         --chmod=u+w \
         --out-format="%n%L" \
-        $(xargs -n1 <<< "${PREVIEW_FRAMEWORK_PATHS:-}") \
+        $(xargs -n1 <<< "$PREVIEW_FRAMEWORK_PATHS") \
         "$BUILD_DIR"
     fi
   fi

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -56,6 +56,22 @@ else
       --out-format="%n%L" \
       "$product_basename" \
       "$TARGET_BUILD_DIR"
+
+    # SwiftUI Previews has a hard time finding frameworks (`@rpath`) when using
+    # framework schemes, so let's copy them to `$BUILD_DIR`
+    if [[ "${ENABLE_PREVIEWS:-}" == "YES" && \
+          -n "${PREVIEW_FRAMEWORK_PATHS:-}" ]]; then
+      # shellcheck disable=SC2046
+      rsync \
+        --copy-links \
+        --recursive \
+        --times \
+        --delete \
+        --chmod=u+w \
+        --out-format="%n%L" \
+        $(xargs -n1 <<< "${PREVIEW_FRAMEWORK_PATHS:-}") \
+        "$BUILD_DIR"
+    fi
   fi
 fi
 

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/copy_outputs.sh
@@ -69,7 +69,7 @@ else
         --delete \
         --chmod=u+w \
         --out-format="%n%L" \
-        $(xargs -n1 <<< "${PREVIEW_FRAMEWORK_PATHS:-}") \
+        $(xargs -n1 <<< "$PREVIEW_FRAMEWORK_PATHS") \
         "$BUILD_DIR"
     fi
   fi

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -378,6 +378,17 @@ $(CONFIGURATION_BUILD_DIR)
                 to: ldRunpathSearchPaths
             )
         }
+
+        if buildMode != .xcode && target.product.type.isFramework {
+            try buildSettings.set(
+                "PREVIEW_FRAMEWORK_PATHS",
+                to: target.linkerInputs.dynamicFrameworks.map { filePath in
+                    return #"""
+"\#(try filePathResolver.resolve(filePath, useBazelOut: true))"
+"""#
+                }
+            )
+        }
         
         // Set VFS overlays
 

--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -56,6 +56,22 @@ else
       --out-format="%n%L" \
       "$product_basename" \
       "$TARGET_BUILD_DIR"
+
+    # SwiftUI Previews has a hard time finding frameworks (`@rpath`) when using
+    # framework schemes, so let's copy them to `$BUILD_DIR`
+    if [[ "${ENABLE_PREVIEWS:-}" == "YES" && \
+          -n "${PREVIEW_FRAMEWORK_PATHS:-}" ]]; then
+      # shellcheck disable=SC2046
+      rsync \
+        --copy-links \
+        --recursive \
+        --times \
+        --delete \
+        --chmod=u+w \
+        --out-format="%n%L" \
+        $(xargs -n1 <<< "${PREVIEW_FRAMEWORK_PATHS:-}") \
+        "$BUILD_DIR"
+    fi
   fi
 fi
 

--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -69,7 +69,7 @@ else
         --delete \
         --chmod=u+w \
         --out-format="%n%L" \
-        $(xargs -n1 <<< "${PREVIEW_FRAMEWORK_PATHS:-}") \
+        $(xargs -n1 <<< "$PREVIEW_FRAMEWORK_PATHS") \
         "$BUILD_DIR"
     fi
   fi


### PR DESCRIPTION
Xcode adds `$BUILD_DIR` to `DYLD_LIBRARY_PATH` for SwiftUI Previews, to make framework based previews work. We don't have our outputs in a flat hierarchy though, and this doesn't account for external frameworks. Our workaround is to copy all dependent frameworks into `$BUILD_DIR` to make them available. For BwX we will adjust `LD_RUNPATH_SEARCH_PATHS` in a future change.