### PR TITLE
Restart Bazel server if `$DEVELOPER_DIR` changes

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -101,6 +101,10 @@ bazel_cmd=(
   TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
   "${bazelrcs[@]}"
 )
 pre_config_flags=(

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -101,6 +101,10 @@ bazel_cmd=(
   TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
   "${bazelrcs[@]}"
 )
 pre_config_flags=(

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -101,6 +101,10 @@ bazel_cmd=(
   TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
   "${bazelrcs[@]}"
 )
 pre_config_flags=(

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -101,6 +101,10 @@ bazel_cmd=(
   TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
   "${bazelrcs[@]}"
 )
 pre_config_flags=(

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -101,6 +101,10 @@ bazel_cmd=(
   TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
   "${bazelrcs[@]}"
 )
 pre_config_flags=(

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -101,6 +101,10 @@ bazel_cmd=(
   TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
   "${bazelrcs[@]}"
 )
 pre_config_flags=(

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -101,6 +101,10 @@ bazel_cmd=(
   TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
   "${bazelrcs[@]}"
 )
 pre_config_flags=(

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -101,6 +101,10 @@ bazel_cmd=(
   TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
   "${bazelrcs[@]}"
 )
 pre_config_flags=(

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -101,6 +101,10 @@ bazel_cmd=(
   TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
   "${bazelrcs[@]}"
 )
 pre_config_flags=(

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -101,6 +101,10 @@ bazel_cmd=(
   TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
   "${bazelrcs[@]}"
 )
 pre_config_flags=(

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -101,6 +101,10 @@ bazel_cmd=(
   TERM="$TERM"
   USER="$USER"
   "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
   "${bazelrcs[@]}"
 )
 pre_config_flags=(

--- a/xcodeproj/internal/installer.template.sh
+++ b/xcodeproj/internal/installer.template.sh
@@ -175,7 +175,9 @@ if [[ -f "$dest/rules_xcodeproj/generated.xcfilelist" ]]; then
   # Re-export `DEVELOPER_DIR` in case a wrapper has wiped it away
   export DEVELOPER_DIR="$developer_dir"
 
-  bazel_out=$("$bazel_path" "${bazelrcs[@]}" \
+  bazel_out=$("$bazel_path" \
+    "--host_jvm_args=-Xdock:name=$developer_dir" \
+    "${bazelrcs[@]}" \
     --output_base "$nested_output_base" \
     info \
     "--repo_env=DEVELOPER_DIR=$developer_dir" \

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -95,6 +95,10 @@ readonly bazel_cmd=(
   env -i
   "${passthrough_envs[@]}"
   "$bazel_path"
+
+  # Restart Bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$developer_dir"
+
   "${bazelrcs[@]}"
   --output_base "$nested_output_base"
 )


### PR DESCRIPTION
This works around the fact that Bazel caches paths for each Xcode version, meaning a rename of Xcode will result in build failures: https://github.com/bazelbuild/bazel/blob/40dc549ec449b61831a59cfacbcaa8dfa65343e6/src/main/java/com/google/devtools/build/lib/exec/local/XcodeLocalEnvProvider.java#L54