### PR TITLE
Revert "Ignore `-enable-bare-slash-regex` (#1073)"

### DIFF
--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -33,7 +33,6 @@ _SWIFTC_SKIP_OPTS = {
     "-debug-prefix-map": 2,
     "-emit-module-path": 2,
     "-emit-object": 1,
-    "-enable-bare-slash-regex": 1,
     "-enable-batch-mode": 1,
     # TODO: See if we need to support this
     "-gline-tables-only": 1,


### PR DESCRIPTION
This reverts commit 05a797078fe81af491496dcc4b7f305fc2d4b9d5. This change was causing issues with indexing. I don't have time to determine why, and having this appear twice in the build command is NBD.