### PR TITLE
Fix swiftc stub for incremental compilation

### DIFF
--- a/tools/swiftc_stub/main.swift
+++ b/tools/swiftc_stub/main.swift
@@ -39,26 +39,28 @@ func touchDepsFiles(_ args: OrderedSet<String>) throws {
     else { return }
 
     if isWMO(args: args) {
-        let dFile = String(outputFileMapPath.path.dropLast("-OutputFileMap.json".count) + "-master.d")
-        var url = URL(fileURLWithPath: dFile)
+        let dPath = String(
+            outputFileMapPath.path.dropLast("-OutputFileMap.json".count) +
+            "-master.d"
+        )
+        var url = URL(fileURLWithPath: dPath)
         try url.touch()
     } else {
-        var swiftFileListPath: String?
-        for arg in args {
-            if arg.hasPrefix("@"), arg.hasSuffix(".SwiftFileList") {
-                swiftFileListPath = String(arg.dropFirst())
-                break
-            }
+        let data = try Data(contentsOf: outputFileMapPath)
+        let outputFileMapRaw = try JSONSerialization.jsonObject(
+            with: data,
+            options: []
+        )
+        guard let outputFileMap = outputFileMapRaw as? [String: [String: Any]]
+        else {
+            return
         }
 
-        let parentDir = outputFileMapPath.deletingLastPathComponent()
-        let swiftFilenames = try String(contentsOfFile: swiftFileListPath!, encoding: .utf8)
-            .components(separatedBy: .newlines)
-            .compactMap { $0.components(separatedBy: "/").last }
-
-        for filename in swiftFilenames {
-            let dFileBasename = filename.dropLast(".swift".count) + ".d" as String
-            var url = URL(fileURLWithPath: dFileBasename, relativeTo: parentDir)
+        for entry in outputFileMap.values {
+            guard let dPath = entry["dependencies"] as? String else {
+                continue
+            }
+            var url = URL(fileURLWithPath: dPath)
             try url.touch()
         }
     }
@@ -67,9 +69,12 @@ func touchDepsFiles(_ args: OrderedSet<String>) throws {
 /// Touch the Xcode-required .swift{module,doc,sourceinfo} files"
 func touchSwiftmoduleArtifacts(_ args: OrderedSet<String>) throws {
     if var swiftmodulePath = findPath(key: "-emit-module-path", from: args) {
-        var swiftdocPath = swiftmodulePath.deletingPathExtension().appendingPathExtension("swiftdoc")
-        var swiftsourceinfoPath = swiftmodulePath.deletingPathExtension().appendingPathExtension("swiftsourceinfo")
-        var swiftinterfacePath = swiftmodulePath.deletingPathExtension().appendingPathExtension("swiftinterface")
+        var swiftdocPath = swiftmodulePath.deletingPathExtension()
+            .appendingPathExtension("swiftdoc")
+        var swiftsourceinfoPath = swiftmodulePath.deletingPathExtension()
+            .appendingPathExtension("swiftsourceinfo")
+        var swiftinterfacePath = swiftmodulePath.deletingPathExtension()
+            .appendingPathExtension("swiftinterface")
 
         try swiftmodulePath.touch()
         try swiftdocPath.touch()
@@ -77,7 +82,10 @@ func touchSwiftmoduleArtifacts(_ args: OrderedSet<String>) throws {
         try swiftinterfacePath.touch()
     }
 
-    if var generatedHeaderPath = findPath(key: "-emit-objc-header-path", from: args) {
+    if var generatedHeaderPath = findPath(
+        key: "-emit-objc-header-path",
+        from: args
+    ) {
         try generatedHeaderPath.touch()
     }
 }
@@ -91,6 +99,38 @@ func runSubProcess(executable: String, args: [String]) throws -> Int32 {
     return task.terminationStatus
 }
 
+func handleSwiftUIPreviewThunk(_ args: OrderedSet<String>) throws {
+    guard let sdkPath = findPath(key: "-sdk", from: args)?.path
+    else {
+        print("warning: No such argument '-sdk'")
+        exit(try runSubProcess(
+            executable: "swiftc",
+            args: Array(args.dropFirst())
+        ))
+    }
+
+    // TODO: Make this work with custom toolchains
+    // We could produce this file at the start of the build?
+    let fullRange = NSRange(sdkPath.startIndex..., in: sdkPath)
+    let matches = try NSRegularExpression(
+        pattern: #".*?/Contents/Developer)/.*"#
+    ).matches(in: sdkPath, range: fullRange)
+    guard let developerDir = matches.first else {
+        print("warning: Failed to parse DEVELOPER_DIR from '-sdk'")
+        exit(try runSubProcess(
+            executable: "swiftc",
+            args: Array(args.dropFirst())
+        ))
+    }
+
+    exit(try runSubProcess(
+        executable: """
+\(developerDir)/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc
+""",
+        args: Array(args.dropFirst())
+    ))
+}
+
 // MARK: - Main
 
 let args = OrderedSet(CommandLine.arguments)
@@ -100,28 +140,10 @@ if args.count == 2, args.last == "-v" {
 }
 
 for arg in args {
-    // Pass through for SwiftUI Preview thunk compilation
-    if arg.hasSuffix(".preview-thunk.swift"), args.contains("-output-file-map") {
-        guard let sdkPath = findPath(key: "-sdk", from: args)?.path
-        else {
-            print("warning: No such argument '-sdk'")
-            exit(try runSubProcess(executable: "swiftc", args: Array(args.dropFirst())))
-        }
-
-        // TODO: Make this work with custom toolchains
-        // We could produce this file at the start of the build?
-        let fullRange = NSRange(sdkPath.startIndex..., in: sdkPath)
-        let matches = try NSRegularExpression(pattern: #".*?/Contents/Developer)/.*"#)
-            .matches(in: sdkPath, range: fullRange)
-        guard let developerDir = matches.first else {
-            print("warning: Failed to parse DEVELOPER_DIR from '-sdk'")
-            exit(try runSubProcess(executable: "swiftc", args: Array(args.dropFirst())))
-        }
-
-        exit(try runSubProcess(
-            executable: "\(developerDir)/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc",
-            args: Array(args.dropFirst())
-        ))
+    if arg.hasSuffix(".preview-thunk.swift"), args.contains("-output-file-map")
+    {
+        // Pass through for SwiftUI Preview thunk compilation
+        try handleSwiftUIPreviewThunk(args)
     }
 }
 


### PR DESCRIPTION
We need to parse the JSON in order to determine the exact paths to dependency files, since Xcode adds a hash to the end of partials.

Also apply some code cleanup.