### PR TITLE
Use `$(BUILD_WORKSPACE_DIRECTORY)` in schemes

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
@@ -110,7 +110,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
@@ -110,7 +110,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineTool.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineTool.xcscheme
@@ -110,7 +110,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineToolTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineToolTests.xcscheme
@@ -107,7 +107,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -140,7 +140,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
@@ -137,7 +137,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
@@ -135,7 +135,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
@@ -110,7 +110,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSApp.xcscheme
@@ -110,7 +110,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
@@ -107,7 +107,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -140,7 +140,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
@@ -110,7 +110,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
@@ -107,7 +107,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -140,7 +140,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
@@ -107,7 +107,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -140,7 +140,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
@@ -124,7 +124,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
@@ -107,7 +107,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -140,7 +140,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
@@ -107,7 +107,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -140,7 +140,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AddressSanitizer.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AddressSanitizer.xcscheme
@@ -111,7 +111,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ThreadSanitizer.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ThreadSanitizer.xcscheme
@@ -111,7 +111,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UndefinedBehaviorSanitizer.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UndefinedBehaviorSanitizer.xcscheme
@@ -111,7 +111,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/examples/simple/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/SwiftBin.xcscheme
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/SwiftBin.xcscheme
@@ -110,7 +110,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -171,7 +171,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable
@@ -246,7 +246,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/swiftc.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/swiftc.xcscheme
@@ -111,7 +111,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "BUILD_WORKSPACE_DIRECTORY"
-            value = "$(SRCROOT)"
+            value = "$(BUILD_WORKSPACE_DIRECTORY)"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/tools/generator/src/Extensions/XCSchemeEnvironmentVariables+Extensions.swift
+++ b/tools/generator/src/Extensions/XCSchemeEnvironmentVariables+Extensions.swift
@@ -11,7 +11,7 @@ extension Array where Element == XCScheme.EnvironmentVariable {
     static let bazelLaunchEnvironmentVariables: [XCScheme.EnvironmentVariable] = [
         .init(
             variable: "BUILD_WORKSPACE_DIRECTORY",
-            value: "$(SRCROOT)",
+            value: "$(BUILD_WORKSPACE_DIRECTORY)",
             enabled: true
         ),
         .init(


### PR DESCRIPTION
We could set `$BUILD_WORKSPACE_DIRECTORY` to something other than `$SRCROOT`, so this is more correct.