### PR TITLE
Set `-framework` in `link.params`

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -22,77 +22,41 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		047B00D7313079854921298B /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48754296ACA596286860C0BF /* CryptoSwift.framework */; };
-		0500EC5BE5ABD402F77760FC /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C23E4536260379513114C6AE /* CryptoSwift.framework */; };
 		062F78DA07E4E8134042F380 /* macOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C902EF36FD111B0B777D8FC /* macOSApp.swift */; };
 		0949513138E1D5853C8C6346 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 477A1F7311A2AEC136215514 /* main.m */; };
-		095A702D68F04B13D7DE1458 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49B79A6A845E24A1CE8611CA /* CryptoSwift.framework */; };
 		0D9682670712CC38E3BD6E1B /* AppClip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = 21B075DF13D48A7176B9FD50 /* AppClip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		0E4D91E102B2FB798BAEA5F6 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7401FDA68482F8B5BE018478 /* CryptoSwift.framework */; };
 		0ED9E092401665CD772D41F6 /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71431169BAB0DE07E96B2BE6 /* private_lib.swift */; };
-		1345A48101C47E242F430CD8 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48754296ACA596286860C0BF /* CryptoSwift.framework */; };
-		140520637EE3E1715DEC6A8C /* UIFramework.iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09D60E14FC71B3F5273333D0 /* UIFramework.iOS.framework */; };
 		1496125D0E4221EA2A41AFD3 /* lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE4E9CAD4595F6808189A4D /* lib.swift */; };
 		15FE44AB45026F044B9251A3 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25CC92246E25D54C0057A04C /* Intents.swift */; };
 		179291A8C3345BF95C0654FE /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DD28EBDE6671DB7B6EC15C3 /* Lib.swift */; };
-		17D28C4F6071247D8148BE16 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49B79A6A845E24A1CE8611CA /* CryptoSwift.framework */; };
-		1F4FBB2FDB7D7960FCBBAD3D /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7401FDA68482F8B5BE018478 /* CryptoSwift.framework */; };
 		23FA77A5D050E0AC4A3D3008 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 410CCB97DA9F35B3AD7371CD /* Lib.swift */; };
-		268106B9996EDC881B2E0AA8 /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3333170CE926366B0A03CBF1 /* GoogleMapsBase.framework */; };
-		2CF8CD9DD353DBDD89036E6D /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7401FDA68482F8B5BE018478 /* CryptoSwift.framework */; };
 		2E864B31D98C808A39FC2370 /* AppClip.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB3DC02BD769EC7A61C9D7D7 /* AppClip.swift */; };
-		31148D81297341297091BE82 /* GoogleMapsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C87E1F983762D987044B07D /* GoogleMapsCore.framework */; };
-		38A20AD3EFD22BEAE8205414 /* ExternalFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94BEEB36D3E48677861539C1 /* ExternalFramework.framework */; };
 		40EBA8F7768FC736C390DB78 /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FA3BA1D4E619BDEDC7F4C24 /* c_lib.c */; };
-		4119529014BB6FAC2E9AA1C1 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7401FDA68482F8B5BE018478 /* CryptoSwift.framework */; };
 		415520D308B3EC73DE595A75 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E063D559D363D5771226A03 /* Lib.swift */; };
-		425BFCDFB51767F26D8E88F9 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C23E4536260379513114C6AE /* CryptoSwift.framework */; };
-		47BBA9797DCC4E826C506F50 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6166E71C87C80120FEFD9124 /* CryptoSwift.framework */; };
 		49615A89672F4FDCDA3100A0 /* UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A04B4D64A65A2EB1309E5FCB /* UITestsLaunchTests.swift */; };
-		4B75293F7455F8CC400AB429 /* LibFramework.tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09459B752328D506AE83BB73 /* LibFramework.tvOS.framework */; };
 		4B9D7C7D6D5DDACAF5F87255 /* watchOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B67D228CAE7657B7CF96BCD /* watchOSApp.swift */; };
 		4DCE1596464F993C9A745426 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF522B1DF94A22805CFB159 /* Lib.swift */; };
 		5003A996FFB25A6D500F8312 /* iMessageAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = E332411DCE28305063274CDF /* iMessageAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		50132650EEA27019BCA2E293 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48754296ACA596286860C0BF /* CryptoSwift.framework */; };
 		511CD055B798496C846A5E4D /* WatchOSAppExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B97B63749CB7B8FCC4C6CD /* WatchOSAppExtensionTests.swift */; };
-		526815DB742350C83EB04495 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7401FDA68482F8B5BE018478 /* CryptoSwift.framework */; };
-		562EDC433A9C193006AAA2C3 /* LibFramework.iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0F4E240A5D25F4ADB40D550 /* LibFramework.iOS.framework */; };
 		57337DB3D95294B5CFA16EFB /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F55A2BE8D7CCF0BE66FBA97 /* iOSApp.swift */; };
-		57990DB9189C856D000061EE /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF2DAFB9141E941BE0B725EF /* GoogleMapsBase.framework */; };
 		580A69352F7B58F8B1733A3E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75394279554A62DCDF2F00B /* ContentView.swift */; };
 		5D406E0B8B7D50C4E86D3AAA /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F02DB5872C15A8176E54D40F /* UnitTests.swift */; };
 		5FA901BB965820A09B540106 /* Answers.mm in Sources */ = {isa = PBXBuildFile; fileRef = 904C69CEFDF8DD18C54E33E3 /* Answers.mm */; };
 		61053BC2DE28ECA05A82621A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FBAFC44AF745D83B41AC29 /* ContentView.swift */; };
-		6245467CFAC1EBCD693291D9 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7401FDA68482F8B5BE018478 /* CryptoSwift.framework */; };
-		69F17F6DE7E2BFA77D3EB409 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48754296ACA596286860C0BF /* CryptoSwift.framework */; };
-		6B2C69A66B14D4AE3F6B725D /* GoogleMaps.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF108DD9E7994AE813AAFEA9 /* GoogleMaps.framework */; };
-		6B42D20D06B50D58944B7CFD /* UIFramework.tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BF15815BABED2C2DBB76EB8 /* UIFramework.tvOS.framework */; };
-		6CA9D84BAB97378C01269FA3 /* ExternalFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94BEEB36D3E48677861539C1 /* ExternalFramework.framework */; };
 		731A6A9A15E9C1C071EC7AC6 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = 15240A701E6FED89576025D5 /* _CompileStub_.m */; };
 		75B1B268CC2B58566ECB9678 /* watchOSApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = B3F2BB6661347D1891100734 /* watchOSApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		82023B60CA7B024EB1DCB1D9 /* LibFramework.iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B0F4E240A5D25F4ADB40D550 /* LibFramework.iOS.framework */; };
-		870D5447845B486C6B63BF2B /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C23E4536260379513114C6AE /* CryptoSwift.framework */; };
 		894DBAC2BA40755C3BA0D9AB /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC449167BD04FC015CC1967 /* Lib.swift */; };
-		9111AE827A5939B3E1C787DC /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C23E4536260379513114C6AE /* CryptoSwift.framework */; };
-		9235E3AEC14B689E7BFB5025 /* GoogleMapsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E25AB0992362AE2E4F48AF2D /* GoogleMapsCore.framework */; };
 		92B9DD43CDC0ED76BB98A614 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9ADDB4A9B43D6CFDDFF25D9 /* Lib.swift */; };
 		987B6F4A8BCF992A6715288B /* Answers.h in Headers */ = {isa = PBXBuildFile; fileRef = 895D403ADE79E63077CCC401 /* Answers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		987C9E038703AA4B4F894708 /* UI.h in Headers */ = {isa = PBXBuildFile; fileRef = DC3FA1C84CE123E17ABEA53D /* UI.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9BC5BB9C121ECEB74DD05E8C /* LibFramework.tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 09459B752328D506AE83BB73 /* LibFramework.tvOS.framework */; };
 		9D533272517E5CDB720006ED /* WatchOSAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F482E2EC1448F43F9E53E78B /* WatchOSAppUITestsLaunchTests.swift */; };
-		A421E22D8A73C776754910CA /* CoreUtilsObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9952967B12D98E5E18576452 /* CoreUtilsObjC.framework */; };
-		A43DE244478F33F52C535852 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CECC22A0360B6F7F39E449B5 /* CryptoSwift.framework */; };
-		A5CE64A318CB5BFD4B52FDE0 /* GoogleMaps.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1E95D84BE74FB253E55EA07 /* GoogleMaps.framework */; };
 		AAD86B0119102EAF7FB2748F /* WidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 293017A3A054170FD9BEBAB9 /* WidgetExtension.swift */; };
 		B2417FA79ED28D6036E9011A /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FBAFC44AF745D83B41AC29 /* ContentView.swift */; };
 		B6F4BA1C6A5297174E72DF8A /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = FEB2B3F1831BB76D5BBA3E5B /* lib.m */; };
 		B82C1CBE3D3E385A31295C7E /* RealAnswer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1AA4147B93D0C841DFC45F3D /* RealAnswer.h */; };
 		B8852841A2FC6C919DE22955 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8605B45BC99BDD7C9D8A293 /* UITests.swift */; };
 		B99E3099B6477352C7DFD270 /* tvOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37024073C534DCC08398F925 /* tvOSApp.swift */; };
-		BEECE3823CD668053A179702 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CECC22A0360B6F7F39E449B5 /* CryptoSwift.framework */; };
 		BF1C6240E2CB3A8C32A1BDF6 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = 15240A701E6FED89576025D5 /* _CompileStub_.m */; };
-		C25C66CB054A310DB4BD2AF2 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C23E4536260379513114C6AE /* CryptoSwift.framework */; };
-		C5B8F0FE0CC2385740743C19 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49B79A6A845E24A1CE8611CA /* CryptoSwift.framework */; };
 		C61E821B3CFE0D5260A796F4 /* WidgetExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 56F16FB28F266E6AABCEA995 /* WidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		C694BD3C1D90778FABCBA1BB /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB279662E03CAB3AD8B23D7C /* MessagesViewController.swift */; };
 		CFBF32FE62028EDA97BFF092 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCAAF270F65B58C26B77C81B /* Intents.swift */; };
@@ -101,7 +65,6 @@
 		D246D6E99DBB71FB43AA2CEB /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79FBAFC44AF745D83B41AC29 /* ContentView.swift */; };
 		D995CD838CBB0D5EC20324B3 /* WatchOSAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836C0333D367673DE5F7FC7A /* WatchOSAppUITests.swift */; };
 		EEF1C918529A5057EECE008F /* UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA5DFF4B34E2E50340D92BE /* UITestsLaunchTests.swift */; };
-		F6901F32DDEB503A636DA3B4 /* ExampleFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E96D4FF845463E2A50FEB3E /* ExampleFramework.framework */; };
 		F87766E8D8D43A7A71792068 /* SwiftGreetingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8876DA78B8E6D3B6331459 /* SwiftGreetingsTests.swift */; };
 		F8DD5EE78EAADB26E27E5BC5 /* watchOSAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = ADBEAB2C84FEA499584D9C18 /* watchOSAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		FE2D229C40D5A473BA58F5AC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88439113041D7EA35BD22E4D /* ContentView.swift */; };
@@ -804,151 +767,6 @@
 		FEB2B3F1831BB76D5BBA3E5B /* lib.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = lib.m; sourceTree = "<group>"; };
 		FFB5B56A6A868E2D1A701C6A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		14A52D246AC24EAA653CD2FC /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				47BBA9797DCC4E826C506F50 /* CryptoSwift.framework in Frameworks */,
-				A43DE244478F33F52C535852 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3D0BBABEDF01532062EA35F5 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C5B8F0FE0CC2385740743C19 /* CryptoSwift.framework in Frameworks */,
-				047B00D7313079854921298B /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		5A9B409C6B42AC407CAEA800 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				425BFCDFB51767F26D8E88F9 /* CryptoSwift.framework in Frameworks */,
-				4119529014BB6FAC2E9AA1C1 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		673AEE26CBCA5AC37617E7DD /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A5CE64A318CB5BFD4B52FDE0 /* GoogleMaps.framework in Frameworks */,
-				9235E3AEC14B689E7BFB5025 /* GoogleMapsCore.framework in Frameworks */,
-				57990DB9189C856D000061EE /* GoogleMapsBase.framework in Frameworks */,
-				6B2C69A66B14D4AE3F6B725D /* GoogleMaps.framework in Frameworks */,
-				31148D81297341297091BE82 /* GoogleMapsCore.framework in Frameworks */,
-				268106B9996EDC881B2E0AA8 /* GoogleMapsBase.framework in Frameworks */,
-				9111AE827A5939B3E1C787DC /* CryptoSwift.framework in Frameworks */,
-				A421E22D8A73C776754910CA /* CoreUtilsObjC.framework in Frameworks */,
-				140520637EE3E1715DEC6A8C /* UIFramework.iOS.framework in Frameworks */,
-				562EDC433A9C193006AAA2C3 /* LibFramework.iOS.framework in Frameworks */,
-				526815DB742350C83EB04495 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		69D556C2BE14D4D0387D3655 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0500EC5BE5ABD402F77760FC /* CryptoSwift.framework in Frameworks */,
-				6245467CFAC1EBCD693291D9 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		6BBC64058F88BC8C000A5516 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F6901F32DDEB503A636DA3B4 /* ExampleFramework.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		984FDDB3D0DCB385902DF1B4 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BEECE3823CD668053A179702 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9914D5AEA900C95BD667AFAA /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6CA9D84BAB97378C01269FA3 /* ExternalFramework.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A5090B3AA4DCA8AF69C219DD /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				17D28C4F6071247D8148BE16 /* CryptoSwift.framework in Frameworks */,
-				6B42D20D06B50D58944B7CFD /* UIFramework.tvOS.framework in Frameworks */,
-				9BC5BB9C121ECEB74DD05E8C /* LibFramework.tvOS.framework in Frameworks */,
-				1345A48101C47E242F430CD8 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		A9F621347E77FF5588B6302E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				095A702D68F04B13D7DE1458 /* CryptoSwift.framework in Frameworks */,
-				4B75293F7455F8CC400AB429 /* LibFramework.tvOS.framework in Frameworks */,
-				69F17F6DE7E2BFA77D3EB409 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		ACEE7EB126C3F28C8C05B7C9 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				50132650EEA27019BCA2E293 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CF5D574E9B6152A6F916506C /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0E4D91E102B2FB798BAEA5F6 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D5673909E06C36E3D882D363 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				38A20AD3EFD22BEAE8205414 /* ExternalFramework.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EF54D68FEC1737EDC18F96BA /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C25C66CB054A310DB4BD2AF2 /* CryptoSwift.framework in Frameworks */,
-				82023B60CA7B024EB1DCB1D9 /* LibFramework.iOS.framework in Frameworks */,
-				2CF8CD9DD353DBDD89036E6D /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F1A4B37998EBB24708A708B2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				870D5447845B486C6B63BF2B /* CryptoSwift.framework in Frameworks */,
-				1F4FBB2FDB7D7960FCBBAD3D /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		01B9192DE283FB94AAED57AC /* rules_xcodeproj */ = {
@@ -3137,7 +2955,6 @@
 				87D2EB6131DC54924D3FA46F /* Copy Bazel Outputs */,
 				E1A1A11A75DFBF854FAFA10E /* Create linking dependencies */,
 				49E604CF100EF12B62E4F2B0 /* Sources */,
-				5A9B409C6B42AC407CAEA800 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3174,7 +2991,6 @@
 				B5F59F69B53E4CD6B729C3DE /* Copy Bazel Outputs */,
 				4A50E185DA5DF9C9FA565E9A /* Create linking dependencies */,
 				F90AB663AB242C7317551B94 /* Sources */,
-				F1A4B37998EBB24708A708B2 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3194,7 +3010,6 @@
 				9F6AC3E78F25E23948AED368 /* Copy Bazel Outputs */,
 				98A71FDC2C7B65B80CB267C4 /* Create linking dependencies */,
 				B0BD8F7B441AB01986AB1F93 /* Sources */,
-				673AEE26CBCA5AC37617E7DD /* Frameworks */,
 				7C574200BE46B3AB33851AA4 /* Embed Watch Content */,
 				B863A176A237329225DDC850 /* Embed App Extensions */,
 				35F0792A0228A41446B47AF3 /* Embed App Clips */,
@@ -3221,7 +3036,6 @@
 				BF56D416F70A066FD9011FA8 /* Copy Bazel Outputs */,
 				DE5C59A752329AE16229AE59 /* Create linking dependencies */,
 				315271AE75D672025F1A9942 /* Sources */,
-				D5673909E06C36E3D882D363 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3241,7 +3055,6 @@
 				56BD3A38019D94C340B5A25C /* Copy Bazel Outputs */,
 				68138666CD6CDC373430A762 /* Create linking dependencies */,
 				E14B9C7D8D225FBE66CC100E /* Sources */,
-				CF5D574E9B6152A6F916506C /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3261,7 +3074,6 @@
 				656CED3E4E2349D88BAA2EF6 /* Copy Bazel Outputs */,
 				868BBA44BDD2BE4A39BFEDEC /* Create linking dependencies */,
 				B09B81014BDBFBE263449393 /* Sources */,
-				14A52D246AC24EAA653CD2FC /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3316,7 +3128,6 @@
 				E4B27AD8C0AABDA4773F3608 /* Create linking dependencies */,
 				DBC93B6C433893E616E4EA29 /* Headers */,
 				64B82A91DCAE8470E0DE6BB4 /* Sources */,
-				EF54D68FEC1737EDC18F96BA /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3337,7 +3148,6 @@
 				76E8F2A01FD31734B232CC78 /* Copy Bazel Outputs */,
 				E5EC86BD0C7F497C585BBD38 /* Create linking dependencies */,
 				32BA1D877616BFC7F2BE635B /* Sources */,
-				69D556C2BE14D4D0387D3655 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3376,7 +3186,6 @@
 				E4DFB42E1E6C49238D7B8878 /* Copy Bazel Outputs */,
 				172D472463796AAA86DE3F16 /* Create linking dependencies */,
 				8386C3E1D1885B4412A44CE2 /* Sources */,
-				9914D5AEA900C95BD667AFAA /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3415,7 +3224,6 @@
 				283DCDF5399761BAD0DB8923 /* Copy Bazel Outputs */,
 				8E99904A6B322FD8DC0AE06D /* Create linking dependencies */,
 				D891ADC38CB5CD0B471E2DC5 /* Sources */,
-				ACEE7EB126C3F28C8C05B7C9 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3506,7 +3314,6 @@
 				1DC3EC3B8C42B6B47B583001 /* Copy Bazel Outputs */,
 				1F6D54F7BA652B6361D1E235 /* Create linking dependencies */,
 				50849A426DC10CD2A4C3DE6E /* Sources */,
-				A9F621347E77FF5588B6302E /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3527,7 +3334,6 @@
 				C3B530109FE5F98A1693F0A1 /* Copy Bazel Outputs */,
 				EC6016F1A034F70C0846B131 /* Create linking dependencies */,
 				F7BFBB107A12DCC806E6F7F2 /* Sources */,
-				A5090B3AA4DCA8AF69C219DD /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3547,7 +3353,6 @@
 				1305E71B397AAD0342B70DA2 /* Copy Bazel Outputs */,
 				1AD5775B0403CB13FDE5DBD3 /* Create linking dependencies */,
 				D4F44477F89180BAF6091C50 /* Sources */,
-				6BBC64058F88BC8C000A5516 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3581,7 +3386,6 @@
 				1977851DBA85D8EF479B3422 /* Copy Bazel Outputs */,
 				67CE6321146319C48DFEBA53 /* Create linking dependencies */,
 				A0357F54171B89382479F0C1 /* Sources */,
-				3D0BBABEDF01532062EA35F5 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3620,7 +3424,6 @@
 				6F779F048E8A5225FE34F009 /* Copy Bazel Outputs */,
 				4C341ABC34320ACDF155DD4F /* Create linking dependencies */,
 				4759015F86C47FF8B0A12DC7 /* Sources */,
-				984FDDB3D0DCB385902DF1B4 /* Frameworks */,
 			);
 			buildRules = (
 			);

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/AppClip/AppClip.link.params
@@ -9,3 +9,5 @@
 -lc++
 -force_load
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/Lib/LibFramework.iOS.link.params
@@ -8,3 +8,5 @@
 -lc++
 -force_load
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/UI/UIFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/UI/UIFramework.iOS.link.params
@@ -7,3 +7,7 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+LibFramework.iOS

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/WidgetExtension/WidgetExtension.link.params
@@ -9,3 +9,5 @@
 -lc++
 -force_load
 $(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/iOSApp/Source/iOSApp.link.params
@@ -17,3 +17,17 @@ CoreTelephony
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+GoogleMaps
+-framework
+GoogleMapsCore
+-framework
+GoogleMapsBase
+-framework
+CryptoSwift
+-framework
+CoreUtilsObjC
+-framework
+UIFramework.iOS
+-framework
+LibFramework.iOS

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/AppClip/AppClip.link.params
@@ -9,3 +9,5 @@
 -lc++
 -force_load
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/Lib/LibFramework.iOS.link.params
@@ -8,3 +8,5 @@
 -lc++
 -force_load
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/UI/UIFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/UI/UIFramework.iOS.link.params
@@ -7,3 +7,7 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+LibFramework.iOS

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/WidgetExtension/WidgetExtension.link.params
@@ -9,3 +9,5 @@
 -lc++
 -force_load
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iMessageApp/iMessageAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iMessageApp/iMessageAppExtension.link.params
@@ -9,3 +9,5 @@
 -lc++
 -force_load
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iOSApp/Source/iOSApp.link.params
@@ -17,3 +17,17 @@ CoreTelephony
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+GoogleMaps
+-framework
+GoogleMapsCore
+-framework
+GoogleMapsBase
+-framework
+CryptoSwift
+-framework
+CoreUtilsObjC
+-framework
+UIFramework.iOS
+-framework
+LibFramework.iOS

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/CommandLine/CommandLineTool/CommandLineTool.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/CommandLine/CommandLineTool/CommandLineTool.link.params
@@ -23,3 +23,5 @@ $(BAZEL_EXTERNAL)/examples_command_line_external/ImportableLibrary/libImportable
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -exported_symbols_list
 CommandLine/CommandLineTool/export_symbol_list.exp
+-framework
+ExternalFramework

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/CommandLine/Tests/CommandLineToolTests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-c0ef0a258197/CommandLine/Tests/CommandLineToolTests.link.params
@@ -22,3 +22,5 @@ $(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-c0ef0a2581
 $(BAZEL_EXTERNAL)/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
 -force_load
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework
+-framework
+ExternalFramework

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-e4309a660cc1/macOSApp/Source/macOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-e4309a660cc1/macOSApp/Source/macOSApp.link.params
@@ -6,3 +6,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+ExampleFramework

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/Lib/LibFramework.tvOS.link.params
@@ -8,3 +8,5 @@
 -lc++
 -force_load
 $(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/UI/UIFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/UI/UIFramework.tvOS.link.params
@@ -7,3 +7,7 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+LibFramework.tvOS

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/tvOSApp/Source/tvOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/tvOSApp/Source/tvOSApp.link.params
@@ -8,3 +8,9 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+UIFramework.tvOS
+-framework
+LibFramework.tvOS

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/Lib/LibFramework.tvOS.link.params
@@ -8,3 +8,5 @@
 -lc++
 -force_load
 $(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/UI/UIFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/UI/UIFramework.tvOS.link.params
@@ -7,3 +7,7 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+LibFramework.tvOS

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/tvOSApp/Source/tvOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/tvOSApp/Source/tvOSApp.link.params
@@ -8,3 +8,9 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+UIFramework.tvOS
+-framework
+LibFramework.tvOS

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/tvOSApp/Test/UnitTests/tvOSAppUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/tvOSApp/Test/UnitTests/tvOSAppUnitTests.link.params
@@ -10,3 +10,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/watchOSAppExtension/watchOSAppExtension.link.params
@@ -12,3 +12,5 @@
 $(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/UI/libUI.a
 -force_load
 $(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.link.params
@@ -13,3 +13,5 @@
 $(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/UI/libUI.a
 -force_load
 $(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/watchOSAppExtension/watchOSAppExtension.link.params
@@ -12,3 +12,5 @@
 $(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/UI/libUI.a
 -force_load
 $(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -24,52 +24,38 @@
 /* Begin PBXBuildFile section */
 		00FA2BB7FC302E681E1692F3 /* iMessageAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A64E82DCF9CD209DC5E8DA47 /* iMessageAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		08B3C347E0D35024B33ECCDD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 94D418DCB51AC773B8A7C269 /* Assets.xcassets */; };
-		0937FB5532B24E4B2B904E92 /* LibFramework.tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 819D7FB47D529D391E218B30 /* LibFramework.tvOS.framework */; };
-		0B7583636FA07AA4E8191DAE /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 270A95ACD2882E4470E9AD1F /* CryptoSwift.framework */; };
 		0C0B4FBD33B0FB63775F84A2 /* Answers.h in Headers */ = {isa = PBXBuildFile; fileRef = AF4F8104F2B6C4A52723BD86 /* Answers.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0E5B5614A96393F1DEF49816 /* WidgetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCED62F2FD581DB88B734527 /* WidgetExtension.swift */; };
 		0FB96922668B0BDBC0603E2F /* watchOSAppExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 5808BF0F847CC0BF0E1128FB /* watchOSAppExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		0FD218B14F012C314354A277 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; };
 		115EAC732D1D5551003F4988 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 95A5CEC36DFCD8E9405557B7 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		11F3CA8F80B0BB2597AF76E1 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 161FCC8E16610CC731029DF1 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		13A6B947448B36A004253831 /* watchOSApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = D76D2C3E02897E2ED28A8958 /* watchOSApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		1705B8940632007097FBD9FD /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; };
 		171DACB244D0CE6D2880DE13 /* GoogleMaps.bundle in Resources */ = {isa = PBXBuildFile; fileRef = A4B9C08059A6D7570552A207 /* GoogleMaps.bundle */; };
 		1816F49F3D5E35861840C19B /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B783B4C2C5DC10B418C574 /* Lib.swift */; };
-		1844D45BC9E3021EE6F61472 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95A5CEC36DFCD8E9405557B7 /* CryptoSwift.framework */; };
 		18D02E436D7EFF7AC15D3E7F /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		19DF31ED754FA3E16A9E069E /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E03EA73D2F5DAB6EDED34595 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		19F59AA7F8D9A24665C930D2 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 664EBD994F1F2924FA4B6C57 /* Localizable.strings */; };
-		1A3D72822DC8F12BC231D972 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; };
 		1B24593A3E5FC103B9762FD6 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDBC8BE73659B49F821DC30 /* UnitTests.swift */; };
 		1BA58B62ACB840A152C43E80 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FFCA16CB57244FE59B40D500 /* MainInterface.storyboard */; };
 		1C749C20C3FAA20FF518DD73 /* macOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83725B51E3CA6DD91F7D6BFF /* macOSApp.swift */; };
-		1F09F6D2662F9F248FFD967A /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; };
 		225B94C4FEA8FB5DD03102A9 /* ExampleResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 087B3E45AA9A7430D1BEC9B8 /* ExampleResources.bundle */; };
-		2286D94B88D52590A6E58F76 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E03EA73D2F5DAB6EDED34595 /* CryptoSwift.framework */; };
 		22FF2DD66A3B3A75624CC621 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		246ECE588944DA7BFEA7D939 /* lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0455E8B425806F8207BF49 /* lib.swift */; };
 		250CE46988EA2F5D57D2B3D8 /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE73CE9A3DEAC184A64A5A5 /* MessagesViewController.swift */; };
 		2756BE0923424079AFD67739 /* ExampleFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CB23CF2A952EAA596B48962C /* ExampleFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		2A874931D044EDD1086C1B07 /* LibFramework.iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE17238A24CF9758B74AE148 /* LibFramework.iOS.framework */; };
 		3663F6F02852C0086A6D8C55 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E03EA73D2F5DAB6EDED34595 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3910302EFF7CF691D051A893 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65757D8CE42B00E7C1504904 /* Intents.swift */; };
-		39B70EB5A4AEE55947BD2DB9 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; };
 		3A69A4774C7709AC642289FD /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EAA93E39BD9134A2D28F54D /* UITests.swift */; };
-		3C8AB3316133B3A7579E4803 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; };
 		3DF6299581EF7C61B8D4793D /* nested in Resources */ = {isa = PBXBuildFile; fileRef = 4631C286EA03DBB429708FD7 /* nested */; };
 		3E5F6986BB6A5BEB0D699875 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3E839693371C8F730E7E4ACF /* UIFramework.tvOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7AFD25EDD786A6C25959B161 /* UIFramework.tvOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3F3040F0EC161A6F56A3DE93 /* Intents.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E4958C56023AC7E82EA5B8 /* Intents.swift */; };
 		40FF91649C3585B4823B3770 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19DF91AAD078DE3B057369B /* ContentView.swift */; };
 		42B24939EF1B27F1EEB23217 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = EA5D27714701CC942BE85FC0 /* main.m */; };
-		44633612150DB57C9D05C2F7 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 270A95ACD2882E4470E9AD1F /* CryptoSwift.framework */; };
 		4EEF26B11D3A6AFB2D2EB8FE /* private_lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981E9E8FD6A149FA01F271A7 /* private_lib.swift */; };
-		4F1FD2B820497A6AFE6B313C /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7460163239595E240435120 /* GoogleMapsBase.framework */; };
 		4F8FED2A0C5F3936F3476757 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9A65559C141C2EE24ED7827 /* Lib.swift */; };
 		57020F3D49287832FE59E70D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A654779A8A096C76BA6E6063 /* Assets.xcassets */; };
 		57B5DBF853C48F559C43D2F7 /* SwiftGreetingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7BE326DA949264866C88EDA /* SwiftGreetingsTests.swift */; };
-		585EA10314D1A3BEE1747DD6 /* UIFramework.iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 912B29F4D90994AF307EFD8E /* UIFramework.iOS.framework */; };
 		596F67C6D0FF1EEAD6A7B4D1 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 244E2707FB6A753B6FAA6317 /* Preview Assets.xcassets */; };
 		5CECD55D1D38CC5B8430A48B /* UI.h in Headers */ = {isa = PBXBuildFile; fileRef = 2750C933EC0EB524264D459F /* UI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5D92A287B558AE3F6616221D /* AltIcon-60@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = A6ED0CB2494372465AE21A46 /* AltIcon-60@3x.png */; };
@@ -81,10 +67,7 @@
 		6ED977A4F14983B074B0E7E5 /* UIFramework.iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 912B29F4D90994AF307EFD8E /* UIFramework.iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6F3C9CF28EA355CFB1B231F5 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3B6491841C8AF0931CA2F1BD /* Preview Assets.xcassets */; };
 		707FC2B9FD5C58A1C69D5853 /* tvOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19F98A9180ADFCA89035E58 /* tvOSApp.swift */; };
-		70DC393F308A98F43AD5FFA6 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; };
 		72135F86F92CBAE46CEAA58F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C152F52FA537BBF0815F7899 /* Assets.xcassets */; };
-		7311E94E23B56BB5576D6E2D /* GoogleMaps.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 301920FC4AA3691CDC2070D7 /* GoogleMaps.framework */; };
-		7588D7A77F079A22223A4CD9 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E03EA73D2F5DAB6EDED34595 /* CryptoSwift.framework */; };
 		76EBD2A85F8B00A3AC785D91 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		79B7C5A659E99494C2DE8CA4 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7A89F29A836A7DB1D3EF7667 /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 161FCC8E16610CC731029DF1 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -99,47 +82,32 @@
 		8A6A3F35728DABE22FACF1B7 /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819D34C18D821AB3B4879798 /* iOSApp.swift */; };
 		8DB8540FF1230C3046C3C413 /* launch_images_ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6024BE681BD1B639F193B1D5 /* launch_images_ios.xcassets */; };
 		91FFC1CB612B99285C89F405 /* LibFramework.tvOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 819D7FB47D529D391E218B30 /* LibFramework.tvOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9241F80C086E7839F0182266 /* GoogleMaps.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4945564FB57B2AAF142EFC4 /* GoogleMaps.framework */; };
 		970930B398EF704E7F2BF918 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = C1427F45C783EFE20E49B1E4 /* _CompileStub_.m */; };
 		980DA518D512CAD9287F569D /* WatchOSAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36D4C8FF1BC1B0BF86F3A298 /* WatchOSAppUITests.swift */; };
 		9B7AB779C8607289AE64F18B /* unprocessed.json in Resources */ = {isa = PBXBuildFile; fileRef = 7172CF19386836C0149A8FAC /* unprocessed.json */; };
 		9DCFC99A86690BF8E086CD2D /* RealAnswer.h in Headers */ = {isa = PBXBuildFile; fileRef = 15BD628D8CB5434E1FBA7F99 /* RealAnswer.h */; };
 		9EBD12B9600E371A1CDC1090 /* Utils.bundle in Resources */ = {isa = PBXBuildFile; fileRef = D1A77D43C2AC29495314BE08 /* Utils.bundle */; };
-		9FE156B470BC662384A5B08C /* LibFramework.iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FE17238A24CF9758B74AE148 /* LibFramework.iOS.framework */; };
 		A1015778E645BAF13F1E3EB6 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9F5C9ECA94AABFD6812E7930 /* Localizable.strings */; };
 		A1736C708A752DBF8E79E4B1 /* Launch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4F25FDB1425AC4C3D5829AD6 /* Launch.storyboard */; };
-		A1E3217330D21B35FF437325 /* UIFramework.tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7AFD25EDD786A6C25959B161 /* UIFramework.tvOS.framework */; };
-		A225636FE42CBCBD21146A91 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 161FCC8E16610CC731029DF1 /* CryptoSwift.framework */; };
-		A25E91927056AD340C78FFAA /* LibFramework.tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 819D7FB47D529D391E218B30 /* LibFramework.tvOS.framework */; };
 		A2881D00B6B4998713F69CDB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7A8C0E241B1307FE7464ADF2 /* Assets.xcassets */; };
 		A3981F7E03800ED5F1A4CE70 /* lib.m in Sources */ = {isa = PBXBuildFile; fileRef = 810E2D447FCAC7D533DFF6D2 /* lib.m */; };
 		A4803FC1A0ED687D63C7DB54 /* _CompileStub_.m in Sources */ = {isa = PBXBuildFile; fileRef = C1427F45C783EFE20E49B1E4 /* _CompileStub_.m */; };
 		A6753619C6B486331D39C220 /* AppClip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76B85F05863EF8DE04D82121 /* AppClip.swift */; };
 		A85575189071436F689B0DAE /* bucket in Resources */ = {isa = PBXBuildFile; fileRef = 66F0C3E3B07C2183208B4129 /* bucket */; };
-		A8AEC27B7E94CDED68030FAA /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; };
-		ACDDAE29AB33F11172E34490 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; };
 		AE41002A41897CC8357C2548 /* private_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = CE231366EAB9CD1B9B2A35C4 /* private_lib.c */; };
-		B0C99CF475161A840337FA46 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; };
 		B4B508B8E137433CAE8F0DA5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220191BD3F7360FCCF281EBD /* ContentView.swift */; };
 		B5AA1F8611D6C8D22E84A354 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 90F4DEBCF534EEC6AF02FECA /* Assets.xcassets */; };
-		B6F3484C7F2A4F19417D4F2B /* ExternalFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D46BEBDD407F679ED938408 /* ExternalFramework.framework */; };
-		B7ECEDBCE40E52EBE04BAF43 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 714F4CDA20A0822521C3B389 /* CryptoSwift.framework */; };
 		BA7E894545DD2EBE183B2DC4 /* dir in Resources */ = {isa = PBXBuildFile; fileRef = 0DBFC9CAC3DF8E34D9C26686 /* dir */; };
 		BEAC2699E6D09C918480F691 /* ExampleNestedResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 1DC6A527C6B5C64DEF9CF7DD /* ExampleNestedResources.bundle */; };
 		BF2E0C58C8A51F60298F8E2A /* ExtensionAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FCFAACAD225B40BD8E7A9724 /* ExtensionAssets.xcassets */; };
 		C08D59671C7F32D27E9F79C6 /* LibFramework.iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FE17238A24CF9758B74AE148 /* LibFramework.iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		C16B1D03864C51CBAF529839 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 161FCC8E16610CC731029DF1 /* CryptoSwift.framework */; };
 		C4539DA67ADCA84EA0A5E191 /* bucket in Resources */ = {isa = PBXBuildFile; fileRef = 8D530FB466B524D1F48E99FE /* bucket */; };
-		C6A280A63EE158A914BA496A /* GoogleMapsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E5A80F2D2B5A04CDA0B5E483 /* GoogleMapsCore.framework */; };
 		C809C1F1BFC4E403DE9AD5A9 /* c_lib.c in Sources */ = {isa = PBXBuildFile; fileRef = 39F034BD3761BD100A223D30 /* c_lib.c */; };
-		CB46722A6D1203DCD9571460 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 161FCC8E16610CC731029DF1 /* CryptoSwift.framework */; };
 		CBA6EA19824B0712FDBCC10E /* CoreUtilsObjC.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 48B6F3CC2447CFF59FDCAD1E /* CoreUtilsObjC.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		CD87ADCDD7A9C865DF997DEE /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 161FCC8E16610CC731029DF1 /* CryptoSwift.framework */; };
 		CE39C055C975A5F329B40BD1 /* watchOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4A29A5D4A09C5CEE6F8E3B /* watchOSApp.swift */; };
 		D364C618DDBA160C7D54E3D4 /* UITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BDD485DDB5B0C92817F896E /* UITestsLaunchTests.swift */; };
 		D589C940D1AC5E3B7ABE246F /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220191BD3F7360FCCF281EBD /* ContentView.swift */; };
 		D87462D63C1B0E87732900D9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0F94EACBDEFA49C24D661D65 /* Assets.xcassets */; };
-		DA5F74ACBE75E5010E38DD96 /* ExternalFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9D46BEBDD407F679ED938408 /* ExternalFramework.framework */; };
 		DEBCB4DCBBB928BD33DFE1FD /* nested in Resources */ = {isa = PBXBuildFile; fileRef = C430EA6EC770042CAF4719B0 /* nested */; };
 		DF03B25D8E7657C2222D9975 /* WidgetExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 47F4F767654EB4A49984A679 /* WidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		DF1BD6294D1ECE92A06DE919 /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DB566A8142C8EAF584F9BE0 /* Lib.swift */; };
@@ -149,13 +117,8 @@
 		E16B5F1B14C088FD1B4A93AA /* Lib.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2126CD665EDDB201E367009 /* Lib.swift */; };
 		E31E3CF6E56E0A5A3623C38A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57F651BDC3C5240B9E39EBCC /* Assets.xcassets */; };
 		E336B4F3C30739616C456ACC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 220191BD3F7360FCCF281EBD /* ContentView.swift */; };
-		E8B3605DB78F38F7CFF33469 /* GoogleMapsBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 12200A389D1ACE33A9160B97 /* GoogleMapsBase.framework */; };
 		EA92CB15E5B88ACB72D7C78A /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F18CCFC74137236D689F0401 /* ExampleFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB23CF2A952EAA596B48962C /* ExampleFramework.framework */; };
-		F1AEBFE5D9FFC676DB35A5CB /* CoreUtilsObjC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48B6F3CC2447CFF59FDCAD1E /* CoreUtilsObjC.framework */; };
 		FA2386224ACA600205984EBB /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5F99A7D79C5DEADA3086ADE2 /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		FA9F78A486181D21F9019C36 /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 270A95ACD2882E4470E9AD1F /* CryptoSwift.framework */; };
-		FC2493D820425CD6E40C08B7 /* GoogleMapsCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB66CE453BB4F66EE19482C5 /* GoogleMapsCore.framework */; };
 		FDD392224B796303A30CE04B /* CryptoSwift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 270A95ACD2882E4470E9AD1F /* CryptoSwift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FE541D1A764869C37235B6D0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5A8B6E34910444050DC7D410 /* Assets.xcassets */; };
 		FEEFF09069C098C84BB943D9 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 298086E5568F80700F542D81 /* UITests.swift */; };
@@ -1004,151 +967,6 @@
 		FCFAACAD225B40BD8E7A9724 /* ExtensionAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ExtensionAssets.xcassets; sourceTree = "<group>"; };
 		FE17238A24CF9758B74AE148 /* LibFramework.iOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LibFramework.iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		15645FD00B6A0A865007A006 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				70DC393F308A98F43AD5FFA6 /* CryptoSwift.framework in Frameworks */,
-				ACDDAE29AB33F11172E34490 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		23F10072F9EECA22EE8F05EE /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0FD218B14F012C314354A277 /* CryptoSwift.framework in Frameworks */,
-				B7ECEDBCE40E52EBE04BAF43 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		381B33A115CA30429D32BA64 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1844D45BC9E3021EE6F61472 /* CryptoSwift.framework in Frameworks */,
-				7588D7A77F079A22223A4CD9 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		471BE19642BDC78C551A7F3C /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				7311E94E23B56BB5576D6E2D /* GoogleMaps.framework in Frameworks */,
-				C6A280A63EE158A914BA496A /* GoogleMapsCore.framework in Frameworks */,
-				4F1FD2B820497A6AFE6B313C /* GoogleMapsBase.framework in Frameworks */,
-				9241F80C086E7839F0182266 /* GoogleMaps.framework in Frameworks */,
-				FC2493D820425CD6E40C08B7 /* GoogleMapsCore.framework in Frameworks */,
-				E8B3605DB78F38F7CFF33469 /* GoogleMapsBase.framework in Frameworks */,
-				39B70EB5A4AEE55947BD2DB9 /* CryptoSwift.framework in Frameworks */,
-				F1AEBFE5D9FFC676DB35A5CB /* CoreUtilsObjC.framework in Frameworks */,
-				585EA10314D1A3BEE1747DD6 /* UIFramework.iOS.framework in Frameworks */,
-				2A874931D044EDD1086C1B07 /* LibFramework.iOS.framework in Frameworks */,
-				3C8AB3316133B3A7579E4803 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		5FC7A3E61026D46CDBE9E11A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1A3D72822DC8F12BC231D972 /* CryptoSwift.framework in Frameworks */,
-				1F09F6D2662F9F248FFD967A /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		74F273E7627927788344FACD /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DA5F74ACBE75E5010E38DD96 /* ExternalFramework.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		78D72E3443AE556204D1DA14 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B6F3484C7F2A4F19417D4F2B /* ExternalFramework.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9CC387A8C29E692EDE26A70A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A225636FE42CBCBD21146A91 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		B8591EE34CB1F19D931156BD /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0B7583636FA07AA4E8191DAE /* CryptoSwift.framework in Frameworks */,
-				CB46722A6D1203DCD9571460 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		BA4845A5192CBB25166B7F2B /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				44633612150DB57C9D05C2F7 /* CryptoSwift.framework in Frameworks */,
-				0937FB5532B24E4B2B904E92 /* LibFramework.tvOS.framework in Frameworks */,
-				CD87ADCDD7A9C865DF997DEE /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CEE7E636ED53BDB69F159646 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B0C99CF475161A840337FA46 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D562D052B77CE368B73AF512 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F18CCFC74137236D689F0401 /* ExampleFramework.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		E991C42C809DB6A394BE9FDB /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				FA9F78A486181D21F9019C36 /* CryptoSwift.framework in Frameworks */,
-				A1E3217330D21B35FF437325 /* UIFramework.tvOS.framework in Frameworks */,
-				A25E91927056AD340C78FFAA /* LibFramework.tvOS.framework in Frameworks */,
-				C16B1D03864C51CBAF529839 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		EC439A40E7332D70AE4B7BF8 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2286D94B88D52590A6E58F76 /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F54CCE1B16142C030AB06B8D /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1705B8940632007097FBD9FD /* CryptoSwift.framework in Frameworks */,
-				9FE156B470BC662384A5B08C /* LibFramework.iOS.framework in Frameworks */,
-				A8AEC27B7E94CDED68030FAA /* CryptoSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		00D30E23347D6A9A21438C63 /* watchos-arm64_32_armv7k */ = {
@@ -3339,7 +3157,6 @@
 				101FAE3A32BED3A2D079B5C5 /* Create linking dependencies */,
 				C2E885889FCDCFE606C4F0B2 /* Headers */,
 				A71A9DBC75ACAD07583F078D /* Sources */,
-				F54CCE1B16142C030AB06B8D /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3398,7 +3215,6 @@
 			buildPhases = (
 				EBA32DA23E3014269AA3E309 /* Create linking dependencies */,
 				3ACE6DE287E99E6549F209F9 /* Sources */,
-				BA4845A5192CBB25166B7F2B /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3435,7 +3251,6 @@
 			buildPhases = (
 				4C4187A35F712B42FD152479 /* Create linking dependencies */,
 				A03CD31EDF0896CF4D6E3A8E /* Sources */,
-				5FC7A3E61026D46CDBE9E11A /* Frameworks */,
 				3D5C074CAFEB91C4A4BD9598 /* Resources */,
 				DC0C1EBED424FEC993517492 /* Embed Frameworks */,
 			);
@@ -3509,7 +3324,6 @@
 			buildPhases = (
 				BC748BEFF6C8DE6895092931 /* Create linking dependencies */,
 				0BC8AFF7DEDFCB5C3735E199 /* Sources */,
-				381B33A115CA30429D32BA64 /* Frameworks */,
 				2B3CFF187E50D66D1247DF0A /* Resources */,
 				60937F0733C881E02787D20D /* Embed Frameworks */,
 			);
@@ -3530,7 +3344,6 @@
 			buildPhases = (
 				FED90F1BECB04CC2A4AD4C32 /* Create linking dependencies */,
 				B66D4C0F56DDC2756403E243 /* Sources */,
-				EC439A40E7332D70AE4B7BF8 /* Frameworks */,
 				8E6A6E861A765F4CA305623A /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -3595,7 +3408,6 @@
 			buildPhases = (
 				DA9D59F71B3003C604D55396 /* Create linking dependencies */,
 				A31230E5E9CCB173049ACD11 /* Sources */,
-				78D72E3443AE556204D1DA14 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3630,7 +3442,6 @@
 			buildPhases = (
 				6E34424248DBC273AB573C53 /* Create linking dependencies */,
 				72C05C54D2004F8886EDBB81 /* Sources */,
-				23F10072F9EECA22EE8F05EE /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3667,7 +3478,6 @@
 			buildPhases = (
 				DFC7E9339093C92AA26D63DC /* Create linking dependencies */,
 				C0746DB917135C251EBC92A3 /* Sources */,
-				471BE19642BDC78C551A7F3C /* Frameworks */,
 				B6738331CF80F57EDBC55412 /* Resources */,
 				54E0573228E25BA06A17C8A4 /* Embed Frameworks */,
 				B728FD36D5E24A1628E973F5 /* Embed Watch Content */,
@@ -3712,7 +3522,6 @@
 			buildPhases = (
 				007AF0E8BB02A51A5B838FF2 /* Create linking dependencies */,
 				C2F0B9B6C5FB6328BF737D5D /* Sources */,
-				D562D052B77CE368B73AF512 /* Frameworks */,
 				C4031A0336EB5DA2A516F76A /* Resources */,
 				B77AD15C284F61BB7B0BC343 /* Embed Frameworks */,
 			);
@@ -3765,7 +3574,6 @@
 			buildPhases = (
 				F54D13C4BABB8D4BACF36A16 /* Create linking dependencies */,
 				26FAAFA8B85EE3161B7FCD08 /* Sources */,
-				74F273E7627927788344FACD /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3784,7 +3592,6 @@
 			buildPhases = (
 				027230613C505EE933350262 /* Create linking dependencies */,
 				A373CFAE1BBE832180746E37 /* Sources */,
-				B8591EE34CB1F19D931156BD /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3803,7 +3610,6 @@
 			buildPhases = (
 				755BE1A07AB48CCBA936E166 /* Create linking dependencies */,
 				EB0951B0308737E469AF753E /* Sources */,
-				9CC387A8C29E692EDE26A70A /* Frameworks */,
 				6D2E1B47A7BF182F648958B4 /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -3823,7 +3629,6 @@
 			buildPhases = (
 				CFF69E2E8383FDD4CBDEEDFA /* Create linking dependencies */,
 				DEA205856817ECFD12A4F6AC /* Sources */,
-				15645FD00B6A0A865007A006 /* Frameworks */,
 				539460B5D34204CEA560D62F /* Resources */,
 				75774963D17D570D0DAF085D /* Embed Frameworks */,
 			);
@@ -3862,7 +3667,6 @@
 			buildPhases = (
 				B43600A65808622189B23F12 /* Create linking dependencies */,
 				5E6FE845F8960F43CFA251FF /* Sources */,
-				E991C42C809DB6A394BE9FDB /* Frameworks */,
 				722134B2E05B89C3F94D49F6 /* Resources */,
 				598B58973F83D2985CC71DDE /* Embed Frameworks */,
 			);
@@ -3898,7 +3702,6 @@
 			buildPhases = (
 				FF5BC946887446687790F9EE /* Create linking dependencies */,
 				BA86548A4F47D1276A48B362 /* Sources */,
-				CEE7E636ED53BDB69F159646 /* Frameworks */,
 				E2E9DE92CCAE70096FFF11AC /* Resources */,
 				80BE391EE175791A5B6B68E1 /* Embed Frameworks */,
 			);

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/AppClip/AppClip.link.params
@@ -9,3 +9,5 @@
 -lc++
 -force_load
 $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/Lib/LibFramework.iOS.link.params
@@ -8,3 +8,5 @@
 -lc++
 -force_load
 $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/UI/UIFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/UI/UIFramework.iOS.link.params
@@ -7,3 +7,7 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+LibFramework.iOS

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/WidgetExtension/WidgetExtension.link.params
@@ -9,3 +9,5 @@
 -lc++
 -force_load
 $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/iOSApp/Source/iOSApp.link.params
@@ -17,3 +17,17 @@ CoreTelephony
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+GoogleMaps
+-framework
+GoogleMapsCore
+-framework
+GoogleMapsBase
+-framework
+CryptoSwift
+-framework
+CoreUtilsObjC
+-framework
+UIFramework.iOS
+-framework
+LibFramework.iOS

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AppClip/AppClip.link.params
@@ -9,3 +9,5 @@
 -lc++
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/Lib/LibFramework.iOS.link.params
@@ -8,3 +8,5 @@
 -lc++
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/UI/UIFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/UI/UIFramework.iOS.link.params
@@ -7,3 +7,7 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+LibFramework.iOS

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/WidgetExtension/WidgetExtension.link.params
@@ -9,3 +9,5 @@
 -lc++
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iMessageApp/iMessageAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iMessageApp/iMessageAppExtension.link.params
@@ -9,3 +9,5 @@
 -lc++
 -force_load
 $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iOSApp/Source/iOSApp.link.params
@@ -17,3 +17,17 @@ CoreTelephony
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+GoogleMaps
+-framework
+GoogleMapsCore
+-framework
+GoogleMapsBase
+-framework
+CryptoSwift
+-framework
+CoreUtilsObjC
+-framework
+UIFramework.iOS
+-framework
+LibFramework.iOS

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/macOSApp/Source/macOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/macOSApp/Source/macOSApp.link.params
@@ -6,3 +6,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+ExampleFramework

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/CommandLine/CommandLineTool/CommandLineTool.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/CommandLine/CommandLineTool/CommandLineTool.link.params
@@ -23,3 +23,5 @@ $(BAZEL_EXTERNAL)/examples_command_line_external/ImportableLibrary/libImportable
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -exported_symbols_list
 CommandLine/CommandLineTool/export_symbol_list.exp
+-framework
+ExternalFramework

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/CommandLine/Tests/CommandLineToolTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/CommandLine/Tests/CommandLineToolTests.link.params
@@ -22,3 +22,5 @@ $(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-
 $(BAZEL_EXTERNAL)/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
 -force_load
 $(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/ExternalFramework
+-framework
+ExternalFramework

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/Lib/LibFramework.tvOS.link.params
@@ -8,3 +8,5 @@
 -lc++
 -force_load
 $(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/UI/UIFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/UI/UIFramework.tvOS.link.params
@@ -7,3 +7,7 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+LibFramework.tvOS

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/tvOSApp/Source/tvOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/tvOSApp/Source/tvOSApp.link.params
@@ -8,3 +8,9 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+UIFramework.tvOS
+-framework
+LibFramework.tvOS

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/Lib/LibFramework.tvOS.link.params
@@ -8,3 +8,5 @@
 -lc++
 -force_load
 $(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/UI/UIFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/UI/UIFramework.tvOS.link.params
@@ -7,3 +7,7 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+LibFramework.tvOS

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Source/tvOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Source/tvOSApp.link.params
@@ -8,3 +8,9 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift
+-framework
+UIFramework.tvOS
+-framework
+LibFramework.tvOS

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Test/UnitTests/tvOSAppUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Test/UnitTests/tvOSAppUnitTests.link.params
@@ -10,3 +10,5 @@
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/watchOSAppExtension/watchOSAppExtension.link.params
@@ -12,3 +12,5 @@
 $(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/UI/libUI.a
 -force_load
 $(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.link.params
@@ -13,3 +13,5 @@
 $(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI/libUI.a
 -force_load
 $(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/watchOSAppExtension.link.params
@@ -12,3 +12,5 @@
 $(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI/libUI.a
 -force_load
 $(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/Lib/libLib.a
+-framework
+CryptoSwift

--- a/tools/generator/src/Generator/AddTargets.swift
+++ b/tools/generator/src/Generator/AddTargets.swift
@@ -65,12 +65,6 @@ Product for target "\(key)" not found in `products`
                     buildMode: buildMode,
                     generatesSwiftHeader: target.generatesSwiftHeader
                 ),
-                try createFrameworksPhase(
-                    in: pbxProj,
-                    frameworks: target.linkerInputs.frameworks,
-                    products: products,
-                    files: files
-                ),
                 try createResourcesPhase(
                     in: pbxProj,
                     buildMode: buildMode,
@@ -343,47 +337,6 @@ cp "${SCRIPT_INPUT_FILE_0}" "${SCRIPT_OUTPUT_FILE_0}"
         pbxProj.add(object: shellScript)
 
         return shellScript
-    }
-
-    private static func createFrameworksPhase(
-        in pbxProj: PBXProj,
-        frameworks: [FilePath],
-        products: Products,
-        files: [FilePath: File]
-    ) throws -> PBXFrameworksBuildPhase? {
-        guard !frameworks.isEmpty else {
-            return nil
-        }
-
-        func fileElement(filePath: FilePath) throws -> PBXFileElement {
-            if let fileElement = products.byFilePath[filePath] {
-                return fileElement
-            }
-            guard let framework = files[filePath] else {
-                throw PreconditionError(message: """
-Framework with file path "\(filePath)" not found in `products` or `files`
-""")
-            }
-            guard let fileElement = framework.fileElement else {
-                throw PreconditionError(message: """
-Framework with file path "\(filePath)" had nil `PBXFileElement` in `files`
-""")
-            }
-            return fileElement
-        }
-
-        func buildFile(fileElement: PBXFileElement) throws -> PBXBuildFile {
-            let pbxBuildFile = PBXBuildFile(file: fileElement)
-            pbxProj.add(object: pbxBuildFile)
-            return pbxBuildFile
-        }
-
-        let buildPhase = PBXFrameworksBuildPhase(
-            files: try frameworks.map(fileElement).uniqued().map(buildFile)
-        )
-        pbxProj.add(object: buildPhase)
-
-        return buildPhase
     }
 
     private static func createResourcesPhase(


### PR DESCRIPTION
This allows BwB builds to unfocus framework targets. It also works towards a future change where we can use Bazel's version of `link.params`.