### PR TITLE
Change `host` config back to `exec`

### DIFF
--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -1247,8 +1247,7 @@ transitive dependencies of the targets specified in the
             default = Label("//xcodeproj/internal:installer.template.sh"),
         ),
         "_swiftc_stub": attr.label(
-            # Not "exec", because it's really for the host machine
-            cfg = "host",
+            cfg = "exec",
             default = Label("//tools/swiftc_stub:universal_swiftc_stub"),
             executable = True,
         ),


### PR DESCRIPTION
It really should be `host`, but I guess that is finally going away soon.