### PR TITLE
Remove unused `//xcodeproj/internal:install_path`

### DIFF
--- a/xcodeproj/internal/BUILD
+++ b/xcodeproj/internal/BUILD
@@ -28,13 +28,6 @@ bzl_library(
 exports_files(glob(["*.template.*"]))
 
 string_setting(
-    name = "install_path",
-    build_setting_default = "",
-    # This is made public for internal use only. Do not depend on this setting.
-    visibility = ["//visibility:public"],
-)
-
-string_setting(
     name = "build_mode",
     build_setting_default = "xcode",
     # This is made public for internal use only. Do not depend on this setting.

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -3,7 +3,6 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_skylib//lib:sets.bzl", "sets")
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":bazel_labels.bzl", "bazel_labels")
 load(":collections.bzl", "set_if_true", "uniq")
 load(":configuration.bzl", "get_configuration")

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -699,12 +699,10 @@ def _write_xcodeproj(
         "{}.xcodeproj".format(ctx.attr.name),
     )
 
-    install_path = ctx.attr._install_path[BuildSettingInfo].value
-    if not install_path:
-        install_path = paths.join(
-            paths.dirname(xcodeproj.short_path),
-            "{}.xcodeproj".format(project_name),
-        )
+    install_path = paths.join(
+        paths.dirname(xcodeproj.short_path),
+        "{}.xcodeproj".format(project_name),
+    )
 
     args = ctx.actions.args()
     args.add(spec_file.path)
@@ -1244,10 +1242,6 @@ transitive dependencies of the targets specified in the
             cfg = "exec",
             default = Label("@rules_xcodeproj_index_import//:index_import"),
             executable = True,
-        ),
-        "_install_path": attr.label(
-            default = Label("//xcodeproj/internal:install_path"),
-            providers = [BuildSettingInfo],
         ),
         "_installer_template": attr.label(
             allow_single_file = True,


### PR DESCRIPTION
This was left over from a very old way of doing fixtures.