### PR TITLE
Revert "Revert "Ignore `-enable-bare-slash-regex` (#1073)" (#1172)"

### DIFF
--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -33,6 +33,7 @@ _SWIFTC_SKIP_OPTS = {
     "-debug-prefix-map": 2,
     "-emit-module-path": 2,
     "-emit-object": 1,
+    "-enable-bare-slash-regex": 1,
     "-enable-batch-mode": 1,
     "-file-prefix-map": 2,
     # TODO: See if we need to support this


### PR DESCRIPTION
This reverts commit cde3617d67fceb718cc585c01b8cb673a1b9b202.

Turns out the real issue was #1173.