### PR TITLE
Stop avoiding frameworks

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		4B9D7C7D6D5DDACAF5F87255 /* watchOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B67D228CAE7657B7CF96BCD /* watchOSApp.swift */; };
 		4DCE1596464F993C9A745426 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF522B1DF94A22805CFB159 /* Lib.swift */; };
 		5003A996FFB25A6D500F8312 /* iMessageAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = E332411DCE28305063274CDF /* iMessageAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		50132650EEA27019BCA2E293 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48754296ACA596286860C0BF /* CryptoSwift.framework */; };
 		511CD055B798496C846A5E4D /* WatchOSAppExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B97B63749CB7B8FCC4C6CD /* WatchOSAppExtensionTests.swift */; };
 		511EF1749DC18A6D29600755 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FBAFC44AF745D83B41AC29 /* ContentView.swift */; };
 		526815DB742350C83EB04495 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7401FDA68482F8B5BE018478 /* CryptoSwift.framework */; };
@@ -750,6 +751,14 @@
 			files = (
 				17D28C4F6071247D8148BE16 /* CryptoSwift.framework in Frameworks */,
 				1345A48101C47E242F430CD8 /* CryptoSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ACEE7EB126C3F28C8C05B7C9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				50132650EEA27019BCA2E293 /* CryptoSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2859,6 +2868,7 @@
 				283DCDF5399761BAD0DB8923 /* Copy Bazel Outputs */,
 				8E99904A6B322FD8DC0AE06D /* Create linking dependencies */,
 				D891ADC38CB5CD0B471E2DC5 /* Sources */,
+				ACEE7EB126C3F28C8C05B7C9 /* Frameworks */,
 			);
 			buildRules = (
 			);

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -6198,6 +6198,12 @@
             "is_testonly": true,
             "label": "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle",
             "linker_inputs": {
+                "dynamic_frameworks": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
+                        "t": "e"
+                    }
+                ],
                 "linkopts": [
                     "-L$(DEVELOPER_DIR)/Platforms/AppleTVSimulator.platform/Developer/usr/lib",
                     "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftmodule",

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		7588D7A77F079A22223A4CD9 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E03EA73D2F5DAB6EDED34595 /* CryptoSwift.framework */; };
 		76EBD2A85F8B00A3AC785D91 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		79B7C5A659E99494C2DE8CA4 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7A89F29A836A7DB1D3EF7667 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 161FCC8E16610CC731029DF1 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7CC5D5ADD1512CBD7146C5CC /* WatchOSAppExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B218A5ABDAE4874D95C93B /* WatchOSAppExtensionTests.swift */; };
 		7DB75EFC83D0E6BF459CDBAD /* AltIcon-60@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = B7A58D8893BD2FBD17F6365C /* AltIcon-60@2x.png */; };
 		7E67547F812C4CB430B3E719 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33769C19E5BDFCC804DB871 /* Lib.swift */; };
@@ -94,6 +95,7 @@
 		9EBD12B9600E371A1CDC1090 /* Utils.bundle in Resources */ = {isa = PBXBuildFile; fileRef = D1A77D43C2AC29495314BE08 /* Utils.bundle */; };
 		A1015778E645BAF13F1E3EB6 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9F5C9ECA94AABFD6812E7930 /* Localizable.strings */; };
 		A1736C708A752DBF8E79E4B1 /* Launch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F25FDB1425AC4C3D5829AD6 /* Launch.storyboard */; };
+		A225636FE42CBCBD21146A91 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 161FCC8E16610CC731029DF1 /* CryptoSwift.framework */; };
 		A2881D00B6B4998713F69CDB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7A8C0E241B1307FE7464ADF2 /* Assets.xcassets */; };
 		A3981F7E03800ED5F1A4CE70 /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = 810E2D447FCAC7D533DFF6D2 /* lib.m */; };
 		A6753619C6B486331D39C220 /* AppClip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B85F05863EF8DE04D82121 /* AppClip.swift */; };
@@ -572,6 +574,17 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6D2E1B47A7BF182F648958B4 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				7A89F29A836A7DB1D3EF7667 /* CryptoSwift.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		75774963D17D570D0DAF085D /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -920,6 +933,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				B6F3484C7F2A4F19417D4F2B /* ExternalFramework.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9CC387A8C29E692EDE26A70A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A225636FE42CBCBD21146A91 /* CryptoSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3170,6 +3191,8 @@
 			buildPhases = (
 				755BE1A07AB48CCBA936E166 /* Create linking dependencies */,
 				EB0951B0308737E469AF753E /* Sources */,
+				9CC387A8C29E692EDE26A70A /* Frameworks */,
+				6D2E1B47A7BF182F648958B4 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -5295,6 +5295,12 @@
             "is_testonly": true,
             "label": "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle",
             "linker_inputs": {
+                "dynamic_frameworks": [
+                    {
+                        "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
+                        "t": "e"
+                    }
+                ],
                 "linkopts": [
                     "-L$(DEVELOPER_DIR)/Platforms/AppleTVSimulator.platform/Developer/usr/lib",
                     "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftmodule",

--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -142,9 +142,6 @@ def _extract_top_level_values(
 `avoid_compilation_providers` doesn't have `ObjcProvider`, but \
 `compilation_providers` does
 """)
-            avoid_dynamic_framework_files = sets.make(
-                avoid_objc.dynamic_framework_file.to_list(),
-            )
             avoid_static_framework_files = sets.make(
                 avoid_objc.static_framework_file.to_list(),
             )
@@ -155,7 +152,6 @@ def _extract_top_level_values(
                 ]).to_list(),
             )
         else:
-            avoid_dynamic_framework_files = sets.make()
             avoid_static_framework_files = sets.make()
             avoid_static_libraries = sets.make()
 
@@ -174,8 +170,7 @@ def _extract_top_level_values(
         dynamic_frameworks = [
             file
             for file in objc.dynamic_framework_file.to_list()
-            if (file.is_source and
-                not sets.contains(avoid_dynamic_framework_files, file))
+            if file.is_source
         ]
         static_frameworks = [
             file


### PR DESCRIPTION
This is to match Bazel's behavior: https://github.com/fmeum/bazel/blob/a55ad95a81a3a0129f66ea36276b92e878852613/src/main/java/com/google/devtools/build/lib/rules/objc/ObjcProvider.java#L386-L404

Ideally in the future we wouldn't be calculating this ourselves, because if Bazel changes its behavior, we will get out of sync.