### PR TITLE
Move `hdrs` into `srcs

### DIFF
--- a/examples/cc/test/fixtures/bwb_spec.json
+++ b/examples/cc/test/fixtures/bwb_spec.json
@@ -79,11 +79,9 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-a9822d5480e1",
             "inputs": {
-                "hdrs": [
-                    "lib2/includes/lib.h"
-                ],
                 "srcs": [
-                    "lib2/lib.c"
+                    "lib2/lib.c",
+                    "lib2/includes/lib.h"
                 ]
             },
             "is_swift": false,
@@ -386,12 +384,6 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-a9822d5480e1",
             "inputs": {
-                "hdrs": [
-                    {
-                        "_": "examples_cc_external/private/private.inc",
-                        "t": "e"
-                    }
-                ],
                 "srcs": [
                     {
                         "_": "examples_cc_external/lib.c",

--- a/examples/cc/test/fixtures/bwx_spec.json
+++ b/examples/cc/test/fixtures/bwx_spec.json
@@ -79,11 +79,9 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-3688109ddba2",
             "inputs": {
-                "hdrs": [
-                    "lib2/includes/lib.h"
-                ],
                 "srcs": [
-                    "lib2/lib.c"
+                    "lib2/lib.c",
+                    "lib2/includes/lib.h"
                 ]
             },
             "is_swift": false,
@@ -386,12 +384,6 @@
             },
             "configuration": "darwin_x86_64-dbg-ST-3688109ddba2",
             "inputs": {
-                "hdrs": [
-                    {
-                        "_": "examples_cc_external/private/private.inc",
-                        "t": "e"
-                    }
-                ],
                 "srcs": [
                     {
                         "_": "examples_cc_external/lib.c",

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -1650,11 +1650,9 @@
             },
             "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197",
             "inputs": {
-                "hdrs": [
-                    "CommandLine/CommandLineToolLib/private_lib.h"
-                ],
                 "srcs": [
-                    "CommandLine/CommandLineToolLib/private_lib.c"
+                    "CommandLine/CommandLineToolLib/private_lib.c",
+                    "CommandLine/CommandLineToolLib/private_lib.h"
                 ]
             },
             "is_swift": false,
@@ -2169,11 +2167,9 @@
             },
             "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197",
             "inputs": {
-                "hdrs": [
-                    "CommandLine/swift_c_module/c_lib.h"
-                ],
                 "srcs": [
-                    "CommandLine/swift_c_module/c_lib.c"
+                    "CommandLine/swift_c_module/c_lib.c",
+                    "CommandLine/swift_c_module/c_lib.h"
                 ]
             },
             "is_swift": false,

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -1364,11 +1364,9 @@
             },
             "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803",
             "inputs": {
-                "hdrs": [
-                    "CommandLine/CommandLineToolLib/private_lib.h"
-                ],
                 "srcs": [
-                    "CommandLine/CommandLineToolLib/private_lib.c"
+                    "CommandLine/CommandLineToolLib/private_lib.c",
+                    "CommandLine/CommandLineToolLib/private_lib.h"
                 ]
             },
             "is_swift": false,
@@ -1760,11 +1758,9 @@
             },
             "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803",
             "inputs": {
-                "hdrs": [
-                    "CommandLine/swift_c_module/c_lib.h"
-                ],
                 "srcs": [
-                    "CommandLine/swift_c_module/c_lib.c"
+                    "CommandLine/swift_c_module/c_lib.c",
+                    "CommandLine/swift_c_module/c_lib.h"
                 ]
             },
             "is_swift": false,

--- a/tools/generator/src/DTO/Inputs.swift
+++ b/tools/generator/src/DTO/Inputs.swift
@@ -1,7 +1,7 @@
 struct Inputs: Equatable {
     var srcs: [FilePath]
     var nonArcSrcs: [FilePath]
-    var hdrs: Set<FilePath>
+    let hdrs: Set<FilePath>
     var pch: FilePath?
     var resources: Set<FilePath>
     var entitlements: FilePath?
@@ -30,7 +30,6 @@ extension Inputs {
     mutating func merge(_ other: Inputs) {
         srcs = other.srcs
         nonArcSrcs = other.nonArcSrcs
-        hdrs = other.hdrs
         pch = other.pch
         resources.formUnion(other.resources)
     }

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -343,13 +343,8 @@ def _collect(
     if CcInfo in target:
         compilation_context = target[CcInfo].compilation_context
         srcs.extend(_process_cc_info_headers(
-            compilation_context.direct_private_headers,
-            output_files = output_files,
-            pch = pch,
-            generated = generated,
-        ))
-        hdrs.extend(_process_cc_info_headers(
-            (compilation_context.direct_public_headers +
+            (compilation_context.direct_private_headers +
+             compilation_context.direct_public_headers +
              compilation_context.direct_textual_headers),
             output_files = output_files,
             pch = pch,


### PR DESCRIPTION
`hdrs` will be used to support framework level headers, which don't use `CcInfo` for their source of truth.