### PR TITLE
Remove `Copy Bazel Outputs` scripts from non-product targets

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -3620,7 +3620,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EFD92156A876B6D6FFBB6CA8 /* Build configuration list for PBXNativeTarget "Lib (watchOS)" */;
 			buildPhases = (
-				1688E39CDF556E908D89600C /* Copy Bazel Outputs */,
 				D9176A0A70D09FD506167F09 /* Sources */,
 			);
 			buildRules = (
@@ -3636,7 +3635,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 426DF0C057EB275136F4B9DC /* Build configuration list for PBXNativeTarget "lib_swift" */;
 			buildPhases = (
-				CF5964970607E7A9795E2A66 /* Copy Bazel Outputs */,
 				18F25BCCAD587CF0E7BE2E95 /* Sources */,
 			);
 			buildRules = (
@@ -3656,7 +3654,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3BFE395FEB493780D77AE664 /* Build configuration list for PBXNativeTarget "Lib (iOS, tvOS)" */;
 			buildPhases = (
-				68B35B01A8AD784A09E66060 /* Copy Bazel Outputs */,
 				376387525A0E44A3FF8EFBE1 /* Sources */,
 			);
 			buildRules = (
@@ -3874,7 +3871,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = C52C33AC1575AF1A3BA03A91 /* Build configuration list for PBXNativeTarget "private_swift_lib" */;
 			buildPhases = (
-				299C08C28223D3237360513C /* Copy Bazel Outputs */,
 				481A5BE8481DD1BD3CF39B15 /* Sources */,
 			);
 			buildRules = (
@@ -4119,22 +4115,6 @@
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"macOSApp.app\" \\\n  \"$INTERNAL_DIR/app.exclude.rsynclist\"\n";
 			showEnvVarsInLog = 0;
 		};
-		1688E39CDF556E908D89600C /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libLib.a\" \\\n  \"\"\n";
-			showEnvVarsInLog = 0;
-		};
 		172D472463796AAA86DE3F16 /* Create linking dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -4306,22 +4286,6 @@
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"tvOSAppUnitTests.xctest\" \\\n  \"\"\n";
 			showEnvVarsInLog = 0;
 		};
-		299C08C28223D3237360513C /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libprivate_swift_lib.a\" \\\n  \"\"\n";
-			showEnvVarsInLog = 0;
-		};
 		4A50E185DA5DF9C9FA565E9A /* Create linking dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -4457,22 +4421,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		68B35B01A8AD784A09E66060 /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libLib.a\" \\\n  \"\"\n";
 			showEnvVarsInLog = 0;
 		};
 		6F779F048E8A5225FE34F009 /* Copy Bazel Outputs */ = {
@@ -4852,22 +4800,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"iMessageApp.app\" \\\n  \"$INTERNAL_DIR/app.exclude.rsynclist\"\n";
-			showEnvVarsInLog = 0;
-		};
-		CF5964970607E7A9795E2A66 /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"liblib_swift.a\" \\\n  \"\"\n";
 			showEnvVarsInLog = 0;
 		};
 		DD9CC37462811E6A32A1ED0C /* Create linking dependencies */ = {

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -1572,7 +1572,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DF2FE5363352BCC115DD4145 /* Build configuration list for PBXNativeTarget "OrderedCollections" */;
 			buildPhases = (
-				90B04C8AB5A07A2ECF257268 /* Copy Bazel Outputs */,
 				D463D3FD3995A74AFC639D34 /* Sources */,
 			);
 			buildRules = (
@@ -1606,7 +1605,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3D2103FB87F295A76D072C9F /* Build configuration list for PBXNativeTarget "CustomDump" */;
 			buildPhases = (
-				8AD6171C2CD18BEE615F0279 /* Copy Bazel Outputs */,
 				ECA0F39C31AA33C5A27E2A13 /* Sources */,
 			);
 			buildRules = (
@@ -1623,7 +1621,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CACF77A1FAAA2F54E5824DC5 /* Build configuration list for PBXNativeTarget "PathKit" */;
 			buildPhases = (
-				552BD18EE10BBA93EBBDB88E /* Copy Bazel Outputs */,
 				CEFFF3DAD94295451F05F496 /* Sources */,
 			);
 			buildRules = (
@@ -1678,7 +1675,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6151A35A4285123290BF712B /* Build configuration list for PBXNativeTarget "XCTestDynamicOverlay" */;
 			buildPhases = (
-				3B581A2D7C1575EF22D8ECDA /* Copy Bazel Outputs */,
 				3902E6234DBCF661FBA29FE8 /* Sources */,
 			);
 			buildRules = (
@@ -1694,7 +1690,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 961CB57C52E0929989B5B13A /* Build configuration list for PBXNativeTarget "XcodeProj" */;
 			buildPhases = (
-				F5738A25C92C3E659EB1C474 /* Copy Bazel Outputs */,
 				831BF4DD9F4124A081FB32B3 /* Sources */,
 			);
 			buildRules = (
@@ -1711,7 +1706,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 537F24897CAC8E48070BBA94 /* Build configuration list for PBXNativeTarget "generator.library" */;
 			buildPhases = (
-				BF93DFB380D1CC637B96A769 /* Copy Bazel Outputs */,
 				CD48CA78C6E062C9AC7C30B5 /* Sources */,
 			);
 			buildRules = (
@@ -1838,22 +1832,6 @@
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"swiftc\" \\\n  \"\"\n";
 			showEnvVarsInLog = 0;
 		};
-		3B581A2D7C1575EF22D8ECDA /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libXCTestDynamicOverlay.a\" \\\n  \"\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3C2F7597AADF65DD2B4DA5CC /* Copy Bazel Outputs */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -1869,38 +1847,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"tests.xctest\" \\\n  \"\"\n";
-			showEnvVarsInLog = 0;
-		};
-		552BD18EE10BBA93EBBDB88E /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libPathKit.a\" \\\n  \"\"\n";
-			showEnvVarsInLog = 0;
-		};
-		8AD6171C2CD18BEE615F0279 /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libCustomDump.a\" \\\n  \"\"\n";
 			showEnvVarsInLog = 0;
 		};
 		8F85B1482AB82E3C5B71ADB3 /* Create linking dependencies */ = {
@@ -1919,22 +1865,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\ntouch \"$SCRIPT_OUTPUT_FILE_1\"\n";
-			showEnvVarsInLog = 0;
-		};
-		90B04C8AB5A07A2ECF257268 /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libOrderedCollections.a\" \\\n  \"\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9335DA9C69E988484C66D986 /* Create linking dependencies */ = {
@@ -1991,22 +1921,6 @@
 			shellScript = "perl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BF93DFB380D1CC637B96A769 /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libgenerator.library.a\" \\\n  \"\"\n";
-			showEnvVarsInLog = 0;
-		};
 		EC63BA6387175B095C7C2F0B /* Copy Bazel Outputs */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -2021,22 +1935,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"generator\" \\\n  \"\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F5738A25C92C3E659EB1C474 /* Copy Bazel Outputs */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Bazel Outputs";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -euo pipefail\n\n\"$BAZEL_INTEGRATION_DIR/copy_outputs.sh\" \\\n  \"_BazelForcedCompile_.swift\" \\\n  \"libXcodeProj.a\" \\\n  \"\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/tools/generator/src/Generator/AddTargets.swift
+++ b/tools/generator/src/Generator/AddTargets.swift
@@ -716,7 +716,7 @@ private extension ConsolidatedTargetOutputs {
         productBasename: String,
         filePathResolver: FilePathResolver
     ) throws -> String? {
-        guard hasOutputs else {
+        guard hasProductOutput else {
             return nil
         }
 

--- a/tools/generator/src/Generator/ConsolidateTargets.swift
+++ b/tools/generator/src/Generator/ConsolidateTargets.swift
@@ -371,6 +371,7 @@ extension ConsolidatedTarget {
         allDependencies = aTarget.allDependencies
         outputs = ConsolidatedTargetOutputs(
             hasOutputs: self.targets.values.contains { $0.outputs.hasOutputs },
+            hasProductOutput: self.targets.values.contains { $0.outputs.hasProductOutput },
             hasSwiftOutputs: self.targets.values
                 .contains { $0.outputs.hasSwiftOutputs }
         )
@@ -484,6 +485,7 @@ struct ConsolidatedTargetLinkerInputs: Equatable {
 
 struct ConsolidatedTargetOutputs: Equatable {
     let hasOutputs: Bool
+    let hasProductOutput: Bool
     let hasSwiftOutputs: Bool
 }
 

--- a/tools/generator/src/Generator/ConsolidateTargets.swift
+++ b/tools/generator/src/Generator/ConsolidateTargets.swift
@@ -266,13 +266,12 @@ struct ConsolidatedTarget: Equatable {
     let isSwift: Bool
     let inputs: ConsolidatedTargetInputs
     let linkerInputs: ConsolidatedTargetLinkerInputs
+    let hasLinkerFlags: Bool
     let resourceBundleDependencies: Set<TargetID>
     let watchApplication: TargetID?
     let extensions: Set<TargetID>
     let appClips: Set<TargetID>
     let outputs: ConsolidatedTargetOutputs
-
-    let hasLinkerFlags: Bool
 
     /// The `Set` of `FilePath`s that each target references above the baseline.
     ///
@@ -344,6 +343,7 @@ extension ConsolidatedTarget {
             .map { $1 }
         inputs = Self.consolidateInputs(targets: sortedTargets)
         linkerInputs = Self.consolidateLinkerInputs(targets: sortedTargets)
+        hasLinkerFlags = aTarget.hasLinkerFlags
 
         var baselineFiles: Set<FilePath> = aTarget
             .allExcludableFiles(xcodeGeneratedFiles: xcodeGeneratedFiles)
@@ -375,8 +375,6 @@ extension ConsolidatedTarget {
             hasSwiftOutputs: self.targets.values
                 .contains { $0.outputs.hasSwiftOutputs }
         )
-
-        hasLinkerFlags = aTarget.hasLinkerFlags
     }
 
     private static func consolidateInputs(

--- a/tools/generator/test/DisambiguateTargetsTests.swift
+++ b/tools/generator/test/DisambiguateTargetsTests.swift
@@ -54,12 +54,14 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -104,12 +106,14 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -145,12 +149,14 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -188,12 +194,14 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -231,12 +239,14 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -274,12 +284,14 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -317,12 +329,14 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -364,12 +378,14 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -407,12 +423,14 @@ final class DisambiguateTargetsTests: XCTestCase {
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -457,12 +475,14 @@ A (Library) (\(ProductTypeComponents.prettyConfigurations(["2"])))
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -510,12 +530,14 @@ A (iOS) (\(ProductTypeComponents.prettyConfigurations(["2"])))
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -588,12 +610,14 @@ A (iOS) (\(ProductTypeComponents.prettyConfigurations(["2"])))
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -653,12 +677,14 @@ A (iOS) (\(ProductTypeComponents.prettyConfigurations(["2"])))
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -724,12 +750,14 @@ A (iOS) (\(ProductTypeComponents.prettyConfigurations(["2"])))
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -791,12 +819,14 @@ B (iOS 11.0 Device, iOS 13.0 Simulator, tvOS)
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -838,12 +868,14 @@ B (iOS 11.0 Device, iOS 13.0 Simulator, tvOS)
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 
@@ -892,12 +924,14 @@ A (iOS) (\(ProductTypeComponents.prettyConfigurations(["2"])))
         // Assert
 
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.name),
-            expectedTargetNames
+            disambiguatedTargets.targets.mapValues(\.name)
+                .map(KeyAndValue.init).sorted(),
+            expectedTargetNames.map(KeyAndValue.init).sorted()
         )
         XCTAssertNoDifference(
-            disambiguatedTargets.targets.mapValues(\.target),
-            consolidatedTargets.targets
+            disambiguatedTargets.targets.mapValues(\.target)
+                .map(KeyAndValue.init).sorted(),
+            consolidatedTargets.targets.map(KeyAndValue.init).sorted()
         )
     }
 }


### PR DESCRIPTION
The idea about keeping them around was that we would use them for copying diagnostics and then modifying a file to force a "recompile". There are other ways to achieve that though, so these scripts are just plain overhead right now.