### PR TITLE
Change example `.bazelversion`s to symlinks

### DIFF
--- a/examples/cc/.bazelversion
+++ b/examples/cc/.bazelversion
@@ -1,1 +1,1 @@
-5.3.0
+../../.bazelversion

--- a/examples/integration/.bazelversion
+++ b/examples/integration/.bazelversion
@@ -1,1 +1,1 @@
-5.3.0
+../../.bazelversion

--- a/examples/sanitizers/.bazelversion
+++ b/examples/sanitizers/.bazelversion
@@ -1,1 +1,1 @@
-5.3.0
+../../.bazelversion

--- a/examples/simple/.bazelversion
+++ b/examples/simple/.bazelversion
@@ -1,1 +1,1 @@
-5.3.0
+../../.bazelversion


### PR DESCRIPTION
This makes it easier to update the targeted Bazel version.