### PR TITLE
Nest output base inside of "outer" output path

### DIFF
--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -99,6 +99,8 @@ actions:
       pull_request:
         branches:
           - "*"
+    git_clean_exclude:
+      - bazel-output-base
     bazel_commands:
       - "run --config=workflows //:buildifier.check"
 
@@ -110,5 +112,7 @@ actions:
       pull_request:
         branches:
           - "*"
+    git_clean_exclude:
+      - bazel-output-base
     bazel_commands:
       - "test --config=workflows //docs:diff_test"

--- a/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 				2D3DFF4472B24F4AD7FC4D86 /* examples_cc_external */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/external";
+			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		BC9D41B5104B7D51C3B01915 /* includes */ = {
@@ -727,11 +727,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -114,17 +114,23 @@ pre_config_flags=(
 
 # Determine Bazel output_path
 
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_path="$build_output_base/../.."
+
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
   # indexing waiting on bazel locks from the other. We nest it inside of the
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-
-  bazel_cmd+=(
-    --output_base "${BAZEL_OUT%/*/*/*}/rules_xcodeproj/indexbuild_output_base"
-  )
+  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
 fi
+bazel_cmd+=(--output_base "$output_base")
 
 if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
   color=yes

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -9,15 +9,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
-# In Xcode 14 the "Index" directory was renamed to "Index.noindex".
-# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can
-# use it to determine the name of the directory regardless of Xcode version.
-readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
-readonly index_dir_name="${index_dir##*/}"
-
-readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
 readonly workspace_name="${execution_root##*/}"
-readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly index_execution_root="${output_base%/*/*/*/*/*}/rules_xcodeproj/indexbuild_output_base/execroot/$workspace_name"
 
 readonly index_bazel_out="$index_execution_root/bazel-out"
 readonly index_external="$index_execution_root/external"

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -35,9 +35,9 @@ fi
 
 # Set remaps
 
-# Since users can override `--output_base`, all we know is that the
-# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
-readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+# We only support importing indexes built with rules_xcodeproj, and we override
+# our output bases, so we know the the ending of the execution root
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -177,7 +177,7 @@
 				C0094871AF8AEE1DBE5F47F3 /* examples_cc_external */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/external";
+			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		C0094871AF8AEE1DBE5F47F3 /* examples_cc_external */ = {
@@ -643,11 +643,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -114,17 +114,23 @@ pre_config_flags=(
 
 # Determine Bazel output_path
 
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_path="$build_output_base/../.."
+
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
   # indexing waiting on bazel locks from the other. We nest it inside of the
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-
-  bazel_cmd+=(
-    --output_base "${BAZEL_OUT%/*/*/*}/rules_xcodeproj/indexbuild_output_base"
-  )
+  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
 fi
+bazel_cmd+=(--output_base "$output_base")
 
 if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
   color=yes

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -9,15 +9,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
-# In Xcode 14 the "Index" directory was renamed to "Index.noindex".
-# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can
-# use it to determine the name of the directory regardless of Xcode version.
-readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
-readonly index_dir_name="${index_dir##*/}"
-
-readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
 readonly workspace_name="${execution_root##*/}"
-readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly index_execution_root="${output_base%/*/*/*/*/*}/rules_xcodeproj/indexbuild_output_base/execroot/$workspace_name"
 
 readonly index_bazel_out="$index_execution_root/bazel-out"
 readonly index_external="$index_execution_root/external"

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -35,9 +35,9 @@ fi
 
 # Set remaps
 
-# Since users can override `--output_base`, all we know is that the
-# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
-readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+# We only support importing indexes built with rules_xcodeproj, and we override
+# our output bases, so we know the the ending of the execution root
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -2194,7 +2194,7 @@
 				BEFC18878DC5748769CC7D24 /* examples_ios_app_external */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/external";
+			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		98EF34BC907E91C8A24D2D8C /* dynamic */ = {
@@ -2668,7 +2668,7 @@
 				F42C67C6B7361A26AE646E15 /* watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/__main__/bazel-out";
+			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 			sourceTree = "<group>";
 		};
 		C830494187F23C2ACF6D66AA /* PreviewContent */ = {
@@ -7332,11 +7332,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -114,17 +114,23 @@ pre_config_flags=(
 
 # Determine Bazel output_path
 
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_path="$build_output_base/../.."
+
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
   # indexing waiting on bazel locks from the other. We nest it inside of the
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-
-  bazel_cmd+=(
-    --output_base "${BAZEL_OUT%/*/*/*}/rules_xcodeproj/indexbuild_output_base"
-  )
+  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
 fi
+bazel_cmd+=(--output_base "$output_base")
 
 if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
   color=yes

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -9,15 +9,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
-# In Xcode 14 the "Index" directory was renamed to "Index.noindex".
-# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can
-# use it to determine the name of the directory regardless of Xcode version.
-readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
-readonly index_dir_name="${index_dir##*/}"
-
-readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
 readonly workspace_name="${execution_root##*/}"
-readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly index_execution_root="${output_base%/*/*/*/*/*}/rules_xcodeproj/indexbuild_output_base/execroot/$workspace_name"
 
 readonly index_bazel_out="$index_execution_root/bazel-out"
 readonly index_external="$index_execution_root/external"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -35,9 +35,9 @@ fi
 
 # Set remaps
 
-# Since users can override `--output_base`, all we know is that the
-# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
-readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+# We only support importing indexes built with rules_xcodeproj, and we override
+# our output bases, so we know the the ending of the execution root
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -2380,7 +2380,7 @@
 				56574692F5ACDED2EE10E84A /* examples_ios_app_external */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/external";
+			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		86016AFC7E66C734E7E1D9D0 /* Lib */ = {
@@ -2667,7 +2667,7 @@
 				3D504DADD5F4AA7AC4AABC01 /* watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/__main__/bazel-out";
+			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 			sourceTree = "<group>";
 		};
 		A6BDB7EBB154DC58FA005345 /* WidgetExtension */ = {
@@ -7607,11 +7607,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -114,17 +114,23 @@ pre_config_flags=(
 
 # Determine Bazel output_path
 
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_path="$build_output_base/../.."
+
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
   # indexing waiting on bazel locks from the other. We nest it inside of the
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-
-  bazel_cmd+=(
-    --output_base "${BAZEL_OUT%/*/*/*}/rules_xcodeproj/indexbuild_output_base"
-  )
+  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
 fi
+bazel_cmd+=(--output_base "$output_base")
 
 if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
   color=yes

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -9,15 +9,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
-# In Xcode 14 the "Index" directory was renamed to "Index.noindex".
-# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can
-# use it to determine the name of the directory regardless of Xcode version.
-readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
-readonly index_dir_name="${index_dir##*/}"
-
-readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
 readonly workspace_name="${execution_root##*/}"
-readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly index_execution_root="${output_base%/*/*/*/*/*}/rules_xcodeproj/indexbuild_output_base/execroot/$workspace_name"
 
 readonly index_bazel_out="$index_execution_root/bazel-out"
 readonly index_external="$index_execution_root/external"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -35,9 +35,9 @@ fi
 
 # Set remaps
 
-# Since users can override `--output_base`, all we know is that the
-# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
-readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+# We only support importing indexes built with rules_xcodeproj, and we override
+# our output bases, so we know the the ending of the execution root
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -229,7 +229,7 @@
 				D308305EB44933FCF28725BC /* applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/__main__/bazel-out";
+			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 			sourceTree = "<group>";
 		};
 		D11D8A623D8736DF294E22E4 /* AddressSanitizerApp */ = {
@@ -702,11 +702,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -114,17 +114,23 @@ pre_config_flags=(
 
 # Determine Bazel output_path
 
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_path="$build_output_base/../.."
+
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
   # indexing waiting on bazel locks from the other. We nest it inside of the
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-
-  bazel_cmd+=(
-    --output_base "${BAZEL_OUT%/*/*/*}/rules_xcodeproj/indexbuild_output_base"
-  )
+  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
 fi
+bazel_cmd+=(--output_base "$output_base")
 
 if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
   color=yes

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -9,15 +9,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
-# In Xcode 14 the "Index" directory was renamed to "Index.noindex".
-# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can
-# use it to determine the name of the directory regardless of Xcode version.
-readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
-readonly index_dir_name="${index_dir##*/}"
-
-readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
 readonly workspace_name="${execution_root##*/}"
-readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly index_execution_root="${output_base%/*/*/*/*/*}/rules_xcodeproj/indexbuild_output_base/execroot/$workspace_name"
 
 readonly index_bazel_out="$index_execution_root/bazel-out"
 readonly index_external="$index_execution_root/external"

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -35,9 +35,9 @@ fi
 
 # Set remaps
 
-# Since users can override `--output_base`, all we know is that the
-# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
-readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+# We only support importing indexes built with rules_xcodeproj, and we override
+# our output bases, so we know the the ending of the execution root
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -209,7 +209,7 @@
 				DB819FF70CEDFDF42E7432FF /* applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/__main__/bazel-out";
+			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 			sourceTree = "<group>";
 		};
 		D2C8CC455B9D27F28D323622 /* test */ = {
@@ -701,11 +701,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -114,17 +114,23 @@ pre_config_flags=(
 
 # Determine Bazel output_path
 
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_path="$build_output_base/../.."
+
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
   # indexing waiting on bazel locks from the other. We nest it inside of the
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-
-  bazel_cmd+=(
-    --output_base "${BAZEL_OUT%/*/*/*}/rules_xcodeproj/indexbuild_output_base"
-  )
+  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
 fi
+bazel_cmd+=(--output_base "$output_base")
 
 if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
   color=yes

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -9,15 +9,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
-# In Xcode 14 the "Index" directory was renamed to "Index.noindex".
-# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can
-# use it to determine the name of the directory regardless of Xcode version.
-readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
-readonly index_dir_name="${index_dir##*/}"
-
-readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
 readonly workspace_name="${execution_root##*/}"
-readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly index_execution_root="${output_base%/*/*/*/*/*}/rules_xcodeproj/indexbuild_output_base/execroot/$workspace_name"
 
 readonly index_bazel_out="$index_execution_root/bazel-out"
 readonly index_external="$index_execution_root/external"

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -35,9 +35,9 @@ fi
 
 # Set remaps
 
-# Since users can override `--output_base`, all we know is that the
-# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
-readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+# We only support importing indexes built with rules_xcodeproj, and we override
+# our output bases, so we know the the ending of the execution root
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/examples/simple/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -328,11 +328,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -114,17 +114,23 @@ pre_config_flags=(
 
 # Determine Bazel output_path
 
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_path="$build_output_base/../.."
+
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
   # indexing waiting on bazel locks from the other. We nest it inside of the
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-
-  bazel_cmd+=(
-    --output_base "${BAZEL_OUT%/*/*/*}/rules_xcodeproj/indexbuild_output_base"
-  )
+  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
 fi
+bazel_cmd+=(--output_base "$output_base")
 
 if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
   color=yes

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -9,15 +9,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
-# In Xcode 14 the "Index" directory was renamed to "Index.noindex".
-# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can
-# use it to determine the name of the directory regardless of Xcode version.
-readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
-readonly index_dir_name="${index_dir##*/}"
-
-readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
 readonly workspace_name="${execution_root##*/}"
-readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly index_execution_root="${output_base%/*/*/*/*/*}/rules_xcodeproj/indexbuild_output_base/execroot/$workspace_name"
 
 readonly index_bazel_out="$index_execution_root/bazel-out"
 readonly index_external="$index_execution_root/external"

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -35,9 +35,9 @@ fi
 
 # Set remaps
 
-# Since users can override `--output_base`, all we know is that the
-# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
-readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+# We only support importing indexes built with rules_xcodeproj, and we override
+# our output bases, so we know the the ending of the execution root
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/examples/simple/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -186,11 +186,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -114,17 +114,23 @@ pre_config_flags=(
 
 # Determine Bazel output_path
 
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_path="$build_output_base/../.."
+
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
   # indexing waiting on bazel locks from the other. We nest it inside of the
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-
-  bazel_cmd+=(
-    --output_base "${BAZEL_OUT%/*/*/*}/rules_xcodeproj/indexbuild_output_base"
-  )
+  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
 fi
+bazel_cmd+=(--output_base "$output_base")
 
 if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
   color=yes

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -9,15 +9,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
-# In Xcode 14 the "Index" directory was renamed to "Index.noindex".
-# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can
-# use it to determine the name of the directory regardless of Xcode version.
-readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
-readonly index_dir_name="${index_dir##*/}"
-
-readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
 readonly workspace_name="${execution_root##*/}"
-readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly index_execution_root="${output_base%/*/*/*/*/*}/rules_xcodeproj/indexbuild_output_base/execroot/$workspace_name"
 
 readonly index_bazel_out="$index_execution_root/bazel-out"
 readonly index_external="$index_execution_root/external"

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -35,9 +35,9 @@ fi
 
 # Set remaps
 
-# Since users can override `--output_base`, all we know is that the
-# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
-readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+# We only support importing indexes built with rules_xcodeproj, and we override
+# our output bases, so we know the the ending of the execution root
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -4,15 +4,18 @@ build --experimental_convenience_symlinks=ignore
 build --remote_default_exec_properties=OSFamily=darwin
 build --remote_default_exec_properties=cache_bust=macOS_12.0/3
 
+# In-repo output_base makes fixtures relative
+startup --output_base=bazel-output-base
+
 # Build with --config=cache to use BuildBuddy Remote Cache
-build:cache --bes_backend=grpcs://remote.buildbuddy.io
-build:cache --bes_results_url=https://app.buildbuddy.io/invocation/
-build:cache --experimental_remote_cache_async
-build:cache --experimental_remote_cache_compression
-build:cache --incompatible_remote_build_event_upload_respect_no_cache
-build:cache --jobs=100
-build:cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
-build:cache --remote_cache=grpcs://remote.buildbuddy.io
+# build:cache --bes_backend=grpcs://remote.buildbuddy.io
+# build:cache --bes_results_url=https://app.buildbuddy.io/invocation/
+# build:cache --experimental_remote_cache_async
+# build:cache --experimental_remote_cache_compression
+# build:cache --incompatible_remote_build_event_upload_respect_no_cache
+# build:cache --jobs=100
+# build:cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
+# build:cache --remote_cache=grpcs://remote.buildbuddy.io
 build:cache --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_common_flags='--config=cache'
 build:cache --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_indexbuild_flags='--bes_backend= --bes_results_url='
 build:cache --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_generator_flags='--bes_backend= --bes_results_url='

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -1180,7 +1180,7 @@
 				CCD52FD22F080CD6DA9BD957 /* com_github_tuist_xcodeproj */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/external";
+			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		98EB7C1365B0DAEC16FDE8B9 /* applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000 */ = {
@@ -1379,7 +1379,7 @@
 				98EB7C1365B0DAEC16FDE8B9 /* applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 			sourceTree = "<group>";
 		};
 		CA7DD8A114179E4211EC51BF /* Project */ = {
@@ -2634,11 +2634,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -114,17 +114,23 @@ pre_config_flags=(
 
 # Determine Bazel output_path
 
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_path="$build_output_base/../.."
+
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
   # indexing waiting on bazel locks from the other. We nest it inside of the
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-
-  bazel_cmd+=(
-    --output_base "${BAZEL_OUT%/*/*/*}/rules_xcodeproj/indexbuild_output_base"
-  )
+  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
 fi
+bazel_cmd+=(--output_base "$output_base")
 
 if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
   color=yes

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -9,15 +9,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
-# In Xcode 14 the "Index" directory was renamed to "Index.noindex".
-# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can
-# use it to determine the name of the directory regardless of Xcode version.
-readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
-readonly index_dir_name="${index_dir##*/}"
-
-readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
 readonly workspace_name="${execution_root##*/}"
-readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly index_execution_root="${output_base%/*/*/*/*/*}/rules_xcodeproj/indexbuild_output_base/execroot/$workspace_name"
 
 readonly index_bazel_out="$index_execution_root/bazel-out"
 readonly index_external="$index_execution_root/external"

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -35,9 +35,9 @@ fi
 
 # Set remaps
 
-# Since users can override `--output_base`, all we know is that the
-# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
-readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+# We only support importing indexes built with rules_xcodeproj, and we override
+# our output bases, so we know the the ending of the execution root
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -1262,7 +1262,7 @@
 				FDA6D5213A699DBCBE8C3656 /* com_github_tuist_xcodeproj */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/external";
+			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		99F2704C9CFA066AF152A571 /* applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889 */ = {
@@ -1298,7 +1298,7 @@
 				99F2704C9CFA066AF152A571 /* applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 			sourceTree = "<group>";
 		};
 		A61FCE87C253B18D1339CA0F /* Scheme */ = {
@@ -2702,11 +2702,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -114,17 +114,23 @@ pre_config_flags=(
 
 # Determine Bazel output_path
 
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_path="$build_output_base/../.."
+
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
   # indexing waiting on bazel locks from the other. We nest it inside of the
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-
-  bazel_cmd+=(
-    --output_base "${BAZEL_OUT%/*/*/*}/rules_xcodeproj/indexbuild_output_base"
-  )
+  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
 fi
+bazel_cmd+=(--output_base "$output_base")
 
 if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
   color=yes

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/create_lldbinit.sh
@@ -9,15 +9,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
-# In Xcode 14 the "Index" directory was renamed to "Index.noindex".
-# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can
-# use it to determine the name of the directory regardless of Xcode version.
-readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
-readonly index_dir_name="${index_dir##*/}"
-
-readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
 readonly workspace_name="${execution_root##*/}"
-readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly index_execution_root="${output_base%/*/*/*/*/*}/rules_xcodeproj/indexbuild_output_base/execroot/$workspace_name"
 
 readonly index_bazel_out="$index_execution_root/bazel-out"
 readonly index_external="$index_execution_root/external"

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -35,9 +35,9 @@ fi
 
 # Set remaps
 
-# Since users can override `--output_base`, all we know is that the
-# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
-readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+# We only support importing indexes built with rules_xcodeproj, and we override
+# our output bases, so we know the the ending of the execution root
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/xcodeproj.bazelrc
+++ b/xcodeproj.bazelrc
@@ -1,6 +1,2 @@
-# In-repo output_base makes fixtures relative
-# Having a separate output_base also reduces analysis cache thrashing
-startup --output_base=bazel-output-base
-
 # Enabling archived bundles for fixture coverage
 build:rules_xcodeproj --define=apple.experimental.tree_artifact_outputs=0

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -114,17 +114,23 @@ pre_config_flags=(
 
 # Determine Bazel output_path
 
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_path="$build_output_base/../.."
+
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
   # indexing waiting on bazel locks from the other. We nest it inside of the
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-
-  bazel_cmd+=(
-    --output_base "${BAZEL_OUT%/*/*/*}/rules_xcodeproj/indexbuild_output_base"
-  )
+  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
 fi
+bazel_cmd+=(--output_base "$output_base")
 
 if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
   color=yes

--- a/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
+++ b/xcodeproj/internal/bazel_integration_files/create_lldbinit.sh
@@ -9,15 +9,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly build_bazel_out="$execution_root/bazel-out"
 readonly build_external="$output_base/external"
 
-# In Xcode 14 the "Index" directory was renamed to "Index.noindex".
-# `$INDEX_DATA_STORE_DIR` is set to `$OBJROOT/INDEX_DIR/DataStore`, so we can
-# use it to determine the name of the directory regardless of Xcode version.
-readonly index_dir="${INDEX_DATA_STORE_DIR%/*}"
-readonly index_dir_name="${index_dir##*/}"
-
-readonly index_objroot="${OBJROOT%/Build/Intermediates.noindex}/$index_dir_name/Build/Intermediates.noindex"
 readonly workspace_name="${execution_root##*/}"
-readonly index_execution_root="$index_objroot/bazel_output_base/execroot/$workspace_name"
+readonly index_execution_root="${output_base%/*/*/*/*/*}/rules_xcodeproj/indexbuild_output_base/execroot/$workspace_name"
 
 readonly index_bazel_out="$index_execution_root/bazel-out"
 readonly index_external="$index_execution_root/external"

--- a/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
+++ b/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
@@ -35,9 +35,9 @@ fi
 
 # Set remaps
 
-# Since users can override `--output_base`, all we know is that the
-# execution_root fits the format of `/OUTPUT_BASE/execroot/WORKSPACE_NAME`
-readonly execution_root_regex='.*?/[^/]+/execroot/[^/]+'
+# We only support importing indexes built with rules_xcodeproj, and we override
+# our output bases, so we know the the ending of the execution root
+readonly execution_root_regex='.*/[^/]+/(?:_)?rules_xcodeproj/[^/]+_output_base/execroot/[^/]+'
 
 # We remove any `/private` prefix from the current execution_root, since it's
 # removed in the Project navigator.

--- a/xcodeproj/internal/installer.template.sh
+++ b/xcodeproj/internal/installer.template.sh
@@ -160,6 +160,9 @@ plutil -replace IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded -bool fals
 if [[ -f "$dest/rules_xcodeproj/generated.xcfilelist" ]]; then
   cd "$BUILD_WORKSPACE_DIRECTORY"
 
+  output_path=$("$bazel_path" info output_path)
+  readonly nested_output_base="$output_path/_rules_xcodeproj/build_output_base"
+
   # Determine bazel-out
   bazelrcs=(
     --noworkspace_rc
@@ -172,6 +175,7 @@ if [[ -f "$dest/rules_xcodeproj/generated.xcfilelist" ]]; then
   xcode_build_version=$(/usr/bin/xcodebuild -version | tail -1 | cut -d " " -f3)
 
   bazel_out=$("$bazel_path" "${bazelrcs[@]}" \
+    --output_base "$nested_output_base" \
     info \
     "--repo_env=USE_CLANG_CL=$xcode_build_version" \
     --config=rules_xcodeproj_info \

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -50,6 +50,11 @@ cd "$BUILD_WORKSPACE_DIRECTORY"
 bazel_path=$(which "%bazel_path%")
 installer_flags+=(--bazel_path "$bazel_path")
 
+output_path=$("$bazel_path" info output_path)
+
+readonly nested_output_base_prefix="$output_path/_rules_xcodeproj"
+readonly nested_output_base="$nested_output_base_prefix/build_output_base"
+
 bazelrcs=(
   --noworkspace_rc
   "--bazelrc=$bazelrc"
@@ -90,6 +95,7 @@ readonly bazel_cmd=(
   "${passthrough_envs[@]}"
   "$bazel_path"
   "${bazelrcs[@]}"
+  --output_base "$nested_output_base"
 )
 
 # Ensure that our top-level cache buster `override_repository` is valid


### PR DESCRIPTION
This is to make sure that the analysis cache stays as hot as possible. This should bring the consistency of BwB performance more in line with BwX.

We currently don't set a different output base for each of the different configs (e.g. SwiftUI Preview, asan, etc.), as some generated build inputs (e.g. Info.plists) currently can't be found that way. This means that switching between SwiftUI Previews and normal builds, or having builds that have different sanitizers set, will clear at least some of the analysis cache.