### PR TITLE
Revert "Revert "Remove single merge restriction on target merging (#937)" (#1017)"

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		047B00D7313079854921298B /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48754296ACA596286860C0BF /* CryptoSwift.framework */; };
 		0500EC5BE5ABD402F77760FC /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C23E4536260379513114C6AE /* CryptoSwift.framework */; };
 		062F78DA07E4E8134042F380 /* macOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C902EF36FD111B0B777D8FC /* macOSApp.swift */; };
+		090545935B32FE5F8B2E2319 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF522B1DF94A22805CFB159 /* Lib.swift */; };
 		0949513138E1D5853C8C6346 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 477A1F7311A2AEC136215514 /* main.m */; };
 		095A702D68F04B13D7DE1458 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49B79A6A845E24A1CE8611CA /* CryptoSwift.framework */; };
 		0D9682670712CC38E3BD6E1B /* AppClip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = 21B075DF13D48A7176B9FD50 /* AppClip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -39,9 +40,11 @@
 		1F4FBB2FDB7D7960FCBBAD3D /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7401FDA68482F8B5BE018478 /* CryptoSwift.framework */; };
 		23FA77A5D050E0AC4A3D3008 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410CCB97DA9F35B3AD7371CD /* Lib.swift */; };
 		268106B9996EDC881B2E0AA8 /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3333170CE926366B0A03CBF1 /* GoogleMapsBase.framework */; };
+		29B680D0D737019EBB3942B3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FBAFC44AF745D83B41AC29 /* ContentView.swift */; };
 		2CF8CD9DD353DBDD89036E6D /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7401FDA68482F8B5BE018478 /* CryptoSwift.framework */; };
 		2E864B31D98C808A39FC2370 /* AppClip.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3DC02BD769EC7A61C9D7D7 /* AppClip.swift */; };
 		31148D81297341297091BE82 /* GoogleMapsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C87E1F983762D987044B07D /* GoogleMapsCore.framework */; };
+		387BF098AF204DE48D223092 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC449167BD04FC015CC1967 /* Lib.swift */; };
 		38A20AD3EFD22BEAE8205414 /* ExternalFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94BEEB36D3E48677861539C1 /* ExternalFramework.framework */; };
 		40EBA8F7768FC736C390DB78 /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FA3BA1D4E619BDEDC7F4C24 /* c_lib.c */; };
 		4119529014BB6FAC2E9AA1C1 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7401FDA68482F8B5BE018478 /* CryptoSwift.framework */; };
@@ -55,10 +58,12 @@
 		5003A996FFB25A6D500F8312 /* iMessageAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = E332411DCE28305063274CDF /* iMessageAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		50132650EEA27019BCA2E293 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48754296ACA596286860C0BF /* CryptoSwift.framework */; };
 		511CD055B798496C846A5E4D /* WatchOSAppExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B97B63749CB7B8FCC4C6CD /* WatchOSAppExtensionTests.swift */; };
+		511EF1749DC18A6D29600755 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FBAFC44AF745D83B41AC29 /* ContentView.swift */; };
 		526815DB742350C83EB04495 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7401FDA68482F8B5BE018478 /* CryptoSwift.framework */; };
 		562EDC433A9C193006AAA2C3 /* LibFramework.iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0F4E240A5D25F4ADB40D550 /* LibFramework.iOS.framework */; };
 		57337DB3D95294B5CFA16EFB /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F55A2BE8D7CCF0BE66FBA97 /* iOSApp.swift */; };
 		57990DB9189C856D000061EE /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF2DAFB9141E941BE0B725EF /* GoogleMapsBase.framework */; };
+		57A8832E41155CAA5B503ED0 /* Answers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 904C69CEFDF8DD18C54E33E3 /* Answers.mm */; };
 		580A69352F7B58F8B1733A3E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75394279554A62DCDF2F00B /* ContentView.swift */; };
 		5D406E0B8B7D50C4E86D3AAA /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F02DB5872C15A8176E54D40F /* UnitTests.swift */; };
 		5FA901BB965820A09B540106 /* Answers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 904C69CEFDF8DD18C54E33E3 /* Answers.mm */; };
@@ -68,7 +73,6 @@
 		6B2C69A66B14D4AE3F6B725D /* GoogleMaps.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF108DD9E7994AE813AAFEA9 /* GoogleMaps.framework */; };
 		6B42D20D06B50D58944B7CFD /* UIFramework.tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BF15815BABED2C2DBB76EB8 /* UIFramework.tvOS.framework */; };
 		6CA9D84BAB97378C01269FA3 /* ExternalFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94BEEB36D3E48677861539C1 /* ExternalFramework.framework */; };
-		731A6A9A15E9C1C071EC7AC6 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = 15240A701E6FED89576025D5 /* _CompileStub_.m */; };
 		75B1B268CC2B58566ECB9678 /* watchOSApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = B3F2BB6661347D1891100734 /* watchOSApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		82023B60CA7B024EB1DCB1D9 /* LibFramework.iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0F4E240A5D25F4ADB40D550 /* LibFramework.iOS.framework */; };
 		870D5447845B486C6B63BF2B /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C23E4536260379513114C6AE /* CryptoSwift.framework */; };
@@ -79,18 +83,18 @@
 		987B6F4A8BCF992A6715288B /* Answers.h in Headers */ = {isa = PBXBuildFile; fileRef = 895D403ADE79E63077CCC401 /* Answers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		987C9E038703AA4B4F894708 /* UI.h in Headers */ = {isa = PBXBuildFile; fileRef = DC3FA1C84CE123E17ABEA53D /* UI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9BC5BB9C121ECEB74DD05E8C /* LibFramework.tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09459B752328D506AE83BB73 /* LibFramework.tvOS.framework */; };
+		9C9EE78A87622A3E85C8A6A7 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410CCB97DA9F35B3AD7371CD /* Lib.swift */; };
 		9D533272517E5CDB720006ED /* WatchOSAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482E2EC1448F43F9E53E78B /* WatchOSAppUITestsLaunchTests.swift */; };
+		A04ECCC2488AFCC71E51730B /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DD28EBDE6671DB7B6EC15C3 /* Lib.swift */; };
 		A421E22D8A73C776754910CA /* CoreUtilsObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9952967B12D98E5E18576452 /* CoreUtilsObjC.framework */; };
 		A43DE244478F33F52C535852 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CECC22A0360B6F7F39E449B5 /* CryptoSwift.framework */; };
 		A5CE64A318CB5BFD4B52FDE0 /* GoogleMaps.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1E95D84BE74FB253E55EA07 /* GoogleMaps.framework */; };
 		AAD86B0119102EAF7FB2748F /* WidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 293017A3A054170FD9BEBAB9 /* WidgetExtension.swift */; };
-		B2417FA79ED28D6036E9011A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FBAFC44AF745D83B41AC29 /* ContentView.swift */; };
 		B6F4BA1C6A5297174E72DF8A /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = FEB2B3F1831BB76D5BBA3E5B /* lib.m */; };
 		B82C1CBE3D3E385A31295C7E /* RealAnswer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AA4147B93D0C841DFC45F3D /* RealAnswer.h */; };
 		B8852841A2FC6C919DE22955 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8605B45BC99BDD7C9D8A293 /* UITests.swift */; };
 		B99E3099B6477352C7DFD270 /* tvOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37024073C534DCC08398F925 /* tvOSApp.swift */; };
 		BEECE3823CD668053A179702 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CECC22A0360B6F7F39E449B5 /* CryptoSwift.framework */; };
-		BF1C6240E2CB3A8C32A1BDF6 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = 15240A701E6FED89576025D5 /* _CompileStub_.m */; };
 		C25C66CB054A310DB4BD2AF2 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C23E4536260379513114C6AE /* CryptoSwift.framework */; };
 		C5B8F0FE0CC2385740743C19 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49B79A6A845E24A1CE8611CA /* CryptoSwift.framework */; };
 		C61E821B3CFE0D5260A796F4 /* WidgetExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 56F16FB28F266E6AABCEA995 /* WidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -122,6 +126,13 @@
 			remoteGlobalIDString = 9D6BB9A04FEC771667C78F54;
 			remoteInfo = "Lib (iOS, tvOS)";
 		};
+		0A06E47BE8D7455B24B5B0A6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2CFFD057A9609E996C8B1899;
+			remoteInfo = "UI (iOS, tvOS)";
+		};
 		0D08B1B3E78FD0DCDACFB09C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -136,19 +147,26 @@
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
-		1AF0A8DBFD4E418C98D4DDD3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
-			remoteInfo = BazelDependencies;
-		};
 		25876A1338D9B5488BEAA787 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 515582434B8B8972F8C9CEE4;
 			remoteInfo = LibFramework.iOS;
+		};
+		264BD78711E41840B2F87311 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9D6BB9A04FEC771667C78F54;
+			remoteInfo = "Lib (iOS, tvOS)";
+		};
+		2E5446FEC378EF59244319A7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2CFFD057A9609E996C8B1899;
+			remoteInfo = "UI (iOS, tvOS)";
 		};
 		2FC9D90BBC92B51DCC9FDAD6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -163,6 +181,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 48A1FAB71CA4985ACB147363;
 			remoteInfo = c_lib;
+		};
+		358E819B657DD5EAD3424075 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8F3CDA8EA17C5FF405D6B44F;
+			remoteInfo = "UI (watchOS)";
 		};
 		3774B935F0A287F4930A9E64 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -220,6 +245,13 @@
 			remoteGlobalIDString = A23C98B4BFB6C775689A2A7D;
 			remoteInfo = UIFramework.tvOS;
 		};
+		5F258A822E71EA770E9F5898 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
 		64291FDA9C4F8EFE675DD30F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -275,13 +307,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
-		};
-		70B8F531B12A26457D3B0982 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 12DB4C040F56113D380794C3;
-			remoteInfo = UI;
 		};
 		7257BF65ACBCED05BD50E030 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -339,13 +364,6 @@
 			remoteGlobalIDString = 632D255CE04E97FB997EBDD7;
 			remoteInfo = watchOSApp;
 		};
-		8C96E253D788550FEFC278F6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9D6BB9A04FEC771667C78F54;
-			remoteInfo = "Lib (iOS, tvOS)";
-		};
 		8E62C8BE6F0B5729027C32DC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -360,12 +378,33 @@
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
+		9D9101CD560E1A52F997A3BC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
+		9E02FA40F7B55953CA4B031D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
+			remoteInfo = BazelDependencies;
+		};
 		9E1293FAB8D5CB7D608E5E4C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
+		};
+		A301390453D7505EC4D765AD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 83D00AD7532094902D925C83;
+			remoteInfo = "Lib (watchOS)";
 		};
 		A35687B467B740DC9895BDED /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -416,6 +455,13 @@
 			remoteGlobalIDString = 9D6BB9A04FEC771667C78F54;
 			remoteInfo = "Lib (iOS, tvOS)";
 		};
+		B6E7BC3DD84A5676B3D7B73F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 64AE6000A6317B9C077F3B1E;
+			remoteInfo = CoreUtilsObjC;
+		};
 		B72B5A378909AA34EF448E32 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -430,12 +476,12 @@
 			remoteGlobalIDString = 2DBD14C7DE92127B94265B10;
 			remoteInfo = watchOSAppExtension;
 		};
-		C87EF466F1120C8A34342BFC /* PBXContainerItemProxy */ = {
+		CB687C469E22C26C6970C297 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 9D6BB9A04FEC771667C78F54;
-			remoteInfo = "Lib (iOS, tvOS)";
+			remoteGlobalIDString = 8F3CDA8EA17C5FF405D6B44F;
+			remoteInfo = "UI (watchOS)";
 		};
 		CED913C91B38F307EEA90999 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -457,13 +503,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 9D6BB9A04FEC771667C78F54;
 			remoteInfo = "Lib (iOS, tvOS)";
-		};
-		DE75BD6142618338C7DECACF /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 12DB4C040F56113D380794C3;
-			remoteInfo = UI;
 		};
 		E5C53509D0C0B3208C581E08 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -506,13 +545,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
-		};
-		FBDE72858B6AD78BADBC5954 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 83D00AD7532094902D925C83;
-			remoteInfo = "Lib (watchOS)";
 		};
 		FCF9E5BF1611C5A1EC3C9302 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -600,7 +632,6 @@
 		110F3C646228CCBC788FE049 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		11ECBBAC4F58A69630BCEE68 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		12E0A2DBA5F2DA9D47BBD433 /* ExtensionAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ExtensionAssets.xcassets; sourceTree = "<group>"; };
-		15240A701E6FED89576025D5 /* _CompileStub_.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = _CompileStub_.m; sourceTree = DERIVED_FILE_DIR; };
 		178B274052D020AA03B97B16 /* CommandLineToolTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CommandLineToolTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		199020BFFB08C1DE5B4383C3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		1AA4147B93D0C841DFC45F3D /* RealAnswer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RealAnswer.h; sourceTree = "<group>"; };
@@ -620,7 +651,7 @@
 		2BF15815BABED2C2DBB76EB8 /* UIFramework.tvOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UIFramework.tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D4A4C50428239BEF26F4911 /* Info.withbundleid.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.withbundleid.plist; sourceTree = "<group>"; };
 		2E063D559D363D5771226A03 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
-		2E5FCD09A34CBBE4187A601E /* libUI.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libUI.a; path = "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/UI/libUI.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2E5FCD09A34CBBE4187A601E /* libUI.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libUI.a; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/UI/libUI.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F371150CFABA7C7408108C8 /* Entitlements.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Entitlements.entitlements; sourceTree = "<group>"; };
 		2F73B1C8F0356F7CDBB70B47 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		31B867D8B23B22316F286C0F /* ownership.yaml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = ownership.yaml; sourceTree = "<group>"; };
@@ -710,6 +741,7 @@
 		8F49CCC488DBF944363A76E3 /* tvOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tvOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8F51FE5E0D007C522EC4D6B7 /* Info.withbundleid.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.withbundleid.plist; sourceTree = "<group>"; };
 		8F55A2BE8D7CCF0BE66FBA97 /* iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSApp.swift; sourceTree = "<group>"; };
+		8F8B001AB6315D99F13FAC92 /* libCoreUtilsObjC.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libCoreUtilsObjC.a; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/iOSApp/Source/CoreUtilsObjC/libCoreUtilsObjC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9032AC682FB92A6CF71CE0BF /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		904C69CEFDF8DD18C54E33E3 /* Answers.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = Answers.mm; sourceTree = "<group>"; };
 		9213816AD54921A542FE95CA /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -756,6 +788,7 @@
 		C256EC8EA9734338A2E31948 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C5814DB7E0B19C80A22EE1F5 /* Launch.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Launch.storyboard; sourceTree = "<group>"; };
 		C7820E9BA81F12DC4A75C422 /* iMessageApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iMessageApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C9592AE9BF4971343F819ABA /* libUI.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libUI.a; path = "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/UI/libUI.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9839B245FE2AD82F977E567 /* iOSApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CA64327604F90D23B6A73F88 /* bucket */ = {isa = PBXFileReference; lastKnownFileType = folder; path = bucket; sourceTree = "<group>"; };
 		CB32C9C36AF8F174F88C27FE /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
@@ -1657,6 +1690,7 @@
 				E332411DCE28305063274CDF /* iMessageAppExtension.appex */,
 				C9839B245FE2AD82F977E567 /* iOSApp.app */,
 				391FE6BAD634D0EBEDCB1127 /* libc_lib.a */,
+				8F8B001AB6315D99F13FAC92 /* libCoreUtilsObjC.a */,
 				B0F4E240A5D25F4ADB40D550 /* LibFramework.iOS.framework */,
 				09459B752328D506AE83BB73 /* LibFramework.tvOS.framework */,
 				3FEB5348BF9F16CDB97FB486 /* liblib_impl.a */,
@@ -1666,6 +1700,7 @@
 				26385BC3A03088371FF9B69F /* libprivate_lib.a */,
 				024E194287BFAE0BA6D08AD1 /* libprivate_swift_lib.a */,
 				2E5FCD09A34CBBE4187A601E /* libUI.a */,
+				C9592AE9BF4971343F819ABA /* libUI.a */,
 				B28790441A2C90C7FEA3E8DC /* macOSApp.app */,
 				CD6DC52D5DCCD0C55BB96204 /* macOSAppUITests.xctest */,
 				8F49CCC488DBF944363A76E3 /* tvOSApp.app */,
@@ -2637,15 +2672,6 @@
 			path = tvOSAppUITests.__internal__.__test_bundle;
 			sourceTree = "<group>";
 		};
-		D182AF8E059C5832405A845F /* rules_xcodeproj */ = {
-			isa = PBXGroup;
-			children = (
-				15240A701E6FED89576025D5 /* _CompileStub_.m */,
-			);
-			name = rules_xcodeproj;
-			path = test/fixtures/bwb.xcodeproj/rules_xcodeproj;
-			sourceTree = "<group>";
-		};
 		D1B83816FA53EE4F00B3BFD9 /* iOSApp */ = {
 			isa = PBXGroup;
 			children = (
@@ -2938,7 +2964,6 @@
 				45DFB3CD348AAC1998F1CEF4 /* README.md */,
 				9811D2ED915829A1A7881AFD /* Bazel External Repositories */,
 				C407A8E68D8C611448A3E699 /* Bazel Generated Files */,
-				D182AF8E059C5832405A845F /* rules_xcodeproj */,
 				593E7C82FAAD94A7E6A04318 /* Products */,
 				C047AF1D451C7E165914273D /* Frameworks */,
 			);
@@ -3150,23 +3175,6 @@
 			productReference = 56F16FB28F266E6AABCEA995 /* WidgetExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
-		12DB4C040F56113D380794C3 /* UI */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 672B7DE9A513BD308831C79E /* Build configuration list for PBXNativeTarget "UI" */;
-			buildPhases = (
-				409167C928AD94DEF9F114B7 /* Copy Bazel Outputs */,
-				5B209563035A87576A7CF56B /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				D56287C50CA49821B77F8677 /* PBXTargetDependency */,
-				814E13F5E76FA696CACB8461 /* PBXTargetDependency */,
-			);
-			name = UI;
-			productName = UI;
-			productType = "com.apple.product-type.library.static";
-		};
 		13A68B4984727F4B3DAE6AFB /* AppClip */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 90F3B40579D75847186F27C6 /* Build configuration list for PBXNativeTarget "AppClip" */;
@@ -3204,7 +3212,9 @@
 			dependencies = (
 				588C37BAE74BD661E5366E96 /* PBXTargetDependency */,
 				BCCE3E1D985584550E4BB4DA /* PBXTargetDependency */,
+				BA85AC9DC3DA35D9C964D4CB /* PBXTargetDependency */,
 				BB052108C6C6C36E9DDAFF7E /* PBXTargetDependency */,
+				6A10692E159B56F6C1FC17F4 /* PBXTargetDependency */,
 				65B4FB639CC1855C1533A870 /* PBXTargetDependency */,
 				5437B75F248043889B16F23E /* PBXTargetDependency */,
 				9C0C27802B5E0218C39B72F4 /* PBXTargetDependency */,
@@ -3254,6 +3264,23 @@
 			productReference = E332411DCE28305063274CDF /* iMessageAppExtension.appex */;
 			productType = "com.apple.product-type.app-extension.messages";
 		};
+		2CFFD057A9609E996C8B1899 /* UI (iOS, tvOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A5932BA83F11D77BC47F6099 /* Build configuration list for PBXNativeTarget "UI (iOS, tvOS)" */;
+			buildPhases = (
+				966707C029861A54C6AC57B5 /* Copy Bazel Outputs */,
+				2908299BE75941558AF883EF /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				12A9B9D4E515CE16B362CABD /* PBXTargetDependency */,
+				7C4319814F3761660FF1492B /* PBXTargetDependency */,
+			);
+			name = "UI (iOS, tvOS)";
+			productName = UI;
+			productType = "com.apple.product-type.library.static";
+		};
 		2DBD14C7DE92127B94265B10 /* watchOSAppExtension */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 543335B1028B94071588C31E /* Build configuration list for PBXNativeTarget "watchOSAppExtension" */;
@@ -3267,7 +3294,7 @@
 			);
 			dependencies = (
 				D5B6D9348B4FF1077A2E0334 /* PBXTargetDependency */,
-				B1135AAE4F1A278A064F7C3E /* PBXTargetDependency */,
+				565F20A6F1AF0163B791D5D6 /* PBXTargetDependency */,
 			);
 			name = watchOSAppExtension;
 			productName = watchOSAppExtension;
@@ -3343,7 +3370,6 @@
 			);
 			dependencies = (
 				D4F849163EAA27B20E9DAA81 /* PBXTargetDependency */,
-				0ADDF5F0C85A178A39C5864C /* PBXTargetDependency */,
 			);
 			name = LibFramework.iOS;
 			productName = LibFramework.iOS;
@@ -3407,6 +3433,21 @@
 			productName = watchOSApp;
 			productReference = B3F2BB6661347D1891100734 /* watchOSApp.app */;
 			productType = "com.apple.product-type.application.watchapp2";
+		};
+		64AE6000A6317B9C077F3B1E /* CoreUtilsObjC */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DF09ED80A9EE83EB12D74F22 /* Build configuration list for PBXNativeTarget "CoreUtilsObjC" */;
+			buildPhases = (
+				5182F34D39B2072D740E29D8 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3D0D293F05E542E6491A9560 /* PBXTargetDependency */,
+			);
+			name = CoreUtilsObjC;
+			productName = CoreUtilsObjC;
+			productType = "com.apple.product-type.library.static";
 		};
 		76D3DE86C1DB5149A9A669ED /* tvOSAppUnitTests */ = {
 			isa = PBXNativeTarget;
@@ -3483,6 +3524,23 @@
 			productName = lib_swift;
 			productType = "com.apple.product-type.library.static";
 		};
+		8F3CDA8EA17C5FF405D6B44F /* UI (watchOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BF80E819D55DF3127EF2A4C1 /* Build configuration list for PBXNativeTarget "UI (watchOS)" */;
+			buildPhases = (
+				12557DEA70360DA44E8B2FAC /* Copy Bazel Outputs */,
+				BCEC56C99FB23512C7254004 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EF8A44314304D53E37087A85 /* PBXTargetDependency */,
+				C911534EF8F04CA414B39F53 /* PBXTargetDependency */,
+			);
+			name = "UI (watchOS)";
+			productName = UI;
+			productType = "com.apple.product-type.library.static";
+		};
 		9D6BB9A04FEC771667C78F54 /* Lib (iOS, tvOS) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3BFE395FEB493780D77AE664 /* Build configuration list for PBXNativeTarget "Lib (iOS, tvOS)" */;
@@ -3533,6 +3591,7 @@
 			);
 			dependencies = (
 				0E54586AEB47B3853C7BA936 /* PBXTargetDependency */,
+				105151C8DE0B0A0FC6B5FC52 /* PBXTargetDependency */,
 				047474D9D308C0730CABABC9 /* PBXTargetDependency */,
 			);
 			name = tvOSApp;
@@ -3587,7 +3646,6 @@
 			);
 			dependencies = (
 				127DF1FA609C87377C876CE1 /* PBXTargetDependency */,
-				8403836D57A53C88F0DD2C3E /* PBXTargetDependency */,
 			);
 			name = LibFramework.tvOS;
 			productName = LibFramework.tvOS;
@@ -3626,7 +3684,7 @@
 			);
 			dependencies = (
 				92344A87083B6565903B692B /* PBXTargetDependency */,
-				B5801367997175E76F44879D /* PBXTargetDependency */,
+				3E499148E852DFFFAB0EA209 /* PBXTargetDependency */,
 			);
 			name = watchOSAppExtensionUnitTests;
 			productName = watchOSAppExtensionUnitTests;
@@ -3697,10 +3755,6 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
 					};
-					12DB4C040F56113D380794C3 = {
-						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 9999;
-					};
 					13A68B4984727F4B3DAE6AFB = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
@@ -3714,6 +3768,10 @@
 						LastSwiftMigration = 9999;
 					};
 					2BECDF067E07C69468ED23A3 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
+					2CFFD057A9609E996C8B1899 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
 					};
@@ -3750,6 +3808,10 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
 					};
+					64AE6000A6317B9C077F3B1E = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
 					76D3DE86C1DB5149A9A669ED = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
@@ -3767,6 +3829,10 @@
 						LastSwiftMigration = 9999;
 					};
 					8E3B6C47A6106921076BC573 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
+					8F3CDA8EA17C5FF405D6B44F = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
 					};
@@ -3837,6 +3903,7 @@
 				48A1FAB71CA4985ACB147363 /* c_lib */,
 				1A40783EF59C680645DD16E1 /* CommandLineTool */,
 				5826810F86C049E80D55353A /* CommandLineToolTests */,
+				64AE6000A6317B9C077F3B1E /* CoreUtilsObjC */,
 				7F21C434B520AB441229E270 /* FrameworkCoreUtilsObjC */,
 				343F031FB3DF1E87C3568525 /* iMessageApp */,
 				2BECDF067E07C69468ED23A3 /* iMessageAppExtension */,
@@ -3854,7 +3921,8 @@
 				ACEF2F653E0F6BEA37D2C7B6 /* tvOSApp */,
 				53852A3B10D473B77DE57F4D /* tvOSAppUITests */,
 				76D3DE86C1DB5149A9A669ED /* tvOSAppUnitTests */,
-				12DB4C040F56113D380794C3 /* UI */,
+				2CFFD057A9609E996C8B1899 /* UI (iOS, tvOS) */,
+				8F3CDA8EA17C5FF405D6B44F /* UI (watchOS) */,
 				4CFF47C3FBF2E6C24127D667 /* UIFramework.iOS */,
 				A23C98B4BFB6C775689A2A7D /* UIFramework.tvOS */,
 				632D255CE04E97FB997EBDD7 /* watchOSApp */,
@@ -3882,6 +3950,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"macOSAppUITests.xctest\" \\\n  \"\"\n";
+			showEnvVarsInLog = 0;
+		};
+		12557DEA70360DA44E8B2FAC /* Copy Bazel Outputs */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Bazel Outputs";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libUI.a\" \\\n  \"\"\n";
 			showEnvVarsInLog = 0;
 		};
 		1305E71B397AAD0342B70DA2 /* Copy Bazel Outputs */ = {
@@ -4069,22 +4153,6 @@
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libprivate_swift_lib.a\" \\\n  \"\"\n";
 			showEnvVarsInLog = 0;
 		};
-		409167C928AD94DEF9F114B7 /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libUI.a\" \\\n  \"\"\n";
-			showEnvVarsInLog = 0;
-		};
 		4A50E185DA5DF9C9FA565E9A /* Create linking dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -4181,11 +4249,10 @@
 			name = "Create linking dependencies";
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/link.params",
-				"$(DERIVED_FILE_DIR)/_CompileStub_.m",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\ntouch \"$SCRIPT_OUTPUT_FILE_1\"\n";
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		68138666CD6CDC373430A762 /* Create linking dependencies */ = {
@@ -4338,6 +4405,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"UIFramework.iOS.framework\" \\\n  \"\"\n";
+			showEnvVarsInLog = 0;
+		};
+		966707C029861A54C6AC57B5 /* Copy Bazel Outputs */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Bazel Outputs";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libUI.a\" \\\n  \"\"\n";
 			showEnvVarsInLog = 0;
 		};
 		98A71FDC2C7B65B80CB267C4 /* Create linking dependencies */ = {
@@ -4641,11 +4724,10 @@
 			name = "Create linking dependencies";
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/link.params",
-				"$(DERIVED_FILE_DIR)/_CompileStub_.m",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\ntouch \"$SCRIPT_OUTPUT_FILE_1\"\n";
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		EC6016F1A034F70C0846B131 /* Create linking dependencies */ = {
@@ -4718,6 +4800,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		2908299BE75941558AF883EF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				511EF1749DC18A6D29600755 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		315271AE75D672025F1A9942 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -4730,7 +4820,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF1C6240E2CB3A8C32A1BDF6 /* _CompileStub_.m in Sources */,
+				387BF098AF204DE48D223092 /* Lib.swift in Sources */,
+				A04ECCC2488AFCC71E51730B /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4787,11 +4878,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5B209563035A87576A7CF56B /* Sources */ = {
+		5182F34D39B2072D740E29D8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B2417FA79ED28D6036E9011A /* ContentView.swift in Sources */,
+				57A8832E41155CAA5B503ED0 /* Answers.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4833,7 +4924,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				731A6A9A15E9C1C071EC7AC6 /* _CompileStub_.m in Sources */,
+				9C9EE78A87622A3E85C8A6A7 /* Lib.swift in Sources */,
+				090545935B32FE5F8B2E2319 /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4867,6 +4959,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				57337DB3D95294B5CFA16EFB /* iOSApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BCEC56C99FB23512C7254004 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				29B680D0D737019EBB3942B3 /* ContentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4950,12 +5050,6 @@
 			target = AE02B41E521B2C6360C30D20 /* macOSApp */;
 			targetProxy = 7699AD76B28DC4F10D3E2421 /* PBXContainerItemProxy */;
 		};
-		0ADDF5F0C85A178A39C5864C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Lib (iOS, tvOS)";
-			target = 9D6BB9A04FEC771667C78F54 /* Lib (iOS, tvOS) */;
-			targetProxy = 8C96E253D788550FEFC278F6 /* PBXContainerItemProxy */;
-		};
 		0E54586AEB47B3853C7BA936 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -4968,11 +5062,23 @@
 			target = 9D6BB9A04FEC771667C78F54 /* Lib (iOS, tvOS) */;
 			targetProxy = 06878CB50987AA39C99D042E /* PBXContainerItemProxy */;
 		};
+		105151C8DE0B0A0FC6B5FC52 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "UI (iOS, tvOS)";
+			target = 2CFFD057A9609E996C8B1899 /* UI (iOS, tvOS) */;
+			targetProxy = 0A06E47BE8D7455B24B5B0A6 /* PBXContainerItemProxy */;
+		};
 		127DF1FA609C87377C876CE1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 9E1293FAB8D5CB7D608E5E4C /* PBXContainerItemProxy */;
+		};
+		12A9B9D4E515CE16B362CABD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = 9D9101CD560E1A52F997A3BC /* PBXContainerItemProxy */;
 		};
 		13CF19A557C5048EBF49ABB3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5022,6 +5128,18 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 849169BEF9E9155A0714BAA6 /* PBXContainerItemProxy */;
 		};
+		3D0D293F05E542E6491A9560 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = 9E02FA40F7B55953CA4B031D /* PBXContainerItemProxy */;
+		};
+		3E499148E852DFFFAB0EA209 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "UI (watchOS)";
+			target = 8F3CDA8EA17C5FF405D6B44F /* UI (watchOS) */;
+			targetProxy = 358E819B657DD5EAD3424075 /* PBXContainerItemProxy */;
+		};
 		3F895115CDC1F65272567F57 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = LibFramework.tvOS;
@@ -5070,6 +5188,12 @@
 			target = 9D6BB9A04FEC771667C78F54 /* Lib (iOS, tvOS) */;
 			targetProxy = B20F5380C5E1CAB4C423AD35 /* PBXContainerItemProxy */;
 		};
+		565F20A6F1AF0163B791D5D6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "UI (watchOS)";
+			target = 8F3CDA8EA17C5FF405D6B44F /* UI (watchOS) */;
+			targetProxy = CB687C469E22C26C6970C297 /* PBXContainerItemProxy */;
+		};
 		588C37BAE74BD661E5366E96 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -5100,29 +5224,29 @@
 			target = 4CFF47C3FBF2E6C24127D667 /* UIFramework.iOS */;
 			targetProxy = 7A48F6CB7139DCFC3AA220E4 /* PBXContainerItemProxy */;
 		};
+		6A10692E159B56F6C1FC17F4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "UI (iOS, tvOS)";
+			target = 2CFFD057A9609E996C8B1899 /* UI (iOS, tvOS) */;
+			targetProxy = 2E5446FEC378EF59244319A7 /* PBXContainerItemProxy */;
+		};
 		6F7D201160B325B83B56C3F0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Lib (iOS, tvOS)";
 			target = 9D6BB9A04FEC771667C78F54 /* Lib (iOS, tvOS) */;
 			targetProxy = 3E24942D9FDE54F366427071 /* PBXContainerItemProxy */;
 		};
+		7C4319814F3761660FF1492B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Lib (iOS, tvOS)";
+			target = 9D6BB9A04FEC771667C78F54 /* Lib (iOS, tvOS) */;
+			targetProxy = 264BD78711E41840B2F87311 /* PBXContainerItemProxy */;
+		};
 		7E75D67BFDB3E5AA6B6772E5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Lib (iOS, tvOS)";
 			target = 9D6BB9A04FEC771667C78F54 /* Lib (iOS, tvOS) */;
 			targetProxy = 3774B935F0A287F4930A9E64 /* PBXContainerItemProxy */;
-		};
-		814E13F5E76FA696CACB8461 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Lib (watchOS)";
-			target = 83D00AD7532094902D925C83 /* Lib (watchOS) */;
-			targetProxy = FBDE72858B6AD78BADBC5954 /* PBXContainerItemProxy */;
-		};
-		8403836D57A53C88F0DD2C3E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Lib (iOS, tvOS)";
-			target = 9D6BB9A04FEC771667C78F54 /* Lib (iOS, tvOS) */;
-			targetProxy = C87EF466F1120C8A34342BFC /* PBXContainerItemProxy */;
 		};
 		86FFAA921A7F01C5E85BC317 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5184,17 +5308,11 @@
 			target = 515582434B8B8972F8C9CEE4 /* LibFramework.iOS */;
 			targetProxy = 25876A1338D9B5488BEAA787 /* PBXContainerItemProxy */;
 		};
-		B1135AAE4F1A278A064F7C3E /* PBXTargetDependency */ = {
+		BA85AC9DC3DA35D9C964D4CB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = UI;
-			target = 12DB4C040F56113D380794C3 /* UI */;
-			targetProxy = 70B8F531B12A26457D3B0982 /* PBXContainerItemProxy */;
-		};
-		B5801367997175E76F44879D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = UI;
-			target = 12DB4C040F56113D380794C3 /* UI */;
-			targetProxy = DE75BD6142618338C7DECACF /* PBXContainerItemProxy */;
+			name = CoreUtilsObjC;
+			target = 64AE6000A6317B9C077F3B1E /* CoreUtilsObjC */;
+			targetProxy = B6E7BC3DD84A5676B3D7B73F /* PBXContainerItemProxy */;
 		};
 		BB052108C6C6C36E9DDAFF7E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5214,6 +5332,12 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = CED913C91B38F307EEA90999 /* PBXContainerItemProxy */;
 		};
+		C911534EF8F04CA414B39F53 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Lib (watchOS)";
+			target = 83D00AD7532094902D925C83 /* Lib (watchOS) */;
+			targetProxy = A301390453D7505EC4D765AD /* PBXContainerItemProxy */;
+		};
 		CA6DBE9DA75C01226CEB0984 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = watchOSApp;
@@ -5231,12 +5355,6 @@
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 8E62C8BE6F0B5729027C32DC /* PBXContainerItemProxy */;
-		};
-		D56287C50CA49821B77F8677 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
-			targetProxy = 1AF0A8DBFD4E418C98D4DDD3 /* PBXContainerItemProxy */;
 		};
 		D5B6D9348B4FF1077A2E0334 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5261,6 +5379,12 @@
 			name = BazelDependencies;
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = F3D6B3D765A91AFD6AE6AD37 /* PBXContainerItemProxy */;
+		};
+		EF8A44314304D53E37087A85 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
+			targetProxy = 5F258A822E71EA770E9F5898 /* PBXContainerItemProxy */;
 		};
 		F050D422C8291B8A659E5E29 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5511,6 +5635,54 @@
 					"$(BAZEL_EXEC_ROOT)",
 					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin",
 				);
+			};
+			name = Debug;
+		};
+		256651E963A06529777B8CC4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				ARCHS = x86_64;
+				"ARCHS[sdk=watchos*]" = arm64_32;
+				BAZEL_LABEL = "//UI:UI";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/UI";
+				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/UI";
+				BAZEL_TARGET_ID = "//UI:UI watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32";
+				"BAZEL_TARGET_ID[sdk=watchos*]" = "//UI:UI watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90";
+				"BAZEL_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = UI;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator";
+				"FRAMEWORK_SEARCH_PATHS[sdk=watchos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -static";
+				"OTHER_SWIFT_FLAGS[sdk=watchos*]" = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -static";
+				PRODUCT_MODULE_NAME = UI;
+				PRODUCT_NAME = UI;
+				SDKROOT = watchos;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/Lib";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = UI;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin",
+				);
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};
 			name = Debug;
 		};
@@ -5882,8 +6054,13 @@
 		4615DEEF57A4345496D3205E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLETVOS_FILES = "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/Lib/Lib.swift";
+				APPLETVSIMULATOR_FILES = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/Lib/Lib.swift";
 				ARCHS = x86_64;
 				"ARCHS[sdk=appletvos*]" = arm64;
+				BAZEL_COMPILE_TARGET_ID = "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvos*]" = "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_LABEL = "//Lib:LibFramework.tvOS";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/Lib/LibFramework.tvOS.framework";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=appletvos*]" = "$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/Lib/LibFramework.tvOS.framework";
@@ -5893,13 +6070,18 @@
 				"BAZEL_TARGET_ID[sdk=appletvos*]" = "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765";
 				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
 				CODE_SIGN_STYLE = Manual;
-				COMPILE_TARGET_NAME = LibFramework.tvOS;
+				COMPILE_TARGET_NAME = Lib;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				EXCLUDED_SOURCE_FILE_NAMES = "$(APPLETVOS_FILES) $(APPLETVSIMULATOR_FILES)";
 				FRAMEWORK_SEARCH_PATHS = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator";
 				"FRAMEWORK_SEARCH_PATHS[sdk=appletvos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64";
 				GCC_OPTIMIZATION_LEVEL = 0;
+				INCLUDED_SOURCE_FILE_NAMES = "";
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=appletvos*]" = "$(APPLETVOS_FILES)";
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=appletvsimulator*]" = "$(APPLETVSIMULATOR_FILES)";
 				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist";
 				"INFOPLIST_FILE[sdk=appletvos*]" = "$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5909,21 +6091,22 @@
 				);
 				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/Lib/LibFramework.tvOS.link.params";
 				"LINK_PARAMS_FILE[sdk=appletvos*]" = "$(INTERNAL_DIR)/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/Lib/LibFramework.tvOS.link.params";
-				OTHER_CFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
-				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -static";
+				"OTHER_SWIFT_FLAGS[sdk=appletvos*]" = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -static";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/Lib $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				"PREVIEWS_SWIFT_INCLUDE_PATHS__YES[sdk=appletvos*]" = "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/Lib $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PREVIEW_FRAMEWORK_PATHS = "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\"";
 				"PREVIEW_FRAMEWORK_PATHS[sdk=appletvos*]" = "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\"";
 				PRODUCT_BUNDLE_IDENTIFIER = io.budilebuddy.LibFramework;
+				PRODUCT_MODULE_NAME = Lib;
 				PRODUCT_NAME = LibFramework.tvOS;
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__$(ENABLE_PREVIEWS))";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -5933,13 +6116,13 @@
 					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/external/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin",
 				);
 				"USER_HEADER_SEARCH_PATHS[sdk=appletvos*]" = (
 					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/external/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin",
+					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin",
 				);
 			};
 			name = Debug;
@@ -6457,6 +6640,166 @@
 			};
 			name = Debug;
 		};
+		9A5566483B61F9D10CB67C4D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				"ARCHS[sdk=iphoneos*]" = arm64;
+				BAZEL_LABEL = "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/iOSApp/Source/CoreUtilsObjC";
+				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/iOSApp/Source/CoreUtilsObjC";
+				BAZEL_TARGET_ID = "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56";
+				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				COMPILE_TARGET_NAME = CoreUtilsObjC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREFIX_HEADER = iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					OS_IOS,
+					"DEBUG=1",
+				);
+				HEADER_SEARCH_PATHS = (
+					iOSApp/Source/CoreUtilsObjC,
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/iOSApp/Source/CoreUtilsObjC",
+				);
+				"HEADER_SEARCH_PATHS[sdk=iphoneos*]" = (
+					iOSApp/Source/CoreUtilsObjC,
+					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/iOSApp/Source/CoreUtilsObjC",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_CFLAGS = (
+					"-ivfsoverlay",
+					"$(OBJROOT)/bazel-out-overlay.yaml",
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-Wshorten-64-to-32",
+					"-Wbool-conversion",
+					"-Wconstant-conversion",
+					"-Wduplicate-method-match",
+					"-Wempty-body",
+					"-Wenum-conversion",
+					"-Wint-conversion",
+					"-Wunreachable-code",
+					"-Wmismatched-return-types",
+					"-Wundeclared-selector",
+					"-Wuninitialized",
+					"-Wunused-function",
+					"-Wunused-variable",
+					"-fno-autolink",
+					"-fexceptions",
+					"-fasm-blocks",
+					"-fobjc-abi-version=2",
+					"-fobjc-legacy-dispatch",
+					"-fstack-protector",
+					"-fstack-protector-all",
+				);
+				"OTHER_CFLAGS[sdk=iphoneos*]" = (
+					"-ivfsoverlay",
+					"$(OBJROOT)/bazel-out-overlay.yaml",
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-Wshorten-64-to-32",
+					"-Wbool-conversion",
+					"-Wconstant-conversion",
+					"-Wduplicate-method-match",
+					"-Wempty-body",
+					"-Wenum-conversion",
+					"-Wint-conversion",
+					"-Wunreachable-code",
+					"-Wmismatched-return-types",
+					"-Wundeclared-selector",
+					"-Wuninitialized",
+					"-Wunused-function",
+					"-Wunused-variable",
+					"-fno-autolink",
+					"-fstack-protector",
+					"-fstack-protector-all",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-ivfsoverlay",
+					"$(OBJROOT)/bazel-out-overlay.yaml",
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-Wshorten-64-to-32",
+					"-Wbool-conversion",
+					"-Wconstant-conversion",
+					"-Wduplicate-method-match",
+					"-Wempty-body",
+					"-Wenum-conversion",
+					"-Wint-conversion",
+					"-Wunreachable-code",
+					"-Wmismatched-return-types",
+					"-Wundeclared-selector",
+					"-Wuninitialized",
+					"-Wunused-function",
+					"-Wunused-variable",
+					"-fno-autolink",
+					"-fexceptions",
+					"-fasm-blocks",
+					"-fobjc-abi-version=2",
+					"-fobjc-legacy-dispatch",
+					"-fstack-protector",
+					"-fstack-protector-all",
+				);
+				"OTHER_CPLUSPLUSFLAGS[sdk=iphoneos*]" = (
+					"-ivfsoverlay",
+					"$(OBJROOT)/bazel-out-overlay.yaml",
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-Wshorten-64-to-32",
+					"-Wbool-conversion",
+					"-Wconstant-conversion",
+					"-Wduplicate-method-match",
+					"-Wempty-body",
+					"-Wenum-conversion",
+					"-Wint-conversion",
+					"-Wunreachable-code",
+					"-Wmismatched-return-types",
+					"-Wundeclared-selector",
+					"-Wuninitialized",
+					"-Wunused-function",
+					"-Wunused-variable",
+					"-fno-autolink",
+					"-fstack-protector",
+					"-fstack-protector-all",
+				);
+				PRODUCT_MODULE_NAME = CoreUtils;
+				PRODUCT_NAME = CoreUtilsObjC;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = CoreUtilsObjC;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=iphoneos*]" = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin",
+				);
+			};
+			name = Debug;
+		};
 		9B77CEE5F1C61532E473154B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -6965,6 +7308,9 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
+				BAZEL_COMPILE_TARGET_ID = "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphoneos*]" = "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_LABEL = "//Lib:LibFramework.iOS";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/Lib/LibFramework.iOS.framework";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/Lib/LibFramework.iOS.framework";
@@ -6974,16 +7320,23 @@
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//Lib:LibFramework.iOS applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00";
 				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				CODE_SIGN_STYLE = Manual;
-				COMPILE_TARGET_NAME = LibFramework.iOS;
+				COMPILE_TARGET_NAME = Lib;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				EXCLUDED_SOURCE_FILE_NAMES = "$(IPHONEOS_FILES) $(IPHONESIMULATOR_FILES)";
 				FRAMEWORK_SEARCH_PATHS = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator";
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7";
 				GCC_OPTIMIZATION_LEVEL = 0;
+				INCLUDED_SOURCE_FILE_NAMES = "";
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*]" = "$(IPHONEOS_FILES)";
+				"INCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*]" = "$(IPHONESIMULATOR_FILES)";
 				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/Lib/rules_xcodeproj/LibFramework.iOS/Info.plist";
 				"INFOPLIST_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/Lib/rules_xcodeproj/LibFramework.iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_FILES = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/Lib/Lib.swift";
+				IPHONESIMULATOR_FILES = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/Lib/Lib.swift";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -6991,22 +7344,23 @@
 				);
 				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/Lib/LibFramework.iOS.link.params";
 				"LINK_PARAMS_FILE[sdk=iphoneos*]" = "$(INTERNAL_DIR)/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/Lib/LibFramework.iOS.link.params";
-				OTHER_CFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
-				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static";
+				"OTHER_SWIFT_FLAGS[sdk=iphoneos*]" = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/Lib $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				"PREVIEWS_SWIFT_INCLUDE_PATHS__YES[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/Lib $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PREVIEW_FRAMEWORK_PATHS = "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework\"";
 				"PREVIEW_FRAMEWORK_PATHS[sdk=iphoneos*]" = "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework\"";
 				PRODUCT_BUNDLE_IDENTIFIER = io.budilebuddy.LibFramework;
+				PRODUCT_MODULE_NAME = Lib;
 				PRODUCT_NAME = LibFramework.iOS;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__$(ENABLE_PREVIEWS))";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -7016,62 +7370,14 @@
 					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/external/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin",
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin",
 				);
 				"USER_HEADER_SEARCH_PATHS[sdk=iphoneos*]" = (
 					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/external/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin",
+					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin",
 				);
-			};
-			name = Debug;
-		};
-		E87ED2FB87DE4C11D17706BA /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				ARCHS = x86_64;
-				"ARCHS[sdk=watchos*]" = arm64_32;
-				BAZEL_LABEL = "//UI:UI";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/UI";
-				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/UI";
-				BAZEL_TARGET_ID = "//UI:UI watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32";
-				"BAZEL_TARGET_ID[sdk=watchos*]" = "//UI:UI watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90";
-				"BAZEL_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = UI;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator";
-				"FRAMEWORK_SEARCH_PATHS[sdk=watchos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k";
-				GCC_OPTIMIZATION_LEVEL = 0;
-				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -static";
-				"OTHER_SWIFT_FLAGS[sdk=watchos*]" = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -static";
-				PRODUCT_MODULE_NAME = UI;
-				PRODUCT_NAME = UI;
-				SDKROOT = watchos;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/Lib";
-				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/Lib";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = UI;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin",
-				);
-				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};
 			name = Debug;
 		};
@@ -7182,6 +7488,79 @@
 					"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-56a8163e2aa7/bin",
 				);
 				WATCHOS_DEPLOYMENT_TARGET = 8.0;
+			};
+			name = Debug;
+		};
+		F3810E2B1179BD0A6D7B872F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				ARCHS = x86_64;
+				"ARCHS[sdk=appletvos*]" = arm64;
+				"ARCHS[sdk=iphoneos*]" = arm64;
+				BAZEL_LABEL = "//UI:UI";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/UI";
+				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/UI";
+				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvsimulator*]" = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/UI";
+				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/UI";
+				BAZEL_TARGET_ID = "//UI:UI ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56";
+				"BAZEL_TARGET_ID[sdk=appletvos*]" = "//UI:UI tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "//UI:UI tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2";
+				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//UI:UI ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = UI;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator";
+				"FRAMEWORK_SEARCH_PATHS[sdk=appletvos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64";
+				"FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator";
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static";
+				"OTHER_SWIFT_FLAGS[sdk=appletvos*]" = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -static";
+				"OTHER_SWIFT_FLAGS[sdk=appletvsimulator*]" = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -static";
+				"OTHER_SWIFT_FLAGS[sdk=iphoneos*]" = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static";
+				PRODUCT_MODULE_NAME = UI;
+				PRODUCT_NAME = UI;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=appletvsimulator*]" = "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/Lib";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = UI;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=appletvos*]" = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=appletvsimulator*]" = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=iphoneos*]" = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin",
+				);
 			};
 			name = Debug;
 		};
@@ -7448,14 +7827,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		672B7DE9A513BD308831C79E /* Build configuration list for PBXNativeTarget "UI" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				E87ED2FB87DE4C11D17706BA /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		75EB161EFF626458F41F0CA7 /* Build configuration list for PBXNativeTarget "iMessageAppExtension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -7528,6 +7899,14 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		A5932BA83F11D77BC47F6099 /* Build configuration list for PBXNativeTarget "UI (iOS, tvOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F3810E2B1179BD0A6D7B872F /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		A8F09F14F4463A8E11725B7D /* Build configuration list for PBXNativeTarget "CommandLineTool" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -7560,6 +7939,14 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		BF80E819D55DF3127EF2A4C1 /* Build configuration list for PBXNativeTarget "UI (watchOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				256651E963A06529777B8CC4 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		C52C33AC1575AF1A3BA03A91 /* Build configuration list for PBXNativeTarget "private_swift_lib" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -7580,6 +7967,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				ACC357DE288648772E706D75 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		DF09ED80A9EE83EB12D74F22 /* Build configuration list for PBXNativeTarget "CoreUtilsObjC" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A5566483B61F9D10CB67C4D /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/Lib/LibFramework.iOS.link.params
@@ -6,5 +6,3 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--force_load
-$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/Lib/LibFramework.iOS.link.params
@@ -6,5 +6,3 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--force_load
-$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/Lib/LibFramework.tvOS.link.params
@@ -6,5 +6,3 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--force_load
-$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/Lib/LibFramework.tvOS.link.params
@@ -6,5 +6,3 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--force_load
-$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Initialize Bazel Build Output Groups File"
+               scriptText = "mkdir -p &quot;${SCHEME_TARGET_IDS_FILE%/*}&quot;&#10;if [[ -s &quot;$SCHEME_TARGET_IDS_FILE&quot; ]]; then&#10;    rm &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;fi&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "64AE6000A6317B9C077F3B1E"
+                     BuildableName = "CoreUtilsObjC"
+                     BlueprintName = "CoreUtilsObjC"
+                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Set Bazel Build Output Groups for CoreUtilsObjC"
+               scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "64AE6000A6317B9C077F3B1E"
+                     BuildableName = "CoreUtilsObjC"
+                     BlueprintName = "CoreUtilsObjC"
+                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "64AE6000A6317B9C077F3B1E"
+               BuildableName = "CoreUtilsObjC"
+               BlueprintName = "CoreUtilsObjC"
+               ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UI (iOS, tvOS).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UI (iOS, tvOS).xcscheme
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Initialize Bazel Build Output Groups File"
+               scriptText = "mkdir -p &quot;${SCHEME_TARGET_IDS_FILE%/*}&quot;&#10;if [[ -s &quot;$SCHEME_TARGET_IDS_FILE&quot; ]]; then&#10;    rm &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;fi&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2CFFD057A9609E996C8B1899"
+                     BuildableName = "UI (iOS, tvOS)"
+                     BlueprintName = "UI (iOS, tvOS)"
+                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Set Bazel Build Output Groups for UI (iOS, tvOS)"
+               scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2CFFD057A9609E996C8B1899"
+                     BuildableName = "UI (iOS, tvOS)"
+                     BlueprintName = "UI (iOS, tvOS)"
+                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2CFFD057A9609E996C8B1899"
+               BuildableName = "UI (iOS, tvOS)"
+               BlueprintName = "UI (iOS, tvOS)"
+               ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UI (watchOS).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UI (watchOS).xcscheme
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Initialize Bazel Build Output Groups File"
+               scriptText = "mkdir -p &quot;${SCHEME_TARGET_IDS_FILE%/*}&quot;&#10;if [[ -s &quot;$SCHEME_TARGET_IDS_FILE&quot; ]]; then&#10;    rm &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;fi&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "8F3CDA8EA17C5FF405D6B44F"
+                     BuildableName = "UI (watchOS)"
+                     BlueprintName = "UI (watchOS)"
+                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Set Bazel Build Output Groups for UI (watchOS)"
+               scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "8F3CDA8EA17C5FF405D6B44F"
+                     BuildableName = "UI (watchOS)"
+                     BlueprintName = "UI (watchOS)"
+                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8F3CDA8EA17C5FF405D6B44F"
+               BuildableName = "UI (watchOS)"
+               BlueprintName = "UI (watchOS)"
+               ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -455,6 +455,22 @@
         [
             "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197"
         ],
+        "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00",
+        [
+            "//Lib:LibFramework.iOS applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00"
+        ],
+        "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56",
+        [
+            "//Lib:LibFramework.iOS applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56"
+        ],
+        "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765",
+        [
+            "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765"
+        ],
+        "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2",
+        [
+            "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2"
+        ],
         "//UI:UI ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00",
         [
             "//UI:UIFramework.iOS applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		0FD218B14F012C314354A277 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; };
 		115EAC732D1D5551003F4988 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95A5CEC36DFCD8E9405557B7 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		11F3CA8F80B0BB2597AF76E1 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 161FCC8E16610CC731029DF1 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1355519BD9DE0384105E8B97 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = F33769C19E5BDFCC804DB871 /* Lib.swift */; };
 		13A6B947448B36A004253831 /* watchOSApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = D76D2C3E02897E2ED28A8958 /* watchOSApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1705B8940632007097FBD9FD /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; };
 		171DACB244D0CE6D2880DE13 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = A4B9C08059A6D7570552A207 /* GoogleMaps.bundle */; };
@@ -45,6 +46,7 @@
 		1BA58B62ACB840A152C43E80 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FFCA16CB57244FE59B40D500 /* MainInterface.storyboard */; };
 		1C749C20C3FAA20FF518DD73 /* macOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83725B51E3CA6DD91F7D6BFF /* macOSApp.swift */; };
 		1F09F6D2662F9F248FFD967A /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; };
+		20A260B9C46C90B1DE12A69D /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220191BD3F7360FCCF281EBD /* ContentView.swift */; };
 		225B94C4FEA8FB5DD03102A9 /* ExampleResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 087B3E45AA9A7430D1BEC9B8 /* ExampleResources.bundle */; };
 		2286D94B88D52590A6E58F76 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E03EA73D2F5DAB6EDED34595 /* CryptoSwift.framework */; };
 		22FF2DD66A3B3A75624CC621 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -52,6 +54,7 @@
 		250CE46988EA2F5D57D2B3D8 /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE73CE9A3DEAC184A64A5A5 /* MessagesViewController.swift */; };
 		2756BE0923424079AFD67739 /* ExampleFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CB23CF2A952EAA596B48962C /* ExampleFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2A874931D044EDD1086C1B07 /* LibFramework.iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE17238A24CF9758B74AE148 /* LibFramework.iOS.framework */; };
+		352F61ECAA34E19F1AE91140 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9A65559C141C2EE24ED7827 /* Lib.swift */; };
 		3663F6F02852C0086A6D8C55 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E03EA73D2F5DAB6EDED34595 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3910302EFF7CF691D051A893 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65757D8CE42B00E7C1504904 /* Intents.swift */; };
 		39B70EB5A4AEE55947BD2DB9 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; };
@@ -63,7 +66,9 @@
 		3F3040F0EC161A6F56A3DE93 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E4958C56023AC7E82EA5B8 /* Intents.swift */; };
 		40FF91649C3585B4823B3770 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19DF91AAD078DE3B057369B /* ContentView.swift */; };
 		42B24939EF1B27F1EEB23217 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = EA5D27714701CC942BE85FC0 /* main.m */; };
+		435CFAEB368D4AE698C9E8A1 /* Answers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 90ABB039CCDE0C38E34F9245 /* Answers.mm */; };
 		44633612150DB57C9D05C2F7 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 270A95ACD2882E4470E9AD1F /* CryptoSwift.framework */; };
+		4B781F3A200CE52286FA2649 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220191BD3F7360FCCF281EBD /* ContentView.swift */; };
 		4EEF26B11D3A6AFB2D2EB8FE /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981E9E8FD6A149FA01F271A7 /* private_lib.swift */; };
 		4F1FD2B820497A6AFE6B313C /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7460163239595E240435120 /* GoogleMapsBase.framework */; };
 		4F8FED2A0C5F3936F3476757 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9A65559C141C2EE24ED7827 /* Lib.swift */; };
@@ -74,6 +79,7 @@
 		5CECD55D1D38CC5B8430A48B /* UI.h in Headers */ = {isa = PBXBuildFile; fileRef = 2750C933EC0EB524264D459F /* UI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D92A287B558AE3F6616221D /* AltIcon-60@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = A6ED0CB2494372465AE21A46 /* AltIcon-60@3x.png */; };
 		60777C5827074DAC40492910 /* Model.xcdatamodeld in Resources */ = {isa = PBXBuildFile; fileRef = 92B5D8AC74143F0FC92E142F /* Model.xcdatamodeld */; };
+		61284A35A2850C35FB03D984 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB566A8142C8EAF584F9BE0 /* Lib.swift */; };
 		63D5686734712406F04578F9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A026E022EE18E3D73915E1B0 /* Assets.xcassets */; };
 		6878EA54E943131A838F824B /* WatchOSAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB265EDEAD6F8B50AC8EE60A /* WatchOSAppUITestsLaunchTests.swift */; };
 		6929865DA0A95F8474ED2907 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFCD318EF54D23BAEEF0EC28 /* Lib.swift */; };
@@ -100,7 +106,6 @@
 		8DB8540FF1230C3046C3C413 /* launch_images_ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6024BE681BD1B639F193B1D5 /* launch_images_ios.xcassets */; };
 		91FFC1CB612B99285C89F405 /* LibFramework.tvOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 819D7FB47D529D391E218B30 /* LibFramework.tvOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9241F80C086E7839F0182266 /* GoogleMaps.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4945564FB57B2AAF142EFC4 /* GoogleMaps.framework */; };
-		970930B398EF704E7F2BF918 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = C1427F45C783EFE20E49B1E4 /* _CompileStub_.m */; };
 		980DA518D512CAD9287F569D /* WatchOSAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D4C8FF1BC1B0BF86F3A298 /* WatchOSAppUITests.swift */; };
 		9B7AB779C8607289AE64F18B /* unprocessed.json in Resources */ = {isa = PBXBuildFile; fileRef = 7172CF19386836C0149A8FAC /* unprocessed.json */; };
 		9DCFC99A86690BF8E086CD2D /* RealAnswer.h in Headers */ = {isa = PBXBuildFile; fileRef = 15BD628D8CB5434E1FBA7F99 /* RealAnswer.h */; };
@@ -113,7 +118,6 @@
 		A25E91927056AD340C78FFAA /* LibFramework.tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 819D7FB47D529D391E218B30 /* LibFramework.tvOS.framework */; };
 		A2881D00B6B4998713F69CDB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7A8C0E241B1307FE7464ADF2 /* Assets.xcassets */; };
 		A3981F7E03800ED5F1A4CE70 /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = 810E2D447FCAC7D533DFF6D2 /* lib.m */; };
-		A4803FC1A0ED687D63C7DB54 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = C1427F45C783EFE20E49B1E4 /* _CompileStub_.m */; };
 		A6753619C6B486331D39C220 /* AppClip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B85F05863EF8DE04D82121 /* AppClip.swift */; };
 		A85575189071436F689B0DAE /* bucket in Resources */ = {isa = PBXBuildFile; fileRef = 66F0C3E3B07C2183208B4129 /* bucket */; };
 		A8AEC27B7E94CDED68030FAA /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; };
@@ -148,7 +152,7 @@
 		E0B2CDE5DC129614666CD9A4 /* Answers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 90ABB039CCDE0C38E34F9245 /* Answers.mm */; };
 		E16B5F1B14C088FD1B4A93AA /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2126CD665EDDB201E367009 /* Lib.swift */; };
 		E31E3CF6E56E0A5A3623C38A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57F651BDC3C5240B9E39EBCC /* Assets.xcassets */; };
-		E336B4F3C30739616C456ACC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220191BD3F7360FCCF281EBD /* ContentView.swift */; };
+		E3F8C774C80B20340DA25FF1 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2126CD665EDDB201E367009 /* Lib.swift */; };
 		E8B3605DB78F38F7CFF33469 /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 12200A389D1ACE33A9160B97 /* GoogleMapsBase.framework */; };
 		EA92CB15E5B88ACB72D7C78A /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F18CCFC74137236D689F0401 /* ExampleFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB23CF2A952EAA596B48962C /* ExampleFramework.framework */; };
@@ -197,20 +201,6 @@
 			remoteGlobalIDString = EDF8F127D3EA3E7481E6D3D5;
 			remoteInfo = WidgetExtension;
 		};
-		0CC9114A9DE54DD04FDAF560 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 801E2436A69733A307109C9A;
-			remoteInfo = "Lib (iOS, tvOS)";
-		};
-		13B182E5183921082BC698F0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 49BB1280EE4B2FB636FBB36E;
-			remoteInfo = UI;
-		};
 		1B1C2595107FD780E0018188 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -224,6 +214,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = 195FCD65F4EB377830E3E996;
 			remoteInfo = lib_swift;
+		};
+		1DC62689CE1B4F80833D8C98 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A0257519AD63A69C6DF51958;
+			remoteInfo = CoreUtilsObjC;
+		};
+		22059E986A28D98C1BA250A2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D094AA317C2527FB0FCC5015;
+			remoteInfo = "Lib (watchOS)";
 		};
 		24A8D31F20B7B8A36E8C7FDF /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -330,13 +334,6 @@
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
 		};
-		49129EEED027EDD87603A8DC /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 49BB1280EE4B2FB636FBB36E;
-			remoteInfo = UI;
-		};
 		4CCF9F788AC4A1B84D4C9BB3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -364,6 +361,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 197909C893D71098F7D5178C;
 			remoteInfo = UIFramework.tvOS;
+		};
+		587D3B5AFA1F9C492C8B859E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
 		};
 		59AB901F8840A59BA8293207 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -414,6 +418,13 @@
 			remoteGlobalIDString = 967BEB9EDFB3230C10A206A8;
 			remoteInfo = ExampleNestedResources;
 		};
+		7987ECA9944421D4AC07A0DB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA7C60469EF398B21BF8EBA0;
+			remoteInfo = "UI (watchOS)";
+		};
 		7E7AC142EDAE3A5597AECBF8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -435,7 +446,21 @@
 			remoteGlobalIDString = F38BE7F734335EF255F553F2;
 			remoteInfo = c_lib;
 		};
+		8709CF92F43EDFFB60A05702 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA7C60469EF398B21BF8EBA0;
+			remoteInfo = "UI (watchOS)";
+		};
 		8820D4116D7075DF884C45CF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 801E2436A69733A307109C9A;
+			remoteInfo = "Lib (iOS, tvOS)";
+		};
+		889DD95949FFBA21076B3F9C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
@@ -484,6 +509,13 @@
 			remoteGlobalIDString = F3451D8089613E01522F3373;
 			remoteInfo = tvOSApp;
 		};
+		AD67F165892092512DB84B8D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F9C625F339475535AB4692D6;
+			remoteInfo = "UI (iOS, tvOS)";
+		};
 		B1E5509E710AAD34090DD08E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -492,6 +524,13 @@
 			remoteInfo = BazelDependencies;
 		};
 		BA90E139F9A2657720980562 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
+		BE13815FCA0403A6A9C0D9CD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
@@ -512,6 +551,13 @@
 			remoteGlobalIDString = 8329F08BE01D4CC32B819CE9;
 			remoteInfo = lib_impl;
 		};
+		CC447DF8A4DD4FF89C49342C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
+			remoteInfo = BazelDependencies;
+		};
 		CFCD97C2433A529E9D15DD32 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -519,12 +565,12 @@
 			remoteGlobalIDString = FDA59F09C0DC31A1D18B6509;
 			remoteInfo = iMessageAppExtension;
 		};
-		D0F2893E8DBEF73FECCF041B /* PBXContainerItemProxy */ = {
+		D43B6167B338D2BE0445394C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 801E2436A69733A307109C9A;
-			remoteInfo = "Lib (iOS, tvOS)";
+			remoteGlobalIDString = F9C625F339475535AB4692D6;
+			remoteInfo = "UI (iOS, tvOS)";
 		};
 		D62491DB4F3B0CD2FCBB852E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -560,20 +606,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
-		};
-		EF1BE8BE45106F3D70F91789 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
-			remoteInfo = BazelDependencies;
-		};
-		F0F012D2694A06C6DF4D9085 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D094AA317C2527FB0FCC5015;
-			remoteInfo = "Lib (watchOS)";
 		};
 		F42CD9468A9C7900AB998DA9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -952,13 +984,12 @@
 		BFDBC8BE73659B49F821DC30 /* UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTests.swift; sourceTree = "<group>"; };
 		C0604CB5EC082460A5DC8781 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C10E39A53740052F32DC2FB9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		C1427F45C783EFE20E49B1E4 /* _CompileStub_.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = _CompileStub_.m; sourceTree = DERIVED_FILE_DIR; };
 		C152F52FA537BBF0815F7899 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C1AAFB89B1693517978884D2 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		C430EA6EC770042CAF4719B0 /* nested */ = {isa = PBXFileReference; lastKnownFileType = folder; path = nested; sourceTree = "<group>"; };
 		C4A548E5B54B533E7A233354 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		C6A29CA667D6ABEE018798A2 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
-		C85146EA4C74AA5FB15E1943 /* libUI.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libUI.a; path = "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI/libUI.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C85146EA4C74AA5FB15E1943 /* libUI.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libUI.a; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/UI/libUI.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C85154A51F065A9EDFD6253C /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		C88A6EEAE9DCE84AE709FE5E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		CB23CF2A952EAA596B48962C /* ExampleFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ExampleFramework.framework; sourceTree = "<group>"; };
@@ -994,6 +1025,7 @@
 		F33769C19E5BDFCC804DB871 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
 		F404D3737E5EF452C02E109E /* c_lib.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = c_lib.modulemap; sourceTree = "<group>"; };
 		F42E64BC8F0D0025C149DF99 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = en; path = en.lproj/unprocessed.json; sourceTree = "<group>"; };
+		F8CB2F3169746EE2EF141C2E /* libUI.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libUI.a; path = "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI/libUI.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F91E328B4F2F603039D66262 /* lib.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = lib.h; sourceTree = "<group>"; };
 		F92E21C55F9CE42CCF8E3E79 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		F9A65559C141C2EE24ED7827 /* Lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lib.swift; sourceTree = "<group>"; };
@@ -1002,6 +1034,7 @@
 		FC55223E2AD6250E5B141FB0 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		FCBC35585DF86503BA37CE58 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		FCFAACAD225B40BD8E7A9724 /* ExtensionAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ExtensionAssets.xcassets; sourceTree = "<group>"; };
+		FD0A412F6FD34BAD4615ACB5 /* libCoreUtilsObjC.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libCoreUtilsObjC.a; path = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Source/CoreUtilsObjC/libCoreUtilsObjC.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE17238A24CF9758B74AE148 /* LibFramework.iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LibFramework.iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -1717,6 +1750,7 @@
 				A64E82DCF9CD209DC5E8DA47 /* iMessageAppExtension.appex */,
 				94B4E46AB654CACC5E8E5C55 /* iOSApp.app */,
 				E5B29EFE9E4782D578874298 /* libc_lib.a */,
+				FD0A412F6FD34BAD4615ACB5 /* libCoreUtilsObjC.a */,
 				FE17238A24CF9758B74AE148 /* LibFramework.iOS.framework */,
 				819D7FB47D529D391E218B30 /* LibFramework.tvOS.framework */,
 				61D4E93D586B426B1BE67C73 /* liblib_impl.a */,
@@ -1726,6 +1760,7 @@
 				D04DA2A609AD72919E00E6F6 /* libprivate_lib.a */,
 				A0252A7A11540E7818811565 /* libprivate_swift_lib.a */,
 				C85146EA4C74AA5FB15E1943 /* libUI.a */,
+				F8CB2F3169746EE2EF141C2E /* libUI.a */,
 				4E0183A010067D0E90916009 /* macOSApp.app */,
 				5329630C06F5BE9FA7DD833E /* macOSAppUITests.xctest */,
 				F17FC436B461919E1DDC0F71 /* tvOSApp.app */,
@@ -2031,15 +2066,6 @@
 			path = "applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0";
 			sourceTree = "<group>";
 		};
-		6AF936B6BAFAF10DCDAE73D3 /* rules_xcodeproj */ = {
-			isa = PBXGroup;
-			children = (
-				C1427F45C783EFE20E49B1E4 /* _CompileStub_.m */,
-			);
-			name = rules_xcodeproj;
-			path = test/fixtures/bwx.xcodeproj/rules_xcodeproj;
-			sourceTree = "<group>";
-		};
 		6BA2263E0B6EC382B3DD33B4 /* UI */ = {
 			isa = PBXGroup;
 			children = (
@@ -2166,7 +2192,6 @@
 				631BA00664D8DD1FAA88F784 /* README.md */,
 				85F708DD1F5484A0D5558108 /* Bazel External Repositories */,
 				A5A3DECCB7E56F0EA3676D12 /* Bazel Generated Files */,
-				6AF936B6BAFAF10DCDAE73D3 /* rules_xcodeproj */,
 				462C3519CA354BE1B04D4855 /* Products */,
 				D9AAB93A5135F69103554470 /* Frameworks */,
 			);
@@ -3468,22 +3493,6 @@
 			productReference = 08BC408C75C2ECC754662C32 /* watchOSAppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
-		49BB1280EE4B2FB636FBB36E /* UI */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 7C0E627AAAB5D184799054F9 /* Build configuration list for PBXNativeTarget "UI" */;
-			buildPhases = (
-				E8E5F627D98A2CB8072BE324 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				8EAD6A48F472DDCD42D93312 /* PBXTargetDependency */,
-				22D113A8237F55A76D6ACED8 /* PBXTargetDependency */,
-			);
-			name = UI;
-			productName = UI;
-			productType = "com.apple.product-type.library.static";
-		};
 		4A81F3A0DADC86D2FCF01DB1 /* iMessageApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = EED69E6677FA4A1D173C9F27 /* Build configuration list for PBXNativeTarget "iMessageApp" */;
@@ -3517,7 +3526,7 @@
 			);
 			dependencies = (
 				2F3392E40FFA06B2AD811927 /* PBXTargetDependency */,
-				A97ADA03A2A030FF08305B1B /* PBXTargetDependency */,
+				7A1F207154E549814F1CD585 /* PBXTargetDependency */,
 			);
 			name = watchOSAppExtension;
 			productName = watchOSAppExtension;
@@ -3537,7 +3546,7 @@
 			);
 			dependencies = (
 				88AB3E0F0D7F995F35D988B2 /* PBXTargetDependency */,
-				A3CF9AD00E493F7CA561B50C /* PBXTargetDependency */,
+				A132635D1E000DEB6B99189F /* PBXTargetDependency */,
 			);
 			name = watchOSAppExtensionUnitTests;
 			productName = watchOSAppExtensionUnitTests;
@@ -3636,12 +3645,26 @@
 			);
 			dependencies = (
 				8963A48C60DE3DBA631BEB83 /* PBXTargetDependency */,
-				4A5D29094F247671CB015045 /* PBXTargetDependency */,
 			);
 			name = LibFramework.iOS;
 			productName = LibFramework.iOS;
 			productReference = FE17238A24CF9758B74AE148 /* LibFramework.iOS.framework */;
 			productType = "com.apple.product-type.framework";
+		};
+		A0257519AD63A69C6DF51958 /* CoreUtilsObjC */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A371FC09C8552CA9AA11EBA0 /* Build configuration list for PBXNativeTarget "CoreUtilsObjC" */;
+			buildPhases = (
+				515BF020C098484F84ED2DAA /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4E2958552EC93E6809BB7908 /* PBXTargetDependency */,
+			);
+			name = CoreUtilsObjC;
+			productName = CoreUtilsObjC;
+			productType = "com.apple.product-type.library.static";
 		};
 		A2CE5EDCDDA5334B00B16BC9 /* FrameworkCoreUtilsObjC */ = {
 			isa = PBXNativeTarget;
@@ -3679,9 +3702,11 @@
 			dependencies = (
 				E6DF8AB88AFBE93299AD4256 /* PBXTargetDependency */,
 				D8784C7B176B790E6096D635 /* PBXTargetDependency */,
+				B52498F5A510BFFB39226839 /* PBXTargetDependency */,
 				A201CF74F0ACB882F47060CB /* PBXTargetDependency */,
 				6F852951E7E95E8B5C4DDCC5 /* PBXTargetDependency */,
 				2F8D04C0891AE51AD62A8C79 /* PBXTargetDependency */,
+				5560490000B5A6C771998EBC /* PBXTargetDependency */,
 				979CA3ADC8BDBB39866CB7C7 /* PBXTargetDependency */,
 				CAF25B094F61CC75910E867C /* PBXTargetDependency */,
 				D1B3453772A36EAD0719B970 /* PBXTargetDependency */,
@@ -3759,6 +3784,22 @@
 			productReference = 5329630C06F5BE9FA7DD833E /* macOSAppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		DA7C60469EF398B21BF8EBA0 /* UI (watchOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3A0DBC6AD32BFBAE5A96743A /* Build configuration list for PBXNativeTarget "UI (watchOS)" */;
+			buildPhases = (
+				8AFC9948279227C98EF4603E /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C1CF0FB8C42073F1F4B2B574 /* PBXTargetDependency */,
+				668A394C3AC0A75CC49055EF /* PBXTargetDependency */,
+			);
+			name = "UI (watchOS)";
+			productName = UI;
+			productType = "com.apple.product-type.library.static";
+		};
 		E569989878EC4D26C4EA6DD0 /* CommandLineTool */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 64F3FC7AEBFC672C9FCF4159 /* Build configuration list for PBXNativeTarget "CommandLineTool" */;
@@ -3790,7 +3831,6 @@
 			);
 			dependencies = (
 				683D905B1D6B27DA0ED9AB14 /* PBXTargetDependency */,
-				046277F6B595DBD37D885140 /* PBXTargetDependency */,
 			);
 			name = LibFramework.tvOS;
 			productName = LibFramework.tvOS;
@@ -3870,6 +3910,7 @@
 			);
 			dependencies = (
 				C112A62A191956EE2E91F3C5 /* PBXTargetDependency */,
+				21BAD0199F30A934EE4CF048 /* PBXTargetDependency */,
 				0CBCE083A929029F369CBB86 /* PBXTargetDependency */,
 			);
 			name = tvOSApp;
@@ -3890,6 +3931,22 @@
 			);
 			name = c_lib;
 			productName = c_lib;
+			productType = "com.apple.product-type.library.static";
+		};
+		F9C625F339475535AB4692D6 /* UI (iOS, tvOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AEAD25F801B1D05F97251BBA /* Build configuration list for PBXNativeTarget "UI (iOS, tvOS)" */;
+			buildPhases = (
+				EA938B9723E76C20E9EFAE7A /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				9350AFF36EB9080A64D841B1 /* PBXTargetDependency */,
+				248FD229640C65E8A6824DCE /* PBXTargetDependency */,
+			);
+			name = "UI (iOS, tvOS)";
+			productName = UI;
 			productType = "com.apple.product-type.library.static";
 		};
 		FDA59F09C0DC31A1D18B6509 /* iMessageAppExtension */ = {
@@ -3952,10 +4009,6 @@
 						LastSwiftMigration = 9999;
 						TestTargetID = 182B42EFE70A5561F1C023E5;
 					};
-					49BB1280EE4B2FB636FBB36E = {
-						CreatedOnToolsVersion = 13.2.1;
-						LastSwiftMigration = 9999;
-					};
 					4A81F3A0DADC86D2FCF01DB1 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
@@ -3992,6 +4045,10 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
 					};
+					A0257519AD63A69C6DF51958 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
 					A2CE5EDCDDA5334B00B16BC9 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
@@ -4016,6 +4073,10 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
 						TestTargetID = C57AEABC99C185745155C88B;
+					};
+					DA7C60469EF398B21BF8EBA0 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
 					};
 					E569989878EC4D26C4EA6DD0 = {
 						CreatedOnToolsVersion = 13.2.1;
@@ -4047,6 +4108,10 @@
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
 					};
+					F9C625F339475535AB4692D6 = {
+						CreatedOnToolsVersion = 13.2.1;
+						LastSwiftMigration = 9999;
+					};
 					FDA59F09C0DC31A1D18B6509 = {
 						CreatedOnToolsVersion = 13.2.1;
 						LastSwiftMigration = 9999;
@@ -4075,6 +4140,7 @@
 				F38BE7F734335EF255F553F2 /* c_lib */,
 				E569989878EC4D26C4EA6DD0 /* CommandLineTool */,
 				8FA9DDD71D382CE2CA2EA479 /* CommandLineToolTests */,
+				A0257519AD63A69C6DF51958 /* CoreUtilsObjC */,
 				967BEB9EDFB3230C10A206A8 /* ExampleNestedResources */,
 				225701F2BB3EA192424F07FE /* ExampleResources */,
 				A2CE5EDCDDA5334B00B16BC9 /* FrameworkCoreUtilsObjC */,
@@ -4094,7 +4160,8 @@
 				F3451D8089613E01522F3373 /* tvOSApp */,
 				F17532B236F0C0D5C4DE571E /* tvOSAppUITests */,
 				E9EB5E36CCE50C3C85A9B4C9 /* tvOSAppUnitTests */,
-				49BB1280EE4B2FB636FBB36E /* UI */,
+				F9C625F339475535AB4692D6 /* UI (iOS, tvOS) */,
+				DA7C60469EF398B21BF8EBA0 /* UI (watchOS) */,
 				02711E9CE92644587DD314DD /* UIFramework.iOS */,
 				197909C893D71098F7D5178C /* UIFramework.tvOS */,
 				182B42EFE70A5561F1C023E5 /* watchOSApp */,
@@ -4250,11 +4317,10 @@
 			name = "Create linking dependencies";
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/link.params",
-				"$(DERIVED_FILE_DIR)/_CompileStub_.m",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\ntouch \"$SCRIPT_OUTPUT_FILE_1\"\n";
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		03D78A6AF4BF88D31B5A73A0 /* Create linking dependencies */ = {
@@ -4370,11 +4436,10 @@
 			name = "Create linking dependencies";
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/link.params",
-				"$(DERIVED_FILE_DIR)/_CompileStub_.m",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\ntouch \"$SCRIPT_OUTPUT_FILE_1\"\n";
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		755BE1A07AB48CCBA936E166 /* Create linking dependencies */ = {
@@ -4690,6 +4755,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		515BF020C098484F84ED2DAA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				435CFAEB368D4AE698C9E8A1 /* Answers.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5E6FE845F8960F43CFA251FF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -4710,7 +4783,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A4803FC1A0ED687D63C7DB54 /* _CompileStub_.m in Sources */,
+				E3F8C774C80B20340DA25FF1 /* Lib.swift in Sources */,
+				61284A35A2850C35FB03D984 /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4719,6 +4793,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				4EEF26B11D3A6AFB2D2EB8FE /* private_lib.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8AFC9948279227C98EF4603E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				20A260B9C46C90B1DE12A69D /* ContentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4768,7 +4850,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				970930B398EF704E7F2BF918 /* _CompileStub_.m in Sources */,
+				352F61ECAA34E19F1AE91140 /* Lib.swift in Sources */,
+				1355519BD9DE0384105E8B97 /* Lib.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4832,11 +4915,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		E8E5F627D98A2CB8072BE324 /* Sources */ = {
+		EA938B9723E76C20E9EFAE7A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E336B4F3C30739616C456ACC /* ContentView.swift in Sources */,
+				4B781F3A200CE52286FA2649 /* ContentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4868,12 +4951,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		046277F6B595DBD37D885140 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Lib (iOS, tvOS)";
-			target = 801E2436A69733A307109C9A /* Lib (iOS, tvOS) */;
-			targetProxy = D0F2893E8DBEF73FECCF041B /* PBXContainerItemProxy */;
-		};
 		04DD845DD36259B6169D70E6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -4910,11 +4987,17 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = A4014EA633D959E595B52DB5 /* PBXContainerItemProxy */;
 		};
-		22D113A8237F55A76D6ACED8 /* PBXTargetDependency */ = {
+		21BAD0199F30A934EE4CF048 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Lib (watchOS)";
-			target = D094AA317C2527FB0FCC5015 /* Lib (watchOS) */;
-			targetProxy = F0F012D2694A06C6DF4D9085 /* PBXContainerItemProxy */;
+			name = "UI (iOS, tvOS)";
+			target = F9C625F339475535AB4692D6 /* UI (iOS, tvOS) */;
+			targetProxy = AD67F165892092512DB84B8D /* PBXContainerItemProxy */;
+		};
+		248FD229640C65E8A6824DCE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Lib (iOS, tvOS)";
+			target = 801E2436A69733A307109C9A /* Lib (iOS, tvOS) */;
+			targetProxy = 889DD95949FFBA21076B3F9C /* PBXContainerItemProxy */;
 		};
 		2F3392E40FFA06B2AD811927 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4940,17 +5023,23 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 6E9E88A2D72789822E1ECF01 /* PBXContainerItemProxy */;
 		};
-		4A5D29094F247671CB015045 /* PBXTargetDependency */ = {
+		4E2958552EC93E6809BB7908 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Lib (iOS, tvOS)";
-			target = 801E2436A69733A307109C9A /* Lib (iOS, tvOS) */;
-			targetProxy = 0CC9114A9DE54DD04FDAF560 /* PBXContainerItemProxy */;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = BE13815FCA0403A6A9C0D9CD /* PBXContainerItemProxy */;
 		};
 		51FBB44334A773AA348A41C1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 28B9C67EAED263621396FB38 /* PBXContainerItemProxy */;
+		};
+		5560490000B5A6C771998EBC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "UI (iOS, tvOS)";
+			target = F9C625F339475535AB4692D6 /* UI (iOS, tvOS) */;
+			targetProxy = D43B6167B338D2BE0445394C /* PBXContainerItemProxy */;
 		};
 		5788E50D72472F75EFAA6061 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4981,6 +5070,12 @@
 			name = "Lib (iOS, tvOS)";
 			target = 801E2436A69733A307109C9A /* Lib (iOS, tvOS) */;
 			targetProxy = 7E7AC142EDAE3A5597AECBF8 /* PBXContainerItemProxy */;
+		};
+		668A394C3AC0A75CC49055EF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Lib (watchOS)";
+			target = D094AA317C2527FB0FCC5015 /* Lib (watchOS) */;
+			targetProxy = 22059E986A28D98C1BA250A2 /* PBXContainerItemProxy */;
 		};
 		67726728402D00D7D9EB3A87 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5018,6 +5113,12 @@
 			target = F3451D8089613E01522F3373 /* tvOSApp */;
 			targetProxy = ABE60D2081FB38DF9AB9982B /* PBXContainerItemProxy */;
 		};
+		7A1F207154E549814F1CD585 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "UI (watchOS)";
+			target = DA7C60469EF398B21BF8EBA0 /* UI (watchOS) */;
+			targetProxy = 8709CF92F43EDFFB60A05702 /* PBXContainerItemProxy */;
+		};
 		7C053575E9800AD0E225F7C3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -5054,12 +5155,6 @@
 			target = 195FCD65F4EB377830E3E996 /* lib_swift */;
 			targetProxy = 1CF542F2FAEB34203B0DCD31 /* PBXContainerItemProxy */;
 		};
-		8EAD6A48F472DDCD42D93312 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = BazelDependencies;
-			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
-			targetProxy = EF1BE8BE45106F3D70F91789 /* PBXContainerItemProxy */;
-		};
 		912FBD722EA10EF086198A14 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = private_lib;
@@ -5071,6 +5166,12 @@
 			name = "Lib (iOS, tvOS)";
 			target = 801E2436A69733A307109C9A /* Lib (iOS, tvOS) */;
 			targetProxy = 28760C832FB598AA729DD365 /* PBXContainerItemProxy */;
+		};
+		9350AFF36EB9080A64D841B1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = 587D3B5AFA1F9C492C8B859E /* PBXContainerItemProxy */;
 		};
 		96292CCC9EBA7C61EDC8CC49 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5102,17 +5203,17 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = E48A8DA13DF6AC2778110F7F /* PBXContainerItemProxy */;
 		};
+		A132635D1E000DEB6B99189F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "UI (watchOS)";
+			target = DA7C60469EF398B21BF8EBA0 /* UI (watchOS) */;
+			targetProxy = 7987ECA9944421D4AC07A0DB /* PBXContainerItemProxy */;
+		};
 		A201CF74F0ACB882F47060CB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = ExampleNestedResources;
 			target = 967BEB9EDFB3230C10A206A8 /* ExampleNestedResources */;
 			targetProxy = 787834EC8E2B3EB8275F62AA /* PBXContainerItemProxy */;
-		};
-		A3CF9AD00E493F7CA561B50C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = UI;
-			target = 49BB1280EE4B2FB636FBB36E /* UI */;
-			targetProxy = 13B182E5183921082BC698F0 /* PBXContainerItemProxy */;
 		};
 		A96C9B502827029262E8ED8A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5120,17 +5221,17 @@
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 802904D3BC7B73ACCD2F47BE /* PBXContainerItemProxy */;
 		};
-		A97ADA03A2A030FF08305B1B /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = UI;
-			target = 49BB1280EE4B2FB636FBB36E /* UI */;
-			targetProxy = 49129EEED027EDD87603A8DC /* PBXContainerItemProxy */;
-		};
 		B4E9A2DE09B1DEB79A242766 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
 			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
 			targetProxy = 4CCF9F788AC4A1B84D4C9BB3 /* PBXContainerItemProxy */;
+		};
+		B52498F5A510BFFB39226839 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CoreUtilsObjC;
+			target = A0257519AD63A69C6DF51958 /* CoreUtilsObjC */;
+			targetProxy = 1DC62689CE1B4F80833D8C98 /* PBXContainerItemProxy */;
 		};
 		BD021B76CADF1D7DE1A2034D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5155,6 +5256,12 @@
 			name = ExampleNestedResources;
 			target = 967BEB9EDFB3230C10A206A8 /* ExampleNestedResources */;
 			targetProxy = F9D160366EDA5A85FB284917 /* PBXContainerItemProxy */;
+		};
+		C1CF0FB8C42073F1F4B2B574 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = BazelDependencies;
+			target = FE59281FE487F27A37DC2EE7 /* BazelDependencies */;
+			targetProxy = CC447DF8A4DD4FF89C49342C /* PBXContainerItemProxy */;
 		};
 		C217275367AF074A80F1AF25 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5293,55 +5400,6 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		0DDE3088BC6E5EF76ABFD56D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				ARCHS = x86_64;
-				"ARCHS[sdk=watchos*]" = arm64_32;
-				BAZEL_LABEL = "//UI:UI";
-				BAZEL_PACKAGE_BIN_DIR = "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI";
-				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/UI";
-				BAZEL_TARGET_ID = "//UI:UI watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0";
-				"BAZEL_TARGET_ID[sdk=watchos*]" = "//UI:UI watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae";
-				"BAZEL_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_TARGET_ID)";
-				COMPILE_TARGET_NAME = UI;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator";
-				"FRAMEWORK_SEARCH_PATHS[sdk=watchos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k";
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GENERATE_INFOPLIST_FILE = YES;
-				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -static";
-				"OTHER_SWIFT_FLAGS[sdk=watchos*]" = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -static";
-				PRODUCT_MODULE_NAME = UI;
-				PRODUCT_NAME = UI;
-				SDKROOT = watchos;
-				SUPPORTED_PLATFORMS = "watchsimulator watchos";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/Lib";
-				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/Lib";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGET_NAME = UI;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin",
-				);
-				WATCHOS_DEPLOYMENT_TARGET = 7.0;
-			};
-			name = Debug;
-		};
 		1431C9CDFD64AF034E1B3274 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5664,6 +5722,9 @@
 			buildSettings = {
 				ARCHS = x86_64;
 				"ARCHS[sdk=iphoneos*]" = arm64;
+				BAZEL_COMPILE_TARGET_ID = "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphoneos*]" = "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd";
+				"BAZEL_COMPILE_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_LABEL = "//Lib:LibFramework.iOS";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib";
@@ -5671,10 +5732,11 @@
 				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//Lib:LibFramework.iOS applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd";
 				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
 				CODE_SIGN_STYLE = Manual;
-				COMPILE_TARGET_NAME = LibFramework.iOS;
+				COMPILE_TARGET_NAME = Lib;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				EXCLUDED_SOURCE_FILE_NAMES = "$(IPHONEOS_FILES) $(IPHONESIMULATOR_FILES)";
 				FRAMEWORK_SEARCH_PATHS = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator";
 				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7";
@@ -5685,24 +5747,14 @@
 				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/rules_xcodeproj/LibFramework.iOS/Info.plist";
 				"INFOPLIST_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib/rules_xcodeproj/LibFramework.iOS/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
-				IPHONEOS_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework";
-				IPHONESIMULATOR_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework";
+				IPHONEOS_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib/Lib.swift";
+				IPHONESIMULATOR_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/Lib.swift";
 				LD_RUNPATH_SEARCH_PATHS = "$(PREVIEWS_LD_RUNPATH_SEARCH_PATHS__$(ENABLE_PREVIEWS))";
 				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/Lib/LibFramework.iOS.link.params";
 				"LINK_PARAMS_FILE[sdk=iphoneos*]" = "$(INTERNAL_DIR)/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/Lib/LibFramework.iOS.link.params";
-				OTHER_CFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/xcode-overlay.yaml",
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
-				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/xcode-overlay.yaml",
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static";
+				"OTHER_SWIFT_FLAGS[sdk=iphoneos*]" = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static";
 				PREVIEWS_LD_RUNPATH_SEARCH_PATHS__ = "$(PREVIEWS_LD_RUNPATH_SEARCH_PATHS__NO)";
 				PREVIEWS_LD_RUNPATH_SEARCH_PATHS__NO = (
 					"$(inherited)",
@@ -5713,11 +5765,18 @@
 					"$(PREVIEWS_LD_RUNPATH_SEARCH_PATHS__NO)",
 					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
+				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				"PREVIEWS_SWIFT_INCLUDE_PATHS__YES[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PRODUCT_BUNDLE_IDENTIFIER = io.budilebuddy.LibFramework;
+				PRODUCT_MODULE_NAME = Lib;
 				PRODUCT_NAME = LibFramework.iOS;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__$(ENABLE_PREVIEWS))";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -5727,13 +5786,13 @@
 					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/external/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin",
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin",
 				);
 				"USER_HEADER_SEARCH_PATHS[sdk=iphoneos*]" = (
 					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/external/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin",
+					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin",
 				);
 			};
 			name = Debug;
@@ -5916,10 +5975,13 @@
 		520905911A7281FB171E30E8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLETVOS_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework";
-				APPLETVSIMULATOR_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework";
+				APPLETVOS_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework $(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib/Lib.swift";
+				APPLETVSIMULATOR_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework $(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib/Lib.swift";
 				ARCHS = x86_64;
 				"ARCHS[sdk=appletvos*]" = arm64;
+				BAZEL_COMPILE_TARGET_ID = "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvos*]" = "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52";
+				"BAZEL_COMPILE_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_LABEL = "//Lib:LibFramework.tvOS";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib";
@@ -5927,10 +5989,11 @@
 				"BAZEL_TARGET_ID[sdk=appletvos*]" = "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-ST-252684668b52";
 				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "$(BAZEL_TARGET_ID)";
 				CODE_SIGN_STYLE = Manual;
-				COMPILE_TARGET_NAME = LibFramework.tvOS;
+				COMPILE_TARGET_NAME = Lib;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				EXCLUDED_SOURCE_FILE_NAMES = "$(APPLETVOS_FILES) $(APPLETVSIMULATOR_FILES)";
 				FRAMEWORK_SEARCH_PATHS = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator";
 				"FRAMEWORK_SEARCH_PATHS[sdk=appletvos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64";
@@ -5943,19 +6006,9 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(PREVIEWS_LD_RUNPATH_SEARCH_PATHS__$(ENABLE_PREVIEWS))";
 				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/Lib/LibFramework.tvOS.link.params";
 				"LINK_PARAMS_FILE[sdk=appletvos*]" = "$(INTERNAL_DIR)/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/Lib/LibFramework.tvOS.link.params";
-				OTHER_CFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/xcode-overlay.yaml",
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
-				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/xcode-overlay.yaml",
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -static";
+				"OTHER_SWIFT_FLAGS[sdk=appletvos*]" = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -static";
 				PREVIEWS_LD_RUNPATH_SEARCH_PATHS__ = "$(PREVIEWS_LD_RUNPATH_SEARCH_PATHS__NO)";
 				PREVIEWS_LD_RUNPATH_SEARCH_PATHS__NO = (
 					"$(inherited)",
@@ -5966,10 +6019,17 @@
 					"$(PREVIEWS_LD_RUNPATH_SEARCH_PATHS__NO)",
 					"$(FRAMEWORK_SEARCH_PATHS)",
 				);
+				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				"PREVIEWS_SWIFT_INCLUDE_PATHS__YES[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib/LibFramework.tvOS.framework/Modules $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PRODUCT_BUNDLE_IDENTIFIER = io.budilebuddy.LibFramework;
+				PRODUCT_MODULE_NAME = Lib;
 				PRODUCT_NAME = LibFramework.tvOS;
 				SDKROOT = appletvos;
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__$(ENABLE_PREVIEWS))";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -5979,13 +6039,13 @@
 					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/external/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin",
 				);
 				"USER_HEADER_SEARCH_PATHS[sdk=appletvos*]" = (
 					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/external/com_github_krzyzanowskim_cryptoswift",
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin",
+					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin",
 				);
 			};
 			name = Debug;
@@ -6045,8 +6105,8 @@
 				);
 				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib";
-				"PREVIEWS_SWIFT_INCLUDE_PATHS__NO[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib";
-				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI/UIFramework.tvOS.framework/Modules $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				"PREVIEWS_SWIFT_INCLUDE_PATHS__NO[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib/LibFramework.tvOS.framework/Modules";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				"PREVIEWS_SWIFT_INCLUDE_PATHS__YES[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/UI/UIFramework.tvOS.framework/Modules $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PRODUCT_BUNDLE_IDENTIFIER = io.budilebuddy.UIFramework;
 				PRODUCT_MODULE_NAME = UI;
@@ -6204,8 +6264,8 @@
 				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator/GoogleMapsBase.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64_x86_64-simulator/GoogleMapsCore.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator/GoogleMaps.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -Fexternal/com_google_google_maps/GoogleMaps.xcframework/ios-arm64_x86_64-simulator -Fexternal/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64_x86_64-simulator -static";
 				"OTHER_SWIFT_FLAGS[sdk=iphoneos*]" = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.swift.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64/GoogleMapsBase.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMapsCore.xcframework/ios-arm64/GoogleMapsCore.framework/Modules/module.modulemap -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_google_google_maps/GoogleMaps.xcframework/ios-arm64/GoogleMaps.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -Fexternal/com_google_google_maps/GoogleMaps.xcframework/ios-arm64 -Fexternal/com_google_google_maps/GoogleMapsBase.xcframework/ios-arm64 -static";
 				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
-				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/UI/UIFramework.iOS.framework/Modules";
-				"PREVIEWS_SWIFT_INCLUDE_PATHS__NO[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib $(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/UI/UIFramework.iOS.framework/Modules";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/UI";
+				"PREVIEWS_SWIFT_INCLUDE_PATHS__NO[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/UI";
 				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Source $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				"PREVIEWS_SWIFT_INCLUDE_PATHS__YES[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Source $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
@@ -6404,6 +6464,224 @@
 			};
 			name = Debug;
 		};
+		7A18C21BB55BC562CF5D419C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				"ARCHS[sdk=iphoneos*]" = arm64;
+				BAZEL_LABEL = "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Source/CoreUtilsObjC";
+				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Source/CoreUtilsObjC";
+				BAZEL_TARGET_ID = "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353";
+				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				COMPILE_TARGET_NAME = CoreUtilsObjC;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREFIX_HEADER = iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"_FORTIFY_SOURCE=1",
+					OS_IOS,
+					"DEBUG=1",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					iOSApp/Source/CoreUtilsObjC,
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Source/CoreUtilsObjC",
+				);
+				"HEADER_SEARCH_PATHS[sdk=iphoneos*]" = (
+					iOSApp/Source/CoreUtilsObjC,
+					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Source/CoreUtilsObjC",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_CFLAGS = (
+					"-ivfsoverlay",
+					"$(OBJROOT)/xcode-overlay.yaml",
+					"-ivfsoverlay",
+					"$(OBJROOT)/bazel-out-overlay.yaml",
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-Wshorten-64-to-32",
+					"-Wbool-conversion",
+					"-Wconstant-conversion",
+					"-Wduplicate-method-match",
+					"-Wempty-body",
+					"-Wenum-conversion",
+					"-Wint-conversion",
+					"-Wunreachable-code",
+					"-Wmismatched-return-types",
+					"-Wundeclared-selector",
+					"-Wuninitialized",
+					"-Wunused-function",
+					"-Wunused-variable",
+					"-fno-autolink",
+					"-fexceptions",
+					"-fasm-blocks",
+					"-fobjc-abi-version=2",
+					"-fobjc-legacy-dispatch",
+					"-fstack-protector",
+					"-fstack-protector-all",
+				);
+				"OTHER_CFLAGS[sdk=iphoneos*]" = (
+					"-ivfsoverlay",
+					"$(OBJROOT)/xcode-overlay.yaml",
+					"-ivfsoverlay",
+					"$(OBJROOT)/bazel-out-overlay.yaml",
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-Wshorten-64-to-32",
+					"-Wbool-conversion",
+					"-Wconstant-conversion",
+					"-Wduplicate-method-match",
+					"-Wempty-body",
+					"-Wenum-conversion",
+					"-Wint-conversion",
+					"-Wunreachable-code",
+					"-Wmismatched-return-types",
+					"-Wundeclared-selector",
+					"-Wuninitialized",
+					"-Wunused-function",
+					"-Wunused-variable",
+					"-fno-autolink",
+					"-fstack-protector",
+					"-fstack-protector-all",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"-ivfsoverlay",
+					"$(OBJROOT)/xcode-overlay.yaml",
+					"-ivfsoverlay",
+					"$(OBJROOT)/bazel-out-overlay.yaml",
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-Wshorten-64-to-32",
+					"-Wbool-conversion",
+					"-Wconstant-conversion",
+					"-Wduplicate-method-match",
+					"-Wempty-body",
+					"-Wenum-conversion",
+					"-Wint-conversion",
+					"-Wunreachable-code",
+					"-Wmismatched-return-types",
+					"-Wundeclared-selector",
+					"-Wuninitialized",
+					"-Wunused-function",
+					"-Wunused-variable",
+					"-fno-autolink",
+					"-fexceptions",
+					"-fasm-blocks",
+					"-fobjc-abi-version=2",
+					"-fobjc-legacy-dispatch",
+					"-fstack-protector",
+					"-fstack-protector-all",
+				);
+				"OTHER_CPLUSPLUSFLAGS[sdk=iphoneos*]" = (
+					"-ivfsoverlay",
+					"$(OBJROOT)/xcode-overlay.yaml",
+					"-ivfsoverlay",
+					"$(OBJROOT)/bazel-out-overlay.yaml",
+					"-fstack-protector",
+					"-Wall",
+					"-Wthread-safety",
+					"-Wself-assign",
+					"-fno-omit-frame-pointer",
+					"-Wshorten-64-to-32",
+					"-Wbool-conversion",
+					"-Wconstant-conversion",
+					"-Wduplicate-method-match",
+					"-Wempty-body",
+					"-Wenum-conversion",
+					"-Wint-conversion",
+					"-Wunreachable-code",
+					"-Wmismatched-return-types",
+					"-Wundeclared-selector",
+					"-Wuninitialized",
+					"-Wunused-function",
+					"-Wunused-variable",
+					"-fno-autolink",
+					"-fstack-protector",
+					"-fstack-protector-all",
+				);
+				PRODUCT_MODULE_NAME = CoreUtils;
+				PRODUCT_NAME = CoreUtilsObjC;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = CoreUtilsObjC;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=iphoneos*]" = (
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin",
+				);
+			};
+			name = Debug;
+		};
+		82BE2E00078FEA14D8F48AE9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				ARCHS = x86_64;
+				"ARCHS[sdk=watchos*]" = arm64_32;
+				BAZEL_LABEL = "//UI:UI";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI";
+				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/UI";
+				BAZEL_TARGET_ID = "//UI:UI watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0";
+				"BAZEL_TARGET_ID[sdk=watchos*]" = "//UI:UI watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae";
+				"BAZEL_TARGET_ID[sdk=watchsimulator*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = UI;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator";
+				"FRAMEWORK_SEARCH_PATHS[sdk=watchos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GENERATE_INFOPLIST_FILE = YES;
+				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -static";
+				"OTHER_SWIFT_FLAGS[sdk=watchos*]" = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -static";
+				PRODUCT_MODULE_NAME = UI;
+				PRODUCT_NAME = UI;
+				SDKROOT = watchos;
+				SUPPORTED_PLATFORMS = "watchsimulator watchos";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=watchos*]" = "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/Lib";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = UI;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin",
+				);
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Debug;
+		};
 		8523C68C85BFBC9D1538E3D0 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -6521,8 +6799,8 @@
 				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -static";
 				"OTHER_SWIFT_FLAGS[sdk=appletvos*]" = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -static";
 				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
-				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI/UIFramework.tvOS.framework/Modules";
-				"PREVIEWS_SWIFT_INCLUDE_PATHS__NO[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/UI/UIFramework.tvOS.framework/Modules";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib $(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI";
+				"PREVIEWS_SWIFT_INCLUDE_PATHS__NO[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib/LibFramework.tvOS.framework/Modules $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/UI/UIFramework.tvOS.framework/Modules";
 				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Source $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				"PREVIEWS_SWIFT_INCLUDE_PATHS__YES[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/tvOSApp/Source $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example;
@@ -6784,6 +7062,80 @@
 					"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin",
 					"$(BAZEL_EXTERNAL)/examples_command_line_external",
 					"$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/external/examples_command_line_external",
+				);
+			};
+			name = Debug;
+		};
+		ABC9A85B556010D358F8B8D3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				ARCHS = x86_64;
+				"ARCHS[sdk=appletvos*]" = arm64;
+				"ARCHS[sdk=iphoneos*]" = arm64;
+				BAZEL_LABEL = "//UI:UI";
+				BAZEL_PACKAGE_BIN_DIR = "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/UI";
+				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvos*]" = "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/UI";
+				"BAZEL_PACKAGE_BIN_DIR[sdk=appletvsimulator*]" = "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI";
+				"BAZEL_PACKAGE_BIN_DIR[sdk=iphoneos*]" = "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/UI";
+				BAZEL_TARGET_ID = "//UI:UI ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353";
+				"BAZEL_TARGET_ID[sdk=appletvos*]" = "//UI:UI tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52";
+				"BAZEL_TARGET_ID[sdk=appletvsimulator*]" = "//UI:UI tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332";
+				"BAZEL_TARGET_ID[sdk=iphoneos*]" = "//UI:UI ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd";
+				"BAZEL_TARGET_ID[sdk=iphonesimulator*]" = "$(BAZEL_TARGET_ID)";
+				COMPILE_TARGET_NAME = UI;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator";
+				"FRAMEWORK_SEARCH_PATHS[sdk=appletvos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64";
+				"FRAMEWORK_SEARCH_PATHS[sdk=appletvsimulator*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator";
+				"FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]" = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7";
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static";
+				"OTHER_SWIFT_FLAGS[sdk=appletvos*]" = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -static";
+				"OTHER_SWIFT_FLAGS[sdk=appletvsimulator*]" = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -static";
+				"OTHER_SWIFT_FLAGS[sdk=iphoneos*]" = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static";
+				PRODUCT_MODULE_NAME = UI;
+				PRODUCT_NAME = UI;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=appletvos*]" = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib/LibFramework.tvOS.framework/Modules";
+				"SWIFT_INCLUDE_PATHS[sdk=appletvsimulator*]" = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib";
+				"SWIFT_INCLUDE_PATHS[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib";
+				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGET_NAME = UI;
+				TVOS_DEPLOYMENT_TARGET = 15.0;
+				USER_HEADER_SEARCH_PATHS = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=appletvos*]" = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=appletvsimulator*]" = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin",
+				);
+				"USER_HEADER_SEARCH_PATHS[sdk=iphoneos*]" = (
+					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/external/com_github_krzyzanowskim_cryptoswift",
+					"$(BAZEL_EXEC_ROOT)",
+					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin",
 				);
 			};
 			name = Debug;
@@ -7348,7 +7700,7 @@
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
 				OTHER_SWIFT_FLAGS = "-Xcc -ivfsoverlay -Xcc $(OBJROOT)/xcode-overlay.yaml -Xcc -ivfsoverlay -Xcc $(OBJROOT)/bazel-out-overlay.yaml -vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -static";
 				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
-				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI/UIFramework.tvOS.framework/Modules $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Source";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib $(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI $(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Source";
 				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Test/UnitTests $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PRODUCT_BUNDLE_IDENTIFIER = io.buildbuddy.example.tests;
 				PRODUCT_MODULE_NAME = tvOSAppUnitTests;
@@ -7430,8 +7782,8 @@
 				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib";
 				"PREVIEWS_SWIFT_INCLUDE_PATHS__NO[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib";
-				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/UI/UIFramework.iOS.framework/Modules $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
-				"PREVIEWS_SWIFT_INCLUDE_PATHS__YES[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/UI/UIFramework.iOS.framework/Modules $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/UI $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
+				"PREVIEWS_SWIFT_INCLUDE_PATHS__YES[sdk=iphoneos*]" = "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/UI $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PRODUCT_BUNDLE_IDENTIFIER = io.budilebuddy.UIFramework;
 				PRODUCT_MODULE_NAME = UI;
 				PRODUCT_NAME = UIFramework.iOS;
@@ -7527,6 +7879,14 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		3A0DBC6AD32BFBAE5A96743A /* Build configuration list for PBXNativeTarget "UI (watchOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				82BE2E00078FEA14D8F48AE9 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 		4873292BAEA7DB2733576859 /* Build configuration list for PBXNativeTarget "lib_impl" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -7591,14 +7951,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		7C0E627AAAB5D184799054F9 /* Build configuration list for PBXNativeTarget "UI" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				0DDE3088BC6E5EF76ABFD56D /* Debug */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		8C14447CB8BDD86ECF450932 /* Build configuration list for PBXProject "bwx" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -7611,6 +7963,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				EFDED053C8359D1929857858 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		A371FC09C8552CA9AA11EBA0 /* Build configuration list for PBXNativeTarget "CoreUtilsObjC" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7A18C21BB55BC562CF5D419C /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -7643,6 +8003,14 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1FD7CBEE6F43F044E611614D /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		AEAD25F801B1D05F97251BBA /* Build configuration list for PBXNativeTarget "UI (iOS, tvOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ABC9A85B556010D358F8B8D3 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/Lib/LibFramework.iOS.link.params
@@ -6,5 +6,3 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/Lib/LibFramework.iOS.link.params
@@ -6,5 +6,3 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/Lib/LibFramework.tvOS.link.params
@@ -6,5 +6,3 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--force_load
-$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/Lib/LibFramework.tvOS.link.params
@@ -6,5 +6,3 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
--force_load
-$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CoreUtilsObjC.xcscheme
@@ -14,10 +14,10 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "12DB4C040F56113D380794C3"
-                     BuildableName = "UI"
-                     BlueprintName = "UI"
-                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "A0257519AD63A69C6DF51958"
+                     BuildableName = "CoreUtilsObjC"
+                     BlueprintName = "CoreUtilsObjC"
+                     ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -25,15 +25,15 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for UI"
+               title = "Set Bazel Build Output Groups for CoreUtilsObjC"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "12DB4C040F56113D380794C3"
-                     BuildableName = "UI"
-                     BlueprintName = "UI"
-                     ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+                     BlueprintIdentifier = "A0257519AD63A69C6DF51958"
+                     BuildableName = "CoreUtilsObjC"
+                     BlueprintName = "CoreUtilsObjC"
+                     ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
             </ActionContent>
@@ -48,10 +48,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "12DB4C040F56113D380794C3"
-               BuildableName = "UI"
-               BlueprintName = "UI"
-               ReferencedContainer = "container:test/fixtures/bwb.xcodeproj">
+               BlueprintIdentifier = "A0257519AD63A69C6DF51958"
+               BuildableName = "CoreUtilsObjC"
+               BlueprintName = "CoreUtilsObjC"
+               ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/UI (iOS, tvOS).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/UI (iOS, tvOS).xcscheme
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "9999"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Initialize Bazel Build Output Groups File"
+               scriptText = "mkdir -p &quot;${SCHEME_TARGET_IDS_FILE%/*}&quot;&#10;if [[ -s &quot;$SCHEME_TARGET_IDS_FILE&quot; ]]; then&#10;    rm &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;fi&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "F9C625F339475535AB4692D6"
+                     BuildableName = "UI (iOS, tvOS)"
+                     BlueprintName = "UI (iOS, tvOS)"
+                     ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Set Bazel Build Output Groups for UI (iOS, tvOS)"
+               scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "F9C625F339475535AB4692D6"
+                     BuildableName = "UI (iOS, tvOS)"
+                     BlueprintName = "UI (iOS, tvOS)"
+                     ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F9C625F339475535AB4692D6"
+               BuildableName = "UI (iOS, tvOS)"
+               BlueprintName = "UI (iOS, tvOS)"
+               ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/UI (watchOS).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/UI (watchOS).xcscheme
@@ -14,9 +14,9 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "49BB1280EE4B2FB636FBB36E"
-                     BuildableName = "UI"
-                     BlueprintName = "UI"
+                     BlueprintIdentifier = "DA7C60469EF398B21BF8EBA0"
+                     BuildableName = "UI (watchOS)"
+                     BlueprintName = "UI (watchOS)"
                      ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -25,14 +25,14 @@
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
-               title = "Set Bazel Build Output Groups for UI"
+               title = "Set Bazel Build Output Groups for UI (watchOS)"
                scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "49BB1280EE4B2FB636FBB36E"
-                     BuildableName = "UI"
-                     BlueprintName = "UI"
+                     BlueprintIdentifier = "DA7C60469EF398B21BF8EBA0"
+                     BuildableName = "UI (watchOS)"
+                     BlueprintName = "UI (watchOS)"
                      ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
                   </BuildableReference>
                </EnvironmentBuildable>
@@ -48,9 +48,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "49BB1280EE4B2FB636FBB36E"
-               BuildableName = "UI"
-               BlueprintName = "UI"
+               BlueprintIdentifier = "DA7C60469EF398B21BF8EBA0"
+               BuildableName = "UI (watchOS)"
+               BlueprintName = "UI (watchOS)"
                ReferencedContainer = "container:test/fixtures/bwx.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -384,6 +384,22 @@
         [
             "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803"
         ],
+        "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd",
+        [
+            "//Lib:LibFramework.iOS applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd"
+        ],
+        "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353",
+        [
+            "//Lib:LibFramework.iOS applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353"
+        ],
+        "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52",
+        [
+            "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-ST-252684668b52"
+        ],
+        "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332",
+        [
+            "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332"
+        ],
         "//UI:UI ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd",
         [
             "//UI:UIFramework.iOS applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd"

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -23,22 +23,28 @@
 
 /* Begin PBXBuildFile section */
 		007447878A5814379E7B765E /* Dictionary+Enumerate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1311F2E17F171A48A8E3B180 /* Dictionary+Enumerate.swift */; };
+		007B16321E95A3F5ADCF5245 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AC147B8AD5876D542B1170 /* Environment.swift */; };
 		020A8DC4A6ADA3F8F686D5E1 /* _HashTable+UnsafeHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCE836ACE8D0A6B4577C665 /* _HashTable+UnsafeHandle.swift */; };
 		02F6B5BD578448C1BA862967 /* PBXProductType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E25F4B3B5010A82A8E2A0CF /* PBXProductType+Extensions.swift */; };
 		03DA8359CF68B4CE3C279FC0 /* PopulateMainGroupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCEBA76F789E9D71187DFF61 /* PopulateMainGroupTests.swift */; };
 		0420D0F838717336BE1C666E /* OrderedSet+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C03DA1E6BE6639739CB623F /* OrderedSet+Hashable.swift */; };
 		05D4C943C91F281CF27F2F83 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68733F62C401C1AA84617E96 /* KeyPath.swift */; };
+		05E31D136E1C8BD5D67D5ECD /* Target.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC947C625E7E6B30468D77B8 /* Target.swift */; };
 		0680A4C2872B98AC70E3ADD4 /* DisambiguateTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE03F64CA13C3461D45773E /* DisambiguateTargetsTests.swift */; };
 		086989EA86F5E2D35BC9FA5B /* CustomDumpStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF072F61E054955564EECDA2 /* CustomDumpStringConvertible.swift */; };
 		08BDB7C9B414A51A9260F683 /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = F972F9B12146B979CA3E0318 /* PBXProject.swift */; };
+		08FCE8EED64E63BD646163C7 /* XCSchemeInfo+ProfileActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DFC10F60508ACDCC0E0C85 /* XCSchemeInfo+ProfileActionInfo.swift */; };
 		08FD41A51102F53B418BD3CE /* JSONDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2F851023E4F4913D1E369CE /* JSONDecoding.swift */; };
+		094FC88B62E8888251AC426F /* PopulateMainGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69926E3303EC6DCEFF83DE3 /* PopulateMainGroup.swift */; };
 		096B05250E4C2E55D79A268D /* XCScheme+BuildableReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02819512A69FF33D58EBA61C /* XCScheme+BuildableReference.swift */; };
 		09CD96D6AF22F8C98E115218 /* Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88CFB36E6D7371DC64BD3D3D /* Sorting.swift */; };
 		0A22A35B5C2350A27CA5A895 /* BuildSettingConditionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08416B4EDA557D797F63BB4F /* BuildSettingConditionalTests.swift */; };
 		0A72F10D9138B4C857C3B358 /* XCScheme+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C55220CE7606CF936497C6E /* XCScheme+ExtensionsTests.swift */; };
+		0A73996503F90E3A5F5EA67C /* XCSchemeInfo+TestActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39F1225A116FA6831750914 /* XCSchemeInfo+TestActionInfo.swift */; };
 		0A904F2FB1E7254686796387 /* PBXReferenceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0152B8A419980E27BD7EE5FB /* PBXReferenceProxy.swift */; };
 		0B5033389291A3C98DAB6E41 /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC7F0486AC72B3E68F194D01 /* PathKit.swift */; };
 		0BFA0A77F5504DCED931F795 /* FilePathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E1E2200AB2DCA91F4999CE /* FilePathResolver.swift */; };
+		0D05FEB20C1D31F5C5B1560D /* CreateXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1D4FDC12476B3E9B9AC4CF /* CreateXcodeProj.swift */; };
 		0D0AC258CDE90DE121688624 /* UserNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 356817EF2BC65A89F7FB439C /* UserNotifications.swift */; };
 		0D6ED2396B7AA4FCCB10F093 /* XCBreakpointList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7C28A43616AE9FC78C05EE0 /* XCBreakpointList.swift */; };
 		0D73F24BA124D94913F801B4 /* PBXProductTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD57C9800BE7773DBBA107B /* PBXProductTypeExtensionsTests.swift */; };
@@ -46,14 +52,21 @@
 		0F1A9B6BE970BA80097FCE6F /* PBXCopyFilesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 958D118534D347C200B0701A /* PBXCopyFilesBuildPhase.swift */; };
 		0F68017F5891C6AD18732F80 /* XCSchemeInfo+TestActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39F1225A116FA6831750914 /* XCSchemeInfo+TestActionInfo.swift */; };
 		0F988C99D14D5314D5DE55AE /* CoreMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = B41944A58347442213CC45E6 /* CoreMotion.swift */; };
+		0FC3C2B36EE048DFFDA71CD8 /* Inputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB9D00963E3FECF87A050AA /* Inputs.swift */; };
+		10D5AB76441FDACB75040173 /* ProcessReplacementLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B02A60F1554A78D3570898B3 /* ProcessReplacementLabels.swift */; };
+		122C541CB4789FD47C478AD9 /* BuildMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61886AE6F5D2C1864AFB163E /* BuildMode.swift */; };
 		1288BFDB7D8BDA0DE5F90F78 /* OrderedDictionary+Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = B850474D28DB907CF28F2410 /* OrderedDictionary+Sequence.swift */; };
 		13C6DF44016DCB53AD3798F0 /* WorkspaceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4ABCD1903D2A2F3FAE064BC /* WorkspaceSettings.swift */; };
 		1473A160F617A0FDE6D1FA4F /* AddTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BA1D7F6DDD6AC3C4D830F3 /* AddTargets.swift */; };
 		1508217D1708C986EB549029 /* PBXTarget+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5A9B6F5C64958B1D054D3A6 /* PBXTarget+ExtensionsTests.swift */; };
 		15120DC7E10B41C7A500DC4C /* Array+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AC38B9E7BDCEE1A00F253C2 /* Array+Extras.swift */; };
 		1532FA28D9B68BDD436146B2 /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCAD7D38A6606771FA4A7436 /* Platform.swift */; };
+		15B92949E7279487C712D85A /* FilePathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E1E2200AB2DCA91F4999CE /* FilePathResolver.swift */; };
 		1602C1E6B3A7B310849DE483 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963808B2F3A1F2B83E6AE6DF /* Product.swift */; };
+		1669AFCA8D50EE60AA4C0351 /* WriteXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4541A6CA919F8EC829FE0B0 /* WriteXcodeProj.swift */; };
 		17645385BCB1B73E46212F31 /* XCScheme+BuildableProductRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC04FD3CCB6BC640D46E158 /* XCScheme+BuildableProductRunnable.swift */; };
+		17870AB7A2F1E7D82B85D2B2 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = F298521A3DBBAD2961DF8973 /* Project.swift */; };
+		185FDEB55130E7FF1C2AC09B /* XCSchemeInfo+TargetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE50955B4ECCB0C891FD4B1 /* XCSchemeInfo+TargetInfo.swift */; };
 		193F6A78FD304D33032124C1 /* XCVersionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C59EAFFB7EF2605BF76058 /* XCVersionGroup.swift */; };
 		1CC4BC9635C0213148A58C93 /* PBXTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90DF1CB872B6732ED05BCF9A /* PBXTarget.swift */; };
 		1D2A68B41A4FA9E2401D41EF /* XCWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0138A3545FE63C005CFAB42F /* XCWorkspace.swift */; };
@@ -61,38 +74,52 @@
 		1DFEAA851DC58E54D5FDC4D5 /* XCSchemeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B31DAEE7BDD3FB52C89121 /* XCSchemeInfo.swift */; };
 		1E3DC0A6287F260FE33F89CE /* Path+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2597D69F32EE134D35CA5EED /* Path+Extras.swift */; };
 		209E823873EA39D5C6A8EF66 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3D4E7C841C2C89DF095466 /* Logger.swift */; };
+		2164512385B75D2A11B9D81D /* ProcessTargetMerges.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF0DCE8B2E461919E45E6D7 /* ProcessTargetMerges.swift */; };
 		219C3E15651600D4892C4387 /* CollectionDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B9525BCADA7A75978D1FCC /* CollectionDifference.swift */; };
 		21EFB487A4B2DCA0539113C6 /* BuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE677C0FD789C4A0ADDC1901 /* BuildPhase.swift */; };
 		23041301A5060235785895F8 /* CoreImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55071574526ADBF7683AB165 /* CoreImage.swift */; };
 		23E55395726FC402185AD081 /* _HashTable+BucketIterator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DD377ABEF6A8CECEE71C6A3 /* _HashTable+BucketIterator.swift */; };
 		23F406E3FAC41A4D999C7470 /* CreateAutogeneratedXCSchemesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50DA1781996A4AC2F6E7EFA2 /* CreateAutogeneratedXCSchemesTests.swift */; };
+		24772E2C413258416674E0D2 /* Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88CFB36E6D7371DC64BD3D3D /* Sorting.swift */; };
 		25608AD5228D99F311C26845 /* PBXBuildRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B537637F91E4A43CAE2CF2 /* PBXBuildRule.swift */; };
 		265A3566719072FF07A20004 /* CustomDumpRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27A40DA2B2633E2E5090B39B /* CustomDumpRepresentable.swift */; };
 		277424E39B6FA6040609F4C2 /* XCScheme+CommandLineArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B23BC150E3266757707492 /* XCScheme+CommandLineArguments.swift */; };
 		2809A9CF1B38F525B3D7B0FF /* XCSchemeInfo+TestActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0C928BAD312B54B2B60DFC /* XCSchemeInfo+TestActionInfoTests.swift */; };
 		28B4A387EFBCB5A423A7931B /* OrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B9DF12DB21E355D72FC72A /* OrderedSet.swift */; };
+		2A015663F38F06BE6AFB5E2E /* TargetResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FCA54B4AC8AD7496FE5261 /* TargetResolver.swift */; };
 		2AE18EB4CD63F9B4052C0899 /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA5E4FE079AEA2D67E28234 /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift */; };
 		2AF393E662D68CBEAC339715 /* Fixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = F238F3E44302DBE53FF70525 /* Fixtures.swift */; };
+		2B7242DDC255D79B8872C85E /* FilePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742FB8D5E3AD34B60B65B2A9 /* FilePath.swift */; };
+		2BC0C48FC74F1B8B5653053F /* XcodeScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253A2904128D2EFC18CEA676 /* XcodeScheme.swift */; };
+		2C0A6DE0A9807483DF671B0C /* XCSchemeInfo+BuildTargetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CC6B4134D1C3D9BDE2F56F1 /* XCSchemeInfo+BuildTargetInfo.swift */; };
 		2C0AEFD36720278D54AF5847 /* String+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0484B5B7FF46952C7EBA2E20 /* String+Utils.swift */; };
 		2C1B9D8CC53EA9F00CC34580 /* XcodeScheme+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FED5A3DD441A96F8D87D685 /* XcodeScheme+ExtensionsTests.swift */; };
 		2C776A46D9F83B6F0BCD48A6 /* CommentedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = D432B71433F4134FFBFA281B /* CommentedString.swift */; };
+		2C7DA51E8BBC26D152BDE7AE /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCAD7D38A6606771FA4A7436 /* Platform.swift */; };
 		2C8449871037AD0BBB828275 /* PBXBuildFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E299B0F3C05FB32D2951414 /* PBXBuildFile.swift */; };
 		2D41550C6C017839EF6AA36E /* Speech.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE1ED821757FFFB97CF9BCA3 /* Speech.swift */; };
+		2FB0CDAC829C35AB56353E5C /* SetTargetDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079FE3313C09B3B7A4383D07 /* SetTargetDependencies.swift */; };
 		30641992040B785DB00E790C /* XCScheme+LocationScenarioReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073FBA88B39294943DB5E5A4 /* XCScheme+LocationScenarioReference.swift */; };
 		30D51D7450B1E5BC999396AC /* AnyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C680A79739F778E13D555285 /* AnyType.swift */; };
 		30F0C043E51363669C0D7E43 /* XCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AC44F6F9D5F1EBF4D7110DD /* XCConfig.swift */; };
-		34B28ED816174289FCA87229 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = 15240A701E6FED89576025D5 /* _CompileStub_.m */; };
+		336C926657F80CB7A611080C /* Outputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E1D04A9DAAEC9FAC5461AF /* Outputs.swift */; };
 		3549F29F57882F4922629FB8 /* XcodeSchemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2482AD02D4DC6C0AE14BBED3 /* XcodeSchemeTests.swift */; };
 		36161192BE3C16570649BB90 /* Photos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C89E41DF806BDFD0AF9A374 /* Photos.swift */; };
+		364DD825AA096D678B3DDC59 /* XCSchemeEnvironmentVariables+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B726EB797B81E4384CAD479B /* XCSchemeEnvironmentVariables+Extensions.swift */; };
 		379B88D547F660FC8CD65C0D /* XcodeScheme+BuildFor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE5674A308EB495272E069F /* XcodeScheme+BuildFor.swift */; };
+		384FB084858E2308E9BE1B10 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3D4E7C841C2C89DF095466 /* Logger.swift */; };
 		390F0EA150BF1F34944B6ADA /* Sourcery.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF0C30E65D6E9C205B83B73E /* Sourcery.swift */; };
 		3A4A00E9748F9B2BE18264A6 /* XCScheme+AditionalOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29A1E648AD1793142280604D /* XCScheme+AditionalOption.swift */; };
 		3A6A70477608C623CA4811AC /* SemanticVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD35FC938306527839D36BDA /* SemanticVersionTests.swift */; };
 		3A7349AFC0C6CBFFC6DEE039 /* SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = D323B626241F566F3B8A2CB7 /* SwiftUI.swift */; };
 		3AFC26185DD79A2294DEB12C /* Optional+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56F2198E67A658E127AFB3F /* Optional+ExtensionsTests.swift */; };
+		3C88AA30F39EE8FA05F015E3 /* SchemeAutogenerationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F3D3F0268B6D1D4DEA68A2 /* SchemeAutogenerationMode.swift */; };
+		3CC1B61E55C316B0AF890309 /* XcodeScheme+BuildFor.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACE5674A308EB495272E069F /* XcodeScheme+BuildFor.swift */; };
+		3D08604592D6BA159CB073FE /* TargetID.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C81405CA830285CE772318 /* TargetID.swift */; };
 		3D313135393850D8995F026E /* XCScheme+TestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDF69A69C5C9048DCF61E301 /* XCScheme+TestAction.swift */; };
 		3D4F39BFCA1C6A8C56DFDCF1 /* OrderedSet+Diffing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 478EF665AE33D9CE9CDBA26F /* OrderedSet+Diffing.swift */; };
 		3D717FFC9EA036D0DF025E6E /* OrderedDictionary+ExpressibleByDictionaryLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27B1BBF60EFF9DE0F3873504 /* OrderedDictionary+ExpressibleByDictionaryLiteral.swift */; };
+		3D7D9E55C8F11F4D9AE08F13 /* CreateProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5388590965F7A015974169E7 /* CreateProducts.swift */; };
 		3E584F6365CEBFF75D4EA9A9 /* OrderedSet+ExpressibleByArrayLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E7928D5D093A503A3E7CF2 /* OrderedSet+ExpressibleByArrayLiteral.swift */; };
 		3E7E07BFCDBA1A5BB01FD38D /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BC151B9FAB4522262F43A7 /* SemanticVersion.swift */; };
 		3F2995EB81E92469E7E2D50D /* Target.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC947C625E7E6B30468D77B8 /* Target.swift */; };
@@ -100,12 +127,16 @@
 		40EAC86C29279A4490B72640 /* XCSchemeInfo+ProfileActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35DFC10F60508ACDCC0E0C85 /* XCSchemeInfo+ProfileActionInfo.swift */; };
 		4200D6B211458A558E256181 /* OrderedDictionary+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F33013AF820E4A2208AA350 /* OrderedDictionary+Equatable.swift */; };
 		42EFDAABD5E997C0347FFE60 /* XCSchemeEnvironmentVariablesExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E68F397DBABDC12E41113B99 /* XCSchemeEnvironmentVariablesExtensionsTests.swift */; };
+		4328382C509F2BE258614FF4 /* ExtensionPointIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F008B03E81D8D0104DB8C /* ExtensionPointIdentifier.swift */; };
+		44622704B435724FB4323D8E /* PBXGroup+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A959229FCAA86770A69AA789 /* PBXGroup+Extensions.swift */; };
 		46565E40B8D7CA2247DF23BF /* OrderedSet+Partial SetAlgebra+Predicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C469D688DDD60A2D8A17B76 /* OrderedSet+Partial SetAlgebra+Predicates.swift */; };
 		4744038ECA6A1F58F45AB520 /* OrderedSet+Partial SetAlgebra+Basics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889B803E192ED98560009C6D /* OrderedSet+Partial SetAlgebra+Basics.swift */; };
 		4978BBDA23E2108C6410D537 /* XCScheme+Runnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A84F2CC6A006E28720D2B /* XCScheme+Runnable.swift */; };
+		4A34D2AFB9762C1542A01C8B /* ConsolidateTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A955F486C1C731F148887B6 /* ConsolidateTargets.swift */; };
 		4C9B7B38FF5ECE3142DB2E35 /* ConsolidatedTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22E436CA9D5D1BCA7C5E800B /* ConsolidatedTargetTests.swift */; };
 		4D10A242113D5E0A454F043B /* Dump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173203DBAEA88407DBBF109D /* Dump.swift */; };
 		4D2097EFFBD4914896E87BA8 /* _HashTable+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C0073B2B714F5319BE5A11 /* _HashTable+Testing.swift */; };
+		4E036B2B9F840B4DEE6E8086 /* Platform+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4348B7A354BE51B128A97DFF /* Platform+Extensions.swift */; };
 		4E28CB9358C8A9F9182DA0E8 /* _Hashtable+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20573500FA17CDB30A03469A /* _Hashtable+Header.swift */; };
 		4E3D153CEB522DFB416A3DBE /* XCScheme+SerialAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58F2246D7AB62C07E1D092E7 /* XCScheme+SerialAction.swift */; };
 		4F07E3CC0E718FBEE0A8821A /* CreateProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5388590965F7A015974169E7 /* CreateProducts.swift */; };
@@ -118,16 +149,19 @@
 		52A6BC70459DEE9D341E6151 /* Mirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0413D918157ADBE8DAEA92D /* Mirror.swift */; };
 		542DF5C2D96F299F5335308D /* XCSchemeEnvironmentVariables+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B726EB797B81E4384CAD479B /* XCSchemeEnvironmentVariables+Extensions.swift */; };
 		54AB2ADC10543F5BA2C20766 /* OrderedDictionary+Elements+SubSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A718E3E604EF56C4193D1A3 /* OrderedDictionary+Elements+SubSequence.swift */; };
+		5555E59ED1B2986332494595 /* LLDBContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BC73B37056313056FED47E /* LLDBContext.swift */; };
 		55B6607209B23D28CEC38448 /* OrderedDictionary+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5480C26E62F605559F11D71C /* OrderedDictionary+Codable.swift */; };
 		561E9544A30BE76E86EF2ED0 /* PBXSourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAADA80AB2FBFD1EB2A75A3D /* PBXSourcesBuildPhase.swift */; };
 		56D1E3A779E64B952444C092 /* Writable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD756B2EEB174424376D063 /* Writable.swift */; };
 		59195F78C9366C3C166CB371 /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AF6892EDF00CA059623628 /* PBXNativeTarget.swift */; };
+		5987C9D482D1ABB8C5513338 /* XCSchemeInfo+LaunchActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50023386D982305A19EB4D8B /* XCSchemeInfo+LaunchActionInfo.swift */; };
 		5A1AB232F984E776A2BD9AC4 /* SetTargetDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 079FE3313C09B3B7A4383D07 /* SetTargetDependencies.swift */; };
 		5AF24276F09A7163D1351514 /* AddBazelDependenciesTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD653DE8BB96227EDAAE9B28 /* AddBazelDependenciesTarget.swift */; };
 		5C69464F742D0B6D2F68B3EA /* OrderedDictionary+Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFB50D8D42412EB98A465DED /* OrderedDictionary+Elements.swift */; };
 		5D3E10C76557BFAFE4ED39EE /* Platform+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4348B7A354BE51B128A97DFF /* Platform+Extensions.swift */; };
 		5D436B3E872B368A77248360 /* PBXBatchUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F395A784F145A641B09FC95 /* PBXBatchUpdater.swift */; };
 		5D50E1896900C92386C932B3 /* SetTargetConfigurationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA554A6803D388E0347F369 /* SetTargetConfigurationsTests.swift */; };
+		5E99132A728C737C28164D47 /* Target+LinkerFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3483283D4E32D0BCB74B78A /* Target+LinkerFlags.swift */; };
 		5ECD0DB0994205C603166004 /* PopulateMainGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69926E3303EC6DCEFF83DE3 /* PopulateMainGroup.swift */; };
 		5F37060A7CB0F58A25A3FC2B /* XCSchemeInfo+BuildTargetInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4CC2F2F9921DD1A5D924C22 /* XCSchemeInfo+BuildTargetInfoTests.swift */; };
 		5F3A7BC39F4A9645B1741DCF /* XCSchemeInfo+LaunchActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50023386D982305A19EB4D8B /* XCSchemeInfo+LaunchActionInfo.swift */; };
@@ -137,18 +171,23 @@
 		60F9CB8234489A813817566D /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09218BC66E9AB080FC139E6 /* String+Extensions.swift */; };
 		6121FE4B0886115AFE30E6EA /* CreateFilesAndGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B75524B71F7B49A73BD453D /* CreateFilesAndGroups.swift */; };
 		61403F6850E38C4F143F564B /* PBXProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CD85080B3E34F2529D7CB8 /* PBXProj.swift */; };
+		615D3340F3DE1787F7AF4463 /* CreateXCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E6551A5EEE9CC51C5A05BD3 /* CreateXCSharedData.swift */; };
 		62F2A43822894D2210058772 /* XcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A47D52C1A48A1ED498719F /* XcodeProj.swift */; };
 		668601395C244CA1314ACE10 /* _UnsafeBitset.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32ACC94716AA176D4B8FA91 /* _UnsafeBitset.swift */; };
 		6695A3C7FADF608E359B1153 /* XCWorkspaceDataGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 748E5C2D56A2ED06BF8F5D39 /* XCWorkspaceDataGroup.swift */; };
 		66DDAAF01C650E4B60FECC5D /* XCSchemeInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 388BFA02F2F42F564CC5060D /* XCSchemeInfoTests.swift */; };
+		687AC29CB99480CDF13FC39D /* TargetIDTargetDictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B6A60A77B6D8BD36AB2320 /* TargetIDTargetDictionary+Extensions.swift */; };
 		68E567532FB9A491B36F4344 /* PBXContainerItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B0689562B36DE6F3668B6E /* PBXContainerItemProxy.swift */; };
 		6A8B43D7AB579FFA4EA560A8 /* CustomDumpReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFFE6348E347FF9ED001081 /* CustomDumpReflectable.swift */; };
 		6BD6785813F2AC9561F5C197 /* PBXProj+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F0B7B94D16AAD3979ACCEFA /* PBXProj+Testing.swift */; };
 		6BEEFB6F9ABBD9DE61F18D20 /* CreateFilesAndGroupsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42EAB1A5AEF651AF8F6F865 /* CreateFilesAndGroupsTests.swift */; };
+		6F79BA8BD3DE3BBB7D1CA907 /* CreateProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F678888C41776A8A45A7BC /* CreateProject.swift */; };
+		70F1FAC6133F5AC1E8217C29 /* XCSchemeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B31DAEE7BDD3FB52C89121 /* XCSchemeInfo.swift */; };
 		71F8B1DD599EA5B0F2D03626 /* _HashTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61319B361ABA09FD294600A /* _HashTable.swift */; };
 		72A3C7DA6BF74DE5F2EFC28C /* CreateProductsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A40EB7581064768B08E6C529 /* CreateProductsTest.swift */; };
 		72C95B9913557F8ABDA0C644 /* XCScheme+AnalyzeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 430A0E83DF369E5ED390CA3A /* XCScheme+AnalyzeAction.swift */; };
 		73237287CCC966570F78F438 /* ConsolidateTargetsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E7CBE278241683B615924F /* ConsolidateTargetsTest.swift */; };
+		7490B9FFF4E33B327A641B2B /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 963808B2F3A1F2B83E6AE6DF /* Product.swift */; };
 		75B34A42A3528868C8D25993 /* AddTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACBE49740AB347EFAE8EC00 /* AddTargetsTests.swift */; };
 		75F5358EA36D1D122ED378E8 /* OrderedSet+Partial MutableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 757D440109F7949F1B412CB9 /* OrderedSet+Partial MutableCollection.swift */; };
 		77E1F8F1C9436E20DAA753EF /* CreateCustomXCSchemesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD29B904771B778499A9DA3E /* CreateCustomXCSchemesTests.swift */; };
@@ -157,9 +196,11 @@
 		78BD2E0C7E5F5A553D4A9032 /* Target+LinkerFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3483283D4E32D0BCB74B78A /* Target+LinkerFlags.swift */; };
 		78D160559CB33620BE055D67 /* PBXTargetDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4E0D9481DEB5CB89790C09F /* PBXTargetDependency.swift */; };
 		7CB1EBC22647A052E1F33593 /* ConsolidatedTargetExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9D15BC7ED54D7EBC0111629 /* ConsolidatedTargetExtensionsTests.swift */; };
+		7DAD46576F5118FA91ED13DB /* DisambiguateTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC2AE826C4EDD1E4BADB41F /* DisambiguateTargets.swift */; };
 		7F476F3EA1860204A2BC970E /* ReferenceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0D02295BBDD7113D940406 /* ReferenceGenerator.swift */; };
 		7F56B654E12D77ECCC467E09 /* XcodeScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253A2904128D2EFC18CEA676 /* XcodeScheme.swift */; };
 		7F58A80D6FBF4CAAB6A6B59C /* PBXProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9A42BDD634CA3FA35830AE1 /* PBXProductType.swift */; };
+		7FC02B3664AF691C07A5A40A /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09218BC66E9AB080FC139E6 /* String+Extensions.swift */; };
 		80172D16E7DA2B9979BAF386 /* TargetID.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C81405CA830285CE772318 /* TargetID.swift */; };
 		80361D1C6E985B1C92E65811 /* CreateXCSharedDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE5F2E4FC573D27FCB8DF34 /* CreateXCSharedDataTests.swift */; };
 		804848AF97DCD0402E5B8587 /* BuildSettingsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD828AC8336C5A1F0C951071 /* BuildSettingsProvider.swift */; };
@@ -173,6 +214,7 @@
 		83B8755AB81932C2FE256B16 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7DE6268B49662138FC0C90 /* Errors.swift */; };
 		83F4AE88CCE3E873D3C395B5 /* OrderedSet+UnstableInternals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9610CD0DCAEE9236869A4628 /* OrderedSet+UnstableInternals.swift */; };
 		83FBDFA33D8A84AEA3DAC61E /* OrderedSet+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACF678DB87E07DDDF0999336 /* OrderedSet+Testing.swift */; };
+		841A2B1BA4B1AECACF4DC2FE /* XCScheme+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEEA3E0B3F45EF982ED29E63 /* XCScheme+Extensions.swift */; };
 		85757625D655CDB101E2C08F /* XcodeScheme+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465DE36011B6355F1ECACA1B /* XcodeScheme+Extensions.swift */; };
 		86824C0BC97C6DA06A465D0C /* XCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AD1D57FD4037EC5BB72645 /* XCSharedData.swift */; };
 		86FE11FE2B8F03BEE4C909B9 /* PathExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493423CD8285C46D06C4169D /* PathExtensionsTests.swift */; };
@@ -180,6 +222,7 @@
 		892C9CFBEE5474105B683C75 /* XCScheme+EnvironmentVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F07848723835EC26C2340C /* XCScheme+EnvironmentVariable.swift */; };
 		8A9EBE0DE562329A750CF522 /* PBXGroup+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A959229FCAA86770A69AA789 /* PBXGroup+Extensions.swift */; };
 		8BF8CFA67C6213113810FCAD /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFE25BEDFD3646AD0AB54C40 /* PBXContainerItem.swift */; };
+		8CFE94DF1A46EA88719F606E /* BuildSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F8C4C7C2081CE4ED3E6131 /* BuildSetting.swift */; };
 		8D60F9D1D81FEDCE8DDF6B73 /* CreateProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A9607F1AB28FE727DED4651 /* CreateProjectTests.swift */; };
 		8FCC248B12F5127B90BCA1A2 /* PlistValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ABD1C801DC25791CF7A9BC2 /* PlistValue.swift */; };
 		8FCC7D3937EEC9B1D3C1D237 /* ExtensionPointIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C1F008B03E81D8D0104DB8C /* ExtensionPointIdentifier.swift */; };
@@ -187,13 +230,17 @@
 		9077EA3A89259730E19B4A78 /* XCSchemeManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007E626D3C6303C4B848B3F6 /* XCSchemeManagement.swift */; };
 		918DEB6EB624CC659A442D18 /* XCConfigurationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6633E691F2753B78D68DD3C9 /* XCConfigurationList.swift */; };
 		940FAC5CFA0F9801AB9595DC /* OrderedSet+SubSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE5268E76227088929BE300 /* OrderedSet+SubSequence.swift */; };
+		94247D2D62855E409E61D12C /* LinkerInputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B53AF9EB4EE0D76B72A641 /* LinkerInputs.swift */; };
 		966E746DD2F4033E07848B84 /* PBXAggregateTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 350D61290C1B602B60DA483A /* PBXAggregateTarget.swift */; };
 		9681C0A77F338F5195DC8C6D /* RandomAccessCollection+Offsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D3B8B5865EEB3775B053CFE /* RandomAccessCollection+Offsets.swift */; };
 		96E4FC19C3BAF8CF01C75ADB /* OrderedSet+Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8645BE71A723C3736CCE7131 /* OrderedSet+Initializers.swift */; };
 		9884BFE5F8802125BBD695CC /* XCSchemeInfo+BuildActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CC88A1EC5D00732D7576F9A /* XCSchemeInfo+BuildActionInfoTests.swift */; };
 		98DC63B7C9C1743065744E2C /* PBXObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA8657DAF8012A508E7FEE54 /* PBXObjects.swift */; };
+		99CCE7639C8B8808981FB146 /* XcodeScheme+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465DE36011B6355F1ECACA1B /* XcodeScheme+Extensions.swift */; };
 		9AECAA3D2388D9FF824EDB5F /* PBXFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C6BD71C5B59C200AE8F91C /* PBXFileReference.swift */; };
+		9C030AD53C363F9D3EF4F996 /* CreateCustomXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C67F66BD1DCF607668ADDC /* CreateCustomXCSchemes.swift */; };
 		9C521A1BDD725800EBB7A77A /* PBXObjectParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB3EDAEB4E2CAE755B7284B /* PBXObjectParser.swift */; };
+		9CB0F21222D0AA8F9B366E9C /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C7DE6268B49662138FC0C90 /* Errors.swift */; };
 		9CFDB1C422ED7123AE999B7E /* TargetIDTargetDictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B6A60A77B6D8BD36AB2320 /* TargetIDTargetDictionary+Extensions.swift */; };
 		9D56629578825A73E01C892C /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20E781CE891F4AB4B0E4C30 /* Dictionary+Extras.swift */; };
 		9D76A26D9FEA7B0640898FA1 /* OrderedSet+Insertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF669164AFB2A01A89F0075F /* OrderedSet+Insertions.swift */; };
@@ -204,6 +251,7 @@
 		A005E475FCF2134825BDB60D /* Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A247C10F4C33288C1500D2D /* Swift.swift */; };
 		A017A60C1F5B32E3FA3AC00A /* OrderedSet+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6E464E0F5C4A2F0ED8DBA80 /* OrderedSet+CustomStringConvertible.swift */; };
 		A0708E97D31DAA3DAEEA5ED6 /* XCSchemeInfo+VariableExpansionContextInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F1423CE1647443474F47591 /* XCSchemeInfo+VariableExpansionContextInfoTests.swift */; };
+		A08DBDBB61E7EC796A776996 /* Path+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3112C0473A89E12C95F6E3DB /* Path+Extensions.swift */; };
 		A222D10EC921D5DAB1ADFDD8 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 737B837AF4D301FD49E5E8DC /* Errors.swift */; };
 		A30CF32F21CDF7FE5B477341 /* PBXTargets+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB622F4E8EA478F6C3D642F6 /* PBXTargets+ExtensionsTests.swift */; };
 		A34F10BEBBC9CABA7EFE3D62 /* OrderedSet+Partial SetAlgebra+Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FF7F282D79BCC8C890152C /* OrderedSet+Partial SetAlgebra+Operations.swift */; };
@@ -215,6 +263,7 @@
 		A9517AAC3411C003E2CB531B /* StoreKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00CD1A85389190652E1BEFC9 /* StoreKit.swift */; };
 		A99C8BF4EB3403A8A0EF7359 /* PBXSourceTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71DFD69623D237CF63C0F232 /* PBXSourceTree.swift */; };
 		AAB0514FC68BB58F07579F02 /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BFD6BE9106FF1721637C0B /* Main.swift */; };
+		AABA1ECDDD4C5E04F1DB21AA /* XCSchemeInfo+PrePostActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B91686D440228A4612AF649D /* XCSchemeInfo+PrePostActionInfo.swift */; };
 		AACDF2550D64805FC90879F6 /* XCCurrentVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86549ABD234E1583AA0655DE /* XCCurrentVersion.swift */; };
 		AB40FAE217E2BAB64BA214AE /* XCWorkspaceDataElementLocationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48CF60E64EACBE1F8C63D3D /* XCWorkspaceDataElementLocationType.swift */; };
 		AB6AAB9A7208DB88DC554AB4 /* XCScheme+ExecutionAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457C541A86E3F05E0865CB70 /* XCScheme+ExecutionAction.swift */; };
@@ -222,6 +271,7 @@
 		ADCE544F51464E00D1D9524D /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86D81D32EB64919C01CE7321 /* KeyedDecodingContainer+Additions.swift */; };
 		AE8961FFE22CBE3B3FD65418 /* XCScheme+ArchiveAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D689E51BC21F8670813CA7 /* XCScheme+ArchiveAction.swift */; };
 		AF8E3F0B5232920781A99260 /* Target+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D3C9C8DAFC01EECD746E229 /* Target+Testing.swift */; };
+		B0662ED0FA83DE84A57B93FF /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BFD6BE9106FF1721637C0B /* Main.swift */; };
 		B07246FF3AFE26CA293A39F7 /* _HashTable+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD5E768F0086402FCD23DDD0 /* _HashTable+Constants.swift */; };
 		B0A2A06473CECEC37ABAA58C /* PBXBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E43EBF1E6F26B25BB157D396 /* PBXBuildPhase.swift */; };
 		B556B319407CEE94214F965A /* CoreLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC8220ADCB2EE90910140F8F /* CoreLocation.swift */; };
@@ -231,17 +281,21 @@
 		B94E786140EF5D646741F635 /* XCSchemeInfo+TargetInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0B189B25267181F6563FE8 /* XCSchemeInfo+TargetInfoTests.swift */; };
 		BB1FEC913287E5B00F096E68 /* XCTFail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6715701A6A75A2BFF85172AD /* XCTFail.swift */; };
 		BB9A479C58B5371EB58BD6E1 /* XCSwiftPackageProductDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4427E84F30EE600A2E568520 /* XCSwiftPackageProductDependency.swift */; };
+		BDE206BDB3298C69CA41B968 /* PBXProductType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E25F4B3B5010A82A8E2A0CF /* PBXProductType+Extensions.swift */; };
 		BE44D239C026145A916BF628 /* OrderedDictionary+CustomReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7D9273757477E754AE95FE /* OrderedDictionary+CustomReflectable.swift */; };
 		BEAD5FDAF78EA4826B89E2BD /* NSRecursiveLock+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF5D934175EDDA9EF296101 /* NSRecursiveLock+Sync.swift */; };
 		BF37FF4AE38FE009AF6A77A5 /* Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB357A8A7280647E5513166A /* Foundation.swift */; };
 		BF65912DF533222FBFA38112 /* XCSchemeInfo+ProfileActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFD9A9F50CD3972B0F674265 /* XCSchemeInfo+ProfileActionInfoTests.swift */; };
 		C0486D5F399197D1D3FF09B0 /* XcodeProj+CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 230BF7ABCF5D7C48951A8641 /* XcodeProj+CustomDump.swift */; };
 		C0C01A34E3B73713C8A5AD93 /* UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D663E878398F3764B9C1A8 /* UIKit.swift */; };
+		C1E5D462186CF4729A9F9CB9 /* AddBazelDependenciesTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD653DE8BB96227EDAAE9B28 /* AddBazelDependenciesTarget.swift */; };
+		C2756B617E6853475E1BC42E /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575B48EB9FAC89FBAB6B4F1A /* Optional+Extensions.swift */; };
 		C28A10245E6237BB03708CF9 /* XCScheme+RemoteRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053AD1C0C7003B91D7B9EB16 /* XCScheme+RemoteRunnable.swift */; };
 		C35B3D77746B4ECCD998CA02 /* Platform+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653871FF351D095F4EEABFB0 /* Platform+ExtensionsTests.swift */; };
 		C3C078F384218F905E374FEF /* XCScheme+PathRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9993D3F386DFC594BC0967A /* XCScheme+PathRunnable.swift */; };
 		C41E28F5D880E1B3B3CE23A6 /* BazelLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4642D1BB48B4523F92FBC3 /* BazelLabel.swift */; };
 		C4A4BDEEBC4DEA94A9C38B98 /* XCScheme+ProfileAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01004934C429F4A4F09C0C85 /* XCScheme+ProfileAction.swift */; };
+		C572F7558C1A5C73EFEC7507 /* SetTargetConfigurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4ED3B78E40B159DC3EEB602 /* SetTargetConfigurations.swift */; };
 		C7312FB20AEA2A3AE3C8111A /* Dictionary+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7B2D64670633C5693521D5 /* Dictionary+ExtensionTests.swift */; };
 		C763631072D70B6887A3037B /* TargetResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9FCA54B4AC8AD7496FE5261 /* TargetResolver.swift */; };
 		C7FE7B26776F35CE278DA25A /* OrderedDictionary+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4142BB8EF88F4DD2D5440E4 /* OrderedDictionary+CustomStringConvertible.swift */; };
@@ -252,17 +306,21 @@
 		CD168B5A573CE3A79098C630 /* PBXProjEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC11446A42A073B91FFC6262 /* PBXProjEncoder.swift */; };
 		CD4B8D1015F9E80BE99DD4CB /* GeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25072DE452FF8EC4AC148C4A /* GeneratorTests.swift */; };
 		CD5048942C21378CDB87CF88 /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4507DAF85285409A7CA226E /* PBXObject.swift */; };
+		CE633D8966137D9C4F82B916 /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BC151B9FAB4522262F43A7 /* SemanticVersion.swift */; };
 		CE6CCF1AF17AA0100D2D2A8E /* Decoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721F82FE7F5FD35511FFFB2B /* Decoders.swift */; };
 		CF836785A4BDAA1811B567F7 /* PBXRezBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D06530EE100F0FBF5366BC5 /* PBXRezBuildPhase.swift */; };
 		CFA993C5630012AEE5CE51C8 /* XCSchemeInfo+BuildActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA91ACA2E565D0C6F88DE03 /* XCSchemeInfo+BuildActionInfo.swift */; };
 		CFB4FD519F8E383FD4BCB1E3 /* String+md5.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AE2420614CF62AD4A8AAB1 /* String+md5.swift */; };
 		D0407AAE9CF50A10917EAE7B /* PBXVariantGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4C427036C3EA7632B3C787 /* PBXVariantGroup.swift */; };
+		D044901213B465B69E609833 /* CreateFilesAndGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B75524B71F7B49A73BD453D /* CreateFilesAndGroups.swift */; };
 		D16602634755ABF029048517 /* PBXFrameworksBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E1EBEDD54BAF02A22166DB /* PBXFrameworksBuildPhase.swift */; };
 		D19739179B7FE91C8CF9BEEC /* AEXML+XcodeFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = B379DE01A53B895F83E8846C /* AEXML+XcodeFormat.swift */; };
+		D33144DB22F4AD3CAA83E450 /* BazelLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD4642D1BB48B4523F92FBC3 /* BazelLabel.swift */; };
 		D36AF35A702DB7F0987E1628 /* XCScheme+BuildAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117052ABC66769C11B7F397A /* XCScheme+BuildAction.swift */; };
 		D396361E6B167F11155EF472 /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F62C432E8BE7AB82AA78D1A /* Generator.swift */; };
 		D3F89CBA24BCB287C6A2C531 /* OrderedDictionary+Partial MutableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 728DDF86F813BA5FBDD6DFE7 /* OrderedDictionary+Partial MutableCollection.swift */; };
 		D548357DA88FF63CF53CB1C5 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8986F9BDAD8DB56D61CBB787 /* String.swift */; };
+		D676630F1620BAC0223F6A96 /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F62C432E8BE7AB82AA78D1A /* Generator.swift */; };
 		D6ABD612562041F923A9DD78 /* XCSchemeInfo+TargetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE50955B4ECCB0C891FD4B1 /* XCSchemeInfo+TargetInfo.swift */; };
 		D75E4FF718EDB764C615241B /* Inputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB9D00963E3FECF87A050AA /* Inputs.swift */; };
 		D7A1F37091591B8DF8803498 /* OrderedDictionary+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = B84817AD8F8BF75C3E9D446A /* OrderedDictionary+Deprecations.swift */; };
@@ -271,13 +329,17 @@
 		DAEB13CD6BB6B939AE66B3FE /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E27E547A12A951FF64D0C4 /* Box.swift */; };
 		DB319A23886D4E34C33673FC /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6130F9568982104094E3C618 /* Bool+Extras.swift */; };
 		DB8227FED04A839CF551406B /* XCScheme+TestableReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E517675E70186E73924EB60 /* XCScheme+TestableReference.swift */; };
+		DBC4D9B30FC2F4466F52336D /* XCSchemeInfo+OtherActionInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93309761AF878C3D25AB9D3 /* XCSchemeInfo+OtherActionInfos.swift */; };
 		DC05871B093AC1BF66E909B3 /* OrderedSet+ReserveCapacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8927068410441502892CCFA /* OrderedSet+ReserveCapacity.swift */; };
 		DC69A9A145F602CB5EAF30D3 /* XcodeScheme+BuildForTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5929C9F46FA959655ACAE16F /* XcodeScheme+BuildForTests.swift */; };
+		DC9E0B07E1F028A6C24949C7 /* XCSchemeInfo+HostInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B194639E9B15A5EBF6F2B8 /* XCSchemeInfo+HostInfo.swift */; };
 		DD5A44735D378BDE1F46118A /* XCRemoteSwiftPackageReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B175666DC0102DE35EBD173 /* XCRemoteSwiftPackageReference.swift */; };
 		DD86AFD01BB9638A2B86EA65 /* CreateAutogeneratedXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4365A36FFD6C0FE9B703B9 /* CreateAutogeneratedXCSchemes.swift */; };
 		DDBE87915A648B7B27AA8A73 /* XCTAssertNoDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA3B2C353EE2A9D305660B47 /* XCTAssertNoDifference.swift */; };
 		DEB20A2BE68A1F25DB71E3AF /* ConsolidateTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A955F486C1C731F148887B6 /* ConsolidateTargets.swift */; };
+		DEE00D0960CE14801F2DC048 /* CreateAutogeneratedXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4365A36FFD6C0FE9B703B9 /* CreateAutogeneratedXCSchemes.swift */; };
 		DF25BF61C1D05BD743396080 /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260960CB90CADC8133DF9725 /* OrderedDictionary.swift */; };
+		DF7079F64B57749F3C4B7A77 /* XCSchemeInfo+VariableExpansionContextInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5703782B462AAC263DCB1541 /* XCSchemeInfo+VariableExpansionContextInfo.swift */; };
 		DFB2A012A2E2890E39923186 /* OrderedSet+Partial RangeReplaceableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55C093347C9C5CF3D5426C9A /* OrderedSet+Partial RangeReplaceableCollection.swift */; };
 		DFBCDDB2887295EA74E15BD4 /* Path+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3112C0473A89E12C95F6E3DB /* Path+Extensions.swift */; };
 		DFDACE372D86DAF5308E0DE2 /* XCScheme+TestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0654DDFDA028387BCAF843F8 /* XCScheme+TestItem.swift */; };
@@ -294,13 +356,17 @@
 		EB4A452EE958D49C8D481FC8 /* XCScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B1A9C414C17FC0CB546CCF5 /* XCScheme.swift */; };
 		EBF46BD547BE8BC0C19D65CC /* ProcessTargetMerges.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBF0DCE8B2E461919E45E6D7 /* ProcessTargetMerges.swift */; };
 		EC95F63F4042536A21DBA804 /* XCSchemeInfo+HostInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68742A2FE4F0B23F0786BC76 /* XCSchemeInfo+HostInfoTests.swift */; };
+		ECB77E6A35606D6E3D7118EB /* PBXTarget+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1074DB099E4140E5585B14CC /* PBXTarget+Extensions.swift */; };
 		ECBD008947BBD15AB1A35FF1 /* OrderedDictionary+Partial RangeReplaceableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 045C88EE3AA908B93ADC7B8F /* OrderedDictionary+Partial RangeReplaceableCollection.swift */; };
 		ECCA99D11A5C71FF33FFA4B0 /* SearchPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E71E5D5A3ED7BDF0B859C36 /* SearchPaths.swift */; };
 		ED5453D41C0823C5AD74357E /* CreateCustomXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33C67F66BD1DCF607668ADDC /* CreateCustomXCSchemes.swift */; };
 		EE33C1B9BAFB8A2D9B2624AA /* OrderedDictionary+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 817B04CE0868E15EFE7D8C44 /* OrderedDictionary+Hashable.swift */; };
+		EF05D7EE3C12A7328BD456A3 /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411840C33954055F18B35AD2 /* Dictionary+Extensions.swift */; };
 		EF60330F67E0BA0980693DDD /* CreateProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6F678888C41776A8A45A7BC /* CreateProject.swift */; };
 		EF6F4E716AA5BE2772001255 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7BF60244CDDEB8780E0A1B /* PBXHeadersBuildPhase.swift */; };
+		F1897E6478D3AB694569E656 /* XCCurrentVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86549ABD234E1583AA0655DE /* XCCurrentVersion.swift */; };
 		F195F74C145AA147C028F541 /* PBXOutputSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BBD0DBAFB6DB4E966DC49EB /* PBXOutputSettings.swift */; };
+		F1C4D818998A5A66D31C794E /* XCSchemeInfo+BuildActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABA91ACA2E565D0C6F88DE03 /* XCSchemeInfo+BuildActionInfo.swift */; };
 		F3A132D9FD8D18A9F79CC49C /* OrderedSet+CustomReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB967E84797720EBD386735A /* OrderedSet+CustomReflectable.swift */; };
 		F3BB0D8F4C733E234D92AA5F /* FilePathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD16E00A1D2C82B5121AB89 /* FilePathResolverTests.swift */; };
 		F408E995D0F6C9C1655544A2 /* ProcessTargetMergesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746AD1E908901BF77306B564 /* ProcessTargetMergesTests.swift */; };
@@ -310,15 +376,26 @@
 		F489A2B6BC16017B0A96F7C5 /* Xcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 726579883BDE5C574DD25742 /* Xcode.swift */; };
 		F4D13ACCE9A32E9C849214DA /* GameKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485411F2F79794474B9E8AAB /* GameKit.swift */; };
 		F87890E59D29431994A8AD60 /* XCBuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD9354E6340A0B10BEB1FDEE /* XCBuildConfiguration.swift */; };
+		F87A31A06054AC72CB2B59AF /* BuildSettingConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5638047BDE3BC92B3CE6C189 /* BuildSettingConditional.swift */; };
 		F8DAB8FCE71E293402C101A7 /* OrderedSet+Invariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2062B3E1312EAF079BC5E26C /* OrderedSet+Invariants.swift */; };
 		F8ED6A8FFAE1FC9C86D48897 /* LLDBContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BC73B37056313056FED47E /* LLDBContext.swift */; };
+		FD24651519FCDE26F80982A1 /* AddTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45BA1D7F6DDD6AC3C4D830F3 /* AddTargets.swift */; };
 		FD83242BF95B2ED90590668A /* PBXShellScriptBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 133D091B34B3EB60A9400C02 /* PBXShellScriptBuildPhase.swift */; };
 		FDDC85A61CA9A72E0ED2CFD8 /* DisambiguateTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC2AE826C4EDD1E4BADB41F /* DisambiguateTargets.swift */; };
 		FE3BD3396FE837CE724065A0 /* OrderedDictionary+Values.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11EF80F5B25255A95D7D8D66 /* OrderedDictionary+Values.swift */; };
+		FEA8A4C363F17B49DE460E45 /* TargetIDConsolidatedTargetKeyDictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 186B5A6EAA26C6BCB1FE6773 /* TargetIDConsolidatedTargetKeyDictionary+Extensions.swift */; };
+		FEB54352AE1763F867E0F2C4 /* SearchPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E71E5D5A3ED7BDF0B859C36 /* SearchPaths.swift */; };
 		FF65ADF9DB385AB43000B4AE /* WriteXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4541A6CA919F8EC829FE0B0 /* WriteXcodeProj.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		0B68E48961CEDB45BDC67383 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 023B2C041CD79AF5B2FDAFE1;
+			remoteInfo = OrderedCollections;
+		};
 		1B37F14BCD93FD7AB94FD7E0 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -375,6 +452,13 @@
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
 		};
+		82A5FB7A1D2CD0FCF74CB1A0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4A2EC1B2D6969F717CB890DE;
+			remoteInfo = PathKit;
+		};
 		8F6708A57B268EEC25458F4B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -410,13 +494,6 @@
 			remoteGlobalIDString = 4A2EC1B2D6969F717CB890DE;
 			remoteInfo = PathKit;
 		};
-		CE545ADAA24F8CEBE7071545 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0805833D09730531AD081697 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F12050E30563A81EEBB2EA9B;
-			remoteInfo = generator.library;
-		};
 		D5437FAEB47AEF0B67E5BB23 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0805833D09730531AD081697 /* Project object */;
@@ -430,6 +507,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 7E7D155EBCA520F35DEA3571;
 			remoteInfo = BazelDependencies;
+		};
+		F3EAC92A418BBFEBF1666E99 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0805833D09730531AD081697 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A09CE18EBBDAC65CD0C6B7D1;
+			remoteInfo = XcodeProj;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -463,7 +547,6 @@
 		11EF80F5B25255A95D7D8D66 /* OrderedDictionary+Values.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Values.swift"; sourceTree = "<group>"; };
 		1311F2E17F171A48A8E3B180 /* Dictionary+Enumerate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Enumerate.swift"; sourceTree = "<group>"; };
 		133D091B34B3EB60A9400C02 /* PBXShellScriptBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXShellScriptBuildPhase.swift; sourceTree = "<group>"; };
-		15240A701E6FED89576025D5 /* _CompileStub_.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = _CompileStub_.m; sourceTree = DERIVED_FILE_DIR; };
 		16F8C4C7C2081CE4ED3E6131 /* BuildSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSetting.swift; sourceTree = "<group>"; };
 		173203DBAEA88407DBBF109D /* Dump.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dump.swift; sourceTree = "<group>"; };
 		186B5A6EAA26C6BCB1FE6773 /* TargetIDConsolidatedTargetKeyDictionary+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TargetIDConsolidatedTargetKeyDictionary+Extensions.swift"; sourceTree = "<group>"; };
@@ -1412,15 +1495,6 @@
 			path = Sourcery;
 			sourceTree = "<group>";
 		};
-		D182AF8E059C5832405A845F /* rules_xcodeproj */ = {
-			isa = PBXGroup;
-			children = (
-				15240A701E6FED89576025D5 /* _CompileStub_.m */,
-			);
-			name = rules_xcodeproj;
-			path = test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj;
-			sourceTree = "<group>";
-		};
 		D7FFCD6C56706B85E75B3AF7 /* com_github_pointfreeco_swift_custom_dump */ = {
 			isa = PBXGroup;
 			children = (
@@ -1482,7 +1556,6 @@
 				73CEA667F51A4B28BFA414FB /* tools */,
 				9811D2ED915829A1A7881AFD /* Bazel External Repositories */,
 				C407A8E68D8C611448A3E699 /* Bazel Generated Files */,
-				D182AF8E059C5832405A845F /* rules_xcodeproj */,
 				593E7C82FAAD94A7E6A04318 /* Products */,
 				C047AF1D451C7E165914273D /* Frameworks */,
 			);
@@ -1604,7 +1677,9 @@
 			);
 			dependencies = (
 				F95C6EAD9F7184C6730E9F61 /* PBXTargetDependency */,
-				C0C4842B0D633EDDA463F849 /* PBXTargetDependency */,
+				0E371ECA4C09BB68C6AE0588 /* PBXTargetDependency */,
+				6A8B144B2EF03C75CE4E5F98 /* PBXTargetDependency */,
+				2CDEBBC842A0E659F12E12E4 /* PBXTargetDependency */,
 			);
 			name = generator;
 			productName = generator;
@@ -1850,11 +1925,10 @@
 			name = "Create linking dependencies";
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/link.params",
-				"$(DERIVED_FILE_DIR)/_CompileStub_.m",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\ntouch \"$SCRIPT_OUTPUT_FILE_1\"\n";
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		90B04C8AB5A07A2ECF257268 /* Copy Bazel Outputs */ = {
@@ -1973,7 +2047,77 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				34B28ED816174289FCA87229 /* _CompileStub_.m in Sources */,
+				F87A31A06054AC72CB2B59AF /* BuildSettingConditional.swift in Sources */,
+				D33144DB22F4AD3CAA83E450 /* BazelLabel.swift in Sources */,
+				122C541CB4789FD47C478AD9 /* BuildMode.swift in Sources */,
+				8CFE94DF1A46EA88719F606E /* BuildSetting.swift in Sources */,
+				4328382C509F2BE258614FF4 /* ExtensionPointIdentifier.swift in Sources */,
+				2B7242DDC255D79B8872C85E /* FilePath.swift in Sources */,
+				0FC3C2B36EE048DFFDA71CD8 /* Inputs.swift in Sources */,
+				5555E59ED1B2986332494595 /* LLDBContext.swift in Sources */,
+				94247D2D62855E409E61D12C /* LinkerInputs.swift in Sources */,
+				336C926657F80CB7A611080C /* Outputs.swift in Sources */,
+				2C7DA51E8BBC26D152BDE7AE /* Platform.swift in Sources */,
+				7490B9FFF4E33B327A641B2B /* Product.swift in Sources */,
+				17870AB7A2F1E7D82B85D2B2 /* Project.swift in Sources */,
+				3C88AA30F39EE8FA05F015E3 /* SchemeAutogenerationMode.swift in Sources */,
+				FEB54352AE1763F867E0F2C4 /* SearchPaths.swift in Sources */,
+				5E99132A728C737C28164D47 /* Target+LinkerFlags.swift in Sources */,
+				05E31D136E1C8BD5D67D5ECD /* Target.swift in Sources */,
+				3D08604592D6BA159CB073FE /* TargetID.swift in Sources */,
+				F1897E6478D3AB694569E656 /* XCCurrentVersion.swift in Sources */,
+				2BC0C48FC74F1B8B5653053F /* XcodeScheme.swift in Sources */,
+				9CB0F21222D0AA8F9B366E9C /* Errors.swift in Sources */,
+				EF05D7EE3C12A7328BD456A3 /* Dictionary+Extensions.swift in Sources */,
+				C2756B617E6853475E1BC42E /* Optional+Extensions.swift in Sources */,
+				44622704B435724FB4323D8E /* PBXGroup+Extensions.swift in Sources */,
+				BDE206BDB3298C69CA41B968 /* PBXProductType+Extensions.swift in Sources */,
+				ECB77E6A35606D6E3D7118EB /* PBXTarget+Extensions.swift in Sources */,
+				A08DBDBB61E7EC796A776996 /* Path+Extensions.swift in Sources */,
+				4E036B2B9F840B4DEE6E8086 /* Platform+Extensions.swift in Sources */,
+				24772E2C413258416674E0D2 /* Sorting.swift in Sources */,
+				7FC02B3664AF691C07A5A40A /* String+Extensions.swift in Sources */,
+				FEA8A4C363F17B49DE460E45 /* TargetIDConsolidatedTargetKeyDictionary+Extensions.swift in Sources */,
+				687AC29CB99480CDF13FC39D /* TargetIDTargetDictionary+Extensions.swift in Sources */,
+				841A2B1BA4B1AECACF4DC2FE /* XCScheme+Extensions.swift in Sources */,
+				364DD825AA096D678B3DDC59 /* XCSchemeEnvironmentVariables+Extensions.swift in Sources */,
+				99CCE7639C8B8808981FB146 /* XcodeScheme+Extensions.swift in Sources */,
+				15B92949E7279487C712D85A /* FilePathResolver.swift in Sources */,
+				C1E5D462186CF4729A9F9CB9 /* AddBazelDependenciesTarget.swift in Sources */,
+				FD24651519FCDE26F80982A1 /* AddTargets.swift in Sources */,
+				4A34D2AFB9762C1542A01C8B /* ConsolidateTargets.swift in Sources */,
+				DEE00D0960CE14801F2DC048 /* CreateAutogeneratedXCSchemes.swift in Sources */,
+				9C030AD53C363F9D3EF4F996 /* CreateCustomXCSchemes.swift in Sources */,
+				D044901213B465B69E609833 /* CreateFilesAndGroups.swift in Sources */,
+				3D7D9E55C8F11F4D9AE08F13 /* CreateProducts.swift in Sources */,
+				6F79BA8BD3DE3BBB7D1CA907 /* CreateProject.swift in Sources */,
+				615D3340F3DE1787F7AF4463 /* CreateXCSharedData.swift in Sources */,
+				0D05FEB20C1D31F5C5B1560D /* CreateXcodeProj.swift in Sources */,
+				7DAD46576F5118FA91ED13DB /* DisambiguateTargets.swift in Sources */,
+				007B16321E95A3F5ADCF5245 /* Environment.swift in Sources */,
+				D676630F1620BAC0223F6A96 /* Generator.swift in Sources */,
+				B0662ED0FA83DE84A57B93FF /* Main.swift in Sources */,
+				094FC88B62E8888251AC426F /* PopulateMainGroup.swift in Sources */,
+				10D5AB76441FDACB75040173 /* ProcessReplacementLabels.swift in Sources */,
+				2164512385B75D2A11B9D81D /* ProcessTargetMerges.swift in Sources */,
+				CE633D8966137D9C4F82B916 /* SemanticVersion.swift in Sources */,
+				C572F7558C1A5C73EFEC7507 /* SetTargetConfigurations.swift in Sources */,
+				2FB0CDAC829C35AB56353E5C /* SetTargetDependencies.swift in Sources */,
+				2A015663F38F06BE6AFB5E2E /* TargetResolver.swift in Sources */,
+				1669AFCA8D50EE60AA4C0351 /* WriteXcodeProj.swift in Sources */,
+				F1C4D818998A5A66D31C794E /* XCSchemeInfo+BuildActionInfo.swift in Sources */,
+				2C0A6DE0A9807483DF671B0C /* XCSchemeInfo+BuildTargetInfo.swift in Sources */,
+				DC9E0B07E1F028A6C24949C7 /* XCSchemeInfo+HostInfo.swift in Sources */,
+				5987C9D482D1ABB8C5513338 /* XCSchemeInfo+LaunchActionInfo.swift in Sources */,
+				DBC4D9B30FC2F4466F52336D /* XCSchemeInfo+OtherActionInfos.swift in Sources */,
+				AABA1ECDDD4C5E04F1DB21AA /* XCSchemeInfo+PrePostActionInfo.swift in Sources */,
+				08FCE8EED64E63BD646163C7 /* XCSchemeInfo+ProfileActionInfo.swift in Sources */,
+				185FDEB55130E7FF1C2AC09B /* XCSchemeInfo+TargetInfo.swift in Sources */,
+				0A73996503F90E3A5F5EA67C /* XCSchemeInfo+TestActionInfo.swift in Sources */,
+				DF7079F64B57749F3C4B7A77 /* XCSchemeInfo+VariableExpansionContextInfo.swift in Sources */,
+				70F1FAC6133F5AC1E8217C29 /* XCSchemeInfo.swift in Sources */,
+				3CC1B61E55C316B0AF890309 /* XcodeScheme+BuildFor.swift in Sources */,
+				384FB084858E2308E9BE1B10 /* Logger.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2320,6 +2464,12 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 1B37F14BCD93FD7AB94FD7E0 /* PBXContainerItemProxy */;
 		};
+		0E371ECA4C09BB68C6AE0588 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = OrderedCollections;
+			target = 023B2C041CD79AF5B2FDAFE1 /* OrderedCollections */;
+			targetProxy = 0B68E48961CEDB45BDC67383 /* PBXContainerItemProxy */;
+		};
 		248C27B8CD62810B45507CD6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -2337,6 +2487,12 @@
 			name = PathKit;
 			target = 4A2EC1B2D6969F717CB890DE /* PathKit */;
 			targetProxy = CD181E6AF3DFD2EF12094EE5 /* PBXContainerItemProxy */;
+		};
+		2CDEBBC842A0E659F12E12E4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = XcodeProj;
+			target = A09CE18EBBDAC65CD0C6B7D1 /* XcodeProj */;
+			targetProxy = F3EAC92A418BBFEBF1666E99 /* PBXContainerItemProxy */;
 		};
 		3880438A5A38C4F764B735E5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2362,6 +2518,12 @@
 			target = 7E7D155EBCA520F35DEA3571 /* BazelDependencies */;
 			targetProxy = 8F6708A57B268EEC25458F4B /* PBXContainerItemProxy */;
 		};
+		6A8B144B2EF03C75CE4E5F98 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PathKit;
+			target = 4A2EC1B2D6969F717CB890DE /* PathKit */;
+			targetProxy = 82A5FB7A1D2CD0FCF74CB1A0 /* PBXContainerItemProxy */;
+		};
 		77B8BAE8D4D903333ACE2953 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = BazelDependencies;
@@ -2385,12 +2547,6 @@
 			name = XCTestDynamicOverlay;
 			target = 9DF90F35406923EA23C68CFC /* XCTestDynamicOverlay */;
 			targetProxy = 34739E478519DAF595040254 /* PBXContainerItemProxy */;
-		};
-		C0C4842B0D633EDDA463F849 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = generator.library;
-			target = F12050E30563A81EEBB2EA9B /* generator.library */;
-			targetProxy = CE545ADAA24F8CEBE7071545 /* PBXContainerItemProxy */;
 		};
 		C30AA64369888C8FA44AC46B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2687,39 +2843,38 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_LABEL = "//tools/generator:generator";
 				BAZEL_OUTPUTS_PRODUCT = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/tools/generator/rules_xcodeproj/generator/generator";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/tools/generator";
 				BAZEL_TARGET_ID = "//tools/generator:generator applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
-				COMPILE_TARGET_NAME = generator;
+				COMPILE_TARGET_NAME = generator.library;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_LOCATION = NO;
 				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				EXECUTABLE_EXTENSION = "";
 				GCC_OPTIMIZATION_LEVEL = 0;
 				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/tools/generator/generator.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				OTHER_CFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
-				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
+				PRODUCT_MODULE_NAME = generator;
 				PRODUCT_NAME = generator;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_apple_swift_collections $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_kylef_pathkit $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_tadija_aexml $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_tuist_xcodeproj";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = generator;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin",
+					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin",
 				);
 			};
 			name = Debug;

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/tools/generator/generator.link.params
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/tools/generator/generator.link.params
@@ -10,7 +10,6 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/tools/generator/libgenerator.library.a
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000/bin/external/com_github_tadija_aexml/libAEXML.a

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -106,6 +106,10 @@
         "//tools/generator/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000",
         [
             "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000"
+        ],
+        "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000",
+        [
+            "//tools/generator:generator applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000"
         ]
     ],
     "targets": [

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -24,7 +24,9 @@
 /* Begin PBXBuildFile section */
 		009666EE93ACF20D701DA0F6 /* OrderedDictionary+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B00CE77FF2B9CC3467460EF /* OrderedDictionary+Deprecations.swift */; };
 		013F331BE2393C1B0227DC2A /* OrderedDictionary+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CDB76232520C291EA49AF3E /* OrderedDictionary+CustomStringConvertible.swift */; };
+		017E3750517AA58C67732319 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C94B3E50786E16F2593999E /* String+Extensions.swift */; };
 		01E9107F5BA31A99809DB660 /* XCSchemeInfo+TestActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E35F12056F276F87B80027 /* XCSchemeInfo+TestActionInfo.swift */; };
+		02090E062598309317CBC063 /* XCSchemeEnvironmentVariables+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBA80C955F05937FF1F85F6 /* XCSchemeEnvironmentVariables+Extensions.swift */; };
 		0211E9F4E28AF5AACDA18BE0 /* _Hashtable+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8C5EDE827922E2C3C04DA62 /* _Hashtable+Header.swift */; };
 		02AE0767BCC9FAA366FA5477 /* XCScheme+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531D200EA8FCF2159E14EB83 /* XCScheme+Extensions.swift */; };
 		02CB4630B04CA81FA5D198F6 /* CommentedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03610C8A88B668CC0E52047B /* CommentedString.swift */; };
@@ -32,13 +34,21 @@
 		03C06C472EA5126C439849F2 /* OrderedDictionary+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA83272F166637CFAFC4C79C /* OrderedDictionary+Hashable.swift */; };
 		03F8083C1314D2DF150F0345 /* CreateProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725DDF6095196743B9BC444A /* CreateProducts.swift */; };
 		0449C2D6F2A01D6B7A98C752 /* PBXTarget+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1133DC1402E9C43EE1126DC4 /* PBXTarget+ExtensionsTests.swift */; };
+		04E2B689E90CB1191865FB82 /* XCSchemeInfo+ProfileActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763B7ADA326CBFF61D3ED7BB /* XCSchemeInfo+ProfileActionInfo.swift */; };
 		06DBC257CCBC0358FA28EB69 /* XCVersionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99F1E8A6B15665DC88FDE6F0 /* XCVersionGroup.swift */; };
 		09A8A87A1E98CA31ABDF94DA /* XCRemoteSwiftPackageReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = A736DF0EDF5D152163A2C7AE /* XCRemoteSwiftPackageReference.swift */; };
+		0A59370FF57FFBCE21665B2F /* WriteXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E387A13DAF448267F1B6410 /* WriteXcodeProj.swift */; };
 		0B06F16B6814BDD36D863BDF /* CreateProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E200ED9999C2E4E55C7EC34E /* CreateProjectTests.swift */; };
 		0C0684F526818ABFCEC92D99 /* XCSchemeInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E789F2E927A58F92C98E98F5 /* XCSchemeInfoTests.swift */; };
+		0C20B16AF81C619443FD9A62 /* XCSchemeInfo+BuildTargetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D040528AE60871FBC180F7C7 /* XCSchemeInfo+BuildTargetInfo.swift */; };
+		0C5590603951CA0566AD33D0 /* XCSchemeInfo+VariableExpansionContextInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB6765F693F0FCA5E5D0A43 /* XCSchemeInfo+VariableExpansionContextInfo.swift */; };
 		0C9998F93EE859EDA61355AF /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D740A39A7753D2B8D21F375 /* PBXNativeTarget.swift */; };
+		0CAF2947F065E1DA1055EC8A /* CreateProducts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 725DDF6095196743B9BC444A /* CreateProducts.swift */; };
 		0D05D88A81FF1ED06AE2BF8B /* SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5320E25757AF149A406D12 /* SwiftUI.swift */; };
+		0D600B275A8F35F0D020DDE1 /* XCSchemeInfo+BuildActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3779D7A3D483AEB25462E7D /* XCSchemeInfo+BuildActionInfo.swift */; };
 		0E16E95D724F1693E1638E94 /* PBXBatchUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = E842D0488C59F4DFAA82FE0E /* PBXBatchUpdater.swift */; };
+		0E70E4BC7CF4B902F0421FC3 /* CreateXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABDF55F0487BB767BB1D401 /* CreateXcodeProj.swift */; };
+		0EC0C4357302F5DC8A5F8991 /* ConsolidateTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392B3A5E6E7324FFD3A3C2C2 /* ConsolidateTargets.swift */; };
 		0FE35AC9CA2FD941D6EF609F /* CreateCustomXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B231AE68988CA7FE86A2B1D9 /* CreateCustomXCSchemes.swift */; };
 		10CC1CB0ECBB0BC5D1AED0EF /* Optional+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0BC8973AD5F053E31C849B4 /* Optional+ExtensionsTests.swift */; };
 		114337D1EE92A54BD108429D /* XCScheme+SerialAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3EB849AA377331B54327E0 /* XCScheme+SerialAction.swift */; };
@@ -52,12 +62,15 @@
 		18CCAFACA2EAB16C738E8D47 /* FilePathResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C2FB94A951A108189B85C1 /* FilePathResolverTests.swift */; };
 		191D41C12EAB8E6F7E406722 /* ReferenceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF2375E72B499C63E3F5AD9 /* ReferenceGenerator.swift */; };
 		1999A73F4F5FEA349DBBED1E /* CreateXCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FBB3302F67B6F51AA1BDFF /* CreateXCSharedData.swift */; };
+		1AD7929A8549BF008FC3DE2D /* Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D073BBDC72BB903314DDADAB /* Sorting.swift */; };
 		1ADFC6401059C141C1C36BFD /* XCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B07275B921C286B94BB3C7 /* XCSharedData.swift */; };
 		1B476ADB9843463BFD8FF847 /* SemanticVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CB639A3FE94348D9BE05DF /* SemanticVersionTests.swift */; };
 		1E0464BA046E4E097616AE8A /* Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D073BBDC72BB903314DDADAB /* Sorting.swift */; };
 		1E7D75AC37D768918BCCFCE0 /* OrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A2CD4E3695EB2BA3CCAAA5 /* OrderedSet.swift */; };
+		1EB517DA2C36FF048A1FEEFA /* Outputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC96161706C3865948E383F4 /* Outputs.swift */; };
 		1F32D3E1F5D84EFCED1F8922 /* PBXProj+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF925DC93003F74678BEE77 /* PBXProj+Testing.swift */; };
 		21B00BEE8064294C920A86C7 /* PBXLegacyTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DB88104FABFF99C3A03C9D /* PBXLegacyTarget.swift */; };
+		21CC50AE5F161AEE412D8435 /* TargetIDTargetDictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C204D1CFF922CE40D3737C /* TargetIDTargetDictionary+Extensions.swift */; };
 		2203DC213FF373396B4426F1 /* PlistValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D6B3354C3E668C09520A602 /* PlistValue.swift */; };
 		2262CB701AFEBB9E636E2F11 /* OrderedDictionary+Elements+SubSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CF3CD21700E806EDB5A456B /* OrderedDictionary+Elements+SubSequence.swift */; };
 		2270950802F9E098901D5269 /* XCScheme+BuildAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 853EA8CC3F834FC8FE6F6A57 /* XCScheme+BuildAction.swift */; };
@@ -68,14 +81,18 @@
 		2658FAB31BA3058C99307C94 /* OrderedDictionary+Partial RangeReplaceableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE17D3B71DBB9EBF4B57169C /* OrderedDictionary+Partial RangeReplaceableCollection.swift */; };
 		28946F3555969302FA53198F /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF689834C09921E2FD1AF2C5 /* Optional+Extensions.swift */; };
 		28CB912ABA9C1989FBAFC1C6 /* PBXCopyFilesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CAD8F80C7070DBFB5989DC /* PBXCopyFilesBuildPhase.swift */; };
+		293A7ADAAC8894FA5A171632 /* AddBazelDependenciesTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD2C5C93092DF2E3566A50E /* AddBazelDependenciesTarget.swift */; };
 		295F0D84D3FAF49CF3D619D8 /* XCScheme+TestPlanReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 061432D2FB4C6E299ACD72D1 /* XCScheme+TestPlanReference.swift */; };
+		29DB00277BBE2E52B7A5E44E /* LLDBContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F864B729FC2C55DF15D2009F /* LLDBContext.swift */; };
 		2B291E95CCB447383EB7AE87 /* XCScheme+EnvironmentVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E22FB6646E89CD0F8B7C2C39 /* XCScheme+EnvironmentVariable.swift */; };
 		2B31FB04E965385B979B1B73 /* TargetID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C939880AE9469811A47AFE6F /* TargetID.swift */; };
 		2B5CE87F591A88AE69E2EA93 /* CustomDumpRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88789669F25DD7E154C15036 /* CustomDumpRepresentable.swift */; };
 		2BD18052028822D1FE63D914 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA8300A923E77CF6E78CD16 /* Project.swift */; };
 		2C881AC89D508171A6B291C3 /* TargetIDTargetDictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C204D1CFF922CE40D3737C /* TargetIDTargetDictionary+Extensions.swift */; };
+		2DD78E94B677D8D21F53C84A /* XCSchemeInfo+PrePostActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84B2291E79EBD2928DB50424 /* XCSchemeInfo+PrePostActionInfo.swift */; };
 		2EF43FD3B7F4AA363B0EE6CF /* SchemeAutogenerationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2C605A9270255AFA43DD80 /* SchemeAutogenerationMode.swift */; };
 		2F23E98B7032105D6B0D28C8 /* OrderedSet+UnstableInternals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8415E01540549AB7D9DC7775 /* OrderedSet+UnstableInternals.swift */; };
+		2F47D5E5C85771C085E327DA /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AC5E89AB62E41A76C6C29A /* Dictionary+Extensions.swift */; };
 		322A732C4364DDAEC21E0A64 /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73F15BBF795A9572A83DF08 /* TargetIDConsolidatedTargetKeyDictionary+ExtensionsTests.swift */; };
 		32A37E02A2B30E7E64730582 /* ProcessReplacementLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D71D769D445395EE393A05F /* ProcessReplacementLabels.swift */; };
 		3468B9267DEA583FB703DC62 /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB78F15F8AFA4FD268CBC7BD /* KeyedDecodingContainer+Additions.swift */; };
@@ -83,7 +100,6 @@
 		37B871D3339996C12526978C /* XCScheme+TestAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0BD1CBCC9A4B6877AA90F0 /* XCScheme+TestAction.swift */; };
 		37D980D7EF5382A6BB2247E3 /* SetTargetConfigurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 280848D0817DF92FDA8FBCE5 /* SetTargetConfigurations.swift */; };
 		38AE84880236CAE285E3EAB0 /* OrderedSet+Diffing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168458212BA2875894C312C /* OrderedSet+Diffing.swift */; };
-		3923531348904B44EC050F3E /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = C1427F45C783EFE20E49B1E4 /* _CompileStub_.m */; };
 		39F5E28C6FE936CA12EE0D71 /* OrderedSet+ExpressibleByArrayLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = D11ACB222035337C305B1ED6 /* OrderedSet+ExpressibleByArrayLiteral.swift */; };
 		3AC6936A00E842FC9B99D112 /* ProcessTargetMerges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BEEDE29672654306B1EF30 /* ProcessTargetMerges.swift */; };
 		3AF702D3EEB45A95468F844D /* CustomDumpStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4412107ACE8EBEC22DB50106 /* CustomDumpStringConvertible.swift */; };
@@ -92,13 +108,16 @@
 		3CB04E4508E9C80D7ECF9E14 /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FAAE1D6B517FE827477880B /* SemanticVersion.swift */; };
 		3CC3CF23728FFF27C3332D92 /* DisambiguateTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85F30A6B61E80F5E31CB607 /* DisambiguateTargetsTests.swift */; };
 		3CE7DB7A952F0BB1CC385D2E /* PBXProjEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9125F5C08D2ECD569EE90D8D /* PBXProjEncoder.swift */; };
+		3CFF2C1C9CA490A81F132B36 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D5358A8116F9302A3808730 /* Errors.swift */; };
 		3D01B6AFC10CED93F041478D /* BuildSettingsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E960E7EE6E2FD116C069453 /* BuildSettingsProvider.swift */; };
+		3D1EECA3BE3CEFD0F474D42E /* XCSchemeInfo+LaunchActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35081833D536B6E2517370AA /* XCSchemeInfo+LaunchActionInfo.swift */; };
 		3D9A78660D051C58D312CA3A /* XcodeProj+CustomDump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598C59FCAC898D6EE23D2CA4 /* XcodeProj+CustomDump.swift */; };
 		3DF3A8E137A26A0B4A8E6609 /* PBXObjectReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = D55EC3436DD504C4BA9A535A /* PBXObjectReference.swift */; };
 		3F4A202E0F23ACC4AEAE5635 /* Target+LinkerFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4392570A140F71AA49560BF /* Target+LinkerFlags.swift */; };
 		407195E0CF479DF499A2DFA8 /* Dictionary+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E319F570B6FA210748E02A2 /* Dictionary+ExtensionTests.swift */; };
 		40925E098B63DCA621A05D22 /* PBXGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDB74D3730A6741F0EBA95CF /* PBXGroup.swift */; };
 		42197EE31143ACFA49F3B0A6 /* CreateProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D646A224A24D4C9E2C8571F /* CreateProject.swift */; };
+		43186E06D00925D3A53F0C1D /* Target.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B450789447FD4495CA19F19 /* Target.swift */; };
 		43597B68A207D3425F0F3F87 /* PBXGroup+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC31D565637D2B8358F9BB7 /* PBXGroup+Extensions.swift */; };
 		4398E46F821E5786EDB024F1 /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCA334E10977F8A11144FFE /* PBXObject.swift */; };
 		43DF4DC9B210E7A0E77AF0B1 /* SetTargetDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408CF783037AE69DA1F0AA9C /* SetTargetDependencies.swift */; };
@@ -113,6 +132,7 @@
 		49A755A42F9F52D030ACDB54 /* OrderedDictionary+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5A44C529ECD155E874667A6 /* OrderedDictionary+Equatable.swift */; };
 		49B873302CFA8778E1F01156 /* OrderedSet+CustomReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 579E550B396E5D50AFB0F114 /* OrderedSet+CustomReflectable.swift */; };
 		4AC11B356CF42741EDE0A5AF /* XCScheme+BuildableProductRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B58E5139DFE06BFC1412642 /* XCScheme+BuildableProductRunnable.swift */; };
+		4B1301EF0E417CC9E89CA911 /* Platform+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB0209755A2B7473D1CD0415 /* Platform+Extensions.swift */; };
 		4BC4F50385C52313E03F4646 /* PBXAggregateTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6C4C6E0602ADE6E5FBAE206 /* PBXAggregateTarget.swift */; };
 		4CFAD61A525D580F5532AB12 /* CoreLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE02F42B39232603B27F1E90 /* CoreLocation.swift */; };
 		4D7DC641F626B31B69ACD7CE /* OrderedDictionary+Elements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27146594D2586076268359D4 /* OrderedDictionary+Elements.swift */; };
@@ -128,25 +148,32 @@
 		54369ADD417A2B0936ABF651 /* XcodeSchemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 275A1D7912B9334C0E3A2931 /* XcodeSchemeTests.swift */; };
 		5506B4252CAAE4E99A1F6305 /* Xcode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85719B580D4DD168206038E1 /* Xcode.swift */; };
 		557BF7507A3798A7DB119838 /* ConsolidatedTargetExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53506B77928F8228012289D3 /* ConsolidatedTargetExtensionsTests.swift */; };
+		558699627030E11670907D56 /* XcodeScheme+BuildFor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319F19FA2255D4B38702C1D5 /* XcodeScheme+BuildFor.swift */; };
+		55E706D3859F5058E6DCDB7F /* Target+LinkerFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4392570A140F71AA49560BF /* Target+LinkerFlags.swift */; };
 		56B79FA316DC4D17D7633323 /* BuildMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D3AD9C0FCEA5D8F2712060 /* BuildMode.swift */; };
 		5882D06AA8D8637C76C6DC33 /* UserNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04CD2B0E70289D9F162FA3E1 /* UserNotifications.swift */; };
 		5984E222D27493D3C041A945 /* XCScheme+PathRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710E99FC78CD9522F4418635 /* XCScheme+PathRunnable.swift */; };
 		59E7A071C1A3448B297846D4 /* ConsolidatedTargetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0FEDB45F02638177A108FC /* ConsolidatedTargetTests.swift */; };
+		5C1B8DA9D91C02A30897619B /* CreateFilesAndGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1A83BA1EEA7A392C83C327 /* CreateFilesAndGroups.swift */; };
+		5CEAF5D6AEBDAB906C05675F /* TargetID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C939880AE9469811A47AFE6F /* TargetID.swift */; };
 		5DAC27354FAE32C67BC99DB6 /* XCSchemeEnvironmentVariables+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBA80C955F05937FF1F85F6 /* XCSchemeEnvironmentVariables+Extensions.swift */; };
 		5E86FF5B228AE32DAB9CE44A /* BuildSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9570F5DB90273906103037E /* BuildSettings.swift */; };
 		5ECED6299B24791AC2FDCE47 /* LinkerInputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C019F3F4CCAA69A6F5565C0D /* LinkerInputs.swift */; };
 		5EF5621C9A6500F51F653FC6 /* XCSchemeInfo+TargetInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D1C4E06D92897ECCFB808A /* XCSchemeInfo+TargetInfoTests.swift */; };
 		5F50664E006EE645FFC8B076 /* CreateXcodeProjTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC5B799900C53A6F581CF62 /* CreateXcodeProjTests.swift */; };
 		60356CFF6DE55ED0B3BFEB50 /* BazelLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C17B4CCC3DB3DC6D8775CE0 /* BazelLabelTests.swift */; };
+		608114D6C786BE9DEC54FC9A /* XCSchemeInfo+HostInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A19324EEB6DC61A66DA1BDD /* XCSchemeInfo+HostInfo.swift */; };
 		61F25C0B5AC2A8359DCF19B2 /* _UnsafeBitset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA9BF8DE4218EEF99B853E /* _UnsafeBitset.swift */; };
 		6369CED21308DDA9A2944D1F /* XCSchemeInfo+HostInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D52B5BEE694F34BAF8F9FE /* XCSchemeInfo+HostInfoTests.swift */; };
 		6391E19BA65B932640B87E40 /* XCSchemeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57820808DA8AE77A8746397 /* XCSchemeInfo.swift */; };
 		641C7B1D35514491C48E478C /* Path+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0277C77247B53722A111757 /* Path+Extras.swift */; };
 		65267FBDE7D0B453B46A4E36 /* XCConfigurationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5909E222A81AD5E732C7A9 /* XCConfigurationList.swift */; };
+		6699FEC79B9F3911B45CB983 /* PBXProductType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CF865CD92AF227C4505C9F /* PBXProductType+Extensions.swift */; };
 		66B889361138116A6C81F646 /* TargetIDTargetDictionary+ExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937EB7D799849987D5B9C7D0 /* TargetIDTargetDictionary+ExtensionsTests.swift */; };
 		66D16F801B599D0D300B8445 /* XCScheme+LaunchAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E300C52FE8308C8610DDCA2 /* XCScheme+LaunchAction.swift */; };
 		67233541C561BF2B646E0691 /* XCWorkspaceDataElementLocationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198C3110BC4D1378F886FABB /* XCWorkspaceDataElementLocationType.swift */; };
 		68A371646C2B0DB2E26FBDBE /* XCSchemeInfo+OtherActionInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027E9B9019409A4B799BF4E8 /* XCSchemeInfo+OtherActionInfos.swift */; };
+		69B7B0CDA45B9A4B1A3CC7FB /* TargetIDConsolidatedTargetKeyDictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433A428C2711607E85545BD4 /* TargetIDConsolidatedTargetKeyDictionary+Extensions.swift */; };
 		69F20613E945D04313E4C5AE /* Path+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34470E90F69D7ED48ABEC831 /* Path+Extensions.swift */; };
 		6B508F325A109B724C7DF650 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70BD10545E43D4098F65BF1B /* PBXResourcesBuildPhase.swift */; };
 		6BD9A192D0DD98964D796656 /* LLDBContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F864B729FC2C55DF15D2009F /* LLDBContext.swift */; };
@@ -156,6 +183,9 @@
 		6EF7A6EF7F6EEB70C10F0236 /* OrderedSet+Partial SetAlgebra+Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87B383CA6F0E63B5353F77F /* OrderedSet+Partial SetAlgebra+Operations.swift */; };
 		6F61010786D4B33B64E17B4D /* PopulateMainGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6B5CD016EB8EEC1665310A /* PopulateMainGroup.swift */; };
 		6FDC63528923882F701C96AE /* CreateXcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABDF55F0487BB767BB1D401 /* CreateXcodeProj.swift */; };
+		71B0957307ED8A7E6DF71C36 /* SemanticVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FAAE1D6B517FE827477880B /* SemanticVersion.swift */; };
+		71C2E76FB855C4A803765AE2 /* SearchPaths.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD9B208E7717F3D77B8335F3 /* SearchPaths.swift */; };
+		72009B32F049F52B6F3623A4 /* XcodeScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA9C49FC544ACD97566F1E4 /* XcodeScheme.swift */; };
 		72049B7D69FF7FD021452042 /* Writable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEFE87E1BA432999CAE565E4 /* Writable.swift */; };
 		73AC905D0A5BCA30C4E708CE /* CreateXCSharedDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6160799DF1E959D7EF7F1CDB /* CreateXCSharedDataTests.swift */; };
 		7409FB4D1290B6C3D1A84D54 /* XCScheme+Runnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1267D8B9A2E0172402C0AD0C /* XCScheme+Runnable.swift */; };
@@ -163,13 +193,16 @@
 		749B0793FC0A4EECC80ADB28 /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 850F1749D2A1AD1CFDC0018B /* Dictionary+Extras.swift */; };
 		74BE9529D3022CC8ED1EF4BC /* PBXSourceTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1823B73B5FA76655C55208 /* PBXSourceTree.swift */; };
 		7707F8E8F006A7AC6E1BC2BB /* PBXVariantGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F59053C0267E06F04377233 /* PBXVariantGroup.swift */; };
+		77B153F0F2C9113A2CD8222A /* CreateCustomXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B231AE68988CA7FE86A2B1D9 /* CreateCustomXCSchemes.swift */; };
 		77E785B4F7C260C0196852B3 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C94B3E50786E16F2593999E /* String+Extensions.swift */; };
 		79F53950A8310BF2A491669C /* XCTAssertNoDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 246DA27DDBB9DDC350093B5E /* XCTAssertNoDifference.swift */; };
+		7B3CD96BD357287A942E4201 /* XCCurrentVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93C0B18E2C3A64A586148442 /* XCCurrentVersion.swift */; };
 		7B645D49A5AC42B87FA526EF /* XCTFail.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB715BB44E25F5C1330F19A /* XCTFail.swift */; };
 		7BBFD440672C1CBE317C9204 /* BazelLabel+TestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD4DFC45C9538AD37FAE2610 /* BazelLabel+TestExtensions.swift */; };
 		7C9193A9C51ECD915E3D66D4 /* Decoders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D850DED77E2FF12781EB199 /* Decoders.swift */; };
 		7CE9451EDC30D4E9AFDD510D /* XCSchemeInfo+PrePostActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CA81A8DCDE1EA3E4C12C65 /* XCSchemeInfo+PrePostActionInfoTests.swift */; };
 		7EE254C9A072AC8581825BBD /* XCSchemeInfo+VariableExpansionContextInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65242AFF0051C0022BD8327B /* XCSchemeInfo+VariableExpansionContextInfoTests.swift */; };
+		7F4C9E6F8759043111688479 /* ProcessTargetMerges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BEEDE29672654306B1EF30 /* ProcessTargetMerges.swift */; };
 		7FDB761F1C5CF4CB8777FD28 /* Dictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AC5E89AB62E41A76C6C29A /* Dictionary+Extensions.swift */; };
 		81082AE9BDF69B75F8F66FFF /* AnyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABAB6A2BBE4B5DB7A7C46B9 /* AnyType.swift */; };
 		8163DAA88E903FCED5EA958C /* Photos.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9501520C482194DB21C3F7C /* Photos.swift */; };
@@ -178,6 +211,7 @@
 		86CBF535AED268AC273CBA78 /* OrderedSet+Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FEDB8A2BE9E625CE7E563BD /* OrderedSet+Initializers.swift */; };
 		87A31E6E62663DEBE6099E9E /* UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F429E38CAA0F9C5F7CBDE63 /* UIKit.swift */; };
 		87B1F5D000D7E3BE6195263A /* OrderedDictionary+CustomReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F6D216045898ECF63040D5E /* OrderedDictionary+CustomReflectable.swift */; };
+		88893C74350592E1DF10F181 /* PopulateMainGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6B5CD016EB8EEC1665310A /* PopulateMainGroup.swift */; };
 		891B99BE1157B9B15A6A5C79 /* WorkspaceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD68E5A7AC6AF524F6B2E4D3 /* WorkspaceSettings.swift */; };
 		891CA7C1DB5C7D8F9B727B6C /* _HashTable+Testing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E8B9C5A208652D1043445D2 /* _HashTable+Testing.swift */; };
 		89DAB71EA5D8EC9FDB226180 /* XCScheme+LocationScenarioReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D748C54DA558132E4013709 /* XCScheme+LocationScenarioReference.swift */; };
@@ -191,22 +225,32 @@
 		90208A3A203AB4E08AE62CC2 /* XCSchemeInfo+VariableExpansionContextInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EB6765F693F0FCA5E5D0A43 /* XCSchemeInfo+VariableExpansionContextInfo.swift */; };
 		91CD4295FE9BCD9EBEEF2B17 /* Array+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F9BEFA618D3A3890BCD95E /* Array+Extras.swift */; };
 		91CF1A0FD3B7354CD5CBB629 /* PathExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B10EBDFE35AB1B27BE34EE2 /* PathExtensionsTests.swift */; };
+		920852CF3BD80982CAA48E43 /* XCSchemeInfo+OtherActionInfos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027E9B9019409A4B799BF4E8 /* XCSchemeInfo+OtherActionInfos.swift */; };
 		949168712DC8282ADD6FF369 /* PBXProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C74A05A5ECD579F928DBBB /* PBXProj.swift */; };
 		94E03F3E14B3B7AAC5E818BE /* XCScheme+ArchiveAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B1B07B1780ED7297DD889B /* XCScheme+ArchiveAction.swift */; };
+		94E5910A46BFC99687D7C057 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF689834C09921E2FD1AF2C5 /* Optional+Extensions.swift */; };
 		9513603529C8D34C341B74ED /* OrderedSet+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 697793A0038D2FB76FD542C4 /* OrderedSet+CustomStringConvertible.swift */; };
 		95D264466C03AFDD8500E4FB /* OrderedSet+Partial SetAlgebra+Basics.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A234AB51A97D97EE651298 /* OrderedSet+Partial SetAlgebra+Basics.swift */; };
 		9763B775672AC96E1AA25415 /* BazelLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAB1232C0C94C42545636DB /* BazelLabel.swift */; };
+		97956BD26D2398A593878ADC /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590304FBC3E994BEFC9D3688 /* Logger.swift */; };
+		97A8511839B0F9FDCF449B8E /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374062F4D95CF3BB823766C7 /* Platform.swift */; };
 		97DB9AA49CCEFBBCA98FC229 /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786B15315524DB56CCC1A6E5 /* Bool+Extras.swift */; };
 		9804BBA597E3344B7F9008C4 /* PBXProductTypeExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 354634746D24325319B693F8 /* PBXProductTypeExtensionsTests.swift */; };
+		981D343AE39896C4C5D3585F /* Path+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34470E90F69D7ED48ABEC831 /* Path+Extensions.swift */; };
 		99CBCF0D4F483E3BC08D99AD /* Dump.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4796B5647870377961BBE65A /* Dump.swift */; };
 		9A5CEEDBC2F4FC0335B36BCD /* SetTargetConfigurationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A5A8217D0CFAC29BA439669 /* SetTargetConfigurationsTests.swift */; };
 		9ABEC4D0AA335255B2A4D1A4 /* CollectionDifference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEF63DBDB0E193B58BCE3AC /* CollectionDifference.swift */; };
 		9B07522FBAC308CB7AE1890C /* XCSchemeInfo+ProfileActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763B7ADA326CBFF61D3ED7BB /* XCSchemeInfo+ProfileActionInfo.swift */; };
 		9B221A0902B095434D0D5AE2 /* OrderedDictionary+ExpressibleByDictionaryLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8BB71068908E1D8FA3058CB /* OrderedDictionary+ExpressibleByDictionaryLiteral.swift */; };
+		9B6121813AAA0FC554A81672 /* PBXTarget+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0B229755A3C99CB6195B86 /* PBXTarget+Extensions.swift */; };
 		9CA2255DE2DF1CAABE346248 /* XCScheme+CommandLineArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA008E08C0FBB48956C0C68 /* XCScheme+CommandLineArguments.swift */; };
 		9CBFD908F210AAE96BE7B082 /* XCWorkspaceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16B6BF78C679DF554D56E1B /* XCWorkspaceData.swift */; };
+		9D1D3F7990428ACC5D462645 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4ACDF966B98589F92E7A9B /* Product.swift */; };
+		9F0187037FCAC53A4C2D6C41 /* DisambiguateTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C23AF9F5FC99FE2A6CE2F7 /* DisambiguateTargets.swift */; };
 		A03877D87C04C9CF1E44DEBE /* Mirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99DAF8494DCC143CFA9CC1DD /* Mirror.swift */; };
+		A0DB048B45D53EAB2AD6AD0F /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95295E71F5AAA0600AD576F7 /* Environment.swift */; };
 		A1CCAEB83ED331C40AB31CEE /* XCWorkspaceDataFileRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4ECB52E246E8BC9158A8A4 /* XCWorkspaceDataFileRef.swift */; };
+		A1D3C1D922E2482040920BE0 /* LinkerInputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C019F3F4CCAA69A6F5565C0D /* LinkerInputs.swift */; };
 		A202ACD33F0C252E82EAC198 /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C013403BC161ACF939B4764 /* Diff.swift */; };
 		A21D997A2360B0A3AD571C8D /* XCScheme+StoreKitConfigurationFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C4DF6F2161A395361A6426 /* XCScheme+StoreKitConfigurationFileReference.swift */; };
 		A227D4F190C6B4B774B63529 /* PBXOutputSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 222FB59B457C825D11B08C04 /* PBXOutputSettings.swift */; };
@@ -216,28 +260,36 @@
 		A3D4A654148025D9B361D30A /* XcodeScheme+BuildForTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38546A39685BFC954D0C8AAF /* XcodeScheme+BuildForTests.swift */; };
 		A59934929C4FEDDE45A5207B /* XCScheme+TestItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3B4F8F76D6E7E466DF0BCB /* XCScheme+TestItem.swift */; };
 		A5D66766F9D7772EE82F9FDA /* StoreKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4AAE743094CADD9B1460D18 /* StoreKit.swift */; };
+		A74A98CDB01ED9ACB0FFE26F /* ExtensionPointIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BCE3D30558882AC418F0B4 /* ExtensionPointIdentifier.swift */; };
 		A78684FED72049D4F92F6FAD /* OrderedDictionary+Initializers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FF7D954BC6981F149890B01 /* OrderedDictionary+Initializers.swift */; };
 		A8DB5738284E29AF2C26C019 /* CreateCustomXCSchemesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05DCCA641AA41C40218CFC8D /* CreateCustomXCSchemesTests.swift */; };
 		A9BD7EB305E42D13573F092B /* OrderedSet+Partial MutableCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E672A55CA5879B1199B3F39 /* OrderedSet+Partial MutableCollection.swift */; };
 		AA1ED0B4D05856EC1D8F35F0 /* XCSchemeInfo+BuildActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6105C073844239D812B1D0C1 /* XCSchemeInfo+BuildActionInfoTests.swift */; };
 		AACDE105D330A480D07B435A /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 006BA29C0C61C275AD3E5F44 /* PBXProject.swift */; };
 		ACCFC8CC1CA547C31F16FA1F /* XCScheme+ProfileAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485E69699461E1A9CFC892D1 /* XCScheme+ProfileAction.swift */; };
+		ACDBA43D417EF3B106EA7AE9 /* Inputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A50CE6E3E953B2F9187B002 /* Inputs.swift */; };
 		B1292E7523C5B611C460B343 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95295E71F5AAA0600AD576F7 /* Environment.swift */; };
 		B27EE3DCE1B5E4DF2D2BB6F2 /* PBXTarget+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C0B229755A3C99CB6195B86 /* PBXTarget+Extensions.swift */; };
 		B560A46102AED9D1C8265D63 /* XcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494BAD9675D98C1B1BCD1BFB /* XcodeProj.swift */; };
 		B5BA989A1EDBB491C93A48F0 /* Target.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B450789447FD4495CA19F19 /* Target.swift */; };
 		B5C89CC2C6F28E47EF288629 /* PBXTargetDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C59DDC699C9D9C08B2D93A /* PBXTargetDependency.swift */; };
 		B639A3AAF48B4FAF6215C48F /* OrderedSet+Invariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3C8D9B37CAF9E9F7002DFF /* OrderedSet+Invariants.swift */; };
+		B646DD836FB60500E6C729C5 /* CreateAutogeneratedXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC91D29F90A5B25DDF6BB509 /* CreateAutogeneratedXCSchemes.swift */; };
 		BB05A4ED620B357AD861257C /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0F8185DC1A11CB7F0BF8D23 /* PBXHeadersBuildPhase.swift */; };
+		BB2A147B7900C210CBDC93ED /* SchemeAutogenerationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B2C605A9270255AFA43DD80 /* SchemeAutogenerationMode.swift */; };
 		BC2E4C154778862EC7A6333F /* OrderedDictionary+Invariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2008AEA61834626CAF9F5918 /* OrderedDictionary+Invariants.swift */; };
 		BCB0C579E8E2BE798C2F18C1 /* OrderedDictionary+Values.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15B947E1837B5A93F9780BD6 /* OrderedDictionary+Values.swift */; };
+		BD374DA1BD7FCEE0D0A5B46A /* BuildSettingConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7331459DA932906C5CB4EF4 /* BuildSettingConditional.swift */; };
 		BE39FE10674A194569FE38B0 /* XCWorkspaceDataGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADBC50485D8BD4E7D39B598D /* XCWorkspaceDataGroup.swift */; };
 		BE60D448058D06333F6324F7 /* PBXFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC45BC1DD67C50E86FEE9DC /* PBXFileReference.swift */; };
 		BEE0091A3F4A4CF9661882B5 /* OrderedDictionary+Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC7E223798EECD44147286FC /* OrderedDictionary+Sequence.swift */; };
 		BF4002DC57D0DFBAC2B78B6E /* NSRecursiveLock+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56255215C39346FDD418691E /* NSRecursiveLock+Sync.swift */; };
+		C0AAF01077DD6D4D8E90F401 /* XCSchemeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A57820808DA8AE77A8746397 /* XCSchemeInfo.swift */; };
 		C12EDE78A425CD8F29EF9E2C /* XcodeScheme+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A11691B2EE7577F0E9A1C3 /* XcodeScheme+Extensions.swift */; };
 		C49FF9B99082756D5EC994AC /* XCSchemeInfo+BuildTargetInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54917E30A695186D9D5F27DA /* XCSchemeInfo+BuildTargetInfoTests.swift */; };
+		C57361F900A12605844EAF8F /* FilePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14F770CF5035EED0B12C3D5E /* FilePath.swift */; };
 		C71B0D3BF08FA0D6A81C69E8 /* OrderedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C89A8E11498D40AEF873719 /* OrderedDictionary.swift */; };
+		C73D6124A220D3FFC321F5C3 /* FilePathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FAEBD49D872651BA24005E /* FilePathResolver.swift */; };
 		C83B7926404866B9FDA64B96 /* OrderedSet+RandomAccessCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E252313444698DA3574515 /* OrderedSet+RandomAccessCollection.swift */; };
 		C8739D353CD5E68DD39107CD /* XCScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81C17692FC25C9277D739EDD /* XCScheme.swift */; };
 		C8BA54D164D46FF2BBC50D59 /* _HashTable+UnsafeHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF9F631C9FD3BB3282EF9F9 /* _HashTable+UnsafeHandle.swift */; };
@@ -248,7 +300,10 @@
 		CC39003DA86BE4968F17BF77 /* AddTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF98E68BB721BBDC7289092C /* AddTargets.swift */; };
 		CCEC5458B7AA97B5A5AFA4D6 /* Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B584159BE8C17D78ED2F8B /* Foundation.swift */; };
 		CD4F9E35FD652C589AFA67AF /* _HashTable+Bucket.swift in Sources */ = {isa = PBXBuildFile; fileRef = F989E51F5A4A6F6C61A92D70 /* _HashTable+Bucket.swift */; };
+		CD86D427ED73B2B52499853F /* CreateProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D646A224A24D4C9E2C8571F /* CreateProject.swift */; };
+		CEAE75B2A62B0EDE678F8F63 /* XcodeScheme+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A11691B2EE7577F0E9A1C3 /* XcodeScheme+Extensions.swift */; };
 		D041837F15819387DD408B84 /* OrderedSet+Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CA2DC08D1A87C12C91B467D /* OrderedSet+Codable.swift */; };
+		D1B2B32B385EF2DC2DBD02E7 /* BuildSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6291A9D4888F94F5597DDA02 /* BuildSetting.swift */; };
 		D1BE9F5DF718C90E4EF40DAC /* PBXBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10D89FCF7B5FEC2EB96BB01 /* PBXBuildPhase.swift */; };
 		D1D4186355C24A52D577240B /* UserNotificationsUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CF6CCE92E630FB3BC410DEB /* UserNotificationsUI.swift */; };
 		D1FF2A2A272865879D4B94D2 /* AddTargetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37060CBDC54D48ADDEEA0274 /* AddTargetsTests.swift */; };
@@ -269,6 +324,7 @@
 		D9977932DECB407F3233A390 /* Speech.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FF2ABBD0B6B98E3FDA61828 /* Speech.swift */; };
 		DA9709D60BCB76AA0A878BB4 /* CreateFilesAndGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD1A83BA1EEA7A392C83C327 /* CreateFilesAndGroups.swift */; };
 		DB7EA8F15CAF1FA932FD8433 /* XCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90FC2D965C257C3B93C28D06 /* XCConfig.swift */; };
+		DBE60324C7AEB1D42747DCAC /* XCScheme+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531D200EA8FCF2159E14EB83 /* XCScheme+Extensions.swift */; };
 		DBFC6572F672F0F7DB57E376 /* PBXRezBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 816ABF7E49ECC39FF0C2BD7C /* PBXRezBuildPhase.swift */; };
 		DC8C087E54F34F07F6AF1D09 /* PBXShellScriptBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD728395ABCED96F30DDD20 /* PBXShellScriptBuildPhase.swift */; };
 		DCB475A0CDD931D6F861D386 /* PBXObjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A9D8A89C2E98C67BF8A8AD /* PBXObjects.swift */; };
@@ -282,7 +338,9 @@
 		E145F1D987DDE58833EE7808 /* JSONDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7B75E96572AFED3A0BCC7CB /* JSONDecoding.swift */; };
 		E19180B08C7C3EA16205E36E /* DisambiguateTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C23AF9F5FC99FE2A6CE2F7 /* DisambiguateTargets.swift */; };
 		E198FCBDA92D1FC848928C04 /* XcodeScheme+BuildFor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 319F19FA2255D4B38702C1D5 /* XcodeScheme+BuildFor.swift */; };
+		E1C6D3F858DBFAA7FBC9EFA3 /* Main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7647397F45D0244E2A792F55 /* Main.swift */; };
 		E200D4225A7F2DAB2E305604 /* CreateAutogeneratedXCSchemes.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC91D29F90A5B25DDF6BB509 /* CreateAutogeneratedXCSchemes.swift */; };
+		E28EDB747409B816088F1465 /* CreateXCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FBB3302F67B6F51AA1BDFF /* CreateXCSharedData.swift */; };
 		E3B9CD028DE83CA5191509FD /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A554F01AB6D14BC7DD05E32 /* String.swift */; };
 		E3F9B2B5483E021A5CD0AC53 /* _HashTable+CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E0508567B3931B91F6BFBF4 /* _HashTable+CustomStringConvertible.swift */; };
 		E60FAE0F122844F0C1DD1CCB /* TargetIDConsolidatedTargetKeyDictionary+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433A428C2711607E85545BD4 /* TargetIDConsolidatedTargetKeyDictionary+Extensions.swift */; };
@@ -292,39 +350,51 @@
 		E7F7E0F6FA045613B200DF99 /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3100C1877D8D628B02BF5584 /* PathKit.swift */; };
 		E84EB7F30EF498EE611C239F /* CreateAutogeneratedXCSchemesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 181821882B45322FC2B11EBE /* CreateAutogeneratedXCSchemesTests.swift */; };
 		E84F5846DA369CCADB5DB03E /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2347A143E1E07ADEF7098E12 /* Errors.swift */; };
+		E8ADE7DEF6E46126895131FA /* ProcessReplacementLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D71D769D445395EE393A05F /* ProcessReplacementLabels.swift */; };
 		E8DBF95F59EB114D5B62B1E3 /* XCSchemeInfo+BuildTargetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D040528AE60871FBC180F7C7 /* XCSchemeInfo+BuildTargetInfo.swift */; };
 		E985F185BF4F3796AB9E0727 /* OrderedSet+Partial SetAlgebra+Predicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30F60F75C8E9D96863387FEB /* OrderedSet+Partial SetAlgebra+Predicates.swift */; };
 		E9D9DE1DC0158944F4D3A029 /* PBXFileElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = B62FC8A00E5F4A6A307E20FD /* PBXFileElement.swift */; };
+		EA150718B1C4AEB702634805 /* AddTargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF98E68BB721BBDC7289092C /* AddTargets.swift */; };
 		EA5E6B3611E3040C9C956B50 /* Sourcery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 631FF94DFE5F13AC99391DD3 /* Sourcery.swift */; };
 		EB1AF4DA32F794B836A2161F /* Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3DF1F6D8B6C99E63E3211A /* Swift.swift */; };
+		EB1E5A79CB3AE028648D026A /* PBXGroup+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC31D565637D2B8358F9BB7 /* PBXGroup+Extensions.swift */; };
+		EB685623314C26594FE9342B /* XCSchemeInfo+TargetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10430B01FC239C6F7D75D87D /* XCSchemeInfo+TargetInfo.swift */; };
 		EB808224EAB30438C1CEBC30 /* XCScheme+AnalyzeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F3F095233E80A0695239834 /* XCScheme+AnalyzeAction.swift */; };
+		EB81C1AF4410C532340651B0 /* BuildMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D3AD9C0FCEA5D8F2712060 /* BuildMode.swift */; };
 		EC37590228C9E717EEF3E3EE /* _HashTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A84BD9EDF510637C6C2BB269 /* _HashTable.swift */; };
+		ECCA5EEC0710E79C8E0E0C70 /* TargetResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84520CFC9A7F2C97E2820F14 /* TargetResolver.swift */; };
 		EE91685693ED53C6E4ED1A73 /* XCSchemeManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32785C5FF661E7B65362F3B /* XCSchemeManagement.swift */; };
 		EFE05DEB652354E4E7D17610 /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D4ACDF966B98589F92E7A9B /* Product.swift */; };
 		F04B6A90306F6BC50799ED5D /* GameKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF90B3C2D109FB81429CDF63 /* GameKit.swift */; };
 		F326E592A70EEE8271776DB1 /* OrderedSet+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D5FFDFF77A15D5835E0E62A /* OrderedSet+Hashable.swift */; };
 		F3C6B34D7DA02C3311D47A73 /* OrderedDictionary+CustomDebugStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5D3E004B591DB4ACA5A68FA /* OrderedDictionary+CustomDebugStringConvertible.swift */; };
 		F43BE9CA61F86296449E282E /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E33D45F79608C7292CC9CA /* PBXContainerItem.swift */; };
+		F45749C3A88339060343B473 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA8300A923E77CF6E78CD16 /* Project.swift */; };
 		F4FC0609C3D762CAC16924D2 /* PBXTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31BC264ECA2884D8C55BD24D /* PBXTarget.swift */; };
 		F577A753538CDA4348644127 /* XCWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD042334686EC625458D787 /* XCWorkspace.swift */; };
+		F67BC2175E5EA66025A2765A /* XCSchemeInfo+TestActionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E35F12056F276F87B80027 /* XCSchemeInfo+TestActionInfo.swift */; };
+		F6C95267A2E56A8D447E717B /* Generator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F558A7D953A3C20394B3D8D0 /* Generator.swift */; };
 		F7AF351045488A3B16AB2A6A /* OrderedSet+CustomDebugStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB6D4C1A760E0F5039DCA16 /* OrderedSet+CustomDebugStringConvertible.swift */; };
 		F7F5AA2F9A629D2B0EAD99CC /* Outputs.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC96161706C3865948E383F4 /* Outputs.swift */; };
 		F8A6256D74FA8C3A7DA7253C /* PBXSourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3134774196A92DDFE6467A90 /* PBXSourcesBuildPhase.swift */; };
+		F98827A935DBBDD02038FA5E /* SetTargetConfigurations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 280848D0817DF92FDA8FBCE5 /* SetTargetConfigurations.swift */; };
 		FAB13E3F45AE78F09CE60F4F /* XCScheme+RemoteRunnable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6438679FD6AB31C5C30165ED /* XCScheme+RemoteRunnable.swift */; };
 		FBD6CC5399F54335BAC4AD08 /* XCSwiftPackageProductDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2432A0EDFA23A5A28222A6E /* XCSwiftPackageProductDependency.swift */; };
+		FBE443B0BFC93A1DE127035E /* SetTargetDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 408CF783037AE69DA1F0AA9C /* SetTargetDependencies.swift */; };
 		FC8F414E5E27000A18EA2767 /* BuildSettingConditional.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7331459DA932906C5CB4EF4 /* BuildSettingConditional.swift */; };
+		FCA43FC6AF85244A81E9B9B8 /* BazelLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCAB1232C0C94C42545636DB /* BazelLabel.swift */; };
 		FD31F0313E6F9BE5D5428129 /* PBXProductType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8CF865CD92AF227C4505C9F /* PBXProductType+Extensions.swift */; };
 		FE0441491AA47513CF076348 /* XCScheme+BuildableReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38B898A6742977CE8C0E174 /* XCScheme+BuildableReference.swift */; };
 		FFBF629A61596A5CC71D8612 /* FilePathResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91FAEBD49D872651BA24005E /* FilePathResolver.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		052BA76161805F1B8304674C /* PBXContainerItemProxy */ = {
+		0BB0E644C279AC184093FAFB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 3A4021D8F5FC68CD4FB8B6F1;
-			remoteInfo = generator.library;
+			remoteGlobalIDString = 19FA71657765A036575B20D8;
+			remoteInfo = XcodeProj;
 		};
 		10F8F2838624AF67BC893D33 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -382,6 +452,13 @@
 			remoteGlobalIDString = B0128CCFCF9E56DA6D808193;
 			remoteInfo = OrderedCollections;
 		};
+		90E75605CFEA0BCAD395A4A6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 299DA591171C10F8AF73F244;
+			remoteInfo = PathKit;
+		};
 		94E23707CC9C8CEEF247C4DB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
@@ -430,6 +507,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = FE59281FE487F27A37DC2EE7;
 			remoteInfo = BazelDependencies;
+		};
+		EF5D6B94657DB4B7C789AE83 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 36B5F79C7ED8B081842AF69D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B0128CCFCF9E56DA6D808193;
+			remoteInfo = OrderedCollections;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -673,7 +757,6 @@
 		BF689834C09921E2FD1AF2C5 /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 		C019F3F4CCAA69A6F5565C0D /* LinkerInputs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkerInputs.swift; sourceTree = "<group>"; };
 		C0277C77247B53722A111757 /* Path+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+Extras.swift"; sourceTree = "<group>"; };
-		C1427F45C783EFE20E49B1E4 /* _CompileStub_.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = _CompileStub_.m; sourceTree = DERIVED_FILE_DIR; };
 		C1A11691B2EE7577F0E9A1C3 /* XcodeScheme+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XcodeScheme+Extensions.swift"; sourceTree = "<group>"; };
 		C317990707348C85FF38D389 /* XCScheme+TestableReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCScheme+TestableReference.swift"; sourceTree = "<group>"; };
 		C3779D7A3D483AEB25462E7D /* XCSchemeInfo+BuildActionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+BuildActionInfo.swift"; sourceTree = "<group>"; };
@@ -1178,15 +1261,6 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
-		6AF936B6BAFAF10DCDAE73D3 /* rules_xcodeproj */ = {
-			isa = PBXGroup;
-			children = (
-				C1427F45C783EFE20E49B1E4 /* _CompileStub_.m */,
-			);
-			name = rules_xcodeproj;
-			path = test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj;
-			sourceTree = "<group>";
-		};
 		71489B62015EDA1167CF520F /* Objects */ = {
 			isa = PBXGroup;
 			children = (
@@ -1216,7 +1290,6 @@
 				BFA9534DF6A126B00EB81FAA /* tools */,
 				85F708DD1F5484A0D5558108 /* Bazel External Repositories */,
 				A5A3DECCB7E56F0EA3676D12 /* Bazel Generated Files */,
-				6AF936B6BAFAF10DCDAE73D3 /* rules_xcodeproj */,
 				462C3519CA354BE1B04D4855 /* Products */,
 				D9AAB93A5135F69103554470 /* Frameworks */,
 			);
@@ -1585,7 +1658,9 @@
 			);
 			dependencies = (
 				10375D5CCD79A0DFFB549B39 /* PBXTargetDependency */,
-				5F445F20107721899DF3B81D /* PBXTargetDependency */,
+				8062471F3F48DEC83D0E2256 /* PBXTargetDependency */,
+				71954AE74C2527094A54E45D /* PBXTargetDependency */,
+				4A2675A12454182FC2A92D0C /* PBXTargetDependency */,
 			);
 			name = generator;
 			productName = generator;
@@ -1760,11 +1835,10 @@
 			name = "Create linking dependencies";
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/link.params",
-				"$(DERIVED_FILE_DIR)/_CompileStub_.m",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\ntouch \"$SCRIPT_OUTPUT_FILE_1\"\n";
+			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		2FB8CA190C5FD287F83F39E3 /* Create swift_debug_settings.py */ = {
@@ -1950,7 +2024,77 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3923531348904B44EC050F3E /* _CompileStub_.m in Sources */,
+				BD374DA1BD7FCEE0D0A5B46A /* BuildSettingConditional.swift in Sources */,
+				FCA43FC6AF85244A81E9B9B8 /* BazelLabel.swift in Sources */,
+				EB81C1AF4410C532340651B0 /* BuildMode.swift in Sources */,
+				D1B2B32B385EF2DC2DBD02E7 /* BuildSetting.swift in Sources */,
+				A74A98CDB01ED9ACB0FFE26F /* ExtensionPointIdentifier.swift in Sources */,
+				C57361F900A12605844EAF8F /* FilePath.swift in Sources */,
+				ACDBA43D417EF3B106EA7AE9 /* Inputs.swift in Sources */,
+				29DB00277BBE2E52B7A5E44E /* LLDBContext.swift in Sources */,
+				A1D3C1D922E2482040920BE0 /* LinkerInputs.swift in Sources */,
+				1EB517DA2C36FF048A1FEEFA /* Outputs.swift in Sources */,
+				97A8511839B0F9FDCF449B8E /* Platform.swift in Sources */,
+				9D1D3F7990428ACC5D462645 /* Product.swift in Sources */,
+				F45749C3A88339060343B473 /* Project.swift in Sources */,
+				BB2A147B7900C210CBDC93ED /* SchemeAutogenerationMode.swift in Sources */,
+				71C2E76FB855C4A803765AE2 /* SearchPaths.swift in Sources */,
+				55E706D3859F5058E6DCDB7F /* Target+LinkerFlags.swift in Sources */,
+				43186E06D00925D3A53F0C1D /* Target.swift in Sources */,
+				5CEAF5D6AEBDAB906C05675F /* TargetID.swift in Sources */,
+				7B3CD96BD357287A942E4201 /* XCCurrentVersion.swift in Sources */,
+				72009B32F049F52B6F3623A4 /* XcodeScheme.swift in Sources */,
+				3CFF2C1C9CA490A81F132B36 /* Errors.swift in Sources */,
+				2F47D5E5C85771C085E327DA /* Dictionary+Extensions.swift in Sources */,
+				94E5910A46BFC99687D7C057 /* Optional+Extensions.swift in Sources */,
+				EB1E5A79CB3AE028648D026A /* PBXGroup+Extensions.swift in Sources */,
+				6699FEC79B9F3911B45CB983 /* PBXProductType+Extensions.swift in Sources */,
+				9B6121813AAA0FC554A81672 /* PBXTarget+Extensions.swift in Sources */,
+				981D343AE39896C4C5D3585F /* Path+Extensions.swift in Sources */,
+				4B1301EF0E417CC9E89CA911 /* Platform+Extensions.swift in Sources */,
+				1AD7929A8549BF008FC3DE2D /* Sorting.swift in Sources */,
+				017E3750517AA58C67732319 /* String+Extensions.swift in Sources */,
+				69B7B0CDA45B9A4B1A3CC7FB /* TargetIDConsolidatedTargetKeyDictionary+Extensions.swift in Sources */,
+				21CC50AE5F161AEE412D8435 /* TargetIDTargetDictionary+Extensions.swift in Sources */,
+				DBE60324C7AEB1D42747DCAC /* XCScheme+Extensions.swift in Sources */,
+				02090E062598309317CBC063 /* XCSchemeEnvironmentVariables+Extensions.swift in Sources */,
+				CEAE75B2A62B0EDE678F8F63 /* XcodeScheme+Extensions.swift in Sources */,
+				C73D6124A220D3FFC321F5C3 /* FilePathResolver.swift in Sources */,
+				293A7ADAAC8894FA5A171632 /* AddBazelDependenciesTarget.swift in Sources */,
+				EA150718B1C4AEB702634805 /* AddTargets.swift in Sources */,
+				0EC0C4357302F5DC8A5F8991 /* ConsolidateTargets.swift in Sources */,
+				B646DD836FB60500E6C729C5 /* CreateAutogeneratedXCSchemes.swift in Sources */,
+				77B153F0F2C9113A2CD8222A /* CreateCustomXCSchemes.swift in Sources */,
+				5C1B8DA9D91C02A30897619B /* CreateFilesAndGroups.swift in Sources */,
+				0CAF2947F065E1DA1055EC8A /* CreateProducts.swift in Sources */,
+				CD86D427ED73B2B52499853F /* CreateProject.swift in Sources */,
+				E28EDB747409B816088F1465 /* CreateXCSharedData.swift in Sources */,
+				0E70E4BC7CF4B902F0421FC3 /* CreateXcodeProj.swift in Sources */,
+				9F0187037FCAC53A4C2D6C41 /* DisambiguateTargets.swift in Sources */,
+				A0DB048B45D53EAB2AD6AD0F /* Environment.swift in Sources */,
+				F6C95267A2E56A8D447E717B /* Generator.swift in Sources */,
+				E1C6D3F858DBFAA7FBC9EFA3 /* Main.swift in Sources */,
+				88893C74350592E1DF10F181 /* PopulateMainGroup.swift in Sources */,
+				E8ADE7DEF6E46126895131FA /* ProcessReplacementLabels.swift in Sources */,
+				7F4C9E6F8759043111688479 /* ProcessTargetMerges.swift in Sources */,
+				71B0957307ED8A7E6DF71C36 /* SemanticVersion.swift in Sources */,
+				F98827A935DBBDD02038FA5E /* SetTargetConfigurations.swift in Sources */,
+				FBE443B0BFC93A1DE127035E /* SetTargetDependencies.swift in Sources */,
+				ECCA5EEC0710E79C8E0E0C70 /* TargetResolver.swift in Sources */,
+				0A59370FF57FFBCE21665B2F /* WriteXcodeProj.swift in Sources */,
+				0D600B275A8F35F0D020DDE1 /* XCSchemeInfo+BuildActionInfo.swift in Sources */,
+				0C20B16AF81C619443FD9A62 /* XCSchemeInfo+BuildTargetInfo.swift in Sources */,
+				608114D6C786BE9DEC54FC9A /* XCSchemeInfo+HostInfo.swift in Sources */,
+				3D1EECA3BE3CEFD0F474D42E /* XCSchemeInfo+LaunchActionInfo.swift in Sources */,
+				920852CF3BD80982CAA48E43 /* XCSchemeInfo+OtherActionInfos.swift in Sources */,
+				2DD78E94B677D8D21F53C84A /* XCSchemeInfo+PrePostActionInfo.swift in Sources */,
+				04E2B689E90CB1191865FB82 /* XCSchemeInfo+ProfileActionInfo.swift in Sources */,
+				EB685623314C26594FE9342B /* XCSchemeInfo+TargetInfo.swift in Sources */,
+				F67BC2175E5EA66025A2765A /* XCSchemeInfo+TestActionInfo.swift in Sources */,
+				0C5590603951CA0566AD33D0 /* XCSchemeInfo+VariableExpansionContextInfo.swift in Sources */,
+				C0AAF01077DD6D4D8E90F401 /* XCSchemeInfo.swift in Sources */,
+				558699627030E11670907D56 /* XcodeScheme+BuildFor.swift in Sources */,
+				97956BD26D2398A593878ADC /* Logger.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2195,6 +2339,12 @@
 			target = 299DA591171C10F8AF73F244 /* PathKit */;
 			targetProxy = 3A1A9FA674016F6D082BD8E2 /* PBXContainerItemProxy */;
 		};
+		4A2675A12454182FC2A92D0C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = XcodeProj;
+			target = 19FA71657765A036575B20D8 /* XcodeProj */;
+			targetProxy = 0BB0E644C279AC184093FAFB /* PBXContainerItemProxy */;
+		};
 		4AA89D33E273962408747D43 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = XcodeProj;
@@ -2207,12 +2357,6 @@
 			target = CFD3DFAB502EFF52937E5E51 /* CustomDump */;
 			targetProxy = CFBF834907E2F47679529098 /* PBXContainerItemProxy */;
 		};
-		5F445F20107721899DF3B81D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = generator.library;
-			target = 3A4021D8F5FC68CD4FB8B6F1 /* generator.library */;
-			targetProxy = 052BA76161805F1B8304674C /* PBXContainerItemProxy */;
-		};
 		6B1BD6C53E3B9BE4EF005D0C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = generator.library;
@@ -2224,6 +2368,18 @@
 			name = PathKit;
 			target = 299DA591171C10F8AF73F244 /* PathKit */;
 			targetProxy = 5F803C1AC4A2B51D785ED2A9 /* PBXContainerItemProxy */;
+		};
+		71954AE74C2527094A54E45D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = PathKit;
+			target = 299DA591171C10F8AF73F244 /* PathKit */;
+			targetProxy = 90E75605CFEA0BCAD395A4A6 /* PBXContainerItemProxy */;
+		};
+		8062471F3F48DEC83D0E2256 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = OrderedCollections;
+			target = B0128CCFCF9E56DA6D808193 /* OrderedCollections */;
+			targetProxy = EF5D6B94657DB4B7C789AE83 /* PBXContainerItemProxy */;
 		};
 		9180B355ABFEE76581F29E80 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2379,43 +2535,38 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				BAZEL_COMPILE_TARGET_ID = "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889";
+				"BAZEL_COMPILE_TARGET_ID[sdk=macosx*]" = "$(BAZEL_COMPILE_TARGET_ID)";
 				BAZEL_LABEL = "//tools/generator:generator";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator";
 				BAZEL_TARGET_ID = "//tools/generator:generator applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889";
 				"BAZEL_TARGET_ID[sdk=macosx*]" = "$(BAZEL_TARGET_ID)";
 				BUILT_PRODUCTS_DIR = "$(CONFIGURATION_BUILD_DIR)";
-				COMPILE_TARGET_NAME = generator;
+				COMPILE_TARGET_NAME = generator.library;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_LOCATION = NO;
 				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
 				EXECUTABLE_EXTENSION = "";
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GENERATE_INFOPLIST_FILE = YES;
 				LINK_PARAMS_FILE = "$(INTERNAL_DIR)/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/generator.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				OTHER_CFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/xcode-overlay.yaml",
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
-				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(OBJROOT)/xcode-overlay.yaml",
-					"-ivfsoverlay",
-					"$(OBJROOT)/bazel-out-overlay.yaml",
-				);
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
+				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
+				PRODUCT_MODULE_NAME = generator;
 				PRODUCT_NAME = generator;
 				SDKROOT = macosx;
 				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_INCLUDE_PATHS = "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj";
 				SWIFT_OBJC_INTERFACE_HEADER_NAME = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = generator;
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXEC_ROOT)",
-					"$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin",
+					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin",
 				);
 			};
 			name = Debug;
@@ -2496,7 +2647,7 @@
 				OTHER_LDFLAGS = "@$(DERIVED_FILE_DIR)/link.params";
 				OTHER_SWIFT_FLAGS = "-vfsoverlay $(OBJROOT)/bazel-out-overlay.yaml -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -static";
 				PREVIEWS_SWIFT_INCLUDE_PATHS__ = "$(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
-				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump";
+				PREVIEWS_SWIFT_INCLUDE_PATHS__NO = "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj $(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/rules_xcodeproj/generator $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump";
 				PREVIEWS_SWIFT_INCLUDE_PATHS__YES = "$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/test/tests.__internal__.__test_bundle_archive-root $(PREVIEWS_SWIFT_INCLUDE_PATHS__NO)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
 				PRODUCT_MODULE_NAME = tests;

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/generator.link.params
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/generator.link.params
@@ -10,7 +10,6 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a
 $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
 $(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
 $(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -106,6 +106,10 @@
         "//tools/generator/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889",
         [
             "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889"
+        ],
+        "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889",
+        [
+            "//tools/generator:generator applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889"
         ]
     ],
     "targets": [

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -146,8 +146,7 @@ enum Fixtures {
                 path: .generated("a/b.framework"),
                 additionalPaths: [.generated("a/frameworks/b.framework")]
             ),
-            inputs: .init(srcs: ["z.h", "z.mm"], hdrs: ["d.h"]),
-            dependencies: ["A 1"]
+            inputs: .init(srcs: ["z.h", "z.mm"], hdrs: ["d.h"])
         ),
         // "B 2" not having a link on "A 1" represents a bundle_loader like
         // relationship. This allows "A 1" to merge into "A 2".
@@ -2684,8 +2683,6 @@ $(MACOSX_FILES)
             .addDependency(target: pbxTargets["C 1"]!)
         _ = try! pbxTargets.nativeTarget("A 2")!
             .addDependency(target: pbxTargets["R 1"]!)
-        _ = try! pbxTargets.nativeTarget("B 1")!
-            .addDependency(target: pbxTargets["A 1"]!)
         _ = try! pbxTargets.nativeTarget("B 2")!
             .addDependency(target: pbxTargets["A 2"]!)
         _ = try! pbxTargets.nativeTarget("B 2")!

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -92,6 +92,7 @@ def _make(
         _search_paths = search_paths,
         _modulemaps = modulemaps,
         _swiftmodules = tuple(swiftmodules),
+        _linker_inputs = linker_inputs,
         _watch_application = watch_application,
         _extensions = tuple(extensions),
         _app_clips = tuple(app_clips),
@@ -100,7 +101,6 @@ def _make(
         id = id,
         label = label,
         product = product,
-        linker_inputs = linker_inputs,
         inputs = inputs,
         outputs = outputs,
         infoplist = infoplist,
@@ -175,7 +175,7 @@ def _to_dto(
     set_if_true(
         dto,
         "linker_inputs",
-        linker_input_files.to_dto(xcode_target.linker_inputs),
+        linker_input_files.to_dto(xcode_target._linker_inputs),
     )
     set_if_true(
         dto,

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -314,38 +314,11 @@ targets: {}
             target_merge_dests[dest] = new_srcs_ids
 
     target_merges = {}
-    target_merge_srcs_by_label = {}
     for dest, src_ids in target_merge_dests.items():
         if len(src_ids) > 1:
             # We can only merge targets with a single library dependency
             continue
-        src = src_ids[0]
-        src_target = targets[src]
-        target_merges.setdefault(src, []).append(dest)
-        target_merge_srcs_by_label.setdefault(src_target.label, []).append(src)
-
-    non_mergable_targets = {}
-    for src, dests in target_merges.items():
-        src_target = targets[src]
-        for dest in dests:
-            dest_target = targets[dest]
-            for library in linker_input_files.get_top_level_static_libraries(
-                dest_target.linker_inputs,
-            ):
-                if library.owner == src_target.label:
-                    continue
-
-                # Other libraries that are not being merged into `dest_target`
-                # can't merge into other targets
-                non_mergable_targets[file_path(library)] = None
-
-    for src in target_merges.keys():
-        src_target = targets[src]
-        if src_target.product.file_path in non_mergable_targets:
-            # Prevent any version of `src` from merging, to prevent odd
-            # target consolidation issues
-            for id in target_merge_srcs_by_label[src_target.label]:
-                target_merges.pop(id, None)
+        target_merges.setdefault(src_ids[0], []).append(dest)
 
     return (
         targets,


### PR DESCRIPTION
This reverts commit 19c7708bc0e4db49a432cf2f92022261cb5478a6.

With 7215544cc88e9dc5c471470c3472937f01e47090, we no longer have duplicate output errors in Xcode.