### PR TITLE
Update lld

### DIFF
--- a/examples/integration/WORKSPACE
+++ b/examples/integration/WORKSPACE
@@ -44,9 +44,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_apple_linker",
-    sha256 = "988979ad64ab210a9e952622398f37cd1f768ff5e51fd526ba1c5ac78a2480aa",
-    strip_prefix = "rules_apple_linker-0.1.3",
-    url = "https://github.com/keith/rules_apple_linker/archive/refs/tags/0.1.3.tar.gz",
+    sha256 = "89a537497197bd3ac1fcdd19c5edbdf296de5fec69b483be56a58c37688322a8",
+    strip_prefix = "rules_apple_linker-0.1.6",
+    url = "https://github.com/keith/rules_apple_linker/archive/refs/tags/0.1.6.tar.gz",
 )
 
 load("@rules_apple_linker//:deps.bzl", "rules_apple_linker_deps")


### PR DESCRIPTION
This PR updates the lld version.

This was needed because running few of the tests failed with undefined symbol errors. Updating to the latest rules_apple_linker works all fine.

```
bazel test iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests

ld64.lld: error: undefined symbol: _objc_msgSend$CGColor
>>> referenced by bazel-out/ios-sim_arm64-min15.0-applebin_ios-ios_sim_arm64-fastbuild-ST-4e6c2a19403f/bin/external/FXPageControl/libFXPageControl.a(FXPageControl.o)


```