### PR TITLE
Adjust `FRAMEWORK_SEARCH_PATHS` to account for framework targets

### DIFF
--- a/tools/generator/src/DTO/FilePath.swift
+++ b/tools/generator/src/DTO/FilePath.swift
@@ -128,7 +128,7 @@ extension FilePath {
     func parent() -> FilePath {
         return FilePath(
             type: type,
-            path: path.parent(),
+            path: path.parent().normalize(),
             isFolder: false,
             includeInNavigator: includeInNavigator,
             forceGroupCreation: forceGroupCreation


### PR DESCRIPTION
The search path will now correctly be either `$BUILD_DIR` or `bazel-out/` based. In BwX mode with unfocused targets, the same original path might produce both paths.