### PR TITLE
Add Address Sanitizer Example Application

### DIFF
--- a/examples/sanitizers/AddressSanitizerApp/AddressSanitizerApp.swift
+++ b/examples/sanitizers/AddressSanitizerApp/AddressSanitizerApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct SanitizerApp: App { // swiftlint:disable:this type_name
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/examples/sanitizers/AddressSanitizerApp/AddressSanitizerExamples.swift
+++ b/examples/sanitizers/AddressSanitizerApp/AddressSanitizerExamples.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+struct AddressSanitizerExamples {
+    func run() {
+        example1()
+    }
+    
+    private func example1() {
+        let pointer = UnsafeMutableRawPointer.allocate(
+            byteCount: 1, 
+            alignment: 1
+        )
+        pointer.storeBytes(
+            of: 1, 
+            as: UInt8.self
+        )
+        pointer.advanced(by: 1).storeBytes(
+            of: 2, 
+            as: UInt8.self
+        )
+    }
+}

--- a/examples/sanitizers/AddressSanitizerApp/BUILD
+++ b/examples/sanitizers/AddressSanitizerApp/BUILD
@@ -1,0 +1,23 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+ios_application(
+    name = "AddressSanitizerApp",
+    bundle_id = "io.buildbuddy.example",
+    bundle_name = "AddressSanitizerApp",
+    families = ["iphone"],
+    infoplists = [":Info.plist"],
+    minimum_os_version = "15.0",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":AddressSanitizerApp.library",
+    ],
+)
+
+swift_library(
+    name = "AddressSanitizerApp.library",
+    srcs = glob(["**/*.swift"]),
+    module_name = "AddressSanitizerApp",
+    tags = ["manual"],
+    visibility = ["//:__subpackages__"],
+)

--- a/examples/sanitizers/AddressSanitizerApp/ContentView.swift
+++ b/examples/sanitizers/AddressSanitizerApp/ContentView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct ContentView: View {
+    init() {
+        AddressSanitizerExamples().run()
+    }
+    
+    var body: some View {
+        Text("""
+        Application to demonstrate Address Sanitizer reporting heap buffer overflows in BwB mode.
+        """)
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/examples/sanitizers/AddressSanitizerApp/Info.plist
+++ b/examples/sanitizers/AddressSanitizerApp/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+</dict>
+</plist>

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -24,10 +24,20 @@
 /* Begin PBXBuildFile section */
 		3494992E8797CB421F0D8212 /* ThreadSanitizerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE026F917B2710D6C999ADE /* ThreadSanitizerApp.swift */; };
 		6683EFF59B8883812B03A6AE /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A203BC864749E0547EB8D5F /* ContentView.swift */; };
+		9088F340FE5A22A9D1D4EDE1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5352DD14AB81EC9A68F1F45C /* ContentView.swift */; };
+		D55A935A5505A004D2EF8E0D /* AddressSanitizerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDEE0E1A80C49B3E9E90BE09 /* AddressSanitizerApp.swift */; };
 		D63F5A91E007259783111A2F /* ThreadSanitizerExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68756A77949C86917FEB04E7 /* ThreadSanitizerExamples.swift */; };
+		F3047DB70C4C915AB0B7F47C /* AddressSanitizerExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = C09292DFA09BA37265C228B2 /* AddressSanitizerExamples.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		75A218794D17005B42EF0C6F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
 		7D84F20B1E474BA5D72322C4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -42,9 +52,16 @@
 		1B6E86525CF42B0DBC06EF8C /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		2B42652E5B67184D38091FD4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		36B74CDD9E74890EDEE6D3C6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		5202C52638AEAF71ED534FF3 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
+		5352DD14AB81EC9A68F1F45C /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		57CFBF7D48B180C738FB2366 /* ThreadSanitizerApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThreadSanitizerApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		58EBCCB950049E1A18D059D9 /* AddressSanitizerApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AddressSanitizerApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C6178C1AFF59CDE09E764D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		68756A77949C86917FEB04E7 /* ThreadSanitizerExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSanitizerExamples.swift; sourceTree = "<group>"; };
+		830EAAF8A0DAF799CFF313D6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		9A203BC864749E0547EB8D5F /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		C09292DFA09BA37265C228B2 /* AddressSanitizerExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressSanitizerExamples.swift; sourceTree = "<group>"; };
+		EDEE0E1A80C49B3E9E90BE09 /* AddressSanitizerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressSanitizerApp.swift; sourceTree = "<group>"; };
 		F9DE6E9EB1D4F15BD617AD9A /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -65,6 +82,14 @@
 			path = rules_xcodeproj;
 			sourceTree = "<group>";
 		};
+		4A23A44C84AAA3B581A60F09 /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				7E893463CF85080D8B9E44CA /* AddressSanitizerApp */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
 		587F00395265AFD727048D86 /* ThreadSanitizerApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -76,6 +101,7 @@
 		593E7C82FAAD94A7E6A04318 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				58EBCCB950049E1A18D059D9 /* AddressSanitizerApp.app */,
 				57CFBF7D48B180C738FB2366 /* ThreadSanitizerApp.app */,
 			);
 			name = Products;
@@ -87,6 +113,26 @@
 				2E6D9E4BA36A87B56922910C /* fixtures */,
 			);
 			path = test;
+			sourceTree = "<group>";
+		};
+		7281DAD38293D8D817385905 /* AddressSanitizerApp */ = {
+			isa = PBXGroup;
+			children = (
+				EDEE0E1A80C49B3E9E90BE09 /* AddressSanitizerApp.swift */,
+				C09292DFA09BA37265C228B2 /* AddressSanitizerExamples.swift */,
+				5202C52638AEAF71ED534FF3 /* BUILD */,
+				5352DD14AB81EC9A68F1F45C /* ContentView.swift */,
+				5C6178C1AFF59CDE09E764D1 /* Info.plist */,
+			);
+			path = AddressSanitizerApp;
+			sourceTree = "<group>";
+		};
+		7E893463CF85080D8B9E44CA /* AddressSanitizerApp */ = {
+			isa = PBXGroup;
+			children = (
+				830EAAF8A0DAF799CFF313D6 /* Info.plist */,
+			);
+			path = AddressSanitizerApp;
 			sourceTree = "<group>";
 		};
 		8FF22E939A4FE043C61895F3 /* ThreadSanitizerApp */ = {
@@ -125,6 +171,14 @@
 			path = "bazel-output-base/execroot/__main__/bazel-out";
 			sourceTree = "<group>";
 		};
+		D11D8A623D8736DF294E22E4 /* AddressSanitizerApp */ = {
+			isa = PBXGroup;
+			children = (
+				4A23A44C84AAA3B581A60F09 /* rules_xcodeproj */,
+			);
+			path = AddressSanitizerApp;
+			sourceTree = "<group>";
+		};
 		D308305EB44933FCF28725BC /* applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56 */ = {
 			isa = PBXGroup;
 			children = (
@@ -136,6 +190,7 @@
 		EC6FEE5AC277A3FEEA95510A = {
 			isa = PBXGroup;
 			children = (
+				7281DAD38293D8D817385905 /* AddressSanitizerApp */,
 				68A1D737225E7A97337523DE /* test */,
 				8FF22E939A4FE043C61895F3 /* ThreadSanitizerApp */,
 				C407A8E68D8C611448A3E699 /* Bazel Generated Files */,
@@ -147,6 +202,7 @@
 		EE5C632F687B3B2B8B51EFC6 /* bin */ = {
 			isa = PBXGroup;
 			children = (
+				D11D8A623D8736DF294E22E4 /* AddressSanitizerApp */,
 				587F00395265AFD727048D86 /* ThreadSanitizerApp */,
 			);
 			path = bin;
@@ -155,6 +211,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		469DDB537DCBED783EA330DB /* AddressSanitizerApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 019FE0CB3277299C53E8849F /* Build configuration list for PBXNativeTarget "AddressSanitizerApp" */;
+			buildPhases = (
+				20C40F57A0089E8CD64F8A80 /* Copy Bazel Outputs */,
+				18AA58D692FF72040878187B /* Create linking dependencies */,
+				4792A74714DC1D313B0E084D /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0D96213066230FD411D73674 /* PBXTargetDependency */,
+			);
+			name = AddressSanitizerApp;
+			productName = AddressSanitizerApp;
+			productReference = 58EBCCB950049E1A18D059D9 /* AddressSanitizerApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 		ED825FF2BCA76CF484AE0486 /* ThreadSanitizerApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D525AFE8A620E02798D82753 /* Build configuration list for PBXNativeTarget "ThreadSanitizerApp" */;
@@ -183,6 +257,10 @@
 				LastSwiftUpdateCheck = 9999;
 				LastUpgradeCheck = 9999;
 				TargetAttributes = {
+					469DDB537DCBED783EA330DB = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
 					7E7D155EBCA520F35DEA3571 = {
 						CreatedOnToolsVersion = 13.2.1;
 					};
@@ -206,12 +284,30 @@
 			projectRoot = "";
 			targets = (
 				7E7D155EBCA520F35DEA3571 /* BazelDependencies */,
+				469DDB537DCBED783EA330DB /* AddressSanitizerApp */,
 				ED825FF2BCA76CF484AE0486 /* ThreadSanitizerApp */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		18AA58D692FF72040878187B /* Create linking dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(LINK_PARAMS_FILE)",
+			);
+			name = "Create linking dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/link.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		20BEB4AE7798C11A8A904F5E /* Create swift_debug_settings.py */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -227,6 +323,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "perl -pe 's/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
+		20C40F57A0089E8CD64F8A80 /* Copy Bazel Outputs */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Copy Bazel Outputs";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"AddressSanitizerApp.app\" \\\n  \"$INTERNAL_DIR/app.exclude.rsynclist\"\n";
 			showEnvVarsInLog = 0;
 		};
 		6B484573E412628982D5B72E /* Create linking dependencies */ = {
@@ -285,6 +398,16 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4792A74714DC1D313B0E084D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D55A935A5505A004D2EF8E0D /* AddressSanitizerApp.swift in Sources */,
+				F3047DB70C4C915AB0B7F47C /* AddressSanitizerExamples.swift in Sources */,
+				9088F340FE5A22A9D1D4EDE1 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A93240159FFDD47DD6077BF3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -298,6 +421,12 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		0D96213066230FD411D73674 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = 75A218794D17005B42EF0C6F /* PBXContainerItemProxy */;
+		};
 		15C5607D4532DE2743ECAB4C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -425,9 +554,68 @@
 			};
 			name = Debug;
 		};
+		F3291B10076EECC92479A062 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
+				BAZEL_LABEL = "//AddressSanitizerApp:AddressSanitizerApp";
+				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/AddressSanitizerApp.ipa";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp";
+				BAZEL_TARGET_ID = "//AddressSanitizerApp:AddressSanitizerApp applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				CODE_SIGN_STYLE = Manual;
+				COMPILE_TARGET_NAME = AddressSanitizerApp.library;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEPLOYMENT_LOCATION = NO;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/AddressSanitizerApp/AddressSanitizerApp.link.params";
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
+				PRODUCT_MODULE_NAME = AddressSanitizerApp;
+				PRODUCT_NAME = AddressSanitizerApp;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = iphonesimulator;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__$(ENABLE_PREVIEWS))";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TARGET_NAME = AddressSanitizerApp;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin",
+				);
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		019FE0CB3277299C53E8849F /* Build configuration list for PBXNativeTarget "AddressSanitizerApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F3291B10076EECC92479A062 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		669B787A5412989389D7BAD5 /* Build configuration list for PBXProject "bwb" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,1 +1,2 @@
+$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/ThreadSanitizerApp/rules_xcodeproj/ThreadSanitizerApp/Info.plist

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -13,6 +13,15 @@ _BUNDLE_EXTENSIONS = [
 ]
 
 _SETTINGS = {
+  "x86_64-apple-ios15.0.0-simulator AddressSanitizerApp.app/AddressSanitizerApp" : {
+    "clang" : "-iquote \"$(PROJECT_DIR)\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
+    "frameworks" : [
+
+    ],
+    "includes" : [
+
+    ]
+  },
   "x86_64-apple-ios15.0.0-simulator ThreadSanitizerApp.app/ThreadSanitizerApp" : {
     "clang" : "-iquote \"$(PROJECT_DIR)\" -iquote \"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin\" -O0 -DDEBUG=1 -fstack-protector -fstack-protector-all",
     "frameworks" : [

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/AddressSanitizerApp/AddressSanitizerApp.link.params
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/AddressSanitizerApp/AddressSanitizerApp.link.params
@@ -1,0 +1,8 @@
+-Wl,-add_ast_path,$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/AddressSanitizerApp.swiftmodule
+-ObjC
+-L/usr/lib/swift
+-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
+-Wl,-rpath,/usr/lib/swift
+-headerpad_max_install_names
+-no-canonical-prefixes
+-lc++

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AddressSanitizerApp.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AddressSanitizerApp.xcscheme
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Initialize Bazel Build Output Groups File"
+               scriptText = "mkdir -p &quot;${SCHEME_TARGET_IDS_FILE%/*}&quot;&#10;if [[ -s &quot;$SCHEME_TARGET_IDS_FILE&quot; ]]; then&#10;    rm &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;fi&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "469DDB537DCBED783EA330DB"
+                     BuildableName = "AddressSanitizerApp.app"
+                     BlueprintName = "AddressSanitizerApp"
+                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Set Bazel Build Output Groups for AddressSanitizerApp"
+               scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "469DDB537DCBED783EA330DB"
+                     BuildableName = "AddressSanitizerApp.app"
+                     BlueprintName = "AddressSanitizerApp"
+                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Symlink Toolchain /usr/lib directory"
+               scriptText = "if [ &quot;${ENABLE_ADDRESS_SANITIZER:-}&quot; == &quot;YES&quot; ] || [ &quot;${ENABLE_THREAD_SANITIZER:-}&quot; == &quot;YES&quot; ]; then&#10;    # TODO: Support custom toolchains once clang.sh supports them &#10;    src=&quot;$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib&quot;&#10;    dest=&quot;$BAZEL_INTEGRATION_DIR/../lib&quot;&#10;    ln -sF &quot;$src&quot; &quot;$dest&quot;&#10;fi">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "469DDB537DCBED783EA330DB"
+                     BuildableName = "AddressSanitizerApp.app"
+                     BlueprintName = "AddressSanitizerApp"
+                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "469DDB537DCBED783EA330DB"
+               BuildableName = "AddressSanitizerApp.app"
+               BlueprintName = "AddressSanitizerApp"
+               ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "469DDB537DCBED783EA330DB"
+            BuildableName = "AddressSanitizerApp.app"
+            BlueprintName = "AddressSanitizerApp"
+            ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "BUILD_WORKING_DIRECTORY"
+            value = "$(BUILT_PRODUCTS_DIR)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "BUILD_WORKSPACE_DIRECTORY"
+            value = "$(SRCROOT)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "469DDB537DCBED783EA330DB"
+            BuildableName = "AddressSanitizerApp.app"
+            BlueprintName = "AddressSanitizerApp"
+            ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/sanitizers/test/fixtures/bwb_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_spec.json
@@ -14,6 +14,12 @@
     "configuration": "darwin_x86_64-dbg-ST-14942f8a2d44",
     "custom_xcode_schemes": [],
     "extra_files": [
+        "AddressSanitizerApp/BUILD",
+        "AddressSanitizerApp/Info.plist",
+        {
+            "_": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist",
+            "t": "g"
+        },
         "ThreadSanitizerApp/BUILD",
         "ThreadSanitizerApp/Info.plist",
         {
@@ -35,12 +41,179 @@
     "scheme_autogeneration_mode": "auto",
     "target_hosts": [],
     "target_merges": [
+        "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56",
+        [
+            "//AddressSanitizerApp:AddressSanitizerApp applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56"
+        ],
         "//ThreadSanitizerApp:ThreadSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56",
         [
             "//ThreadSanitizerApp:ThreadSanitizerApp applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56"
         ]
     ],
     "targets": [
+        "//AddressSanitizerApp:AddressSanitizerApp applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56",
+        {
+            "build_settings": {
+                "CODE_SIGN_STYLE": "Manual",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "GCC_OPTIMIZATION_LEVEL": "0",
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5.0",
+                "TARGETED_DEVICE_FAMILY": "1"
+            },
+            "configuration": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56",
+            "dependencies": [
+                "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56"
+            ],
+            "info_plist": {
+                "_": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist",
+                "t": "g"
+            },
+            "is_swift": false,
+            "label": "//AddressSanitizerApp:AddressSanitizerApp",
+            "linker_inputs": {
+                "linkopts": [
+                    "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/AddressSanitizerApp.swiftmodule",
+                    "-ObjC",
+                    "-L/usr/lib/swift",
+                    "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
+                    "-Wl,-rpath,/usr/lib/swift",
+                    "-headerpad_max_install_names",
+                    "-no-canonical-prefixes",
+                    "-lc++"
+                ],
+                "static_libraries": [
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/libAddressSanitizerApp.library.a",
+                        "t": "g"
+                    }
+                ]
+            },
+            "lldb_context": {
+                "c": [
+                    {
+                        "o": [
+                            "-O0",
+                            "-DDEBUG=1",
+                            "-fstack-protector",
+                            "-fstack-protector-all"
+                        ],
+                        "q": [
+                            ".",
+                            {
+                                "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin",
+                                "t": "g"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "name": "AddressSanitizerApp",
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/AddressSanitizerApp.ipa",
+                    "t": "g"
+                }
+            },
+            "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "15.0",
+                "os": "ios",
+                "variant": "iphonesimulator"
+            },
+            "product": {
+                "additional_paths": [],
+                "executable_name": "AddressSanitizerApp",
+                "is_resource_bundle": false,
+                "name": "AddressSanitizerApp",
+                "path": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/AddressSanitizerApp_archive-root/Payload/AddressSanitizerApp.app",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.application"
+            },
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin",
+                        "t": "g"
+                    }
+                ]
+            }
+        },
+        "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56",
+        {
+            "build_settings": {
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_OPTIMIZATION_LEVEL": "0",
+                "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
+                "PRODUCT_MODULE_NAME": "AddressSanitizerApp",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5.0"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56",
+            "inputs": {
+                "srcs": [
+                    "AddressSanitizerApp/AddressSanitizerApp.swift",
+                    "AddressSanitizerApp/AddressSanitizerExamples.swift",
+                    "AddressSanitizerApp/ContentView.swift"
+                ]
+            },
+            "label": "//AddressSanitizerApp:AddressSanitizerApp.library",
+            "name": "AddressSanitizerApp.library",
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/AddressSanitizerApp.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/AddressSanitizerApp.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/AddressSanitizerApp.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "15.0",
+                "os": "ios",
+                "variant": "iphonesimulator"
+            },
+            "product": {
+                "additional_paths": [],
+                "executable_name": null,
+                "is_resource_bundle": false,
+                "name": "AddressSanitizerApp.library",
+                "path": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/AddressSanitizerApp/libAddressSanitizerApp.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin",
+                        "t": "g"
+                    }
+                ]
+            }
+        },
         "//ThreadSanitizerApp:ThreadSanitizerApp applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56",
         {
             "build_settings": {

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -22,12 +22,22 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		35AB3BD68F5FB4F736B6E2A2 /* AddressSanitizerExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD20E5E290D99A0950B3170F /* AddressSanitizerExamples.swift */; };
+		63EF2CD7B92D04B366777BE3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 553540A086F6A1C1B34D9FFD /* ContentView.swift */; };
 		6D9E4F102F4C4860CD35D77B /* ThreadSanitizerExamples.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4151C01B89D55346060A70 /* ThreadSanitizerExamples.swift */; };
 		6FD653DC005D5040058082BA /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAE4CDFA2DB2240A7876CCCF /* ContentView.swift */; };
 		84000B13FAC1BF709CEFCCD6 /* ThreadSanitizerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5354F45B895C34AC1E22203E /* ThreadSanitizerApp.swift */; };
+		A8740C6EBAFEBE7BA2CC1D11 /* AddressSanitizerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94BBFA15DE3AB409D346C7C0 /* AddressSanitizerApp.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		14DF5AD2DADD0BC55908C6A1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
 		FA587BA0C641234037D32695 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -40,12 +50,19 @@
 /* Begin PBXFileReference section */
 		44BAB1CBCBF61A8FD7891DE3 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		5354F45B895C34AC1E22203E /* ThreadSanitizerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSanitizerApp.swift; sourceTree = "<group>"; };
+		553540A086F6A1C1B34D9FFD /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		5B4151C01B89D55346060A70 /* ThreadSanitizerExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadSanitizerExamples.swift; sourceTree = "<group>"; };
+		670F93CC36DEE4A3E81ABD3D /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		7A4E8244AA32AE04D23B06A6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		91D247EBC4E9656FC80B0E34 /* AddressSanitizerApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AddressSanitizerApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		94BBFA15DE3AB409D346C7C0 /* AddressSanitizerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressSanitizerApp.swift; sourceTree = "<group>"; };
 		97ADB761BAE21D828622D393 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		B14030E28AEC60D674861538 /* ThreadSanitizerApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThreadSanitizerApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C9820E0AD53B8D61FAD8E30C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		EAE4CDFA2DB2240A7876CCCF /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		EF40894F935DE611D8DA51A2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		F8CE55A2C2C0A38D04D9C992 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		FD20E5E290D99A0950B3170F /* AddressSanitizerExamples.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressSanitizerExamples.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -76,14 +93,24 @@
 		462C3519CA354BE1B04D4855 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				91D247EBC4E9656FC80B0E34 /* AddressSanitizerApp.app */,
 				B14030E28AEC60D674861538 /* ThreadSanitizerApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
+		67883DF65EBA956F0085B0E5 /* AddressSanitizerApp */ = {
+			isa = PBXGroup;
+			children = (
+				EF40894F935DE611D8DA51A2 /* Info.plist */,
+			);
+			path = AddressSanitizerApp;
+			sourceTree = "<group>";
+		};
 		77E0714FDD425211EBA209DF = {
 			isa = PBXGroup;
 			children = (
+				E7887F034DAF3F0502AC2938 /* AddressSanitizerApp */,
 				D2C8CC455B9D27F28D323622 /* test */,
 				992BCA016CF388EC3E3D52F2 /* ThreadSanitizerApp */,
 				A5A3DECCB7E56F0EA3676D12 /* Bazel Generated Files */,
@@ -92,9 +119,18 @@
 			);
 			sourceTree = "<group>";
 		};
+		869F4E0790019FCCF60ED23F /* rules_xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				67883DF65EBA956F0085B0E5 /* AddressSanitizerApp */,
+			);
+			path = rules_xcodeproj;
+			sourceTree = "<group>";
+		};
 		9586E9FDDEFA835A6B44D71C /* bin */ = {
 			isa = PBXGroup;
 			children = (
+				EF5DA4E7707087C68BD6653D /* AddressSanitizerApp */,
 				DF19025439C1510AEA0D5ACD /* ThreadSanitizerApp */,
 			);
 			path = bin;
@@ -152,9 +188,46 @@
 			path = ThreadSanitizerApp;
 			sourceTree = "<group>";
 		};
+		E7887F034DAF3F0502AC2938 /* AddressSanitizerApp */ = {
+			isa = PBXGroup;
+			children = (
+				94BBFA15DE3AB409D346C7C0 /* AddressSanitizerApp.swift */,
+				FD20E5E290D99A0950B3170F /* AddressSanitizerExamples.swift */,
+				670F93CC36DEE4A3E81ABD3D /* BUILD */,
+				553540A086F6A1C1B34D9FFD /* ContentView.swift */,
+				C9820E0AD53B8D61FAD8E30C /* Info.plist */,
+			);
+			path = AddressSanitizerApp;
+			sourceTree = "<group>";
+		};
+		EF5DA4E7707087C68BD6653D /* AddressSanitizerApp */ = {
+			isa = PBXGroup;
+			children = (
+				869F4E0790019FCCF60ED23F /* rules_xcodeproj */,
+			);
+			path = AddressSanitizerApp;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		3EAFF74229A8CE2544154BF9 /* AddressSanitizerApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8BE00A149812934FA86F8678 /* Build configuration list for PBXNativeTarget "AddressSanitizerApp" */;
+			buildPhases = (
+				5E351775A9D4F280A4CF47A2 /* Create linking dependencies */,
+				CA1A90C1E573DF82AAA9E452 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DDB6627492E6ED161AC62CB6 /* PBXTargetDependency */,
+			);
+			name = AddressSanitizerApp;
+			productName = AddressSanitizerApp;
+			productReference = 91D247EBC4E9656FC80B0E34 /* AddressSanitizerApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 		E0A7BFDFC0C3D6AB230925A8 /* ThreadSanitizerApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EFC73C679A7E0F171E6E990A /* Build configuration list for PBXNativeTarget "ThreadSanitizerApp" */;
@@ -182,6 +255,10 @@
 				LastSwiftUpdateCheck = 9999;
 				LastUpgradeCheck = 9999;
 				TargetAttributes = {
+					3EAFF74229A8CE2544154BF9 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
 					E0A7BFDFC0C3D6AB230925A8 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
@@ -205,6 +282,7 @@
 			projectRoot = "";
 			targets = (
 				FE59281FE487F27A37DC2EE7 /* BazelDependencies */,
+				3EAFF74229A8CE2544154BF9 /* AddressSanitizerApp */,
 				E0A7BFDFC0C3D6AB230925A8 /* ThreadSanitizerApp */,
 			);
 		};
@@ -245,6 +323,23 @@
 			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
+		5E351775A9D4F280A4CF47A2 /* Create linking dependencies */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(LINK_PARAMS_FILE)",
+			);
+			name = "Create linking dependencies";
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/link.params",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
+			showEnvVarsInLog = 0;
+		};
 		773C70B69E7F801B38FDC01C /* Generate Files */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -267,6 +362,16 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		CA1A90C1E573DF82AAA9E452 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A8740C6EBAFEBE7BA2CC1D11 /* AddressSanitizerApp.swift in Sources */,
+				35AB3BD68F5FB4F736B6E2A2 /* AddressSanitizerExamples.swift in Sources */,
+				63EF2CD7B92D04B366777BE3 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		EC62A2AC37691AEA4041381D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -285,6 +390,12 @@
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = FA587BA0C641234037D32695 /* PBXContainerItemProxy */;
+		};
+		DDB6627492E6ED161AC62CB6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = 14DF5AD2DADD0BC55908C6A1 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -305,6 +416,56 @@
 				SUPPORTED_PLATFORMS = iphonesimulator;
 				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = BazelDependencies;
+			};
+			name = Debug;
+		};
+		6B31E39AA453F8E107939198 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
+				BAZEL_LABEL = "//AddressSanitizerApp:AddressSanitizerApp";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp";
+				BAZEL_TARGET_ID = "//AddressSanitizerApp:AddressSanitizerApp applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
+				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
+				CODE_SIGN_STYLE = Manual;
+				COMPILE_TARGET_NAME = AddressSanitizerApp.library;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEPLOYMENT_LOCATION = NO;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AddressSanitizerApp/AddressSanitizerApp.link.params";
+				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp_archive-root/Payload $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
+				PRODUCT_MODULE_NAME = AddressSanitizerApp;
+				PRODUCT_NAME = AddressSanitizerApp;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = iphonesimulator;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__$(ENABLE_PREVIEWS))";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				TARGET_NAME = AddressSanitizerApp;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin",
+				);
 			};
 			name = Debug;
 		};
@@ -401,6 +562,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		8BE00A149812934FA86F8678 /* Build configuration list for PBXNativeTarget "AddressSanitizerApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6B31E39AA453F8E107939198 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		8C14447CB8BDD86ECF450932 /* Build configuration list for PBXProject "bwx" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -1,1 +1,2 @@
+$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist
 $(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/ThreadSanitizerApp/rules_xcodeproj/ThreadSanitizerApp/Info.plist

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AddressSanitizerApp/AddressSanitizerApp.link.params
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AddressSanitizerApp/AddressSanitizerApp.link.params
@@ -1,0 +1,8 @@
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
+-ObjC
+-L/usr/lib/swift
+-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
+-Wl,-rpath,/usr/lib/swift
+-headerpad_max_install_names
+-no-canonical-prefixes
+-lc++

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/AddressSanitizerApp.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/AddressSanitizerApp.xcscheme
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Initialize Bazel Build Output Groups File"
+               scriptText = "mkdir -p &quot;${SCHEME_TARGET_IDS_FILE%/*}&quot;&#10;if [[ -s &quot;$SCHEME_TARGET_IDS_FILE&quot; ]]; then&#10;    rm &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;fi&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "3EAFF74229A8CE2544154BF9"
+                     BuildableName = "AddressSanitizerApp.app"
+                     BlueprintName = "AddressSanitizerApp"
+                     ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Set Bazel Build Output Groups for AddressSanitizerApp"
+               scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "3EAFF74229A8CE2544154BF9"
+                     BuildableName = "AddressSanitizerApp.app"
+                     BlueprintName = "AddressSanitizerApp"
+                     ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3EAFF74229A8CE2544154BF9"
+               BuildableName = "AddressSanitizerApp.app"
+               BlueprintName = "AddressSanitizerApp"
+               ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3EAFF74229A8CE2544154BF9"
+            BuildableName = "AddressSanitizerApp.app"
+            BlueprintName = "AddressSanitizerApp"
+            ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3EAFF74229A8CE2544154BF9"
+            BuildableName = "AddressSanitizerApp.app"
+            BlueprintName = "AddressSanitizerApp"
+            ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/sanitizers/test/fixtures/bwx_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_spec.json
@@ -14,6 +14,12 @@
     "configuration": "darwin_x86_64-dbg-ST-14942f8a2d44",
     "custom_xcode_schemes": [],
     "extra_files": [
+        "AddressSanitizerApp/BUILD",
+        "AddressSanitizerApp/Info.plist",
+        {
+            "_": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist",
+            "t": "g"
+        },
         "ThreadSanitizerApp/BUILD",
         "ThreadSanitizerApp/Info.plist",
         {
@@ -35,12 +41,160 @@
     "scheme_autogeneration_mode": "auto",
     "target_hosts": [],
     "target_merges": [
+        "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353",
+        [
+            "//AddressSanitizerApp:AddressSanitizerApp applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353"
+        ],
         "//ThreadSanitizerApp:ThreadSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353",
         [
             "//ThreadSanitizerApp:ThreadSanitizerApp applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353"
         ]
     ],
     "targets": [
+        "//AddressSanitizerApp:AddressSanitizerApp applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353",
+        {
+            "build_settings": {
+                "CODE_SIGN_STYLE": "Manual",
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "GCC_OPTIMIZATION_LEVEL": "0",
+                "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5.0",
+                "TARGETED_DEVICE_FAMILY": "1"
+            },
+            "configuration": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353",
+            "dependencies": [
+                "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353"
+            ],
+            "info_plist": {
+                "_": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist",
+                "t": "g"
+            },
+            "is_swift": false,
+            "label": "//AddressSanitizerApp:AddressSanitizerApp",
+            "linker_inputs": {
+                "linkopts": [
+                    "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftmodule",
+                    "-ObjC",
+                    "-L/usr/lib/swift",
+                    "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
+                    "-Wl,-rpath,/usr/lib/swift",
+                    "-headerpad_max_install_names",
+                    "-no-canonical-prefixes",
+                    "-lc++"
+                ],
+                "static_libraries": [
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/libAddressSanitizerApp.library.a",
+                        "t": "g"
+                    }
+                ]
+            },
+            "name": "AddressSanitizerApp",
+            "outputs": {
+                "p": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.ipa",
+                    "t": "g"
+                }
+            },
+            "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "15.0",
+                "os": "ios",
+                "variant": "iphonesimulator"
+            },
+            "product": {
+                "additional_paths": [],
+                "executable_name": "AddressSanitizerApp",
+                "is_resource_bundle": false,
+                "name": "AddressSanitizerApp",
+                "path": {
+                    "_": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp_archive-root/Payload/AddressSanitizerApp.app",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.application"
+            },
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin",
+                        "t": "g"
+                    }
+                ]
+            }
+        },
+        "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353",
+        {
+            "build_settings": {
+                "DEBUG_INFORMATION_FORMAT": "dwarf",
+                "ENABLE_BITCODE": false,
+                "ENABLE_TESTABILITY": true,
+                "GCC_OPTIMIZATION_LEVEL": "0",
+                "OTHER_SWIFT_FLAGS": "-Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static",
+                "PRODUCT_MODULE_NAME": "AddressSanitizerApp",
+                "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
+                "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+                "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+                "SWIFT_VERSION": "5.0"
+            },
+            "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353",
+            "inputs": {
+                "srcs": [
+                    "AddressSanitizerApp/AddressSanitizerApp.swift",
+                    "AddressSanitizerApp/AddressSanitizerExamples.swift",
+                    "AddressSanitizerApp/ContentView.swift"
+                ]
+            },
+            "label": "//AddressSanitizerApp:AddressSanitizerApp.library",
+            "name": "AddressSanitizerApp.library",
+            "outputs": {
+                "s": {
+                    "d": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftdoc",
+                        "t": "g"
+                    },
+                    "m": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftmodule",
+                        "t": "g"
+                    },
+                    "s": {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftsourceinfo",
+                        "t": "g"
+                    }
+                }
+            },
+            "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp",
+            "platform": {
+                "arch": "x86_64",
+                "minimum_os_version": "15.0",
+                "os": "ios",
+                "variant": "iphonesimulator"
+            },
+            "product": {
+                "additional_paths": [],
+                "executable_name": null,
+                "is_resource_bundle": false,
+                "name": "AddressSanitizerApp.library",
+                "path": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/libAddressSanitizerApp.library.a",
+                    "t": "g"
+                },
+                "type": "com.apple.product-type.library.static"
+            },
+            "search_paths": {
+                "quote_includes": [
+                    ".",
+                    {
+                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin",
+                        "t": "g"
+                    }
+                ]
+            }
+        },
         "//ThreadSanitizerApp:ThreadSanitizerApp applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353",
         {
             "build_settings": {

--- a/examples/sanitizers/xcodeproj_targets.bzl
+++ b/examples/sanitizers/xcodeproj_targets.bzl
@@ -1,5 +1,6 @@
 """Exposes targets used by `xcodeproj` to allow use in fixture tests."""
 
 XCODEPROJ_TARGETS = [
+    "//AddressSanitizerApp",
     "//ThreadSanitizerApp",
 ]


### PR DESCRIPTION
This PR adds the Address Sanitizer Example Application. This was marked as a TODO in this PR (https://github.com/buildbuddy-io/rules_xcodeproj/pull/1155).

The enclosed screenshot demonstrates that asan works as expected in the BwB mode.
![Screen Shot 2022-09-26 at 10 02 16 PM](https://user-images.githubusercontent.com/11925399/192436457-5f9f0f58-3bd2-4549-ba5e-c3983081dc8f.png)

TODO:
- There was a suggestion of enhancing the custom scheme support with the `diagnostics` option. This will be added in a separate PR.
