### PR TITLE
Use `productType: .framework` for `.staticFramework`

### DIFF
--- a/tools/generator/src/Extensions/PBXProductType+Extensions.swift
+++ b/tools/generator/src/Extensions/PBXProductType+Extensions.swift
@@ -295,6 +295,13 @@ extension PBXProductType {
         return isLaunchable || isBundle
     }
 
+    var forXcode: Self {
+        if self == .staticFramework {
+            return .framework
+        }
+        return self
+    }
+
     // MARK: Schemes
 
     var canUseDebugLauncher: Bool {

--- a/tools/generator/src/Generator/AddTargets.swift
+++ b/tools/generator/src/Generator/AddTargets.swift
@@ -116,7 +116,7 @@ Product for target "\(key)" not found in `products`
                 productName: target.product.name,
                 product: productType.setsAssociatedProduct ?
                     product : nil,
-                productType: productType
+                productType: productType.forXcode
             )
             pbxProj.add(object: pbxTarget)
             pbxProject.targets.append(pbxTarget)

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -291,6 +291,12 @@ Target with id "\(id)" not found in `consolidatedTarget.uniqueFiles`
             buildSettings.set("BAZEL_LABEL", to: target.label.description)
         }
 
+        if target.product.type == .staticFramework {
+            // We set the `productType` to `.framework` to get the better
+            // looking icon, so we need to manually set `MACH_O_TYPE`
+            buildSettings["MACH_O_TYPE"] = "staticlib"
+        }
+
         let compileTargetName: String
         if let compileTarget = target.compileTarget {
             buildSettings.set(

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1976,7 +1976,7 @@ touch "$SCRIPT_OUTPUT_FILE_1"
                 buildPhases: buildPhases["B 1"] ?? [],
                 productName: "b",
                 product: products.byTarget["B 1"],
-                productType: .staticFramework
+                productType: .framework
             ),
             "B 2": PBXNativeTarget(
                 name: disambiguatedTargets.targets["B 2"]!.name,
@@ -2318,6 +2318,7 @@ $(PREVIEWS_SWIFT_INCLUDE_PATH__$(ENABLE_PREVIEWS)) $(BUILD_DIR)/bazel-out/z
                 "COMPILE_TARGET_NAME": targets["B 1"]!.name,
                 "DYLIB_INSTALL_NAME_BASE": "@rpath",
                 "GENERATE_INFOPLIST_FILE": "YES",
+                "MACH_O_TYPE": "staticlib",
                 "MACOSX_DEPLOYMENT_TARGET": "11.0",
                 "OTHER_CFLAGS": [
                     "-ivfsoverlay",


### PR DESCRIPTION
This gives us a better icon in Xcode.