### PR TITLE
Rename `forceAbsoluteProjectPath` to `forceFullBuildSettingPath`

### DIFF
--- a/tools/generator/src/FilePathResolver.swift
+++ b/tools/generator/src/FilePathResolver.swift
@@ -72,7 +72,7 @@ struct FilePathResolver: Equatable {
         transform: (_ filePath: FilePath) -> FilePath = { $0 },
         xcodeGeneratedTransform: ((_ filePath: FilePath) -> FilePath)? = nil,
         useBazelOut: Bool? = nil,
-        forceAbsoluteProjectPath: Bool = false,
+        forceFullBuildSettingPath: Bool = false,
         mode: Mode = .buildSetting
     ) throws -> Path {
         switch filePath.type {
@@ -80,7 +80,7 @@ struct FilePathResolver: Equatable {
             let projectDir: Path
             switch mode {
             case .buildSetting:
-                projectDir = forceAbsoluteProjectPath ? "$(SRCROOT)" : ""
+                projectDir = forceFullBuildSettingPath ? "$(SRCROOT)" : ""
             case .script:
                 projectDir = "$SRCROOT"
             case .srcRoot:

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -713,7 +713,7 @@ EOF
                             .resolve(
                                 filePath,
                                 useBazelOut: true,
-                                forceAbsoluteProjectPath: true
+                                forceFullBuildSettingPath: true
                             )
                             .string
                     }
@@ -724,7 +724,7 @@ EOF
                             .resolve(
                                 filePath,
                                 transform: { $0.parent() },
-                                forceAbsoluteProjectPath: true
+                                forceFullBuildSettingPath: true
                             )
                             .string
                     }
@@ -998,7 +998,7 @@ private extension LLDBContext.Clang {
                 .resolve(
                     filePath,
                     useBazelOut: true,
-                    forceAbsoluteProjectPath: true
+                    forceFullBuildSettingPath: true
                 )
                 .string
             return #"-iquote "\#(path)""#
@@ -1015,7 +1015,7 @@ private extension LLDBContext.Clang {
                 .resolve(
                     filePath,
                     useBazelOut: true,
-                    forceAbsoluteProjectPath: true
+                    forceFullBuildSettingPath: true
                 )
                 .string
             includesArgs.append(#"-I "\#(path)""#)
@@ -1026,7 +1026,7 @@ private extension LLDBContext.Clang {
                 .resolve(
                     filePath,
                     useBazelOut: true,
-                    forceAbsoluteProjectPath: true
+                    forceFullBuildSettingPath: true
                 )
                 .string
             return #"-isystem "\#(path)""#
@@ -1055,7 +1055,7 @@ private extension LLDBContext.Clang {
                 .resolve(
                     filePath,
                     useBazelOut: true,
-                    forceAbsoluteProjectPath: true
+                    forceFullBuildSettingPath: true
                 )
                 .string
             modulemapArgs.append(#"-fmodule-map-file="\#(modulemap)""#)

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -247,7 +247,7 @@ Target with id "\(id)" not found in `consolidatedTarget.uniqueFiles`
                         .resolve(
                             filePath,
                             useBazelOut: true,
-                            forceAbsoluteProjectPath: true
+                            forceFullBuildSettingPath: true
                         )
                         .string.quoted
                     return "-Xcc -fmodule-map-file=\(modulemap)"


### PR DESCRIPTION
In the future this flag can apply to more than just project paths.