### PR TITLE
Add Address Sanitizer Support

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -193,10 +193,10 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
-elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
-  config="${BAZEL_CONFIG}_tsan"
 elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_asan"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -195,6 +195,8 @@ elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_tsan"
+elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_asan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -99,6 +99,13 @@ build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 build:rules_xcodeproj_tsan --config=rules_xcodeproj
 build:rules_xcodeproj_tsan --features=tsan
 
+### `--config=rules_xcodeproj_asan`
+#
+# Used when building with Address Sanitizer enabled.
+
+build:rules_xcodeproj_asan --config=rules_xcodeproj
+build:rules_xcodeproj_asan --features=asan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,19 +92,19 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=rules_xcodeproj_tsan`
-#
-# Used when building with Thread Sanitizer enabled.
-
-build:rules_xcodeproj_tsan --config=rules_xcodeproj
-build:rules_xcodeproj_tsan --features=tsan
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.
 
 build:rules_xcodeproj_asan --config=rules_xcodeproj
 build:rules_xcodeproj_asan --features=asan
+
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/examples/cc/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/cc/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -193,10 +193,10 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
-elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
-  config="${BAZEL_CONFIG}_tsan"
 elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_asan"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -195,6 +195,8 @@ elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_tsan"
+elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_asan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -99,6 +99,13 @@ build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 build:rules_xcodeproj_tsan --config=rules_xcodeproj
 build:rules_xcodeproj_tsan --features=tsan
 
+### `--config=rules_xcodeproj_asan`
+#
+# Used when building with Address Sanitizer enabled.
+
+build:rules_xcodeproj_asan --config=rules_xcodeproj
+build:rules_xcodeproj_asan --features=asan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,19 +92,19 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=rules_xcodeproj_tsan`
-#
-# Used when building with Thread Sanitizer enabled.
-
-build:rules_xcodeproj_tsan --config=rules_xcodeproj
-build:rules_xcodeproj_tsan --features=tsan
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.
 
 build:rules_xcodeproj_asan --config=rules_xcodeproj
 build:rules_xcodeproj_asan --features=asan
+
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/app.exclude.rsynclist
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/app.exclude.rsynclist
@@ -1,3 +1,4 @@
+/*.app/Frameworks/libclang_rt.asan*.dylib
 /*.app/Frameworks/libclang_rt.tsan*.dylib
 /*.app/Frameworks/libXCTestBundleInject.dylib
 /*.app/Frameworks/libXCTestSwiftSupport.dylib

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -193,10 +193,10 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
-elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
-  config="${BAZEL_CONFIG}_tsan"
 elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_asan"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -195,6 +195,8 @@ elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_tsan"
+elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_asan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -99,6 +99,13 @@ build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 build:rules_xcodeproj_tsan --config=rules_xcodeproj
 build:rules_xcodeproj_tsan --features=tsan
 
+### `--config=rules_xcodeproj_asan`
+#
+# Used when building with Address Sanitizer enabled.
+
+build:rules_xcodeproj_asan --config=rules_xcodeproj
+build:rules_xcodeproj_asan --features=asan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust
@@ -124,6 +131,8 @@ build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_swift
 build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_integration
 build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_tsan
 build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_integration
+build:rules_xcodeproj_integration_asan --config=rules_xcodeproj_asan
+build:rules_xcodeproj_integration_asan --config=rules_xcodeproj_integration
 
 # Private implementation detail. Don't adjust this config, adjust
 # `rules_xcodeproj_integration` instead.

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,19 +92,19 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=rules_xcodeproj_tsan`
-#
-# Used when building with Thread Sanitizer enabled.
-
-build:rules_xcodeproj_tsan --config=rules_xcodeproj
-build:rules_xcodeproj_tsan --features=tsan
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.
 
 build:rules_xcodeproj_asan --config=rules_xcodeproj
 build:rules_xcodeproj_asan --features=asan
+
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
 
 ### `--config=_rules_xcodeproj_build`
 #
@@ -129,10 +129,10 @@ info:rules_xcodeproj_integration_info --config=rules_xcodeproj_info
 info:rules_xcodeproj_integration_info --config=rules_xcodeproj_integration
 build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_swiftuipreviews
 build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_integration
-build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_tsan
-build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_integration
 build:rules_xcodeproj_integration_asan --config=rules_xcodeproj_asan
 build:rules_xcodeproj_integration_asan --config=rules_xcodeproj_integration
+build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_tsan
+build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_integration
 
 # Private implementation detail. Don't adjust this config, adjust
 # `rules_xcodeproj_integration` instead.

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineTool.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineTool.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineTool.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineTool.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineToolTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineToolTests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineToolTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineToolTests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
@@ -43,7 +43,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
@@ -43,7 +43,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
@@ -43,7 +43,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
@@ -43,7 +43,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSApp.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSApp.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -193,10 +193,10 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
-elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
-  config="${BAZEL_CONFIG}_tsan"
 elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_asan"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -195,6 +195,8 @@ elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_tsan"
+elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_asan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -99,6 +99,13 @@ build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 build:rules_xcodeproj_tsan --config=rules_xcodeproj
 build:rules_xcodeproj_tsan --features=tsan
 
+### `--config=rules_xcodeproj_asan`
+#
+# Used when building with Address Sanitizer enabled.
+
+build:rules_xcodeproj_asan --config=rules_xcodeproj
+build:rules_xcodeproj_asan --features=asan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust
@@ -124,6 +131,8 @@ build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_swift
 build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_integration
 build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_tsan
 build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_integration
+build:rules_xcodeproj_integration_asan --config=rules_xcodeproj_asan
+build:rules_xcodeproj_integration_asan --config=rules_xcodeproj_integration
 
 # Private implementation detail. Don't adjust this config, adjust
 # `rules_xcodeproj_integration` instead.

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,19 +92,19 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=rules_xcodeproj_tsan`
-#
-# Used when building with Thread Sanitizer enabled.
-
-build:rules_xcodeproj_tsan --config=rules_xcodeproj
-build:rules_xcodeproj_tsan --features=tsan
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.
 
 build:rules_xcodeproj_asan --config=rules_xcodeproj
 build:rules_xcodeproj_asan --features=asan
+
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
 
 ### `--config=_rules_xcodeproj_build`
 #
@@ -129,10 +129,10 @@ info:rules_xcodeproj_integration_info --config=rules_xcodeproj_info
 info:rules_xcodeproj_integration_info --config=rules_xcodeproj_integration
 build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_swiftuipreviews
 build:rules_xcodeproj_integration_swiftuipreviews --config=rules_xcodeproj_integration
-build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_tsan
-build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_integration
 build:rules_xcodeproj_integration_asan --config=rules_xcodeproj_asan
 build:rules_xcodeproj_integration_asan --config=rules_xcodeproj_integration
+build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_tsan
+build:rules_xcodeproj_integration_tsan --config=rules_xcodeproj_integration
 
 # Private implementation detail. Don't adjust this config, adjust
 # `rules_xcodeproj_integration` instead.

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/app.exclude.rsynclist
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/app.exclude.rsynclist
@@ -1,3 +1,4 @@
+/*.app/Frameworks/libclang_rt.asan*.dylib
 /*.app/Frameworks/libclang_rt.tsan*.dylib
 /*.app/Frameworks/libXCTestBundleInject.dylib
 /*.app/Frameworks/libXCTestSwiftSupport.dylib

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -193,10 +193,10 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
-elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
-  config="${BAZEL_CONFIG}_tsan"
 elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_asan"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -195,6 +195,8 @@ elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_tsan"
+elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_asan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -99,6 +99,13 @@ build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 build:rules_xcodeproj_tsan --config=rules_xcodeproj
 build:rules_xcodeproj_tsan --features=tsan
 
+### `--config=rules_xcodeproj_asan`
+#
+# Used when building with Address Sanitizer enabled.
+
+build:rules_xcodeproj_asan --config=rules_xcodeproj
+build:rules_xcodeproj_asan --features=asan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,19 +92,19 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=rules_xcodeproj_tsan`
-#
-# Used when building with Thread Sanitizer enabled.
-
-build:rules_xcodeproj_tsan --config=rules_xcodeproj
-build:rules_xcodeproj_tsan --features=tsan
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.
 
 build:rules_xcodeproj_asan --config=rules_xcodeproj
 build:rules_xcodeproj_asan --features=asan
+
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ThreadSanitizerApp.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ThreadSanitizerApp.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ThreadSanitizerApp.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ThreadSanitizerApp.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -193,10 +193,10 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
-elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
-  config="${BAZEL_CONFIG}_tsan"
 elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_asan"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -195,6 +195,8 @@ elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_tsan"
+elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_asan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -99,6 +99,13 @@ build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 build:rules_xcodeproj_tsan --config=rules_xcodeproj
 build:rules_xcodeproj_tsan --features=tsan
 
+### `--config=rules_xcodeproj_asan`
+#
+# Used when building with Address Sanitizer enabled.
+
+build:rules_xcodeproj_asan --config=rules_xcodeproj
+build:rules_xcodeproj_asan --features=asan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,19 +92,19 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=rules_xcodeproj_tsan`
-#
-# Used when building with Thread Sanitizer enabled.
-
-build:rules_xcodeproj_tsan --config=rules_xcodeproj
-build:rules_xcodeproj_tsan --features=tsan
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.
 
 build:rules_xcodeproj_asan --config=rules_xcodeproj
 build:rules_xcodeproj_asan --features=asan
+
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -193,10 +193,10 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
-elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
-  config="${BAZEL_CONFIG}_tsan"
 elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_asan"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -195,6 +195,8 @@ elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_tsan"
+elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_asan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -99,6 +99,13 @@ build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 build:rules_xcodeproj_tsan --config=rules_xcodeproj
 build:rules_xcodeproj_tsan --features=tsan
 
+### `--config=rules_xcodeproj_asan`
+#
+# Used when building with Address Sanitizer enabled.
+
+build:rules_xcodeproj_asan --config=rules_xcodeproj
+build:rules_xcodeproj_asan --features=asan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,19 +92,19 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=rules_xcodeproj_tsan`
-#
-# Used when building with Thread Sanitizer enabled.
-
-build:rules_xcodeproj_tsan --config=rules_xcodeproj
-build:rules_xcodeproj_tsan --features=tsan
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.
 
 build:rules_xcodeproj_asan --config=rules_xcodeproj
 build:rules_xcodeproj_asan --features=asan
+
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/examples/simple/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/SwiftBin.xcscheme
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/SwiftBin.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/simple/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/SwiftBin.xcscheme
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/SwiftBin.xcscheme
@@ -42,7 +42,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -193,10 +193,10 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
-elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
-  config="${BAZEL_CONFIG}_tsan"
 elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_asan"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -195,6 +195,8 @@ elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_tsan"
+elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_asan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -99,6 +99,13 @@ build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 build:rules_xcodeproj_tsan --config=rules_xcodeproj
 build:rules_xcodeproj_tsan --features=tsan
 
+### `--config=rules_xcodeproj_asan`
+#
+# Used when building with Address Sanitizer enabled.
+
+build:rules_xcodeproj_asan --config=rules_xcodeproj
+build:rules_xcodeproj_asan --features=asan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,19 +92,19 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=rules_xcodeproj_tsan`
-#
-# Used when building with Thread Sanitizer enabled.
-
-build:rules_xcodeproj_tsan --config=rules_xcodeproj
-build:rules_xcodeproj_tsan --features=tsan
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.
 
 build:rules_xcodeproj_asan --config=rules_xcodeproj
 build:rules_xcodeproj_asan --features=asan
+
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -193,10 +193,10 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
-elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
-  config="${BAZEL_CONFIG}_tsan"
 elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_asan"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -195,6 +195,8 @@ elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_tsan"
+elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_asan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -99,6 +99,13 @@ build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 build:rules_xcodeproj_tsan --config=rules_xcodeproj
 build:rules_xcodeproj_tsan --features=tsan
 
+### `--config=rules_xcodeproj_asan`
+#
+# Used when building with Address Sanitizer enabled.
+
+build:rules_xcodeproj_asan --config=rules_xcodeproj
+build:rules_xcodeproj_asan --features=asan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,19 +92,19 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=rules_xcodeproj_tsan`
-#
-# Used when building with Thread Sanitizer enabled.
-
-build:rules_xcodeproj_tsan --config=rules_xcodeproj
-build:rules_xcodeproj_tsan --features=tsan
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.
 
 build:rules_xcodeproj_asan --config=rules_xcodeproj
 build:rules_xcodeproj_asan --features=asan
+
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -74,7 +74,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -74,7 +74,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Symlink Toolchain /usr/lib directory"
-               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               scriptText = "if [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -193,10 +193,10 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
-elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
-  config="${BAZEL_CONFIG}_tsan"
 elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_asan"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -195,6 +195,8 @@ elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_tsan"
+elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_asan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -99,6 +99,13 @@ build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 build:rules_xcodeproj_tsan --config=rules_xcodeproj
 build:rules_xcodeproj_tsan --features=tsan
 
+### `--config=rules_xcodeproj_asan`
+#
+# Used when building with Address Sanitizer enabled.
+
+build:rules_xcodeproj_asan --config=rules_xcodeproj
+build:rules_xcodeproj_asan --features=asan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -92,19 +92,19 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=rules_xcodeproj_tsan`
-#
-# Used when building with Thread Sanitizer enabled.
-
-build:rules_xcodeproj_tsan --config=rules_xcodeproj
-build:rules_xcodeproj_tsan --features=tsan
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.
 
 build:rules_xcodeproj_asan --config=rules_xcodeproj
 build:rules_xcodeproj_asan --features=asan
+
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/tools/generator/src/Extensions/XCScheme+Extensions.swift
+++ b/tools/generator/src/Extensions/XCScheme+Extensions.swift
@@ -171,7 +171,7 @@ echo "$BAZEL_LABEL,$BAZEL_TARGET_ID" >> "$SCHEME_TARGET_IDS_FILE"
     ) -> XCScheme.ExecutionAction {
         return .init(
             scriptText: #"""
-if [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+if [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ] || [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
     # TODO: Support custom toolchains once clang.sh supports them 
     src="$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib"
     dest="$BAZEL_INTEGRATION_DIR/../lib"

--- a/tools/generator/src/Extensions/XCScheme+Extensions.swift
+++ b/tools/generator/src/Extensions/XCScheme+Extensions.swift
@@ -171,7 +171,7 @@ echo "$BAZEL_LABEL,$BAZEL_TARGET_ID" >> "$SCHEME_TARGET_IDS_FILE"
     ) -> XCScheme.ExecutionAction {
         return .init(
             scriptText: #"""
-if [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ] || [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+if [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ] || [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
     # TODO: Support custom toolchains once clang.sh supports them 
     src="$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib"
     dest="$BAZEL_INTEGRATION_DIR/../lib"

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -563,6 +563,7 @@ extension Generator {
         {
             files[.internal(appRsyncExcludeFileListPath)] =
                 .nonReferencedContent(#"""
+/*.app/Frameworks/libclang_rt.asan*.dylib
 /*.app/Frameworks/libclang_rt.tsan*.dylib
 /*.app/Frameworks/libXCTestBundleInject.dylib
 /*.app/Frameworks/libXCTestSwiftSupport.dylib

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -193,10 +193,10 @@ if [ "$ACTION" == "indexbuild" ]; then
   config="${BAZEL_CONFIG}_indexbuild"
 elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
-elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
-  config="${BAZEL_CONFIG}_tsan"
 elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_asan"
+elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_tsan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -195,6 +195,8 @@ elif [ "${ENABLE_PREVIEWS:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_swiftuipreviews"
 elif [ "${ENABLE_THREAD_SANITIZER:-}" == "YES" ]; then
   config="${BAZEL_CONFIG}_tsan"
+elif [ "${ENABLE_ADDRESS_SANITIZER:-}" == "YES" ]; then
+  config="${BAZEL_CONFIG}_asan"
 else
   config="_${BAZEL_CONFIG}_build"
 fi

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -99,6 +99,13 @@ build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 build:rules_xcodeproj_tsan --config=rules_xcodeproj
 build:rules_xcodeproj_tsan --features=tsan
 
+### `--config=rules_xcodeproj_asan`
+#
+# Used when building with Address Sanitizer enabled.
+
+build:rules_xcodeproj_asan --config=rules_xcodeproj
+build:rules_xcodeproj_asan --features=asan
+
 ### `--config=_rules_xcodeproj_build`
 #
 # Private implementation detail. Don't adjust this config, adjust

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -92,19 +92,19 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 # we already have cache misses from the `swiftc` flags above
 build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
 
-### `--config=rules_xcodeproj_tsan`
-#
-# Used when building with Thread Sanitizer enabled.
-
-build:rules_xcodeproj_tsan --config=rules_xcodeproj
-build:rules_xcodeproj_tsan --features=tsan
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.
 
 build:rules_xcodeproj_asan --config=rules_xcodeproj
 build:rules_xcodeproj_asan --features=asan
+
+### `--config=rules_xcodeproj_tsan`
+#
+# Used when building with Thread Sanitizer enabled.
+
+build:rules_xcodeproj_tsan --config=rules_xcodeproj
+build:rules_xcodeproj_tsan --features=tsan
 
 ### `--config=_rules_xcodeproj_build`
 #

--- a/xcodeproj/internal/xcodeproj_runner.bzl
+++ b/xcodeproj/internal/xcodeproj_runner.bzl
@@ -30,6 +30,8 @@ build:{config}_swiftuipreviews --config=rules_xcodeproj_swiftuipreviews
 build:{config}_swiftuipreviews --config={config}
 build:{config}_tsan --config=rules_xcodeproj_tsan
 build:{config}_tsan --config={config}
+build:{config}_asan --config=rules_xcodeproj_asan
+build:{config}_asan --config={config}
 
 # Private implementation detail. Don't adjust this config, adjust
 # `{config}` instead.

--- a/xcodeproj/internal/xcodeproj_runner.bzl
+++ b/xcodeproj/internal/xcodeproj_runner.bzl
@@ -28,10 +28,10 @@ info:{config}_info --config=rules_xcodeproj_info
 info:{config}_info --config={config}
 build:{config}_swiftuipreviews --config=rules_xcodeproj_swiftuipreviews
 build:{config}_swiftuipreviews --config={config}
-build:{config}_tsan --config=rules_xcodeproj_tsan
-build:{config}_tsan --config={config}
 build:{config}_asan --config=rules_xcodeproj_asan
 build:{config}_asan --config={config}
+build:{config}_tsan --config=rules_xcodeproj_tsan
+build:{config}_tsan --config={config}
 
 # Private implementation detail. Don't adjust this config, adjust
 # `{config}` instead.


### PR DESCRIPTION
This PR adds Address Sanitizer Support.

- Add the following example in the sanitizers app and enable Address Sanitizer.
```
let pointer = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
pointer.storeBytes(of: 1, as: UInt8.self)
pointer.advanced(by: 1).storeBytes(of: 2, as: UInt8.self)
```

- Since we are advancing a pointer to take care of 2 bytes but the declared byteCount is 1, it should give a Heap Overflow Asan error.
- Tested and it works as expected.

TODO:

- AddressSanitizer application will be added inside `examples/sanitizers` similar to Tsan in the next PR.