### PR TITLE
Fix `swift_binary`

### DIFF
--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -385,12 +385,14 @@ $(CONFIGURATION_BUILD_DIR)
             buildSettings.set("GCC_PREFIX_HEADER", to: pchPath)
         }
 
-        if let swiftmodule = target.outputs.swift?.module {
+        if target.isSwift {
             let includePaths: OrderedSet =
                 .init(try target.swiftmodules.map(handleSwiftModule))
 
             let previewsInclude: String?
-            if target.product.type.isBundle {
+            if target.product.type.isBundle,
+               let swiftmodule = target.outputs.swift?.module
+            {
                 let selfInclude = try handleSwiftModule(swiftmodule)
                 if !includePaths.contains(selfInclude) {
                     previewsInclude = selfInclude


### PR DESCRIPTION
727681df4f91e2e2f38c35f78cea9f6f001430e3 didn't account for the fact that `swift_binary` targets don't produce their own `.swiftmodule`.