### PR TITLE
Fix `-add_ast_path` for merged targets

### DIFF
--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/AppClip/AppClip.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/AppClip/AppClip.swiftmodule/arm64-apple-ios.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/AppClip/AppClip.swiftmodule/arm64-apple-ios.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/UI/UIFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/UI/UIFramework.iOS.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/UI/UI.swiftmodule/arm64-apple-ios.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/UI/UIFramework.iOS.framework/Modules/UI.swiftmodule/arm64-apple-ios.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/WidgetExtension/WidgetExtension.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/WidgetExtension/WidgetExtension.swiftmodule/arm64-apple-ios.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/WidgetExtension/WidgetExtension.swiftmodule/arm64-apple-ios.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/iOSApp/Source/iOSApp.link.params
@@ -1,6 +1,6 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Source/iOSApp.swiftmodule/arm64-apple-ios.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/iOSApp/Source/iOSApp.swiftmodule/arm64-apple-ios.swiftmodule
 --ld-path=$(BAZEL_EXTERNAL)/rules_apple_linker_lld/ld64.lld
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/UI/UI.swiftmodule/arm64-apple-ios.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/UI/UIFramework.iOS.framework/Modules/UI.swiftmodule/arm64-apple-ios.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AppClip/AppClip.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AppClip/AppClip.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AppClip/AppClip.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/UI/UIFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/UI/UIFramework.iOS.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/UI/UI.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/UI/UIFramework.iOS.framework/Modules/UI.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/WidgetExtension/WidgetExtension.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/WidgetExtension/WidgetExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/WidgetExtension/WidgetExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iMessageApp/iMessageAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iMessageApp/iMessageAppExtension.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iMessageApp/iMessageAppExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iMessageApp/iMessageAppExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/iOSApp/Source/iOSApp.link.params
@@ -1,6 +1,6 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Source/iOSApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/iOSApp/Source/iOSApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 --ld-path=$(BAZEL_EXTERNAL)/rules_apple_linker_lld/ld64.lld
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/UI/UI.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/UI/UIFramework.iOS.framework/Modules/UI.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/macOSApp/Source/macOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/macOSApp/Source/macOSApp.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/macOSApp/Source/macOSApp.swiftmodule/x86_64-apple-macos.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/macOSApp/Source/macOSApp.swiftmodule/x86_64-apple-macos.swiftmodule
 -ObjC
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/macOSApp/Test/UITests/macOSAppUITests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/macOSApp/Test/UITests/macOSAppUITests.link.params
@@ -1,5 +1,5 @@
 -L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/macOSApp/Test/UITests/macOSAppUITests.swiftmodule/x86_64-apple-macos.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/macOSApp/Test/UITests/macOSAppUITests.swiftmodule/x86_64-apple-macos.swiftmodule
 -ObjC
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/CommandLine/Tests/CommandLineToolTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/CommandLine/Tests/CommandLineToolTests.link.params
@@ -1,5 +1,5 @@
 -L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule/x86_64-apple-macos.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule/x86_64-apple-macos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule/x86_64-apple-macos.swiftmodule
 -Wl,-add_ast_path,$(BAZEL_EXTERNAL)/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-7ab8ee5d0803/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule/x86_64-apple-macos.swiftmodule

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/UI/UIFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/UI/UIFramework.tvOS.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/UI/UI.swiftmodule/arm64-apple-tvos.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/UI/UIFramework.tvOS.framework/Modules/UI.swiftmodule/arm64-apple-tvos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/tvOSApp/Source/tvOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/tvOSApp/Source/tvOSApp.link.params
@@ -1,5 +1,5 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/tvOSApp/Source/tvOSApp.swiftmodule/arm64-apple-tvos.swiftmodule
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/UI/UI.swiftmodule/arm64-apple-tvos.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/tvOSApp/Source/tvOSApp.swiftmodule/arm64-apple-tvos.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/UI/UIFramework.tvOS.framework/Modules/UI.swiftmodule/arm64-apple-tvos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-252684668b52/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/UI/UIFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/UI/UIFramework.tvOS.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI/UI.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI/UIFramework.tvOS.framework/Modules/UI.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Source/tvOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Source/tvOSApp.link.params
@@ -1,5 +1,5 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Source/tvOSApp.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI/UI.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Source/tvOSApp.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI/UIFramework.tvOS.framework/Modules/UI.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Test/UITests/tvOSAppUITests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Test/UITests/tvOSAppUITests.link.params
@@ -1,5 +1,5 @@
 -L$(DEVELOPER_DIR)/Platforms/AppleTVSimulator.platform/Developer/usr/lib
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Test/UITests/tvOSAppUITests.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Test/UITests/tvOSAppUITests.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Test/UnitTests/tvOSAppUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/tvOSApp/Test/UnitTests/tvOSAppUnitTests.link.params
@@ -1,7 +1,7 @@
 -L$(DEVELOPER_DIR)/Platforms/AppleTVSimulator.platform/Developer/usr/lib
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Source/tvOSApp.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI/UI.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/tvOSApp/Source/tvOSApp.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/UI/UIFramework.tvOS.framework/Modules/UI.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-bb5377ca9332/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/UI/UIFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/UI/UIFramework.watchOS.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/UI/UI.swiftmodule/arm64_32-apple-watchos.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/UI/UIFramework.watchOS.framework/Modules/UI.swiftmodule/arm64_32-apple-watchos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/watchOSAppExtension/watchOSAppExtension.link.params
@@ -1,5 +1,5 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule/arm64_32-apple-watchos.swiftmodule
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/UI/UI.swiftmodule/arm64_32-apple-watchos.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule/arm64_32-apple-watchos.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/UI/UIFramework.watchOS.framework/Modules/UI.swiftmodule/arm64_32-apple-watchos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/UI/UIFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/UI/UIFramework.watchOS.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI/UI.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI/UIFramework.watchOS.framework/Modules/UI.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSApp/Test/UITests/watchOSAppUITests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSApp/Test/UITests/watchOSAppUITests.link.params
@@ -1,5 +1,5 @@
 -L$(DEVELOPER_DIR)/Platforms/WatchSimulator.platform/Developer/usr/lib
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSApp/Test/UITests/watchOSAppUITestsLibrary.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSApp/Test/UITests/watchOSAppUITestsLibrary.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.link.params
@@ -1,6 +1,6 @@
 -L$(DEVELOPER_DIR)/Platforms/WatchSimulator.platform/Developer/usr/lib
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTestsLibrary.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI/UI.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTestsLibrary.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI/UIFramework.watchOS.framework/Modules/UI.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/watchOSAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/watchOSAppExtension/watchOSAppExtension.link.params
@@ -1,5 +1,5 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI/UI.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/UI/UIFramework.watchOS.framework/Modules/UI.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AddressSanitizerApp/AddressSanitizerApp.link.params
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/AddressSanitizerApp/AddressSanitizerApp.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp_archive-root/Payload/AddressSanitizerApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/ThreadSanitizerApp/ThreadSanitizerApp.link.params
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/ThreadSanitizerApp/ThreadSanitizerApp.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/ThreadSanitizerApp/ThreadSanitizerApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/ThreadSanitizerApp/ThreadSanitizerApp_archive-root/Payload/ThreadSanitizerApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/test/tests.link.params
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/test/tests.link.params
@@ -1,5 +1,5 @@
 -L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/test/tests.swiftmodule/x86_64-apple-macos.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/test/tests.__internal__.__test_bundle_archive-root/tests.swiftmodule/x86_64-apple-macos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/generator.swiftmodule/x86_64-apple-macos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule/x86_64-apple-macos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule/x86_64-apple-macos.swiftmodule

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/swiftc_stub/swiftc.link.params
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/swiftc_stub/swiftc.link.params
@@ -1,4 +1,4 @@
--Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/swiftc_stub/tools_swiftc_stub_swiftc_stub_library.swiftmodule/x86_64-apple-macos.swiftmodule
+-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/swiftc_stub/rules_xcodeproj/swiftc/tools_swiftc_stub_swiftc_stub_library.swiftmodule/x86_64-apple-macos.swiftmodule
 -ObjC
 -L/usr/lib/swift
 -L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx

--- a/tools/generator/src/DTO/Target+LinkerFlags.swift
+++ b/tools/generator/src/DTO/Target+LinkerFlags.swift
@@ -134,21 +134,19 @@ private func processLinkoptComponent(
         filePath = nil
     }
 
-    if var filePath = filePath {
-        let xcodeGenerated = filePathResolver.xcodeGeneratedFiles.keys
-            .contains(filePath)
-
-        if xcodeGenerated {
-            if let `extension` = filePath.path.extension,
-               `extension` == "swiftmodule"
-            {
-                // swiftlint:disable:next shorthand_operator
-                filePath = filePath + "\(swiftTriple).swiftmodule"
-            }
-        }
-
+    if let filePath = filePath {
         value = try filePathResolver
-            .resolve(filePath, useBazelOut: !xcodeGenerated)
+            .resolve(
+                filePath,
+                xcodeGeneratedTransform: { filePath in
+                    guard let `extension` = filePath.path.extension,
+                       `extension` == "swiftmodule" else {
+                        return filePath
+                    }
+                    // swiftlint:disable:next shorthand_operator
+                    return filePath + "\(swiftTriple).swiftmodule"
+                }
+            )
             .string.quoted
     }
 

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -722,9 +722,8 @@ EOF
                     .map { filePath -> String in
                         return try filePathResolver
                             .resolve(
-                                filePath.parent(),
-                                useBazelOut: !xcodeGeneratedFiles.keys
-                                    .contains(filePath),
+                                filePath,
+                                transform: { $0.parent() },
                                 forceAbsoluteProjectPath: true
                             )
                             .string

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -399,13 +399,10 @@ $(CONFIGURATION_BUILD_DIR)
 
         if target.isSwift {
             func handleSwiftModule(_ filePath: FilePath) throws -> String {
-                let xcodeFilePath = filePathResolver
-                    .xcodeGeneratedFiles[filePath]
-                let filePath = xcodeFilePath ?? filePath
                 return try filePathResolver
                     .resolve(
-                        filePath.parent(),
-                        useBazelOut: xcodeFilePath == nil
+                        filePath,
+                        transform: { $0.parent() }
                     )
                     .string.quoted
             }


### PR DESCRIPTION
We now process linkopts post-`xcodeGeneratedFiles` lookup.