### PR TITLE
Remove optionality of `XCScheme.Diagnostics`

### DIFF
--- a/tools/generator/src/Extensions/XCScheme+Extensions.swift
+++ b/tools/generator/src/Extensions/XCScheme+Extensions.swift
@@ -244,9 +244,12 @@ extension XCScheme.LaunchAction {
             askForAppToLaunch: launchActionInfo.askForAppToLaunch ? true : nil,
             customWorkingDirectory: launchActionInfo.workingDirectory,
             useCustomWorkingDirectory: launchActionInfo.workingDirectory != nil,
-            enableAddressSanitizer: launchActionInfo.diagnostics?.sanitizers?.address ?? false,
-            enableThreadSanitizer: launchActionInfo.diagnostics?.sanitizers?.thread ?? false,
-            enableUBSanitizer: launchActionInfo.diagnostics?.sanitizers?.undefinedBehavior ?? false,
+            enableAddressSanitizer: launchActionInfo.diagnostics.sanitizers
+                .address,
+            enableThreadSanitizer: launchActionInfo.diagnostics.sanitizers
+                .thread,
+            enableUBSanitizer: launchActionInfo.diagnostics.sanitizers
+                .undefinedBehavior,
             commandlineArguments: commandlineArguments,
             environmentVariables: environmentVariables.isEmpty ? nil : environmentVariables,
             launchAutomaticallySubstyle: launchActionInfo.targetInfo.productType

--- a/tools/generator/src/Generator/XCSchemeInfo+DiagnosticsInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+DiagnosticsInfo.swift
@@ -3,32 +3,27 @@ import Foundation
 // MARK: DiagnosticsInfo
 
 extension XCSchemeInfo {
-    struct DiagnosticsInfo: Equatable, Decodable {
-        struct Sanitizers: Equatable, Decodable {
+    struct DiagnosticsInfo: Equatable {
+        struct Sanitizers: Equatable {
             let address: Bool
             let thread: Bool
             let undefinedBehavior: Bool
         }
-        let sanitizers: Sanitizers?
+        let sanitizers: Sanitizers
     }
 }
 
 // MARK: Custom Diagnostics Initializer
 
 extension XCSchemeInfo.DiagnosticsInfo {
-    init?(
-        diagnostics: XcodeScheme.Diagnostics?
+    init(
+        diagnostics: XcodeScheme.Diagnostics
     ) {
-        guard let diagnostics = diagnostics else {
-            return nil
-        }
-        let sanitizers = diagnostics.sanitizers.map {
-            XCSchemeInfo.DiagnosticsInfo.Sanitizers(
-                address: $0.address,
-                thread: $0.thread,
-                undefinedBehavior: $0.undefinedBehavior
-            )
-        }
+        let sanitizers = XCSchemeInfo.DiagnosticsInfo.Sanitizers(
+            address: diagnostics.sanitizers.address,
+            thread: diagnostics.sanitizers.thread,
+            undefinedBehavior: diagnostics.sanitizers.undefinedBehavior
+        )
         self.init(
             sanitizers: sanitizers
         )

--- a/tools/generator/src/Generator/XCSchemeInfo+LaunchActionInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+LaunchActionInfo.swift
@@ -5,7 +5,7 @@ extension XCSchemeInfo {
         let buildConfigurationName: String
         let targetInfo: XCSchemeInfo.TargetInfo
         let args: [String]
-        let diagnostics: DiagnosticsInfo?
+        let diagnostics: DiagnosticsInfo
         let env: [String: String]
         let workingDirectory: String?
 
@@ -13,13 +13,14 @@ extension XCSchemeInfo {
             buildConfigurationName: String,
             targetInfo: XCSchemeInfo.TargetInfo,
             args: [String] = [],
-            diagnostics: DiagnosticsInfo? = nil,
+            diagnostics: DiagnosticsInfo = .init(diagnostics: .init()),
             env: [String: String] = [:],
             workingDirectory: String? = nil
         ) throws {
             guard targetInfo.productType.isLaunchable else {
                 throw PreconditionError(message: """
-An `XCSchemeInfo.LaunchActionInfo` should have a launchable `XCSchemeInfo.TargetInfo` value.
+An `XCSchemeInfo.LaunchActionInfo` should have a launchable \
+`XCSchemeInfo.TargetInfo` value.
 """)
             }
             self.buildConfigurationName = buildConfigurationName
@@ -35,7 +36,8 @@ An `XCSchemeInfo.LaunchActionInfo` should have a launchable `XCSchemeInfo.Target
 // MARK: Host Resolution Initializer
 
 extension XCSchemeInfo.LaunchActionInfo {
-    /// Create a copy of the `LaunchActionInfo` with the host in the `TargetInfo` resolved.
+    /// Create a copy of the `LaunchActionInfo` with the host in the
+    /// `TargetInfo` resolved.
     init?<TargetInfos: Sequence>(
         resolveHostsFor launchActionInfo: XCSchemeInfo.LaunchActionInfo?,
         topLevelTargetInfos: TargetInfos
@@ -61,8 +63,8 @@ extension XCSchemeInfo.LaunchActionInfo {
 
 extension XCSchemeInfo.LaunchActionInfo {
     var runnable: XCScheme.Runnable? {
-        // We want to provide a `LaunchActionInfo`, but we do not want to provide a `runnable`, if
-        // it is testable.
+        // We want to provide a `LaunchActionInfo`, but we do not want to
+        // provide a `runnable`, if it is testable.
         if targetInfo.pbxTarget.isTestable {
             return nil
         }

--- a/tools/generator/test/XCScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XCScheme+ExtensionsTests.swift
@@ -1,3 +1,4 @@
+import CustomDump
 import XcodeProj
 import XCTest
 
@@ -545,6 +546,6 @@ extension XCSchemeExtensionsTests {
             launchAutomaticallySubstyle: productType.launchAutomaticallySubstyle,
             customLLDBInitFile: XCSchemeConstants.customLLDBInitFile
         )
-        XCTAssertEqual(launchAction, expected)
+        XCTAssertNoDifference(launchAction, expected)
     }
 }


### PR DESCRIPTION
Since the value always exist, just with default values, this makes more sense. It also works around a Swift miscompile when adding future changes.