### PR TITLE
Move nested output base down into `execroot`

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -172,7 +172,7 @@
 				2D3DFF4472B24F4AD7FC4D86 /* examples_cc_external */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		BC9D41B5104B7D51C3B01915 /* includes */ = {
@@ -730,11 +730,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -124,7 +124,7 @@ pre_config_flags=(
 # of the outer bazel's output path (`bazel-out/`). So here we need to make
 # our output base changes relative to that changed path.
 readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_path="$build_output_base/../.."
+readonly outer_output_base="$build_output_base/../.."
 
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
@@ -132,7 +132,7 @@ if [ "$ACTION" == "indexbuild" ]; then
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
 fi

--- a/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -177,7 +177,7 @@
 				C0094871AF8AEE1DBE5F47F3 /* examples_cc_external */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		C0094871AF8AEE1DBE5F47F3 /* examples_cc_external */ = {
@@ -643,11 +643,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -124,7 +124,7 @@ pre_config_flags=(
 # of the outer bazel's output path (`bazel-out/`). So here we need to make
 # our output base changes relative to that changed path.
 readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_path="$build_output_base/../.."
+readonly outer_output_base="$build_output_base/../.."
 
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
@@ -132,7 +132,7 @@ if [ "$ACTION" == "indexbuild" ]; then
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
 fi

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -2194,7 +2194,7 @@
 				BEFC18878DC5748769CC7D24 /* examples_ios_app_external */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		98EF34BC907E91C8A24D2D8C /* dynamic */ = {
@@ -2668,7 +2668,7 @@
 				F42C67C6B7361A26AE646E15 /* watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-25d904fdfd32 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 			sourceTree = "<group>";
 		};
 		C830494187F23C2ACF6D66AA /* PreviewContent */ = {
@@ -7302,11 +7302,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -124,7 +124,7 @@ pre_config_flags=(
 # of the outer bazel's output path (`bazel-out/`). So here we need to make
 # our output base changes relative to that changed path.
 readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_path="$build_output_base/../.."
+readonly outer_output_base="$build_output_base/../.."
 
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
@@ -132,7 +132,7 @@ if [ "$ACTION" == "indexbuild" ]; then
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
 fi

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -2380,7 +2380,7 @@
 				56574692F5ACDED2EE10E84A /* examples_ios_app_external */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		86016AFC7E66C734E7E1D9D0 /* Lib */ = {
@@ -2667,7 +2667,7 @@
 				3D504DADD5F4AA7AC4AABC01 /* watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-38a9c27fdda0 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 			sourceTree = "<group>";
 		};
 		A6BDB7EBB154DC58FA005345 /* WidgetExtension */ = {
@@ -7566,11 +7566,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -124,7 +124,7 @@ pre_config_flags=(
 # of the outer bazel's output path (`bazel-out/`). So here we need to make
 # our output base changes relative to that changed path.
 readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_path="$build_output_base/../.."
+readonly outer_output_base="$build_output_base/../.."
 
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
@@ -132,7 +132,7 @@ if [ "$ACTION" == "indexbuild" ]; then
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
 fi

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -229,7 +229,7 @@
 				D308305EB44933FCF28725BC /* applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 			sourceTree = "<group>";
 		};
 		D11D8A623D8736DF294E22E4 /* AddressSanitizerApp */ = {
@@ -703,11 +703,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -124,7 +124,7 @@ pre_config_flags=(
 # of the outer bazel's output path (`bazel-out/`). So here we need to make
 # our output base changes relative to that changed path.
 readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_path="$build_output_base/../.."
+readonly outer_output_base="$build_output_base/../.."
 
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
@@ -132,7 +132,7 @@ if [ "$ACTION" == "indexbuild" ]; then
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
 fi

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -209,7 +209,7 @@
 				DB819FF70CEDFDF42E7432FF /* applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 			sourceTree = "<group>";
 		};
 		D2C8CC455B9D27F28D323622 /* test */ = {
@@ -701,11 +701,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -124,7 +124,7 @@ pre_config_flags=(
 # of the outer bazel's output path (`bazel-out/`). So here we need to make
 # our output base changes relative to that changed path.
 readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_path="$build_output_base/../.."
+readonly outer_output_base="$build_output_base/../.."
 
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
@@ -132,7 +132,7 @@ if [ "$ACTION" == "indexbuild" ]; then
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
 fi

--- a/examples/simple/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -328,11 +328,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -124,7 +124,7 @@ pre_config_flags=(
 # of the outer bazel's output path (`bazel-out/`). So here we need to make
 # our output base changes relative to that changed path.
 readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_path="$build_output_base/../.."
+readonly outer_output_base="$build_output_base/../.."
 
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
@@ -132,7 +132,7 @@ if [ "$ACTION" == "indexbuild" ]; then
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
 fi

--- a/examples/simple/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -186,11 +186,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/__main__/bazel-out/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -124,7 +124,7 @@ pre_config_flags=(
 # of the outer bazel's output path (`bazel-out/`). So here we need to make
 # our output base changes relative to that changed path.
 readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_path="$build_output_base/../.."
+readonly outer_output_base="$build_output_base/../.."
 
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
@@ -132,7 +132,7 @@ if [ "$ACTION" == "indexbuild" ]; then
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
 fi

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -1180,7 +1180,7 @@
 				CCD52FD22F080CD6DA9BD957 /* com_github_tuist_xcodeproj */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/external";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		98EB7C1365B0DAEC16FDE8B9 /* applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000 */ = {
@@ -1379,7 +1379,7 @@
 				98EB7C1365B0DAEC16FDE8B9 /* applebin_macos-darwin_x86_64-dbg-ST-fd2ea17bd000 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 			sourceTree = "<group>";
 		};
 		CA7DD8A114179E4211EC51BF /* Project */ = {
@@ -2634,11 +2634,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -124,7 +124,7 @@ pre_config_flags=(
 # of the outer bazel's output path (`bazel-out/`). So here we need to make
 # our output base changes relative to that changed path.
 readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_path="$build_output_base/../.."
+readonly outer_output_base="$build_output_base/../.."
 
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
@@ -132,7 +132,7 @@ if [ "$ACTION" == "indexbuild" ]; then
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
 fi

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -1262,7 +1262,7 @@
 				FDA6D5213A699DBCBE8C3656 /* com_github_tuist_xcodeproj */,
 			);
 			name = "Bazel External Repositories";
-			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/external";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 			sourceTree = "<group>";
 		};
 		99F2704C9CFA066AF152A571 /* applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889 */ = {
@@ -1298,7 +1298,7 @@
 				99F2704C9CFA066AF152A571 /* applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889 */,
 			);
 			name = "Bazel Generated Files";
-			path = "bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+			path = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 			sourceTree = "<group>";
 		};
 		A61FCE87C253B18D1339CA0F /* Scheme */ = {
@@ -2702,11 +2702,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
-				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/external";
+				BAZEL_EXEC_ROOT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+				BAZEL_EXTERNAL = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/external";
 				BAZEL_INTEGRATION_DIR = "$(INTERNAL_DIR)/bazel";
 				BAZEL_LLDB_INIT = "$(OBJROOT)/bazel.lldbinit";
-				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
+				BAZEL_OUT = "$(PROJECT_DIR)/bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				BAZEL_PATH = bazel;
 				BAZEL_WORKSPACE_ROOT = "$(SRCROOT)";
 				BUILD_WORKSPACE_DIRECTORY = "$(SRCROOT)";

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -124,7 +124,7 @@ pre_config_flags=(
 # of the outer bazel's output path (`bazel-out/`). So here we need to make
 # our output base changes relative to that changed path.
 readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_path="$build_output_base/../.."
+readonly outer_output_base="$build_output_base/../.."
 
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
@@ -132,7 +132,7 @@ if [ "$ACTION" == "indexbuild" ]; then
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
 fi

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -124,7 +124,7 @@ pre_config_flags=(
 # of the outer bazel's output path (`bazel-out/`). So here we need to make
 # our output base changes relative to that changed path.
 readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_path="$build_output_base/../.."
+readonly outer_output_base="$build_output_base/../.."
 
 if [ "$ACTION" == "indexbuild" ]; then
   # We use a different output base for Index Build to prevent normal builds and
@@ -132,7 +132,7 @@ if [ "$ACTION" == "indexbuild" ]; then
   # normal output base directory so that it's not cleaned up when running
   # `bazel clean`, but is when running `bazel clean --expunge`. This matches
   # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_path/../../../rules_xcodeproj/indexbuild_output_base"
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
 fi

--- a/xcodeproj/internal/installer.template.sh
+++ b/xcodeproj/internal/installer.template.sh
@@ -157,8 +157,8 @@ plutil -replace IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded -bool fals
 if [[ -f "$dest/rules_xcodeproj/generated.xcfilelist" ]]; then
   cd "$BUILD_WORKSPACE_DIRECTORY"
 
-  output_path=$("$bazel_path" info output_path)
-  readonly nested_output_base="$output_path/_rules_xcodeproj/build_output_base"
+  output_base=$("$bazel_path" info output_base)
+  readonly nested_output_base="$output_base/execroot/_rules_xcodeproj/build_output_base"
 
   # Determine bazel-out
   bazelrcs=(

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -48,9 +48,9 @@ cd "$BUILD_WORKSPACE_DIRECTORY"
 bazel_path=$(which "%bazel_path%")
 installer_flags+=(--bazel_path "$bazel_path")
 
-output_path=$("$bazel_path" info output_path)
+output_base=$("$bazel_path" info output_base)
 
-readonly nested_output_base_prefix="$output_path/_rules_xcodeproj"
+readonly nested_output_base_prefix="$output_base/execroot/_rules_xcodeproj"
 readonly nested_output_base="$nested_output_base_prefix/build_output_base"
 
 bazelrcs=(


### PR DESCRIPTION
This way it's still cleaned with `bazel clean`, but there is no chance of recursive symlinks.

The name has an underscore, so it shouldn't conflict with another external repo when using `--experimental_sibling_repository_layout`.