### PR TITLE
Import SwiftUI Preview built indexstores

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -51,7 +51,8 @@ then
   # matches.
   readonly object_file_prefix="/${PROJECT_TEMP_DIR##*/}"
 else
-  readonly object_file_prefix="$PROJECT_TEMP_DIR"
+  # Remove SwiftUI Previews part of path
+  readonly object_file_prefix="${PROJECT_TEMP_DIR/\/Intermediates.noindex\/Previews\/*\/Intermediates.noindex\///Intermediates.noindex/}"
 fi
 
 # The order of remaps is important. The first match is used. So we try the most
@@ -67,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
 
   # Generated sources and swiftmodules
   #

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -88,10 +88,6 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
 
-# Unset `swift.index-while-building` since we don't need index store data, and
-# we already have cache misses from the `swiftc` flags above
-build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -51,7 +51,8 @@ then
   # matches.
   readonly object_file_prefix="/${PROJECT_TEMP_DIR##*/}"
 else
-  readonly object_file_prefix="$PROJECT_TEMP_DIR"
+  # Remove SwiftUI Previews part of path
+  readonly object_file_prefix="${PROJECT_TEMP_DIR/\/Intermediates.noindex\/Previews\/*\/Intermediates.noindex\///Intermediates.noindex/}"
 fi
 
 # The order of remaps is important. The first match is used. So we try the most
@@ -67,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
 
   # Generated sources and swiftmodules
   #

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -88,10 +88,6 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
 
-# Unset `swift.index-while-building` since we don't need index store data, and
-# we already have cache misses from the `swiftc` flags above
-build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -51,7 +51,8 @@ then
   # matches.
   readonly object_file_prefix="/${PROJECT_TEMP_DIR##*/}"
 else
-  readonly object_file_prefix="$PROJECT_TEMP_DIR"
+  # Remove SwiftUI Previews part of path
+  readonly object_file_prefix="${PROJECT_TEMP_DIR/\/Intermediates.noindex\/Previews\/*\/Intermediates.noindex\///Intermediates.noindex/}"
 fi
 
 # The order of remaps is important. The first match is used. So we try the most
@@ -67,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
 
   # Generated sources and swiftmodules
   #

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -88,10 +88,6 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
 
-# Unset `swift.index-while-building` since we don't need index store data, and
-# we already have cache misses from the `swiftc` flags above
-build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -51,7 +51,8 @@ then
   # matches.
   readonly object_file_prefix="/${PROJECT_TEMP_DIR##*/}"
 else
-  readonly object_file_prefix="$PROJECT_TEMP_DIR"
+  # Remove SwiftUI Previews part of path
+  readonly object_file_prefix="${PROJECT_TEMP_DIR/\/Intermediates.noindex\/Previews\/*\/Intermediates.noindex\///Intermediates.noindex/}"
 fi
 
 # The order of remaps is important. The first match is used. So we try the most
@@ -67,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
 
   # Generated sources and swiftmodules
   #

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -88,10 +88,6 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
 
-# Unset `swift.index-while-building` since we don't need index store data, and
-# we already have cache misses from the `swiftc` flags above
-build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -51,7 +51,8 @@ then
   # matches.
   readonly object_file_prefix="/${PROJECT_TEMP_DIR##*/}"
 else
-  readonly object_file_prefix="$PROJECT_TEMP_DIR"
+  # Remove SwiftUI Previews part of path
+  readonly object_file_prefix="${PROJECT_TEMP_DIR/\/Intermediates.noindex\/Previews\/*\/Intermediates.noindex\///Intermediates.noindex/}"
 fi
 
 # The order of remaps is important. The first match is used. So we try the most
@@ -67,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
 
   # Generated sources and swiftmodules
   #

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -88,10 +88,6 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
 
-# Unset `swift.index-while-building` since we don't need index store data, and
-# we already have cache misses from the `swiftc` flags above
-build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -51,7 +51,8 @@ then
   # matches.
   readonly object_file_prefix="/${PROJECT_TEMP_DIR##*/}"
 else
-  readonly object_file_prefix="$PROJECT_TEMP_DIR"
+  # Remove SwiftUI Previews part of path
+  readonly object_file_prefix="${PROJECT_TEMP_DIR/\/Intermediates.noindex\/Previews\/*\/Intermediates.noindex\///Intermediates.noindex/}"
 fi
 
 # The order of remaps is important. The first match is used. So we try the most
@@ -67,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
 
   # Generated sources and swiftmodules
   #

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -88,10 +88,6 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
 
-# Unset `swift.index-while-building` since we don't need index store data, and
-# we already have cache misses from the `swiftc` flags above
-build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -51,7 +51,8 @@ then
   # matches.
   readonly object_file_prefix="/${PROJECT_TEMP_DIR##*/}"
 else
-  readonly object_file_prefix="$PROJECT_TEMP_DIR"
+  # Remove SwiftUI Previews part of path
+  readonly object_file_prefix="${PROJECT_TEMP_DIR/\/Intermediates.noindex\/Previews\/*\/Intermediates.noindex\///Intermediates.noindex/}"
 fi
 
 # The order of remaps is important. The first match is used. So we try the most
@@ -67,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
 
   # Generated sources and swiftmodules
   #

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -88,10 +88,6 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
 
-# Unset `swift.index-while-building` since we don't need index store data, and
-# we already have cache misses from the `swiftc` flags above
-build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -51,7 +51,8 @@ then
   # matches.
   readonly object_file_prefix="/${PROJECT_TEMP_DIR##*/}"
 else
-  readonly object_file_prefix="$PROJECT_TEMP_DIR"
+  # Remove SwiftUI Previews part of path
+  readonly object_file_prefix="${PROJECT_TEMP_DIR/\/Intermediates.noindex\/Previews\/*\/Intermediates.noindex\///Intermediates.noindex/}"
 fi
 
 # The order of remaps is important. The first match is used. So we try the most
@@ -67,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
 
   # Generated sources and swiftmodules
   #

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -88,10 +88,6 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
 
-# Unset `swift.index-while-building` since we don't need index store data, and
-# we already have cache misses from the `swiftc` flags above
-build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -51,7 +51,8 @@ then
   # matches.
   readonly object_file_prefix="/${PROJECT_TEMP_DIR##*/}"
 else
-  readonly object_file_prefix="$PROJECT_TEMP_DIR"
+  # Remove SwiftUI Previews part of path
+  readonly object_file_prefix="${PROJECT_TEMP_DIR/\/Intermediates.noindex\/Previews\/*\/Intermediates.noindex\///Intermediates.noindex/}"
 fi
 
 # The order of remaps is important. The first match is used. So we try the most
@@ -67,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
 
   # Generated sources and swiftmodules
   #

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -88,10 +88,6 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
 
-# Unset `swift.index-while-building` since we don't need index store data, and
-# we already have cache misses from the `swiftc` flags above
-build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/import_indexstores.sh
@@ -51,7 +51,8 @@ then
   # matches.
   readonly object_file_prefix="/${PROJECT_TEMP_DIR##*/}"
 else
-  readonly object_file_prefix="$PROJECT_TEMP_DIR"
+  # Remove SwiftUI Previews part of path
+  readonly object_file_prefix="${PROJECT_TEMP_DIR/\/Intermediates.noindex\/Previews\/*\/Intermediates.noindex\///Intermediates.noindex/}"
 fi
 
 # The order of remaps is important. The first match is used. So we try the most
@@ -67,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
 
   # Generated sources and swiftmodules
   #

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -88,10 +88,6 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
 
-# Unset `swift.index-while-building` since we don't need index store data, and
-# we already have cache misses from the `swiftc` flags above
-build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.

--- a/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
+++ b/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
@@ -51,7 +51,8 @@ then
   # matches.
   readonly object_file_prefix="/${PROJECT_TEMP_DIR##*/}"
 else
-  readonly object_file_prefix="$PROJECT_TEMP_DIR"
+  # Remove SwiftUI Previews part of path
+  readonly object_file_prefix="${PROJECT_TEMP_DIR/\/Intermediates.noindex\/Previews\/*\/Intermediates.noindex\///Intermediates.noindex/}"
 fi
 
 # The order of remaps is important. The first match is used. So we try the most
@@ -67,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
 
   # Generated sources and swiftmodules
   #

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -88,10 +88,6 @@ build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-dynamic-replacement-chaining
 
-# Unset `swift.index-while-building` since we don't need index store data, and
-# we already have cache misses from the `swiftc` flags above
-build:rules_xcodeproj_swiftuipreviews --features=-swift.index_while_building
-
 ### `--config=rules_xcodeproj_asan`
 #
 # Used when building with Address Sanitizer enabled.


### PR DESCRIPTION
Fixes #1126.

This matches Xcode's behavior, allowing indexing to be accelerated by SwiftUI Preview builds.