### PR TITLE
Stop including framework target outputs in `allExcludableFiles`

### DIFF
--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -25,6 +25,7 @@ struct Environment {
 
     let consolidateTargets: (
         _ targets: [TargetID: Target],
+        _ xcodeGeneratedFiles: [FilePath: FilePath],
         _ logger: Logger
     ) throws -> ConsolidatedTargets
 

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -88,11 +88,6 @@ class Generator {
             targets[id]!.dependencies.subtract(isUnfocusedDependencyTargetIDs)
         }
 
-        let consolidatedTargets = try environment.consolidateTargets(
-            targets,
-            logger
-        )
-
         let (
             files,
             rootElements,
@@ -106,6 +101,12 @@ class Generator {
             project.extraFiles,
             xccurrentversions,
             filePathResolver,
+            logger
+        )
+
+        let consolidatedTargets = try environment.consolidateTargets(
+            targets,
+            xcodeGeneratedFiles,
             logger
         )
         let (products, productsGroup) = environment.createProducts(

--- a/tools/generator/test/ConsolidateTargetsTest.swift
+++ b/tools/generator/test/ConsolidateTargetsTest.swift
@@ -30,6 +30,7 @@ final class ConsolidateTargetsTests: XCTestCase {
         let logger = StubLogger()
         let consolidatedTargets = try Generator.consolidateTargets(
             targets,
+            [:],
             logger: logger
         )
 
@@ -68,6 +69,7 @@ final class ConsolidateTargetsTests: XCTestCase {
         let logger = StubLogger()
         let consolidatedTargets = try Generator.consolidateTargets(
             targets,
+            [:],
             logger: logger
         )
 
@@ -129,6 +131,7 @@ final class ConsolidateTargetsTests: XCTestCase {
         let logger = StubLogger()
         let consolidatedTargets = try Generator.consolidateTargets(
             targets,
+            [:],
             logger: logger
         )
 
@@ -169,6 +172,7 @@ final class ConsolidateTargetsTests: XCTestCase {
         let logger = StubLogger()
         let consolidatedTargets = try Generator.consolidateTargets(
             targets,
+            [:],
             logger: logger
         )
 
@@ -205,6 +209,7 @@ final class ConsolidateTargetsTests: XCTestCase {
         let logger = StubLogger()
         let consolidatedTargets = try Generator.consolidateTargets(
             targets,
+            [:],
             logger: logger
         )
 
@@ -258,6 +263,7 @@ final class ConsolidateTargetsTests: XCTestCase {
         let logger = StubLogger()
         let consolidatedTargets = try Generator.consolidateTargets(
             targets,
+            [:],
             logger: logger
         )
 
@@ -323,6 +329,7 @@ final class ConsolidateTargetsTests: XCTestCase {
         let logger = StubLogger()
         let consolidatedTargets = try Generator.consolidateTargets(
             targets,
+            [:],
             logger: logger
         )
 
@@ -430,6 +437,7 @@ conditional `deps`
         let logger = StubLogger()
         let consolidatedTargets = try Generator.consolidateTargets(
             targets,
+            [:],
             logger: logger
         )
 
@@ -551,6 +559,7 @@ conditional `test_host`
         let logger = StubLogger()
         let consolidatedTargets = try Generator.consolidateTargets(
             targets,
+            [:],
             logger: logger
         )
 

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -311,27 +311,6 @@ final class GeneratorTests: XCTestCase {
             targetMerges: project.targetMerges
         )]
 
-        // MARK: consolidateTargets()
-
-        struct ConsolidateTargetsCalled: Equatable {
-            let targets: [TargetID: Target]
-        }
-
-        var consolidateTargetsCalled: [ConsolidateTargetsCalled] = []
-        func consolidateTargets(
-            _ targets: [TargetID: Target],
-            logger _: Logger
-        ) -> ConsolidatedTargets {
-            consolidateTargetsCalled.append(.init(
-                targets: targets
-            ))
-            return consolidatedTargets
-        }
-
-        let expectedConsolidateTargetsCalled = [ConsolidateTargetsCalled(
-            targets: mergedTargets
-        )]
-
         // MARK: createFilesAndGroups()
 
         struct CreateFilesAndGroupsCalled: Equatable {
@@ -385,6 +364,31 @@ final class GeneratorTests: XCTestCase {
             extraFiles: project.extraFiles,
             xccurrentversions: xccurrentversions,
             filePathResolver: filePathResolver
+        )]
+
+        // MARK: consolidateTargets()
+
+        struct ConsolidateTargetsCalled: Equatable {
+            let targets: [TargetID: Target]
+            let xcodeGeneratedFiles: [FilePath: FilePath]
+        }
+
+        var consolidateTargetsCalled: [ConsolidateTargetsCalled] = []
+        func consolidateTargets(
+            _ targets: [TargetID: Target],
+            _ xcodeGeneratedFiles: [FilePath: FilePath],
+            logger _: Logger
+        ) -> ConsolidatedTargets {
+            consolidateTargetsCalled.append(.init(
+                targets: targets,
+                xcodeGeneratedFiles: xcodeGeneratedFiles
+            ))
+            return consolidatedTargets
+        }
+
+        let expectedConsolidateTargetsCalled = [ConsolidateTargetsCalled(
+            targets: mergedTargets,
+            xcodeGeneratedFiles: xcodeGeneratedFiles
         )]
 
         // MARK: createProducts()

--- a/tools/generator/test/Target+Testing.swift
+++ b/tools/generator/test/Target+Testing.swift
@@ -118,8 +118,17 @@ extension Platform {
     }
 }
 
-extension ConsolidatedTargets {
+extension ConsolidatedTarget {
     init(targets: [TargetID: Target]) {
+        self.init(targets: targets, xcodeGeneratedFiles: [:])
+    }
+}
+
+extension ConsolidatedTargets {
+    init(
+        targets: [TargetID: Target],
+        xcodeGeneratedFiles: [FilePath: FilePath] = [:]
+    ) {
         var keys: [TargetID: ConsolidatedTarget.Key] = [:]
         var consolidatedTargets: [ConsolidatedTarget.Key: ConsolidatedTarget] =
             [:]
@@ -127,13 +136,20 @@ extension ConsolidatedTargets {
         for (id, target) in targets {
             let key = ConsolidatedTarget.Key([id])
             keys[id] = key
-            consolidatedTargets[key] = ConsolidatedTarget(targets: [id: target])
+            consolidatedTargets[key] = ConsolidatedTarget(
+                targets: [id: target],
+                xcodeGeneratedFiles: xcodeGeneratedFiles
+            )
         }
 
         self.init(keys: keys, targets: consolidatedTargets)
     }
 
-    init(allTargets: [TargetID: Target], keys: Set<Set<TargetID>>) {
+    init(
+        allTargets: [TargetID: Target],
+        keys: Set<Set<TargetID>>,
+        xcodeGeneratedFiles: [FilePath: FilePath] = [:]
+    ) {
         var mapping: [TargetID: ConsolidatedTarget.Key] = [:]
         var consolidatedTargets: [ConsolidatedTarget.Key: ConsolidatedTarget] =
             [:]
@@ -144,7 +160,8 @@ extension ConsolidatedTargets {
                 mapping[targetID] = key
             }
             consolidatedTargets[key] = ConsolidatedTarget(
-                targets: allTargets.filter { id, _ in targetIDs.contains(id) }
+                targets: allTargets.filter { id, _ in targetIDs.contains(id) },
+                xcodeGeneratedFiles: xcodeGeneratedFiles
             )
         }
 


### PR DESCRIPTION
This is needed for upcoming framework support.