### PR TITLE
Add `$DEVELOPER_DIR` to `USE_CLANG_CL` key

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -109,7 +109,7 @@ pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=USE_CLANG_CL=$DEVELOPER_DIR-$XCODE_PRODUCT_BUILD_VERSION"
 )
 
 # Determine Bazel output_path

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -109,7 +109,7 @@ pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=USE_CLANG_CL=$DEVELOPER_DIR-$XCODE_PRODUCT_BUILD_VERSION"
 )
 
 # Determine Bazel output_path

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -109,7 +109,7 @@ pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=USE_CLANG_CL=$DEVELOPER_DIR-$XCODE_PRODUCT_BUILD_VERSION"
 )
 
 # Determine Bazel output_path

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -109,7 +109,7 @@ pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=USE_CLANG_CL=$DEVELOPER_DIR-$XCODE_PRODUCT_BUILD_VERSION"
 )
 
 # Determine Bazel output_path

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -109,7 +109,7 @@ pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=USE_CLANG_CL=$DEVELOPER_DIR-$XCODE_PRODUCT_BUILD_VERSION"
 )
 
 # Determine Bazel output_path

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -109,7 +109,7 @@ pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=USE_CLANG_CL=$DEVELOPER_DIR-$XCODE_PRODUCT_BUILD_VERSION"
 )
 
 # Determine Bazel output_path

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -109,7 +109,7 @@ pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=USE_CLANG_CL=$DEVELOPER_DIR-$XCODE_PRODUCT_BUILD_VERSION"
 )
 
 # Determine Bazel output_path

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -109,7 +109,7 @@ pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=USE_CLANG_CL=$DEVELOPER_DIR-$XCODE_PRODUCT_BUILD_VERSION"
 )
 
 # Determine Bazel output_path

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -109,7 +109,7 @@ pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=USE_CLANG_CL=$DEVELOPER_DIR-$XCODE_PRODUCT_BUILD_VERSION"
 )
 
 # Determine Bazel output_path

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -109,7 +109,7 @@ pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=USE_CLANG_CL=$DEVELOPER_DIR-$XCODE_PRODUCT_BUILD_VERSION"
 )
 
 # Determine Bazel output_path

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -109,7 +109,7 @@ pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+  "--repo_env=USE_CLANG_CL=$DEVELOPER_DIR-$XCODE_PRODUCT_BUILD_VERSION"
 )
 
 # Determine Bazel output_path

--- a/xcodeproj/internal/installer.template.sh
+++ b/xcodeproj/internal/installer.template.sh
@@ -169,12 +169,13 @@ if [[ -f "$dest/rules_xcodeproj/generated.xcfilelist" ]]; then
     bazelrcs+=("--bazelrc=.bazelrc")
   fi
 
+  developer_dir=$(xcode-select -p)
   xcode_build_version=$(/usr/bin/xcodebuild -version | tail -1 | cut -d " " -f3)
 
   bazel_out=$("$bazel_path" "${bazelrcs[@]}" \
     --output_base "$nested_output_base" \
     info \
-    "--repo_env=USE_CLANG_CL=$xcode_build_version" \
+    "--repo_env=USE_CLANG_CL=$developer_dir-$xcode_build_version" \
     --config=rules_xcodeproj_info \
     output_path)
 

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -64,12 +64,13 @@ if [[ -s "$extra_flags_bazelrc" ]]; then
   bazelrcs+=("--bazelrc=$extra_flags_bazelrc")
 fi
 
+developer_dir=$(xcode-select -p)
 xcode_build_version=$(/usr/bin/xcodebuild -version | tail -1 | cut -d " " -f3)
 pre_config_flags=(
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$xcode_build_version"
+  "--repo_env=USE_CLANG_CL=$developer_dir-$xcode_build_version"
 )
 
 # We do want the `tools/bazel` to run if possible


### PR DESCRIPTION
This helps work around when the Bazel server caches `DEVELOPER_DIR` in a different directory, like `~/Downloads`.