### PR TITLE
Add a new output group for generated source files

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -21,8 +21,8 @@ if [ "$ACTION" == "indexbuild" ]; then
     # Inputs for compiling
     readonly output_group_prefixes="xc"
   else
-    # Compiled outputs (i.e. swiftmodules)
-    readonly output_group_prefixes="bc"
+    # Compiled outputs (i.e. swiftmodules), and generated inputs
+    readonly output_group_prefixes="bc,bg"
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -29,9 +29,9 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
-    # store data
-    readonly output_group_prefixes="bc,bp,bi"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), generated
+    # inputs, and index store data
+    readonly output_group_prefixes="bc,bp,bg,bi"
   fi
 fi
 

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -21,8 +21,8 @@ if [ "$ACTION" == "indexbuild" ]; then
     # Inputs for compiling
     readonly output_group_prefixes="xc"
   else
-    # Compiled outputs (i.e. swiftmodules)
-    readonly output_group_prefixes="bc"
+    # Compiled outputs (i.e. swiftmodules), and generated inputs
+    readonly output_group_prefixes="bc,bg"
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -29,9 +29,9 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
-    # store data
-    readonly output_group_prefixes="bc,bp,bi"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), generated
+    # inputs, and index store data
+    readonly output_group_prefixes="bc,bp,bg,bi"
   fi
 fi
 

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -21,8 +21,8 @@ if [ "$ACTION" == "indexbuild" ]; then
     # Inputs for compiling
     readonly output_group_prefixes="xc"
   else
-    # Compiled outputs (i.e. swiftmodules)
-    readonly output_group_prefixes="bc"
+    # Compiled outputs (i.e. swiftmodules), and generated inputs
+    readonly output_group_prefixes="bc,bg"
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -29,9 +29,9 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
-    # store data
-    readonly output_group_prefixes="bc,bp,bi"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), generated
+    # inputs, and index store data
+    readonly output_group_prefixes="bc,bp,bg,bi"
   fi
 fi
 

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -21,8 +21,8 @@ if [ "$ACTION" == "indexbuild" ]; then
     # Inputs for compiling
     readonly output_group_prefixes="xc"
   else
-    # Compiled outputs (i.e. swiftmodules)
-    readonly output_group_prefixes="bc"
+    # Compiled outputs (i.e. swiftmodules), and generated inputs
+    readonly output_group_prefixes="bc,bg"
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -29,9 +29,9 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
-    # store data
-    readonly output_group_prefixes="bc,bp,bi"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), generated
+    # inputs, and index store data
+    readonly output_group_prefixes="bc,bp,bg,bi"
   fi
 fi
 

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -21,8 +21,8 @@ if [ "$ACTION" == "indexbuild" ]; then
     # Inputs for compiling
     readonly output_group_prefixes="xc"
   else
-    # Compiled outputs (i.e. swiftmodules)
-    readonly output_group_prefixes="bc"
+    # Compiled outputs (i.e. swiftmodules), and generated inputs
+    readonly output_group_prefixes="bc,bg"
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -29,9 +29,9 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
-    # store data
-    readonly output_group_prefixes="bc,bp,bi"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), generated
+    # inputs, and index store data
+    readonly output_group_prefixes="bc,bp,bg,bi"
   fi
 fi
 

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -21,8 +21,8 @@ if [ "$ACTION" == "indexbuild" ]; then
     # Inputs for compiling
     readonly output_group_prefixes="xc"
   else
-    # Compiled outputs (i.e. swiftmodules)
-    readonly output_group_prefixes="bc"
+    # Compiled outputs (i.e. swiftmodules), and generated inputs
+    readonly output_group_prefixes="bc,bg"
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -29,9 +29,9 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
-    # store data
-    readonly output_group_prefixes="bc,bp,bi"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), generated
+    # inputs, and index store data
+    readonly output_group_prefixes="bc,bp,bg,bi"
   fi
 fi
 

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -21,8 +21,8 @@ if [ "$ACTION" == "indexbuild" ]; then
     # Inputs for compiling
     readonly output_group_prefixes="xc"
   else
-    # Compiled outputs (i.e. swiftmodules)
-    readonly output_group_prefixes="bc"
+    # Compiled outputs (i.e. swiftmodules), and generated inputs
+    readonly output_group_prefixes="bc,bg"
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -29,9 +29,9 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
-    # store data
-    readonly output_group_prefixes="bc,bp,bi"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), generated
+    # inputs, and index store data
+    readonly output_group_prefixes="bc,bp,bg,bi"
   fi
 fi
 

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -21,8 +21,8 @@ if [ "$ACTION" == "indexbuild" ]; then
     # Inputs for compiling
     readonly output_group_prefixes="xc"
   else
-    # Compiled outputs (i.e. swiftmodules)
-    readonly output_group_prefixes="bc"
+    # Compiled outputs (i.e. swiftmodules), and generated inputs
+    readonly output_group_prefixes="bc,bg"
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -29,9 +29,9 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
-    # store data
-    readonly output_group_prefixes="bc,bp,bi"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), generated
+    # inputs, and index store data
+    readonly output_group_prefixes="bc,bp,bg,bi"
   fi
 fi
 

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -21,8 +21,8 @@ if [ "$ACTION" == "indexbuild" ]; then
     # Inputs for compiling
     readonly output_group_prefixes="xc"
   else
-    # Compiled outputs (i.e. swiftmodules)
-    readonly output_group_prefixes="bc"
+    # Compiled outputs (i.e. swiftmodules), and generated inputs
+    readonly output_group_prefixes="bc,bg"
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -29,9 +29,9 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
-    # store data
-    readonly output_group_prefixes="bc,bp,bi"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), generated
+    # inputs, and index store data
+    readonly output_group_prefixes="bc,bp,bg,bi"
   fi
 fi
 

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -21,8 +21,8 @@ if [ "$ACTION" == "indexbuild" ]; then
     # Inputs for compiling
     readonly output_group_prefixes="xc"
   else
-    # Compiled outputs (i.e. swiftmodules)
-    readonly output_group_prefixes="bc"
+    # Compiled outputs (i.e. swiftmodules), and generated inputs
+    readonly output_group_prefixes="bc,bg"
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -29,9 +29,9 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
-    # store data
-    readonly output_group_prefixes="bc,bp,bi"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), generated
+    # inputs, and index store data
+    readonly output_group_prefixes="bc,bp,bg,bi"
   fi
 fi
 

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -21,8 +21,8 @@ if [ "$ACTION" == "indexbuild" ]; then
     # Inputs for compiling
     readonly output_group_prefixes="xc"
   else
-    # Compiled outputs (i.e. swiftmodules)
-    readonly output_group_prefixes="bc"
+    # Compiled outputs (i.e. swiftmodules), and generated inputs
+    readonly output_group_prefixes="bc,bg"
   fi
 else
   if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -29,9 +29,9 @@ else
     # Inputs for compiling, inputs for linking, and index store data
     readonly output_group_prefixes="xc,xl,xi"
   else
-    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), and index
-    # store data
-    readonly output_group_prefixes="bc,bp,bi"
+    # Compiled outputs (i.e. swiftmodules), products (i.e. bundles), generated
+    # inputs, and index store data
+    readonly output_group_prefixes="bc,bp,bg,bi"
   fi
 fi
 

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -65,6 +65,17 @@ def _create(
                 ))
         ],
     )
+    transitive_generated_srcs = depset(
+        transitive = [
+            info.inputs.generated
+            for attr, info in transitive_infos
+            if (not automatic_target_info or
+                info.target_type in automatic_target_info.xcode_targets.get(
+                    attr,
+                    [None],
+                ))
+        ],
+    )
     transitive_indexestores = depset(
         [indexstore] if indexstore else None,
         transitive = [
@@ -106,6 +117,7 @@ def _create(
         products_output_group_name = "bp {}".format(direct_outputs.id)
         direct_group_list = [
             ("bc {}".format(direct_outputs.id), transitive_compiles),
+            ("bg {}".format(direct_outputs.id), transitive_generated_srcs),
             ("bi {}".format(direct_outputs.id), transitive_indexestores),
             (products_output_group_name, transitive_products),
         ]


### PR DESCRIPTION
This ensures that generated source files are downloaded when buiding
with "Builds without the Bytes".
