### PR TITLE
Use `cc_toolchain` implicit SDK frameworks

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/AppClip/AppClip.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/Lib/Lib.framework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/Lib/Lib.framework.iOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/UI/UIFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/UI/UIFramework.iOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/WidgetExtension/WidgetExtension.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.link.params
@@ -1,4 +1,6 @@
 -lc++
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00/iOSApp/Source/iOSApp.link.params
@@ -14,6 +14,8 @@ CoreLocation
 CoreTelephony
 -lc++
 -lz
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/AppClip/AppClip.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/Lib/Lib.framework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/Lib/Lib.framework.iOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/UI/UIFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/UI/UIFramework.iOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/WidgetExtension/WidgetExtension.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iMessageApp/iMessageApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iMessageApp/iMessageApp.link.params
@@ -1,3 +1,5 @@
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iMessageApp/iMessageAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iMessageApp/iMessageAppExtension.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.link.params
@@ -1,4 +1,6 @@
 -lc++
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/iOSApp/Source/iOSApp.link.params
@@ -14,6 +14,8 @@ CoreLocation
 CoreTelephony
 -lc++
 -lz
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/Lib/Lib.framework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/Lib/Lib.framework.tvOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/Lib/LibFramework.tvOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/UI/UIFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/UI/UIFramework.tvOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/tvOSApp/Source/tvOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-70b4e492b765/tvOSApp/Source/tvOSApp.link.params
@@ -5,6 +5,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/Lib/Lib.framework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/Lib/Lib.framework.tvOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/Lib/LibFramework.tvOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/UI/UIFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/UI/UIFramework.tvOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/tvOSApp/Source/tvOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/tvOSApp/Source/tvOSApp.link.params
@@ -5,6 +5,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/tvOSApp/Test/UITests/tvOSAppUITests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/tvOSApp/Test/UITests/tvOSAppUITests.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/tvOSApp/Test/UnitTests/tvOSAppUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-b6268cc80bf2/tvOSApp/Test/UnitTests/tvOSAppUnitTests.link.params
@@ -7,6 +7,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/Lib/Lib.framework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/Lib/Lib.framework.watchOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/Lib/LibFramework.watchOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/UI/UIFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/UI/UIFramework.watchOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90/watchOSAppExtension/watchOSAppExtension.link.params
@@ -5,6 +5,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-56a8163e2aa7/watchOSApp/watchOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-56a8163e2aa7/watchOSApp/watchOSApp.link.params
@@ -1,3 +1,5 @@
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/Lib/Lib.framework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/Lib/Lib.framework.watchOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/Lib/LibFramework.watchOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/UI/UIFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/UI/UIFramework.watchOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/watchOSApp/Test/UITests/watchOSAppUITests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/watchOSApp/Test/UITests/watchOSAppUITests.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.link.params
@@ -6,6 +6,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32/watchOSAppExtension/watchOSAppExtension.link.params
@@ -5,6 +5,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-3df60cf154e9/watchOSApp/watchOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-3df60cf154e9/watchOSApp/watchOSApp.link.params
@@ -1,3 +1,5 @@
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -632,6 +632,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -816,6 +818,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -2902,6 +2906,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3043,6 +3049,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3183,6 +3191,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3323,6 +3333,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3463,6 +3475,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3603,6 +3617,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3743,6 +3759,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3883,6 +3901,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -4023,6 +4043,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -4163,6 +4185,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -4890,6 +4914,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -5080,6 +5106,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -5265,6 +5293,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -5450,6 +5480,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -5635,6 +5667,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -5820,6 +5854,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -6002,6 +6038,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -6180,6 +6218,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -6541,6 +6581,8 @@
             "label": "//iMessageApp:iMessageApp",
             "linker_inputs": {
                 "linkopts": [
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -6625,6 +6667,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -7115,6 +7159,8 @@
             "linker_inputs": {
                 "linkopts": [
                     "-lc++",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -7208,6 +7254,8 @@
             "linker_inputs": {
                 "linkopts": [
                     "-lc++",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -7345,6 +7393,8 @@
                     "CoreTelephony",
                     "-lc++",
                     "-lz",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -7687,6 +7737,8 @@
                     "CoreTelephony",
                     "-lc++",
                     "-lz",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -8638,6 +8690,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -8859,6 +8913,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -9264,6 +9320,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -9439,6 +9497,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -9776,6 +9836,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -9939,6 +10001,8 @@
             "label": "//watchOSApp:watchOSApp",
             "linker_inputs": {
                 "linkopts": [
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -10007,6 +10071,8 @@
             "label": "//watchOSApp:watchOSApp",
             "linker_inputs": {
                 "linkopts": [
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -10095,6 +10161,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -10418,6 +10486,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -10640,6 +10710,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/AppClip/AppClip.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/Lib/Lib.framework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/Lib/Lib.framework.iOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/Lib/LibFramework.iOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/UI/UIFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/UI/UIFramework.iOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/WidgetExtension/WidgetExtension.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.link.params
@@ -1,4 +1,6 @@
 -lc++
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/iOSApp/Source/iOSApp.link.params
@@ -14,6 +14,8 @@ CoreLocation
 CoreTelephony
 -lc++
 -lz
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AppClip/AppClip.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/Lib/Lib.framework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/Lib/Lib.framework.iOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/Lib/LibFramework.iOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/UI/UIFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/UI/UIFramework.iOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/WidgetExtension/WidgetExtension.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iMessageApp/iMessageApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iMessageApp/iMessageApp.link.params
@@ -1,3 +1,5 @@
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iMessageApp/iMessageAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iMessageApp/iMessageAppExtension.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iOSApp/Source/CoreUtilsObjC/FrameworkCoreUtilsObjC.link.params
@@ -1,4 +1,6 @@
 -lc++
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iOSApp/Source/iOSApp.link.params
@@ -14,6 +14,8 @@ CoreLocation
 CoreTelephony
 -lc++
 -lz
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/Lib/Lib.framework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/Lib/Lib.framework.tvOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/Lib/LibFramework.tvOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/UI/UIFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/UI/UIFramework.tvOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/tvOSApp/Source/tvOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/tvOSApp/Source/tvOSApp.link.params
@@ -5,6 +5,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/Lib/Lib.framework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/Lib/Lib.framework.tvOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/Lib/LibFramework.tvOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/UI/UIFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/UI/UIFramework.tvOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Source/tvOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Source/tvOSApp.link.params
@@ -5,6 +5,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Test/UITests/tvOSAppUITests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Test/UITests/tvOSAppUITests.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Test/UnitTests/tvOSAppUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Test/UnitTests/tvOSAppUnitTests.link.params
@@ -7,6 +7,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/Lib/Lib.framework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/Lib/Lib.framework.watchOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/Lib/LibFramework.watchOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/UI/UIFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/UI/UIFramework.watchOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/watchOSAppExtension/watchOSAppExtension.link.params
@@ -5,6 +5,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-8e65bd00489d/watchOSApp/watchOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-8e65bd00489d/watchOSApp/watchOSApp.link.params
@@ -1,3 +1,5 @@
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-2f849b1d5a93/watchOSApp/watchOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-2f849b1d5a93/watchOSApp/watchOSApp.link.params
@@ -1,3 +1,5 @@
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/Lib/Lib.framework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/Lib/Lib.framework.watchOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/Lib/LibFramework.watchOS.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/UI/UIFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/UI/UIFramework.watchOS.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSApp/Test/UITests/watchOSAppUITests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSApp/Test/UITests/watchOSAppUITests.link.params
@@ -4,6 +4,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.link.params
@@ -6,6 +6,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/watchOSAppExtension.link.params
@@ -5,6 +5,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -573,6 +573,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -687,6 +689,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -2501,6 +2505,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -2603,6 +2609,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -2704,6 +2712,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -2805,6 +2815,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -2906,6 +2918,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3007,6 +3021,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3109,6 +3125,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3211,6 +3229,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3312,6 +3332,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3413,6 +3435,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3514,6 +3538,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -3615,6 +3641,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -4304,6 +4332,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -4421,6 +4451,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -4532,6 +4564,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -4643,6 +4677,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -4754,6 +4790,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -4865,6 +4903,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -4978,6 +5018,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -5087,6 +5129,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -5379,6 +5423,8 @@
             "label": "//iMessageApp:iMessageApp",
             "linker_inputs": {
                 "linkopts": [
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -5469,6 +5515,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -6077,6 +6125,8 @@
             "linker_inputs": {
                 "linkopts": [
                     "-lc++",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -6170,6 +6220,8 @@
             "linker_inputs": {
                 "linkopts": [
                     "-lc++",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -6331,6 +6383,8 @@
                     "CoreTelephony",
                     "-lc++",
                     "-lz",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -6551,6 +6605,8 @@
                     "CoreTelephony",
                     "-lc++",
                     "-lz",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -7324,6 +7380,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -7444,6 +7502,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -7742,6 +7802,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -7898,6 +7960,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -8095,6 +8159,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -8244,6 +8310,8 @@
             "label": "//watchOSApp:watchOSApp",
             "linker_inputs": {
                 "linkopts": [
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -8317,6 +8385,8 @@
             "label": "//watchOSApp:watchOSApp",
             "linker_inputs": {
                 "linkopts": [
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -8405,6 +8475,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -8626,6 +8698,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -8746,6 +8820,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/AddressSanitizerApp/AddressSanitizerApp.link.params
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/AddressSanitizerApp/AddressSanitizerApp.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/ThreadSanitizerApp/ThreadSanitizerApp.link.params
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/ThreadSanitizerApp/ThreadSanitizerApp.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/UndefinedBehaviorSanitizerApp/UndefinedBehaviorSanitizerApp.link.params
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56/UndefinedBehaviorSanitizerApp/UndefinedBehaviorSanitizerApp.link.params
@@ -1,5 +1,7 @@
 -framework
 UIKit
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/sanitizers/test/fixtures/bwb_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_spec.json
@@ -91,6 +91,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -254,6 +256,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -412,6 +416,8 @@
             "label": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
             "linker_inputs": {
                 "linkopts": [
+                    "-framework",
+                    "UIKit",
                     "-framework",
                     "UIKit",
                     "-headerpad_max_install_names",

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AddressSanitizerApp/AddressSanitizerApp.link.params
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AddressSanitizerApp/AddressSanitizerApp.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/ThreadSanitizerApp/ThreadSanitizerApp.link.params
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/ThreadSanitizerApp/ThreadSanitizerApp.link.params
@@ -3,6 +3,8 @@
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator
 -Wl,-rpath,/usr/lib/swift
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/UndefinedBehaviorSanitizerApp/UndefinedBehaviorSanitizerApp.link.params
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/UndefinedBehaviorSanitizerApp/UndefinedBehaviorSanitizerApp.link.params
@@ -1,5 +1,7 @@
 -framework
 UIKit
+-framework
+UIKit
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++

--- a/examples/sanitizers/test/fixtures/bwx_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_spec.json
@@ -91,6 +91,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -235,6 +237,8 @@
                     "-L/usr/lib/swift",
                     "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
                     "-Wl,-rpath,/usr/lib/swift",
+                    "-framework",
+                    "UIKit",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-lc++"
@@ -374,6 +378,8 @@
             "label": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
             "linker_inputs": {
                 "linkopts": [
+                    "-framework",
+                    "UIKit",
                     "-framework",
                     "UIKit",
                     "-headerpad_max_install_names",

--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -15,10 +15,6 @@ _LD_SKIP_OPTS = {
     "-target": 2,
 }
 
-_CC_LD_SKIP_OPTS = {
-    "-framework": 2,
-}
-
 _SKIP_INPUT_EXTENSIONS = {
     "a": None,
     "app": None,
@@ -264,7 +260,8 @@ def _extract_top_level_values(
             action_name = "c++-link-executable",
             variables = variables,
         )
-        raw_linkopts.extend(_process_cc_linkopts(cc_linkopts))
+
+        raw_linkopts.extend(cc_linkopts)
 
         linkopts = _process_linkopts(raw_linkopts)
     else:
@@ -349,22 +346,6 @@ def _get_library_static_libraries(linker_inputs, *, dep_compilation_providers):
     )
 
     return (direct, transitive)
-
-def _process_cc_linkopts(linkopts):
-    ret = []
-    skip_next = 0
-    for linkopt in linkopts:
-        if skip_next:
-            skip_next -= 1
-            continue
-        skip_next = _CC_LD_SKIP_OPTS.get(linkopt, 0)
-        if skip_next:
-            skip_next -= 1
-            continue
-
-        ret.append(linkopt)
-
-    return ret
 
 def _process_linkopts(linkopts):
     ret = []


### PR DESCRIPTION
This fixes linking in BwX projects when they depend on these implicit frameworks that `cc_toolchain` currently sets.