### PR TITLE
Apply the same `env -i` command in the runner

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -97,6 +97,7 @@ bazel_cmd=(
   env -i
   HOME="$HOME"
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
   "${bazelrcs[@]}"

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -97,6 +97,7 @@ bazel_cmd=(
   env -i
   HOME="$HOME"
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
   "${bazelrcs[@]}"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -97,6 +97,7 @@ bazel_cmd=(
   env -i
   HOME="$HOME"
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
   "${bazelrcs[@]}"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -97,6 +97,7 @@ bazel_cmd=(
   env -i
   HOME="$HOME"
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
   "${bazelrcs[@]}"

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -97,6 +97,7 @@ bazel_cmd=(
   env -i
   HOME="$HOME"
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
   "${bazelrcs[@]}"

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -97,6 +97,7 @@ bazel_cmd=(
   env -i
   HOME="$HOME"
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
   "${bazelrcs[@]}"

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -97,6 +97,7 @@ bazel_cmd=(
   env -i
   HOME="$HOME"
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
   "${bazelrcs[@]}"

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -97,6 +97,7 @@ bazel_cmd=(
   env -i
   HOME="$HOME"
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
   "${bazelrcs[@]}"

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -97,6 +97,7 @@ bazel_cmd=(
   env -i
   HOME="$HOME"
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
   "${bazelrcs[@]}"

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -97,6 +97,7 @@ bazel_cmd=(
   env -i
   HOME="$HOME"
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
   "${bazelrcs[@]}"

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -97,6 +97,7 @@ bazel_cmd=(
   env -i
   HOME="$HOME"
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
   "${bazelrcs[@]}"

--- a/xcodeproj/internal/installer.template.sh
+++ b/xcodeproj/internal/installer.template.sh
@@ -22,6 +22,10 @@ for_fixture=0
 
 while (("$#")); do
   case "${1}" in
+    "--bazel_path")
+      bazel_path="${2}"
+      shift 2
+      ;;
     "--bazelrc")
       bazelrc="${2}"
       shift 2
@@ -47,6 +51,10 @@ while (("$#")); do
       ;;
   esac
 done
+
+if [[ -z "${bazel_path:-}" ]]; then
+  fail "Missing required argument: --bazel_path"
+fi
 
 # Resolve the source
 readonly src="$PWD/%source_path%"
@@ -163,7 +171,7 @@ if [[ -f "$dest/rules_xcodeproj/generated.xcfilelist" ]]; then
 
   xcode_build_version=$(/usr/bin/xcodebuild -version | tail -1 | cut -d " " -f3)
 
-  bazel_out=$("%bazel_path%" "${bazelrcs[@]}" \
+  bazel_out=$("$bazel_path" "${bazelrcs[@]}" \
     info \
     "--repo_env=USE_CLANG_CL=$xcode_build_version" \
     --config=rules_xcodeproj_info \

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -747,7 +747,6 @@ def _write_installer(
         output = installer,
         is_executable = True,
         substitutions = {
-            "%bazel_path%": ctx.attr.bazel_path,
             "%output_path%": install_path,
             "%source_path%": xcodeproj.short_path,
             "%spec_path%": spec_file.short_path,


### PR DESCRIPTION
This is to ensure the generator run and the in-Xcode build are as similar as possible.