### PR TITLE
Reduce unneeded invocations in libtool stub

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/libtool.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/libtool.sh
@@ -6,8 +6,7 @@ while test $# -gt 0
 do
   case $1 in
   *_dependency_info.dat)
-    libtool_version=$(libtool -V | cut -d " " -f4)
-    printf "\0%s\0" "$libtool_version" > "$1"
+    printf "\0 \0" > "$1"
     break
     ;;
   esac

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/libtool.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/libtool.sh
@@ -6,8 +6,7 @@ while test $# -gt 0
 do
   case $1 in
   *_dependency_info.dat)
-    libtool_version=$(libtool -V | cut -d " " -f4)
-    printf "\0%s\0" "$libtool_version" > "$1"
+    printf "\0 \0" > "$1"
     break
     ;;
   esac

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/libtool.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/libtool.sh
@@ -6,8 +6,7 @@ while test $# -gt 0
 do
   case $1 in
   *_dependency_info.dat)
-    libtool_version=$(libtool -V | cut -d " " -f4)
-    printf "\0%s\0" "$libtool_version" > "$1"
+    printf "\0 \0" > "$1"
     break
     ;;
   esac

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/libtool.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/libtool.sh
@@ -6,8 +6,7 @@ while test $# -gt 0
 do
   case $1 in
   *_dependency_info.dat)
-    libtool_version=$(libtool -V | cut -d " " -f4)
-    printf "\0%s\0" "$libtool_version" > "$1"
+    printf "\0 \0" > "$1"
     break
     ;;
   esac

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/libtool.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/libtool.sh
@@ -6,8 +6,7 @@ while test $# -gt 0
 do
   case $1 in
   *_dependency_info.dat)
-    libtool_version=$(libtool -V | cut -d " " -f4)
-    printf "\0%s\0" "$libtool_version" > "$1"
+    printf "\0 \0" > "$1"
     break
     ;;
   esac

--- a/xcodeproj/internal/bazel_integration_files/libtool.sh
+++ b/xcodeproj/internal/bazel_integration_files/libtool.sh
@@ -6,8 +6,7 @@ while test $# -gt 0
 do
   case $1 in
   *_dependency_info.dat)
-    libtool_version=$(libtool -V | cut -d " " -f4)
-    printf "\0%s\0" "$libtool_version" > "$1"
+    printf "\0 \0" > "$1"
     break
     ;;
   esac


### PR DESCRIPTION
Apparently "\0 \0" is valid dependency file contents. This reduces some
extra invocations since we're not using this file right now.
