### PR TITLE
Remove unneeded `--symlink_prefix=/`

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -236,7 +236,6 @@ touch "$build_marker"
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  --symlink_prefix=/ \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
   2>&1

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -236,7 +236,6 @@ touch "$build_marker"
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  --symlink_prefix=/ \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
   2>&1

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -236,7 +236,6 @@ touch "$build_marker"
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  --symlink_prefix=/ \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
   2>&1

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -236,7 +236,6 @@ touch "$build_marker"
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  --symlink_prefix=/ \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
   2>&1

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -236,7 +236,6 @@ touch "$build_marker"
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  --symlink_prefix=/ \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
   2>&1

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -236,7 +236,6 @@ touch "$build_marker"
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  --symlink_prefix=/ \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
   2>&1

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -236,7 +236,6 @@ touch "$build_marker"
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  --symlink_prefix=/ \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
   2>&1

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -236,7 +236,6 @@ touch "$build_marker"
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  --symlink_prefix=/ \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
   2>&1

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -236,7 +236,6 @@ touch "$build_marker"
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  --symlink_prefix=/ \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
   2>&1

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -236,7 +236,6 @@ touch "$build_marker"
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  --symlink_prefix=/ \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
   2>&1

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -236,7 +236,6 @@ touch "$build_marker"
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  --symlink_prefix=/ \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
   2>&1


### PR DESCRIPTION
We no longer parse the output log, so we don't care how the output is formatted (i.e. 6cf9028a82492ceaca7d83111ff52e1ff8081aef).