### PR TITLE
Fix BwX SwiftUI Previews output group selection

### DIFF
--- a/examples/cc/test/fixtures/bwb_spec.json
+++ b/examples/cc/test/fixtures/bwb_spec.json
@@ -99,6 +99,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "lib_impl",
                 "path": {
                     "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib2/liblib_impl.a",
@@ -183,6 +184,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "lib_impl",
                 "path": {
                     "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/lib/liblib_impl.lo",
@@ -301,6 +303,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tool",
+                "is_resource_bundle": false,
                 "name": "tool",
                 "path": {
                     "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/tool/rules_xcodeproj/tool/tool",
@@ -413,6 +416,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "lib_impl",
                 "path": {
                     "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/external/examples_cc_external/liblib_impl.a",

--- a/examples/cc/test/fixtures/bwx_spec.json
+++ b/examples/cc/test/fixtures/bwx_spec.json
@@ -99,6 +99,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "lib_impl",
                 "path": {
                     "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a",
@@ -183,6 +184,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "lib_impl",
                 "path": {
                     "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo",
@@ -301,6 +303,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tool",
+                "is_resource_bundle": false,
                 "name": "tool",
                 "path": {
                     "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/tool/rules_xcodeproj/tool/tool",
@@ -413,6 +416,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "lib_impl",
                 "path": {
                     "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a",

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -618,6 +618,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "AppClip",
+                "is_resource_bundle": false,
                 "name": "AppClip",
                 "path": {
                     "_": "applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/AppClip/AppClip.app",
@@ -801,6 +802,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "AppClip",
+                "is_resource_bundle": false,
                 "name": "AppClip",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AppClip/AppClip.app",
@@ -890,6 +892,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "AppClip.library",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/AppClip/libAppClip.library.a",
@@ -985,6 +988,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "AppClip.library",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AppClip/libAppClip.library.a",
@@ -1207,6 +1211,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "CommandLineTool",
+                "is_resource_bundle": false,
                 "name": "CommandLineTool",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/bin/CommandLine/CommandLineTool/rules_xcodeproj/CommandLineTool/CommandLineTool",
@@ -1342,6 +1347,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tool.library",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/bin/CommandLine/CommandLineTool/libtool.library.a",
@@ -1470,6 +1476,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "lib_impl",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
@@ -1564,6 +1571,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "lib_swift",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
@@ -1662,6 +1670,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "private_lib",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
@@ -1727,6 +1736,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "private_swift_lib",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
@@ -1815,6 +1825,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "CommandLineLibSwiftTestsLib",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/bin/CommandLine/Tests/libCommandLineLibSwiftTestsLib.a",
@@ -2081,6 +2092,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "CommandLineToolTests",
+                "is_resource_bundle": false,
                 "name": "CommandLineToolTests",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/bin/CommandLine/Tests/CommandLineToolTests.xctest",
@@ -2177,6 +2189,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "c_lib",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/bin/CommandLine/swift_c_module/libc_lib.a",
@@ -2251,6 +2264,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/Lib/libLib.a",
@@ -2339,6 +2353,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/Lib/libLib.a",
@@ -2427,6 +2442,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/Lib/libLib.a",
@@ -2515,6 +2531,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/Lib/libLib.a",
@@ -2603,6 +2620,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/Lib/libLib.a",
@@ -2691,6 +2709,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/Lib/libLib.a",
@@ -2779,6 +2798,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/UI/libUI.a",
@@ -2873,6 +2893,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/UI/libUI.a",
@@ -2967,6 +2988,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/UI/libUI.a",
@@ -3061,6 +3083,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/UI/libUI.a",
@@ -3155,6 +3178,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/UI/libUI.a",
@@ -3249,6 +3273,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/UI/libUI.a",
@@ -3432,6 +3457,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "WidgetExtension",
+                "is_resource_bundle": false,
                 "name": "WidgetExtension",
                 "path": {
                     "_": "applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/WidgetExtension/WidgetExtension.appex",
@@ -3608,6 +3634,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "WidgetExtension",
+                "is_resource_bundle": false,
                 "name": "WidgetExtension",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/WidgetExtension/WidgetExtension.appex",
@@ -3700,6 +3727,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "WidgetExtension.library",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/WidgetExtension/libWidgetExtension.library.a",
@@ -3798,6 +3826,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "WidgetExtension.library",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/WidgetExtension/libWidgetExtension.library.a",
@@ -3886,6 +3915,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "iMessageApp",
+                "is_resource_bundle": false,
                 "name": "iMessageApp",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/iMessageApp/iMessageApp.app",
@@ -4048,6 +4078,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "iMessageAppExtension",
+                "is_resource_bundle": false,
                 "name": "iMessageAppExtension",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/iMessageApp/iMessageAppExtension.appex",
@@ -4136,6 +4167,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "iMessageAppExtension.library",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/iMessageApp/libiMessageAppExtension.library.a",
@@ -4425,6 +4457,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "iOSApp_ExecutableName",
+                "is_resource_bundle": false,
                 "name": "iOSApp",
                 "path": {
                     "_": "applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/iOSApp/Source/iOSApp.app",
@@ -4728,6 +4761,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "iOSApp_ExecutableName",
+                "is_resource_bundle": false,
                 "name": "iOSApp",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/iOSApp/Source/iOSApp.app",
@@ -4849,6 +4883,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "iOSApp.library",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/iOSApp/Source/libiOSApp.library.a",
@@ -4979,6 +5014,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "iOSApp.library",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/iOSApp/Source/libiOSApp.library.a",
@@ -5126,6 +5162,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "macOSApp",
+                "is_resource_bundle": false,
                 "name": "macOSApp",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-e4309a660cc1/bin/macOSApp/Source/macOSApp.app",
@@ -5202,6 +5239,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "macOSApp.library",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-e4309a660cc1/bin/macOSApp/Source/libmacOSApp.library.a",
@@ -5301,6 +5339,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "macOSAppUITests",
+                "is_resource_bundle": false,
                 "name": "macOSAppUITests",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-e4309a660cc1/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
@@ -5369,6 +5408,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "macOSAppUITests.library",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-e4309a660cc1/bin/macOSApp/Test/UITests/libmacOSAppUITests.library.a",
@@ -5569,6 +5609,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tvOSApp",
+                "is_resource_bundle": false,
                 "name": "tvOSApp",
                 "path": {
                     "_": "applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/tvOSApp/Source/tvOSApp.app",
@@ -5782,6 +5823,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tvOSApp",
+                "is_resource_bundle": false,
                 "name": "tvOSApp",
                 "path": {
                     "_": "applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/tvOSApp/Source/tvOSApp.app",
@@ -5870,6 +5912,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tvOSApp.library",
                 "path": {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/tvOSApp/Source/libtvOSApp.library.a",
@@ -5968,6 +6011,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tvOSApp.library",
                 "path": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/tvOSApp/Source/libtvOSApp.library.a",
@@ -6088,6 +6132,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tvOSAppUITests",
+                "is_resource_bundle": false,
                 "name": "tvOSAppUITests",
                 "path": {
                     "_": "applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
@@ -6156,6 +6201,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tvOSAppUITests.library",
                 "path": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/tvOSApp/Test/UITests/libtvOSAppUITests.library.a",
@@ -6382,6 +6428,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tvOSAppUnitTests",
+                "is_resource_bundle": false,
                 "name": "tvOSAppUnitTests",
                 "path": {
                     "_": "applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
@@ -6472,6 +6519,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tvOSAppUnitTests.library",
                 "path": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/tvOSApp/Test/UnitTests/libtvOSAppUnitTests.library.a",
@@ -6596,6 +6644,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSAppUITests",
+                "is_resource_bundle": false,
                 "name": "watchOSAppUITests",
                 "path": {
                     "_": "applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
@@ -6664,6 +6713,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "watchOSAppUITests.library",
                 "path": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/watchOSApp/Test/UITests/libwatchOSAppUITests.library.a",
@@ -6732,6 +6782,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSApp",
+                "is_resource_bundle": false,
                 "name": "watchOSApp",
                 "path": {
                     "_": "applebin_watchos-watchos_arm64_32-dbg-ST-56a8163e2aa7/bin/watchOSApp/watchOSApp.app",
@@ -6799,6 +6850,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSApp",
+                "is_resource_bundle": false,
                 "name": "watchOSApp",
                 "path": {
                     "_": "applebin_watchos-watchos_x86_64-dbg-ST-3df60cf154e9/bin/watchOSApp/watchOSApp.app",
@@ -7000,6 +7052,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSAppExtensionUnitTests",
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtensionUnitTests",
                 "path": {
                     "_": "applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
@@ -7089,6 +7142,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtensionUnitTests.library",
                 "path": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/watchOSAppExtension/Test/UnitTests/libwatchOSAppExtensionUnitTests.library.a",
@@ -7313,6 +7367,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSAppExtension",
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtension",
                 "path": {
                     "_": "applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/watchOSAppExtension/watchOSAppExtension.appex",
@@ -7526,6 +7581,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSAppExtension",
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtension",
                 "path": {
                     "_": "applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/watchOSAppExtension/watchOSAppExtension.appex",
@@ -7614,6 +7670,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtension.library",
                 "path": {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/watchOSAppExtension/libwatchOSAppExtension.library.a",
@@ -7712,6 +7769,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtension.library",
                 "path": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/watchOSAppExtension/libwatchOSAppExtension.library.a",

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -4721,7 +4721,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
-				BAZEL_LABEL = "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Resources/ExampleNestedResources";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Resources/ExampleNestedResources";
 				BAZEL_TARGET_ID = "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353";
@@ -4798,7 +4797,6 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
-				BAZEL_LABEL = "//iOSApp/Resources/ExampleResources:ExampleResources";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Resources/ExampleResources";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Resources/ExampleResources";
 				BAZEL_TARGET_ID = "//iOSApp/Resources/ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353";

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -477,6 +477,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "AppClip",
+                "is_resource_bundle": false,
                 "name": "AppClip",
                 "path": {
                     "_": "applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/AppClip/AppClip.app",
@@ -590,6 +591,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "AppClip",
+                "is_resource_bundle": false,
                 "name": "AppClip",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AppClip/AppClip.app",
@@ -679,6 +681,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "AppClip.library",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/AppClip/libAppClip.library.a",
@@ -774,6 +777,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "AppClip.library",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AppClip/libAppClip.library.a",
@@ -921,6 +925,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "CommandLineTool",
+                "is_resource_bundle": false,
                 "name": "CommandLineTool",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/CommandLineTool/rules_xcodeproj/CommandLineTool/CommandLineTool",
@@ -1056,6 +1061,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tool.library",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/CommandLineTool/libtool.library.a",
@@ -1184,6 +1190,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "lib_impl",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
@@ -1278,6 +1285,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "lib_swift",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
@@ -1376,6 +1384,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "private_lib",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
@@ -1441,6 +1450,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "private_swift_lib",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
@@ -1529,6 +1539,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "CommandLineLibSwiftTestsLib",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/Tests/libCommandLineLibSwiftTestsLib.a",
@@ -1672,6 +1683,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "CommandLineToolTests",
+                "is_resource_bundle": false,
                 "name": "CommandLineToolTests",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/Tests/CommandLineToolTests.xctest",
@@ -1768,6 +1780,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "c_lib",
                 "path": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/swift_c_module/libc_lib.a",
@@ -1842,6 +1855,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib/libLib.a",
@@ -1930,6 +1944,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/libLib.a",
@@ -2018,6 +2033,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib/libLib.a",
@@ -2106,6 +2122,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib/libLib.a",
@@ -2194,6 +2211,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/Lib/libLib.a",
@@ -2282,6 +2300,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "Lib",
                 "path": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/Lib/libLib.a",
@@ -2370,6 +2389,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/UI/libUI.a",
@@ -2464,6 +2484,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/UI/libUI.a",
@@ -2558,6 +2579,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/UI/libUI.a",
@@ -2652,6 +2674,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI/libUI.a",
@@ -2746,6 +2769,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/UI/libUI.a",
@@ -2840,6 +2864,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "UI",
                 "path": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI/libUI.a",
@@ -2954,6 +2979,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "WidgetExtension",
+                "is_resource_bundle": false,
                 "name": "WidgetExtension",
                 "path": {
                     "_": "applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/WidgetExtension/WidgetExtension.appex",
@@ -3061,6 +3087,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "WidgetExtension",
+                "is_resource_bundle": false,
                 "name": "WidgetExtension",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/WidgetExtension/WidgetExtension.appex",
@@ -3153,6 +3180,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "WidgetExtension.library",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/WidgetExtension/libWidgetExtension.library.a",
@@ -3251,6 +3279,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "WidgetExtension.library",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/WidgetExtension/libWidgetExtension.library.a",
@@ -3344,6 +3373,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "iMessageApp",
+                "is_resource_bundle": false,
                 "name": "iMessageApp",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iMessageApp/iMessageApp.app",
@@ -3438,6 +3468,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "iMessageAppExtension",
+                "is_resource_bundle": false,
                 "name": "iMessageAppExtension",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iMessageApp/iMessageAppExtension.appex",
@@ -3526,6 +3557,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "iMessageAppExtension.library",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iMessageApp/libiMessageAppExtension.library.a",
@@ -3600,6 +3632,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": true,
                 "name": "ExampleNestedResources",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Resources/ExampleNestedResources/ExampleNestedResources.bundle",
@@ -3645,6 +3678,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": true,
                 "name": "ExampleNestedResources",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Resources/ExampleNestedResources/ExampleNestedResources.bundle",
@@ -3691,6 +3725,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": true,
                 "name": "ExampleResources",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Resources/ExampleResources/ExampleResources.bundle",
@@ -3740,6 +3775,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": true,
                 "name": "ExampleResources",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Resources/ExampleResources/ExampleResources.bundle",
@@ -3888,6 +3924,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "iOSApp_ExecutableName",
+                "is_resource_bundle": false,
                 "name": "iOSApp",
                 "path": {
                     "_": "applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Source/iOSApp.app",
@@ -4080,6 +4117,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "iOSApp_ExecutableName",
+                "is_resource_bundle": false,
                 "name": "iOSApp",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Source/iOSApp.app",
@@ -4205,6 +4243,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "iOSApp.library",
                 "path": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Source/libiOSApp.library.a",
@@ -4335,6 +4374,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "iOSApp.library",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Source/libiOSApp.library.a",
@@ -4463,6 +4503,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "macOSApp",
+                "is_resource_bundle": false,
                 "name": "macOSApp",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/macOSApp/Source/macOSApp.app",
@@ -4539,6 +4580,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "macOSApp.library",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/macOSApp/Source/libmacOSApp.library.a",
@@ -4619,6 +4661,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "macOSAppUITests",
+                "is_resource_bundle": false,
                 "name": "macOSAppUITests",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
@@ -4687,6 +4730,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "macOSAppUITests.library",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/macOSApp/Test/UITests/libmacOSAppUITests.library.a",
@@ -4786,6 +4830,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tvOSApp",
+                "is_resource_bundle": false,
                 "name": "tvOSApp",
                 "path": {
                     "_": "applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/tvOSApp/Source/tvOSApp.app",
@@ -4898,6 +4943,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tvOSApp",
+                "is_resource_bundle": false,
                 "name": "tvOSApp",
                 "path": {
                     "_": "applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Source/tvOSApp.app",
@@ -4986,6 +5032,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tvOSApp.library",
                 "path": {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/tvOSApp/Source/libtvOSApp.library.a",
@@ -5084,6 +5131,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tvOSApp.library",
                 "path": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Source/libtvOSApp.library.a",
@@ -5185,6 +5233,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tvOSAppUITests",
+                "is_resource_bundle": false,
                 "name": "tvOSAppUITests",
                 "path": {
                     "_": "applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
@@ -5253,6 +5302,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tvOSAppUITests.library",
                 "path": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Test/UITests/libtvOSAppUITests.library.a",
@@ -5339,6 +5389,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tvOSAppUnitTests",
+                "is_resource_bundle": false,
                 "name": "tvOSAppUnitTests",
                 "path": {
                     "_": "applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
@@ -5429,6 +5480,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tvOSAppUnitTests.library",
                 "path": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Test/UnitTests/libtvOSAppUnitTests.library.a",
@@ -5534,6 +5586,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSAppUITests",
+                "is_resource_bundle": false,
                 "name": "watchOSAppUITests",
                 "path": {
                     "_": "applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
@@ -5602,6 +5655,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "watchOSAppUITests.library",
                 "path": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSApp/Test/UITests/libwatchOSAppUITests.library.a",
@@ -5675,6 +5729,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSApp",
+                "is_resource_bundle": false,
                 "name": "watchOSApp",
                 "path": {
                     "_": "applebin_watchos-watchos_arm64_32-dbg-ST-8e65bd00489d/bin/watchOSApp/watchOSApp.app",
@@ -5747,6 +5802,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSApp",
+                "is_resource_bundle": false,
                 "name": "watchOSApp",
                 "path": {
                     "_": "applebin_watchos-watchos_x86_64-dbg-ST-2f849b1d5a93/bin/watchOSApp/watchOSApp.app",
@@ -5841,6 +5897,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSAppExtensionUnitTests",
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtensionUnitTests",
                 "path": {
                     "_": "applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
@@ -5930,6 +5987,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtensionUnitTests.library",
                 "path": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSAppExtension/Test/UnitTests/libwatchOSAppExtensionUnitTests.library.a",
@@ -6052,6 +6110,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSAppExtension",
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtension",
                 "path": {
                     "_": "applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/watchOSAppExtension/watchOSAppExtension.appex",
@@ -6163,6 +6222,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "watchOSAppExtension",
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtension",
                 "path": {
                     "_": "applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSAppExtension/watchOSAppExtension.appex",
@@ -6251,6 +6311,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtension.library",
                 "path": {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/watchOSAppExtension/libwatchOSAppExtension.library.a",
@@ -6349,6 +6410,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "watchOSAppExtension.library",
                 "path": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSAppExtension/libwatchOSAppExtension.library.a",

--- a/examples/sanitizers/test/fixtures/bwb_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_spec.json
@@ -118,6 +118,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "ThreadSanitizerApp",
+                "is_resource_bundle": false,
                 "name": "ThreadSanitizerApp",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/ThreadSanitizerApp/ThreadSanitizerApp_archive-root/Payload/ThreadSanitizerApp.app",
@@ -185,6 +186,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "ThreadSanitizerApp.library",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/ThreadSanitizerApp/libThreadSanitizerApp.library.a",

--- a/examples/sanitizers/test/fixtures/bwx_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_spec.json
@@ -99,6 +99,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "ThreadSanitizerApp",
+                "is_resource_bundle": false,
                 "name": "ThreadSanitizerApp",
                 "path": {
                     "_": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/ThreadSanitizerApp/ThreadSanitizerApp_archive-root/Payload/ThreadSanitizerApp.app",
@@ -166,6 +167,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "ThreadSanitizerApp.library",
                 "path": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/ThreadSanitizerApp/libThreadSanitizerApp.library.a",

--- a/examples/simple/test/fixtures/bwb_spec.json
+++ b/examples/simple/test/fixtures/bwb_spec.json
@@ -95,6 +95,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "SwiftBin",
+                "is_resource_bundle": false,
                 "name": "SwiftBin",
                 "path": {
                     "_": "darwin_x86_64-dbg-ST-a9822d5480e1/bin/rules_xcodeproj/SwiftBin/SwiftBin",

--- a/examples/simple/test/fixtures/bwx_spec.json
+++ b/examples/simple/test/fixtures/bwx_spec.json
@@ -76,6 +76,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "SwiftBin",
+                "is_resource_bundle": false,
                 "name": "SwiftBin",
                 "path": {
                     "_": "darwin_x86_64-dbg-ST-3688109ddba2/bin/rules_xcodeproj/SwiftBin/SwiftBin",

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -357,6 +357,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tests",
+                "is_resource_bundle": false,
                 "name": "tests",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/tools/generator/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
@@ -476,6 +477,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tests.library",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/tools/generator/test/libtests.library.a",
@@ -691,6 +693,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "generator",
+                "is_resource_bundle": false,
                 "name": "generator",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/tools/generator/rules_xcodeproj/generator/generator",
@@ -831,6 +834,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "generator.library",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/tools/generator/libgenerator.library.a",
@@ -1113,6 +1117,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "OrderedCollections",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
@@ -1181,6 +1186,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "PathKit",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_kylef_pathkit/libPathKit.a",
@@ -1348,6 +1354,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "CustomDump",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
@@ -1422,6 +1429,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "XCTestDynamicOverlay",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a",
@@ -1869,6 +1877,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "XcodeProj",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -357,6 +357,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "tests",
+                "is_resource_bundle": false,
                 "name": "tests",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
@@ -476,6 +477,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "tests.library",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/test/libtests.library.a",
@@ -691,6 +693,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": "generator",
+                "is_resource_bundle": false,
                 "name": "generator",
                 "path": {
                     "_": "applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/rules_xcodeproj/generator/generator",
@@ -831,6 +834,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "generator.library",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a",
@@ -1113,6 +1117,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "OrderedCollections",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
@@ -1181,6 +1186,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "PathKit",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a",
@@ -1348,6 +1354,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "CustomDump",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
@@ -1422,6 +1429,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "XCTestDynamicOverlay",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a",
@@ -1869,6 +1877,7 @@
             "product": {
                 "additional_paths": [],
                 "executable_name": null,
+                "is_resource_bundle": false,
                 "name": "XcodeProj",
                 "path": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",

--- a/tools/generator/src/DTO/Product.swift
+++ b/tools/generator/src/DTO/Product.swift
@@ -3,6 +3,7 @@ import XcodeProj
 
 struct Product: Equatable, Decodable {
     let type: PBXProductType
+    let isResourceBundle: Bool
     let name: String
     var path: FilePath
     var additionalPaths: [FilePath]
@@ -11,12 +12,14 @@ struct Product: Equatable, Decodable {
     /// Custom initializer for easier testing.
     init(
         type: PBXProductType,
+        isResourceBundle: Bool = false,
         name: String,
         path: FilePath,
         additionalPaths: [FilePath] = [],
         executableName: String? = nil
     ) {
         self.type = type
+        self.isResourceBundle = isResourceBundle
         self.name = name
         self.path = path
         self.additionalPaths = additionalPaths

--- a/xcodeproj/internal/product.bzl
+++ b/xcodeproj/internal/product.bzl
@@ -66,6 +66,7 @@ def process_product(
         target,
         product_name,
         product_type,
+        is_resource_bundle = False,
         bundle_file = None,
         bundle_file_path = None,
         archive_file_path = None,
@@ -81,6 +82,7 @@ def process_product(
         product_type: A PBXProductType string. See
             https://github.com/tuist/XcodeProj/blob/main/Sources/XcodeProj/Objects/Targets/PBXProductType.swift
             for examples.
+        is_resource_bundle: Whether the product is a resource bundle.
         bundle_file: If the product is a bundle, this is `File` for the bundle,
             otherwise `None`.
         bundle_file_path: If the product is a bundle, this is the `file_path` to
@@ -132,6 +134,7 @@ def process_product(
         file_path = fp,
         actual_file_path = actual_fp,
         type = product_type,
+        is_resource_bundle = is_resource_bundle,
     )
 
 # TODO: Make this into a module
@@ -142,6 +145,7 @@ def product_to_dto(product):
             for file in product.linker_files.to_list()
         ],
         "executable_name": product.executable_name,
+        "is_resource_bundle": product.is_resource_bundle,
         "name": product.name,
         "path": (
             file_path_to_dto(product.file_path) if product.file_path else None

--- a/xcodeproj/internal/resource_target.bzl
+++ b/xcodeproj/internal/resource_target.bzl
@@ -36,6 +36,7 @@ def _process_resource_bundle(bundle, *, information):
         target = None,
         product_name = name,
         product_type = "com.apple.product-type.bundle",
+        is_resource_bundle = True,
         bundle_file = None,
         bundle_file_path = bundle_file_path,
         linker_inputs = None,


### PR DESCRIPTION
When there were resource bundles this would break. Broke in 74ec1431367e1d8f4c05931ada26429f2ecfbb7f.