### PR TITLE
Extract `bazel_build.sh`

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -1,0 +1,170 @@
+# It is assumed that this file is `source`ed from another script, with the following variable set:
+#
+# - BAZEL_CONFIG
+# - BAZEL_INTEGRATION_DIR
+# - BAZEL_OUT
+# - BAZEL_PATH
+# - DEVELOPER_DIR
+# - GENERATOR_LABEL
+# - GENERATOR_TARGET_NAME
+# - GENERATOR_PACKAGE_BIN_DIR
+# - HOME
+# - INTERNAL_DIR
+# - OBJROOT
+# - RULES_XCODEPROJ_BUILD_MODE
+# - SRCROOT
+# - TERM
+# - USER
+# - XCODE_PRODUCT_BUILD_VERSION
+# - (optional) build_pre_config_flags
+# - config
+# - (optional) labels
+# - output_base
+# - output_groups
+
+output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
+readonly output_groups_flag
+
+# Set `bazel_cmd` for calling `bazel`
+
+bazelrcs=(
+  --noworkspace_rc
+  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
+)
+if [[ -s ".bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=.bazelrc")
+fi
+if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
+fi
+readonly bazelrcs
+
+readonly bazel_cmd=(
+  env -i
+  DEVELOPER_DIR="$DEVELOPER_DIR"
+  HOME="$HOME"
+  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
+  USER="$USER"
+  "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
+  "${bazelrcs[@]}"
+
+  --output_base "$output_base"
+)
+
+readonly base_pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Work around https://github.com/bazelbuild/bazel/issues/8902
+  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
+  # re-evaluate the cc_toolchain for a different Xcode version
+  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
+  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+)
+
+# Determine Bazel output_path
+
+if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
+  readonly info_color=yes
+else
+  readonly info_color=no
+fi
+
+output_path=$("${bazel_cmd[@]}" \
+  info \
+  "${base_pre_config_flags[@]}" \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$info_color" \
+  output_path)
+readonly output_path
+
+# Create VFS overlays
+
+# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
+if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
+  readonly bazel_out_prefix=
+else
+  readonly bazel_out_prefix="$SRCROOT/"
+fi
+
+if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
+fi
+
+readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
+if [[ "$output_path" != "$absolute_bazel_out" ]]; then
+  # Use current path for bazel-out
+  # This fixes Index Build to use its version of generated files
+  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
+else
+  readonly roots=""
+fi
+
+cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
+{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
+EOF
+
+# Custom Swift toolchains
+
+if [[ -n "${TOOLCHAINS-}" ]]; then
+  toolchain="${TOOLCHAINS%% *}"
+  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+    unset toolchain
+  fi
+fi
+
+# Build
+
+# Ensure that our top-level cache buster `override_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
+readonly build_marker="$OBJROOT/bazel_build_start"
+touch "$build_marker"
+
+"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
+  "${bazel_cmd[@]}" \
+  build \
+  "${base_pre_config_flags[@]}" \
+  --config="$config" \
+  --color=yes \
+  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
+  "$output_groups_flag" \
+  "$GENERATOR_LABEL" \
+  2>&1
+
+# Check filelists
+
+indexstores_filelists=()
+for output_group in "${output_groups[@]}"; do
+  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
+  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
+  if [[ "$filelist" -ot "$build_marker" ]]; then
+    echo "error: Bazel didn't generate the correct files (it should have" \
+"generated outputs for output group \"$output_group\", but the timestamp for" \
+"\"$filelist\" was from before the build). Please regenerate the project to" \
+"fix this." >&2
+    echo "error: If your bazel version is less than 5.2, you may need to" \
+"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
+"generation." >&2
+    echo "error: If you are still getting this error after all of that," \
+"please file a bug report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+    exit 1
+  fi
+done
+readonly indexstores_filelists

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,23 +82,6 @@ else
   readonly labels
 fi
 
-output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
-readonly output_groups_flag
-
-# Set `bazel_cmd` for calling `bazel`
-
-bazelrcs=(
-  --noworkspace_rc
-  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
-)
-if [[ -s ".bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=.bazelrc")
-fi
-if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
-fi
-readonly bazelrcs
-
 # Set `output_base`
 
 # In `runner.template.sh` the generator has the build output base set inside
@@ -116,85 +99,6 @@ if [ "$ACTION" == "indexbuild" ]; then
   readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
-fi
-
-readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
-  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
-  "$BAZEL_PATH"
-
-  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
-  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
-
-  "${bazelrcs[@]}"
-
-  --output_base "$output_base"
-)
-
-readonly base_pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Work around https://github.com/bazelbuild/bazel/issues/8902
-  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
-  # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-)
-
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
-# Create VFS overlays
-
-# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
-if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
-  readonly bazel_out_prefix=
-else
-  readonly bazel_out_prefix="$SRCROOT/"
-fi
-
-if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$INTERNAL_DIR/create_xcode_overlay.sh"
-fi
-
-readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
-if [[ "$output_path" != "$absolute_bazel_out" ]]; then
-  # Use current path for bazel-out
-  # This fixes Index Build to use its version of generated files
-  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
-else
-  readonly roots=
-fi
-
-cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
-{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
-EOF
-
-# Custom Swift toolchains
-
-if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
-  fi
 fi
 
 # Build
@@ -226,58 +130,8 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# Ensure that our top-level cache buster `override_repository` is valid
-mkdir -p /tmp/rules_xcodeproj
-touch /tmp/rules_xcodeproj/WORKSPACE
-echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
-date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
-
-readonly build_marker="$OBJROOT/bazel_build_start"
-touch "$build_marker"
-
-# TODO: Include labels in some sort of BES metadata
-# See https://github.com/buildbuddy-io/rules_xcodeproj/issues/1224 for why we
-# don't set the labels in the target pattern
-"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
-  "${bazel_cmd[@]}" \
-  build \
-  "${base_pre_config_flags[@]}" \
-  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
-  --config="$config" \
-  --color=yes \
-  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  "$output_groups_flag" \
-  "$GENERATOR_LABEL" \
-  2>&1
-
-# Check filelists
-
-indexstores_filelists=()
-for output_group in "${output_groups[@]}"; do
-  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
-  filelist="${filelist/%/.filelist}"
-
-  if [[ "$output_group" =~ ^(xi|bi) ]]; then
-    indexstores_filelists+=("$filelist")
-  fi
-
-  if [[ "$filelist" -ot "$build_marker" ]]; then
-    echo "error: Bazel didn't generate the correct files (it should have" \
-"generated outputs for output group \"$output_group\", but the timestamp for" \
-"\"$filelist\" was from before the build). Please regenerate the project to" \
-"fix this." >&2
-    echo "error: If your bazel version is less than 5.2, you may need to" \
-"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
-"generation." >&2
-    echo "error: If you are still getting this error after all of that," \
-"please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
-  fi
-done
-readonly indexstores_filelists
+# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -1,0 +1,170 @@
+# It is assumed that this file is `source`ed from another script, with the following variable set:
+#
+# - BAZEL_CONFIG
+# - BAZEL_INTEGRATION_DIR
+# - BAZEL_OUT
+# - BAZEL_PATH
+# - DEVELOPER_DIR
+# - GENERATOR_LABEL
+# - GENERATOR_TARGET_NAME
+# - GENERATOR_PACKAGE_BIN_DIR
+# - HOME
+# - INTERNAL_DIR
+# - OBJROOT
+# - RULES_XCODEPROJ_BUILD_MODE
+# - SRCROOT
+# - TERM
+# - USER
+# - XCODE_PRODUCT_BUILD_VERSION
+# - (optional) build_pre_config_flags
+# - config
+# - (optional) labels
+# - output_base
+# - output_groups
+
+output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
+readonly output_groups_flag
+
+# Set `bazel_cmd` for calling `bazel`
+
+bazelrcs=(
+  --noworkspace_rc
+  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
+)
+if [[ -s ".bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=.bazelrc")
+fi
+if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
+fi
+readonly bazelrcs
+
+readonly bazel_cmd=(
+  env -i
+  DEVELOPER_DIR="$DEVELOPER_DIR"
+  HOME="$HOME"
+  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
+  USER="$USER"
+  "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
+  "${bazelrcs[@]}"
+
+  --output_base "$output_base"
+)
+
+readonly base_pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Work around https://github.com/bazelbuild/bazel/issues/8902
+  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
+  # re-evaluate the cc_toolchain for a different Xcode version
+  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
+  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+)
+
+# Determine Bazel output_path
+
+if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
+  readonly info_color=yes
+else
+  readonly info_color=no
+fi
+
+output_path=$("${bazel_cmd[@]}" \
+  info \
+  "${base_pre_config_flags[@]}" \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$info_color" \
+  output_path)
+readonly output_path
+
+# Create VFS overlays
+
+# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
+if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
+  readonly bazel_out_prefix=
+else
+  readonly bazel_out_prefix="$SRCROOT/"
+fi
+
+if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
+fi
+
+readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
+if [[ "$output_path" != "$absolute_bazel_out" ]]; then
+  # Use current path for bazel-out
+  # This fixes Index Build to use its version of generated files
+  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
+else
+  readonly roots=""
+fi
+
+cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
+{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
+EOF
+
+# Custom Swift toolchains
+
+if [[ -n "${TOOLCHAINS-}" ]]; then
+  toolchain="${TOOLCHAINS%% *}"
+  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+    unset toolchain
+  fi
+fi
+
+# Build
+
+# Ensure that our top-level cache buster `override_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
+readonly build_marker="$OBJROOT/bazel_build_start"
+touch "$build_marker"
+
+"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
+  "${bazel_cmd[@]}" \
+  build \
+  "${base_pre_config_flags[@]}" \
+  --config="$config" \
+  --color=yes \
+  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
+  "$output_groups_flag" \
+  "$GENERATOR_LABEL" \
+  2>&1
+
+# Check filelists
+
+indexstores_filelists=()
+for output_group in "${output_groups[@]}"; do
+  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
+  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
+  if [[ "$filelist" -ot "$build_marker" ]]; then
+    echo "error: Bazel didn't generate the correct files (it should have" \
+"generated outputs for output group \"$output_group\", but the timestamp for" \
+"\"$filelist\" was from before the build). Please regenerate the project to" \
+"fix this." >&2
+    echo "error: If your bazel version is less than 5.2, you may need to" \
+"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
+"generation." >&2
+    echo "error: If you are still getting this error after all of that," \
+"please file a bug report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+    exit 1
+  fi
+done
+readonly indexstores_filelists

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,23 +82,6 @@ else
   readonly labels
 fi
 
-output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
-readonly output_groups_flag
-
-# Set `bazel_cmd` for calling `bazel`
-
-bazelrcs=(
-  --noworkspace_rc
-  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
-)
-if [[ -s ".bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=.bazelrc")
-fi
-if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
-fi
-readonly bazelrcs
-
 # Set `output_base`
 
 # In `runner.template.sh` the generator has the build output base set inside
@@ -116,85 +99,6 @@ if [ "$ACTION" == "indexbuild" ]; then
   readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
-fi
-
-readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
-  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
-  "$BAZEL_PATH"
-
-  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
-  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
-
-  "${bazelrcs[@]}"
-
-  --output_base "$output_base"
-)
-
-readonly base_pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Work around https://github.com/bazelbuild/bazel/issues/8902
-  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
-  # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-)
-
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
-# Create VFS overlays
-
-# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
-if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
-  readonly bazel_out_prefix=
-else
-  readonly bazel_out_prefix="$SRCROOT/"
-fi
-
-if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$INTERNAL_DIR/create_xcode_overlay.sh"
-fi
-
-readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
-if [[ "$output_path" != "$absolute_bazel_out" ]]; then
-  # Use current path for bazel-out
-  # This fixes Index Build to use its version of generated files
-  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
-else
-  readonly roots=
-fi
-
-cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
-{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
-EOF
-
-# Custom Swift toolchains
-
-if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
-  fi
 fi
 
 # Build
@@ -226,58 +130,8 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# Ensure that our top-level cache buster `override_repository` is valid
-mkdir -p /tmp/rules_xcodeproj
-touch /tmp/rules_xcodeproj/WORKSPACE
-echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
-date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
-
-readonly build_marker="$OBJROOT/bazel_build_start"
-touch "$build_marker"
-
-# TODO: Include labels in some sort of BES metadata
-# See https://github.com/buildbuddy-io/rules_xcodeproj/issues/1224 for why we
-# don't set the labels in the target pattern
-"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
-  "${bazel_cmd[@]}" \
-  build \
-  "${base_pre_config_flags[@]}" \
-  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
-  --config="$config" \
-  --color=yes \
-  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  "$output_groups_flag" \
-  "$GENERATOR_LABEL" \
-  2>&1
-
-# Check filelists
-
-indexstores_filelists=()
-for output_group in "${output_groups[@]}"; do
-  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
-  filelist="${filelist/%/.filelist}"
-
-  if [[ "$output_group" =~ ^(xi|bi) ]]; then
-    indexstores_filelists+=("$filelist")
-  fi
-
-  if [[ "$filelist" -ot "$build_marker" ]]; then
-    echo "error: Bazel didn't generate the correct files (it should have" \
-"generated outputs for output group \"$output_group\", but the timestamp for" \
-"\"$filelist\" was from before the build). Please regenerate the project to" \
-"fix this." >&2
-    echo "error: If your bazel version is less than 5.2, you may need to" \
-"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
-"generation." >&2
-    echo "error: If you are still getting this error after all of that," \
-"please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
-  fi
-done
-readonly indexstores_filelists
+# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -1,0 +1,170 @@
+# It is assumed that this file is `source`ed from another script, with the following variable set:
+#
+# - BAZEL_CONFIG
+# - BAZEL_INTEGRATION_DIR
+# - BAZEL_OUT
+# - BAZEL_PATH
+# - DEVELOPER_DIR
+# - GENERATOR_LABEL
+# - GENERATOR_TARGET_NAME
+# - GENERATOR_PACKAGE_BIN_DIR
+# - HOME
+# - INTERNAL_DIR
+# - OBJROOT
+# - RULES_XCODEPROJ_BUILD_MODE
+# - SRCROOT
+# - TERM
+# - USER
+# - XCODE_PRODUCT_BUILD_VERSION
+# - (optional) build_pre_config_flags
+# - config
+# - (optional) labels
+# - output_base
+# - output_groups
+
+output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
+readonly output_groups_flag
+
+# Set `bazel_cmd` for calling `bazel`
+
+bazelrcs=(
+  --noworkspace_rc
+  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
+)
+if [[ -s ".bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=.bazelrc")
+fi
+if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
+fi
+readonly bazelrcs
+
+readonly bazel_cmd=(
+  env -i
+  DEVELOPER_DIR="$DEVELOPER_DIR"
+  HOME="$HOME"
+  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
+  USER="$USER"
+  "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
+  "${bazelrcs[@]}"
+
+  --output_base "$output_base"
+)
+
+readonly base_pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Work around https://github.com/bazelbuild/bazel/issues/8902
+  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
+  # re-evaluate the cc_toolchain for a different Xcode version
+  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
+  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+)
+
+# Determine Bazel output_path
+
+if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
+  readonly info_color=yes
+else
+  readonly info_color=no
+fi
+
+output_path=$("${bazel_cmd[@]}" \
+  info \
+  "${base_pre_config_flags[@]}" \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$info_color" \
+  output_path)
+readonly output_path
+
+# Create VFS overlays
+
+# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
+if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
+  readonly bazel_out_prefix=
+else
+  readonly bazel_out_prefix="$SRCROOT/"
+fi
+
+if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
+fi
+
+readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
+if [[ "$output_path" != "$absolute_bazel_out" ]]; then
+  # Use current path for bazel-out
+  # This fixes Index Build to use its version of generated files
+  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
+else
+  readonly roots=""
+fi
+
+cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
+{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
+EOF
+
+# Custom Swift toolchains
+
+if [[ -n "${TOOLCHAINS-}" ]]; then
+  toolchain="${TOOLCHAINS%% *}"
+  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+    unset toolchain
+  fi
+fi
+
+# Build
+
+# Ensure that our top-level cache buster `override_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
+readonly build_marker="$OBJROOT/bazel_build_start"
+touch "$build_marker"
+
+"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
+  "${bazel_cmd[@]}" \
+  build \
+  "${base_pre_config_flags[@]}" \
+  --config="$config" \
+  --color=yes \
+  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
+  "$output_groups_flag" \
+  "$GENERATOR_LABEL" \
+  2>&1
+
+# Check filelists
+
+indexstores_filelists=()
+for output_group in "${output_groups[@]}"; do
+  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
+  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
+  if [[ "$filelist" -ot "$build_marker" ]]; then
+    echo "error: Bazel didn't generate the correct files (it should have" \
+"generated outputs for output group \"$output_group\", but the timestamp for" \
+"\"$filelist\" was from before the build). Please regenerate the project to" \
+"fix this." >&2
+    echo "error: If your bazel version is less than 5.2, you may need to" \
+"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
+"generation." >&2
+    echo "error: If you are still getting this error after all of that," \
+"please file a bug report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+    exit 1
+  fi
+done
+readonly indexstores_filelists

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,23 +82,6 @@ else
   readonly labels
 fi
 
-output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
-readonly output_groups_flag
-
-# Set `bazel_cmd` for calling `bazel`
-
-bazelrcs=(
-  --noworkspace_rc
-  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
-)
-if [[ -s ".bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=.bazelrc")
-fi
-if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
-fi
-readonly bazelrcs
-
 # Set `output_base`
 
 # In `runner.template.sh` the generator has the build output base set inside
@@ -116,85 +99,6 @@ if [ "$ACTION" == "indexbuild" ]; then
   readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
-fi
-
-readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
-  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
-  "$BAZEL_PATH"
-
-  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
-  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
-
-  "${bazelrcs[@]}"
-
-  --output_base "$output_base"
-)
-
-readonly base_pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Work around https://github.com/bazelbuild/bazel/issues/8902
-  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
-  # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-)
-
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
-# Create VFS overlays
-
-# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
-if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
-  readonly bazel_out_prefix=
-else
-  readonly bazel_out_prefix="$SRCROOT/"
-fi
-
-if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$INTERNAL_DIR/create_xcode_overlay.sh"
-fi
-
-readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
-if [[ "$output_path" != "$absolute_bazel_out" ]]; then
-  # Use current path for bazel-out
-  # This fixes Index Build to use its version of generated files
-  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
-else
-  readonly roots=
-fi
-
-cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
-{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
-EOF
-
-# Custom Swift toolchains
-
-if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
-  fi
 fi
 
 # Build
@@ -226,58 +130,8 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# Ensure that our top-level cache buster `override_repository` is valid
-mkdir -p /tmp/rules_xcodeproj
-touch /tmp/rules_xcodeproj/WORKSPACE
-echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
-date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
-
-readonly build_marker="$OBJROOT/bazel_build_start"
-touch "$build_marker"
-
-# TODO: Include labels in some sort of BES metadata
-# See https://github.com/buildbuddy-io/rules_xcodeproj/issues/1224 for why we
-# don't set the labels in the target pattern
-"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
-  "${bazel_cmd[@]}" \
-  build \
-  "${base_pre_config_flags[@]}" \
-  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
-  --config="$config" \
-  --color=yes \
-  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  "$output_groups_flag" \
-  "$GENERATOR_LABEL" \
-  2>&1
-
-# Check filelists
-
-indexstores_filelists=()
-for output_group in "${output_groups[@]}"; do
-  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
-  filelist="${filelist/%/.filelist}"
-
-  if [[ "$output_group" =~ ^(xi|bi) ]]; then
-    indexstores_filelists+=("$filelist")
-  fi
-
-  if [[ "$filelist" -ot "$build_marker" ]]; then
-    echo "error: Bazel didn't generate the correct files (it should have" \
-"generated outputs for output group \"$output_group\", but the timestamp for" \
-"\"$filelist\" was from before the build). Please regenerate the project to" \
-"fix this." >&2
-    echo "error: If your bazel version is less than 5.2, you may need to" \
-"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
-"generation." >&2
-    echo "error: If you are still getting this error after all of that," \
-"please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
-  fi
-done
-readonly indexstores_filelists
+# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -1,0 +1,170 @@
+# It is assumed that this file is `source`ed from another script, with the following variable set:
+#
+# - BAZEL_CONFIG
+# - BAZEL_INTEGRATION_DIR
+# - BAZEL_OUT
+# - BAZEL_PATH
+# - DEVELOPER_DIR
+# - GENERATOR_LABEL
+# - GENERATOR_TARGET_NAME
+# - GENERATOR_PACKAGE_BIN_DIR
+# - HOME
+# - INTERNAL_DIR
+# - OBJROOT
+# - RULES_XCODEPROJ_BUILD_MODE
+# - SRCROOT
+# - TERM
+# - USER
+# - XCODE_PRODUCT_BUILD_VERSION
+# - (optional) build_pre_config_flags
+# - config
+# - (optional) labels
+# - output_base
+# - output_groups
+
+output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
+readonly output_groups_flag
+
+# Set `bazel_cmd` for calling `bazel`
+
+bazelrcs=(
+  --noworkspace_rc
+  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
+)
+if [[ -s ".bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=.bazelrc")
+fi
+if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
+fi
+readonly bazelrcs
+
+readonly bazel_cmd=(
+  env -i
+  DEVELOPER_DIR="$DEVELOPER_DIR"
+  HOME="$HOME"
+  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
+  USER="$USER"
+  "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
+  "${bazelrcs[@]}"
+
+  --output_base "$output_base"
+)
+
+readonly base_pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Work around https://github.com/bazelbuild/bazel/issues/8902
+  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
+  # re-evaluate the cc_toolchain for a different Xcode version
+  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
+  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+)
+
+# Determine Bazel output_path
+
+if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
+  readonly info_color=yes
+else
+  readonly info_color=no
+fi
+
+output_path=$("${bazel_cmd[@]}" \
+  info \
+  "${base_pre_config_flags[@]}" \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$info_color" \
+  output_path)
+readonly output_path
+
+# Create VFS overlays
+
+# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
+if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
+  readonly bazel_out_prefix=
+else
+  readonly bazel_out_prefix="$SRCROOT/"
+fi
+
+if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
+fi
+
+readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
+if [[ "$output_path" != "$absolute_bazel_out" ]]; then
+  # Use current path for bazel-out
+  # This fixes Index Build to use its version of generated files
+  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
+else
+  readonly roots=""
+fi
+
+cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
+{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
+EOF
+
+# Custom Swift toolchains
+
+if [[ -n "${TOOLCHAINS-}" ]]; then
+  toolchain="${TOOLCHAINS%% *}"
+  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+    unset toolchain
+  fi
+fi
+
+# Build
+
+# Ensure that our top-level cache buster `override_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
+readonly build_marker="$OBJROOT/bazel_build_start"
+touch "$build_marker"
+
+"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
+  "${bazel_cmd[@]}" \
+  build \
+  "${base_pre_config_flags[@]}" \
+  --config="$config" \
+  --color=yes \
+  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
+  "$output_groups_flag" \
+  "$GENERATOR_LABEL" \
+  2>&1
+
+# Check filelists
+
+indexstores_filelists=()
+for output_group in "${output_groups[@]}"; do
+  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
+  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
+  if [[ "$filelist" -ot "$build_marker" ]]; then
+    echo "error: Bazel didn't generate the correct files (it should have" \
+"generated outputs for output group \"$output_group\", but the timestamp for" \
+"\"$filelist\" was from before the build). Please regenerate the project to" \
+"fix this." >&2
+    echo "error: If your bazel version is less than 5.2, you may need to" \
+"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
+"generation." >&2
+    echo "error: If you are still getting this error after all of that," \
+"please file a bug report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+    exit 1
+  fi
+done
+readonly indexstores_filelists

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,23 +82,6 @@ else
   readonly labels
 fi
 
-output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
-readonly output_groups_flag
-
-# Set `bazel_cmd` for calling `bazel`
-
-bazelrcs=(
-  --noworkspace_rc
-  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
-)
-if [[ -s ".bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=.bazelrc")
-fi
-if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
-fi
-readonly bazelrcs
-
 # Set `output_base`
 
 # In `runner.template.sh` the generator has the build output base set inside
@@ -116,85 +99,6 @@ if [ "$ACTION" == "indexbuild" ]; then
   readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
-fi
-
-readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
-  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
-  "$BAZEL_PATH"
-
-  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
-  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
-
-  "${bazelrcs[@]}"
-
-  --output_base "$output_base"
-)
-
-readonly base_pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Work around https://github.com/bazelbuild/bazel/issues/8902
-  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
-  # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-)
-
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
-# Create VFS overlays
-
-# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
-if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
-  readonly bazel_out_prefix=
-else
-  readonly bazel_out_prefix="$SRCROOT/"
-fi
-
-if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$INTERNAL_DIR/create_xcode_overlay.sh"
-fi
-
-readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
-if [[ "$output_path" != "$absolute_bazel_out" ]]; then
-  # Use current path for bazel-out
-  # This fixes Index Build to use its version of generated files
-  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
-else
-  readonly roots=
-fi
-
-cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
-{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
-EOF
-
-# Custom Swift toolchains
-
-if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
-  fi
 fi
 
 # Build
@@ -226,58 +130,8 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# Ensure that our top-level cache buster `override_repository` is valid
-mkdir -p /tmp/rules_xcodeproj
-touch /tmp/rules_xcodeproj/WORKSPACE
-echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
-date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
-
-readonly build_marker="$OBJROOT/bazel_build_start"
-touch "$build_marker"
-
-# TODO: Include labels in some sort of BES metadata
-# See https://github.com/buildbuddy-io/rules_xcodeproj/issues/1224 for why we
-# don't set the labels in the target pattern
-"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
-  "${bazel_cmd[@]}" \
-  build \
-  "${base_pre_config_flags[@]}" \
-  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
-  --config="$config" \
-  --color=yes \
-  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  "$output_groups_flag" \
-  "$GENERATOR_LABEL" \
-  2>&1
-
-# Check filelists
-
-indexstores_filelists=()
-for output_group in "${output_groups[@]}"; do
-  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
-  filelist="${filelist/%/.filelist}"
-
-  if [[ "$output_group" =~ ^(xi|bi) ]]; then
-    indexstores_filelists+=("$filelist")
-  fi
-
-  if [[ "$filelist" -ot "$build_marker" ]]; then
-    echo "error: Bazel didn't generate the correct files (it should have" \
-"generated outputs for output group \"$output_group\", but the timestamp for" \
-"\"$filelist\" was from before the build). Please regenerate the project to" \
-"fix this." >&2
-    echo "error: If your bazel version is less than 5.2, you may need to" \
-"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
-"generation." >&2
-    echo "error: If you are still getting this error after all of that," \
-"please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
-  fi
-done
-readonly indexstores_filelists
+# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -1,0 +1,170 @@
+# It is assumed that this file is `source`ed from another script, with the following variable set:
+#
+# - BAZEL_CONFIG
+# - BAZEL_INTEGRATION_DIR
+# - BAZEL_OUT
+# - BAZEL_PATH
+# - DEVELOPER_DIR
+# - GENERATOR_LABEL
+# - GENERATOR_TARGET_NAME
+# - GENERATOR_PACKAGE_BIN_DIR
+# - HOME
+# - INTERNAL_DIR
+# - OBJROOT
+# - RULES_XCODEPROJ_BUILD_MODE
+# - SRCROOT
+# - TERM
+# - USER
+# - XCODE_PRODUCT_BUILD_VERSION
+# - (optional) build_pre_config_flags
+# - config
+# - (optional) labels
+# - output_base
+# - output_groups
+
+output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
+readonly output_groups_flag
+
+# Set `bazel_cmd` for calling `bazel`
+
+bazelrcs=(
+  --noworkspace_rc
+  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
+)
+if [[ -s ".bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=.bazelrc")
+fi
+if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
+fi
+readonly bazelrcs
+
+readonly bazel_cmd=(
+  env -i
+  DEVELOPER_DIR="$DEVELOPER_DIR"
+  HOME="$HOME"
+  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
+  USER="$USER"
+  "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
+  "${bazelrcs[@]}"
+
+  --output_base "$output_base"
+)
+
+readonly base_pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Work around https://github.com/bazelbuild/bazel/issues/8902
+  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
+  # re-evaluate the cc_toolchain for a different Xcode version
+  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
+  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+)
+
+# Determine Bazel output_path
+
+if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
+  readonly info_color=yes
+else
+  readonly info_color=no
+fi
+
+output_path=$("${bazel_cmd[@]}" \
+  info \
+  "${base_pre_config_flags[@]}" \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$info_color" \
+  output_path)
+readonly output_path
+
+# Create VFS overlays
+
+# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
+if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
+  readonly bazel_out_prefix=
+else
+  readonly bazel_out_prefix="$SRCROOT/"
+fi
+
+if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
+fi
+
+readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
+if [[ "$output_path" != "$absolute_bazel_out" ]]; then
+  # Use current path for bazel-out
+  # This fixes Index Build to use its version of generated files
+  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
+else
+  readonly roots=""
+fi
+
+cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
+{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
+EOF
+
+# Custom Swift toolchains
+
+if [[ -n "${TOOLCHAINS-}" ]]; then
+  toolchain="${TOOLCHAINS%% *}"
+  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+    unset toolchain
+  fi
+fi
+
+# Build
+
+# Ensure that our top-level cache buster `override_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
+readonly build_marker="$OBJROOT/bazel_build_start"
+touch "$build_marker"
+
+"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
+  "${bazel_cmd[@]}" \
+  build \
+  "${base_pre_config_flags[@]}" \
+  --config="$config" \
+  --color=yes \
+  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
+  "$output_groups_flag" \
+  "$GENERATOR_LABEL" \
+  2>&1
+
+# Check filelists
+
+indexstores_filelists=()
+for output_group in "${output_groups[@]}"; do
+  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
+  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
+  if [[ "$filelist" -ot "$build_marker" ]]; then
+    echo "error: Bazel didn't generate the correct files (it should have" \
+"generated outputs for output group \"$output_group\", but the timestamp for" \
+"\"$filelist\" was from before the build). Please regenerate the project to" \
+"fix this." >&2
+    echo "error: If your bazel version is less than 5.2, you may need to" \
+"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
+"generation." >&2
+    echo "error: If you are still getting this error after all of that," \
+"please file a bug report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+    exit 1
+  fi
+done
+readonly indexstores_filelists

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,23 +82,6 @@ else
   readonly labels
 fi
 
-output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
-readonly output_groups_flag
-
-# Set `bazel_cmd` for calling `bazel`
-
-bazelrcs=(
-  --noworkspace_rc
-  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
-)
-if [[ -s ".bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=.bazelrc")
-fi
-if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
-fi
-readonly bazelrcs
-
 # Set `output_base`
 
 # In `runner.template.sh` the generator has the build output base set inside
@@ -116,85 +99,6 @@ if [ "$ACTION" == "indexbuild" ]; then
   readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
-fi
-
-readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
-  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
-  "$BAZEL_PATH"
-
-  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
-  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
-
-  "${bazelrcs[@]}"
-
-  --output_base "$output_base"
-)
-
-readonly base_pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Work around https://github.com/bazelbuild/bazel/issues/8902
-  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
-  # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-)
-
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
-# Create VFS overlays
-
-# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
-if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
-  readonly bazel_out_prefix=
-else
-  readonly bazel_out_prefix="$SRCROOT/"
-fi
-
-if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$INTERNAL_DIR/create_xcode_overlay.sh"
-fi
-
-readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
-if [[ "$output_path" != "$absolute_bazel_out" ]]; then
-  # Use current path for bazel-out
-  # This fixes Index Build to use its version of generated files
-  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
-else
-  readonly roots=
-fi
-
-cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
-{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
-EOF
-
-# Custom Swift toolchains
-
-if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
-  fi
 fi
 
 # Build
@@ -226,58 +130,8 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# Ensure that our top-level cache buster `override_repository` is valid
-mkdir -p /tmp/rules_xcodeproj
-touch /tmp/rules_xcodeproj/WORKSPACE
-echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
-date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
-
-readonly build_marker="$OBJROOT/bazel_build_start"
-touch "$build_marker"
-
-# TODO: Include labels in some sort of BES metadata
-# See https://github.com/buildbuddy-io/rules_xcodeproj/issues/1224 for why we
-# don't set the labels in the target pattern
-"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
-  "${bazel_cmd[@]}" \
-  build \
-  "${base_pre_config_flags[@]}" \
-  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
-  --config="$config" \
-  --color=yes \
-  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  "$output_groups_flag" \
-  "$GENERATOR_LABEL" \
-  2>&1
-
-# Check filelists
-
-indexstores_filelists=()
-for output_group in "${output_groups[@]}"; do
-  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
-  filelist="${filelist/%/.filelist}"
-
-  if [[ "$output_group" =~ ^(xi|bi) ]]; then
-    indexstores_filelists+=("$filelist")
-  fi
-
-  if [[ "$filelist" -ot "$build_marker" ]]; then
-    echo "error: Bazel didn't generate the correct files (it should have" \
-"generated outputs for output group \"$output_group\", but the timestamp for" \
-"\"$filelist\" was from before the build). Please regenerate the project to" \
-"fix this." >&2
-    echo "error: If your bazel version is less than 5.2, you may need to" \
-"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
-"generation." >&2
-    echo "error: If you are still getting this error after all of that," \
-"please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
-  fi
-done
-readonly indexstores_filelists
+# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -1,0 +1,170 @@
+# It is assumed that this file is `source`ed from another script, with the following variable set:
+#
+# - BAZEL_CONFIG
+# - BAZEL_INTEGRATION_DIR
+# - BAZEL_OUT
+# - BAZEL_PATH
+# - DEVELOPER_DIR
+# - GENERATOR_LABEL
+# - GENERATOR_TARGET_NAME
+# - GENERATOR_PACKAGE_BIN_DIR
+# - HOME
+# - INTERNAL_DIR
+# - OBJROOT
+# - RULES_XCODEPROJ_BUILD_MODE
+# - SRCROOT
+# - TERM
+# - USER
+# - XCODE_PRODUCT_BUILD_VERSION
+# - (optional) build_pre_config_flags
+# - config
+# - (optional) labels
+# - output_base
+# - output_groups
+
+output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
+readonly output_groups_flag
+
+# Set `bazel_cmd` for calling `bazel`
+
+bazelrcs=(
+  --noworkspace_rc
+  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
+)
+if [[ -s ".bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=.bazelrc")
+fi
+if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
+fi
+readonly bazelrcs
+
+readonly bazel_cmd=(
+  env -i
+  DEVELOPER_DIR="$DEVELOPER_DIR"
+  HOME="$HOME"
+  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
+  USER="$USER"
+  "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
+  "${bazelrcs[@]}"
+
+  --output_base "$output_base"
+)
+
+readonly base_pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Work around https://github.com/bazelbuild/bazel/issues/8902
+  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
+  # re-evaluate the cc_toolchain for a different Xcode version
+  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
+  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+)
+
+# Determine Bazel output_path
+
+if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
+  readonly info_color=yes
+else
+  readonly info_color=no
+fi
+
+output_path=$("${bazel_cmd[@]}" \
+  info \
+  "${base_pre_config_flags[@]}" \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$info_color" \
+  output_path)
+readonly output_path
+
+# Create VFS overlays
+
+# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
+if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
+  readonly bazel_out_prefix=
+else
+  readonly bazel_out_prefix="$SRCROOT/"
+fi
+
+if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
+fi
+
+readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
+if [[ "$output_path" != "$absolute_bazel_out" ]]; then
+  # Use current path for bazel-out
+  # This fixes Index Build to use its version of generated files
+  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
+else
+  readonly roots=""
+fi
+
+cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
+{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
+EOF
+
+# Custom Swift toolchains
+
+if [[ -n "${TOOLCHAINS-}" ]]; then
+  toolchain="${TOOLCHAINS%% *}"
+  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+    unset toolchain
+  fi
+fi
+
+# Build
+
+# Ensure that our top-level cache buster `override_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
+readonly build_marker="$OBJROOT/bazel_build_start"
+touch "$build_marker"
+
+"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
+  "${bazel_cmd[@]}" \
+  build \
+  "${base_pre_config_flags[@]}" \
+  --config="$config" \
+  --color=yes \
+  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
+  "$output_groups_flag" \
+  "$GENERATOR_LABEL" \
+  2>&1
+
+# Check filelists
+
+indexstores_filelists=()
+for output_group in "${output_groups[@]}"; do
+  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
+  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
+  if [[ "$filelist" -ot "$build_marker" ]]; then
+    echo "error: Bazel didn't generate the correct files (it should have" \
+"generated outputs for output group \"$output_group\", but the timestamp for" \
+"\"$filelist\" was from before the build). Please regenerate the project to" \
+"fix this." >&2
+    echo "error: If your bazel version is less than 5.2, you may need to" \
+"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
+"generation." >&2
+    echo "error: If you are still getting this error after all of that," \
+"please file a bug report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+    exit 1
+  fi
+done
+readonly indexstores_filelists

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,23 +82,6 @@ else
   readonly labels
 fi
 
-output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
-readonly output_groups_flag
-
-# Set `bazel_cmd` for calling `bazel`
-
-bazelrcs=(
-  --noworkspace_rc
-  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
-)
-if [[ -s ".bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=.bazelrc")
-fi
-if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
-fi
-readonly bazelrcs
-
 # Set `output_base`
 
 # In `runner.template.sh` the generator has the build output base set inside
@@ -116,85 +99,6 @@ if [ "$ACTION" == "indexbuild" ]; then
   readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
-fi
-
-readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
-  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
-  "$BAZEL_PATH"
-
-  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
-  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
-
-  "${bazelrcs[@]}"
-
-  --output_base "$output_base"
-)
-
-readonly base_pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Work around https://github.com/bazelbuild/bazel/issues/8902
-  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
-  # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-)
-
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
-# Create VFS overlays
-
-# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
-if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
-  readonly bazel_out_prefix=
-else
-  readonly bazel_out_prefix="$SRCROOT/"
-fi
-
-if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$INTERNAL_DIR/create_xcode_overlay.sh"
-fi
-
-readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
-if [[ "$output_path" != "$absolute_bazel_out" ]]; then
-  # Use current path for bazel-out
-  # This fixes Index Build to use its version of generated files
-  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
-else
-  readonly roots=
-fi
-
-cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
-{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
-EOF
-
-# Custom Swift toolchains
-
-if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
-  fi
 fi
 
 # Build
@@ -226,58 +130,8 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# Ensure that our top-level cache buster `override_repository` is valid
-mkdir -p /tmp/rules_xcodeproj
-touch /tmp/rules_xcodeproj/WORKSPACE
-echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
-date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
-
-readonly build_marker="$OBJROOT/bazel_build_start"
-touch "$build_marker"
-
-# TODO: Include labels in some sort of BES metadata
-# See https://github.com/buildbuddy-io/rules_xcodeproj/issues/1224 for why we
-# don't set the labels in the target pattern
-"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
-  "${bazel_cmd[@]}" \
-  build \
-  "${base_pre_config_flags[@]}" \
-  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
-  --config="$config" \
-  --color=yes \
-  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  "$output_groups_flag" \
-  "$GENERATOR_LABEL" \
-  2>&1
-
-# Check filelists
-
-indexstores_filelists=()
-for output_group in "${output_groups[@]}"; do
-  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
-  filelist="${filelist/%/.filelist}"
-
-  if [[ "$output_group" =~ ^(xi|bi) ]]; then
-    indexstores_filelists+=("$filelist")
-  fi
-
-  if [[ "$filelist" -ot "$build_marker" ]]; then
-    echo "error: Bazel didn't generate the correct files (it should have" \
-"generated outputs for output group \"$output_group\", but the timestamp for" \
-"\"$filelist\" was from before the build). Please regenerate the project to" \
-"fix this." >&2
-    echo "error: If your bazel version is less than 5.2, you may need to" \
-"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
-"generation." >&2
-    echo "error: If you are still getting this error after all of that," \
-"please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
-  fi
-done
-readonly indexstores_filelists
+# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -1,0 +1,170 @@
+# It is assumed that this file is `source`ed from another script, with the following variable set:
+#
+# - BAZEL_CONFIG
+# - BAZEL_INTEGRATION_DIR
+# - BAZEL_OUT
+# - BAZEL_PATH
+# - DEVELOPER_DIR
+# - GENERATOR_LABEL
+# - GENERATOR_TARGET_NAME
+# - GENERATOR_PACKAGE_BIN_DIR
+# - HOME
+# - INTERNAL_DIR
+# - OBJROOT
+# - RULES_XCODEPROJ_BUILD_MODE
+# - SRCROOT
+# - TERM
+# - USER
+# - XCODE_PRODUCT_BUILD_VERSION
+# - (optional) build_pre_config_flags
+# - config
+# - (optional) labels
+# - output_base
+# - output_groups
+
+output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
+readonly output_groups_flag
+
+# Set `bazel_cmd` for calling `bazel`
+
+bazelrcs=(
+  --noworkspace_rc
+  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
+)
+if [[ -s ".bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=.bazelrc")
+fi
+if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
+fi
+readonly bazelrcs
+
+readonly bazel_cmd=(
+  env -i
+  DEVELOPER_DIR="$DEVELOPER_DIR"
+  HOME="$HOME"
+  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
+  USER="$USER"
+  "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
+  "${bazelrcs[@]}"
+
+  --output_base "$output_base"
+)
+
+readonly base_pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Work around https://github.com/bazelbuild/bazel/issues/8902
+  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
+  # re-evaluate the cc_toolchain for a different Xcode version
+  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
+  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+)
+
+# Determine Bazel output_path
+
+if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
+  readonly info_color=yes
+else
+  readonly info_color=no
+fi
+
+output_path=$("${bazel_cmd[@]}" \
+  info \
+  "${base_pre_config_flags[@]}" \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$info_color" \
+  output_path)
+readonly output_path
+
+# Create VFS overlays
+
+# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
+if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
+  readonly bazel_out_prefix=
+else
+  readonly bazel_out_prefix="$SRCROOT/"
+fi
+
+if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
+fi
+
+readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
+if [[ "$output_path" != "$absolute_bazel_out" ]]; then
+  # Use current path for bazel-out
+  # This fixes Index Build to use its version of generated files
+  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
+else
+  readonly roots=""
+fi
+
+cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
+{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
+EOF
+
+# Custom Swift toolchains
+
+if [[ -n "${TOOLCHAINS-}" ]]; then
+  toolchain="${TOOLCHAINS%% *}"
+  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+    unset toolchain
+  fi
+fi
+
+# Build
+
+# Ensure that our top-level cache buster `override_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
+readonly build_marker="$OBJROOT/bazel_build_start"
+touch "$build_marker"
+
+"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
+  "${bazel_cmd[@]}" \
+  build \
+  "${base_pre_config_flags[@]}" \
+  --config="$config" \
+  --color=yes \
+  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
+  "$output_groups_flag" \
+  "$GENERATOR_LABEL" \
+  2>&1
+
+# Check filelists
+
+indexstores_filelists=()
+for output_group in "${output_groups[@]}"; do
+  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
+  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
+  if [[ "$filelist" -ot "$build_marker" ]]; then
+    echo "error: Bazel didn't generate the correct files (it should have" \
+"generated outputs for output group \"$output_group\", but the timestamp for" \
+"\"$filelist\" was from before the build). Please regenerate the project to" \
+"fix this." >&2
+    echo "error: If your bazel version is less than 5.2, you may need to" \
+"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
+"generation." >&2
+    echo "error: If you are still getting this error after all of that," \
+"please file a bug report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+    exit 1
+  fi
+done
+readonly indexstores_filelists

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,23 +82,6 @@ else
   readonly labels
 fi
 
-output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
-readonly output_groups_flag
-
-# Set `bazel_cmd` for calling `bazel`
-
-bazelrcs=(
-  --noworkspace_rc
-  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
-)
-if [[ -s ".bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=.bazelrc")
-fi
-if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
-fi
-readonly bazelrcs
-
 # Set `output_base`
 
 # In `runner.template.sh` the generator has the build output base set inside
@@ -116,85 +99,6 @@ if [ "$ACTION" == "indexbuild" ]; then
   readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
-fi
-
-readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
-  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
-  "$BAZEL_PATH"
-
-  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
-  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
-
-  "${bazelrcs[@]}"
-
-  --output_base "$output_base"
-)
-
-readonly base_pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Work around https://github.com/bazelbuild/bazel/issues/8902
-  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
-  # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-)
-
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
-# Create VFS overlays
-
-# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
-if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
-  readonly bazel_out_prefix=
-else
-  readonly bazel_out_prefix="$SRCROOT/"
-fi
-
-if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$INTERNAL_DIR/create_xcode_overlay.sh"
-fi
-
-readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
-if [[ "$output_path" != "$absolute_bazel_out" ]]; then
-  # Use current path for bazel-out
-  # This fixes Index Build to use its version of generated files
-  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
-else
-  readonly roots=
-fi
-
-cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
-{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
-EOF
-
-# Custom Swift toolchains
-
-if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
-  fi
 fi
 
 # Build
@@ -226,58 +130,8 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# Ensure that our top-level cache buster `override_repository` is valid
-mkdir -p /tmp/rules_xcodeproj
-touch /tmp/rules_xcodeproj/WORKSPACE
-echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
-date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
-
-readonly build_marker="$OBJROOT/bazel_build_start"
-touch "$build_marker"
-
-# TODO: Include labels in some sort of BES metadata
-# See https://github.com/buildbuddy-io/rules_xcodeproj/issues/1224 for why we
-# don't set the labels in the target pattern
-"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
-  "${bazel_cmd[@]}" \
-  build \
-  "${base_pre_config_flags[@]}" \
-  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
-  --config="$config" \
-  --color=yes \
-  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  "$output_groups_flag" \
-  "$GENERATOR_LABEL" \
-  2>&1
-
-# Check filelists
-
-indexstores_filelists=()
-for output_group in "${output_groups[@]}"; do
-  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
-  filelist="${filelist/%/.filelist}"
-
-  if [[ "$output_group" =~ ^(xi|bi) ]]; then
-    indexstores_filelists+=("$filelist")
-  fi
-
-  if [[ "$filelist" -ot "$build_marker" ]]; then
-    echo "error: Bazel didn't generate the correct files (it should have" \
-"generated outputs for output group \"$output_group\", but the timestamp for" \
-"\"$filelist\" was from before the build). Please regenerate the project to" \
-"fix this." >&2
-    echo "error: If your bazel version is less than 5.2, you may need to" \
-"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
-"generation." >&2
-    echo "error: If you are still getting this error after all of that," \
-"please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
-  fi
-done
-readonly indexstores_filelists
+# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -1,0 +1,170 @@
+# It is assumed that this file is `source`ed from another script, with the following variable set:
+#
+# - BAZEL_CONFIG
+# - BAZEL_INTEGRATION_DIR
+# - BAZEL_OUT
+# - BAZEL_PATH
+# - DEVELOPER_DIR
+# - GENERATOR_LABEL
+# - GENERATOR_TARGET_NAME
+# - GENERATOR_PACKAGE_BIN_DIR
+# - HOME
+# - INTERNAL_DIR
+# - OBJROOT
+# - RULES_XCODEPROJ_BUILD_MODE
+# - SRCROOT
+# - TERM
+# - USER
+# - XCODE_PRODUCT_BUILD_VERSION
+# - (optional) build_pre_config_flags
+# - config
+# - (optional) labels
+# - output_base
+# - output_groups
+
+output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
+readonly output_groups_flag
+
+# Set `bazel_cmd` for calling `bazel`
+
+bazelrcs=(
+  --noworkspace_rc
+  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
+)
+if [[ -s ".bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=.bazelrc")
+fi
+if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
+fi
+readonly bazelrcs
+
+readonly bazel_cmd=(
+  env -i
+  DEVELOPER_DIR="$DEVELOPER_DIR"
+  HOME="$HOME"
+  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
+  USER="$USER"
+  "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
+  "${bazelrcs[@]}"
+
+  --output_base "$output_base"
+)
+
+readonly base_pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Work around https://github.com/bazelbuild/bazel/issues/8902
+  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
+  # re-evaluate the cc_toolchain for a different Xcode version
+  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
+  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+)
+
+# Determine Bazel output_path
+
+if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
+  readonly info_color=yes
+else
+  readonly info_color=no
+fi
+
+output_path=$("${bazel_cmd[@]}" \
+  info \
+  "${base_pre_config_flags[@]}" \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$info_color" \
+  output_path)
+readonly output_path
+
+# Create VFS overlays
+
+# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
+if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
+  readonly bazel_out_prefix=
+else
+  readonly bazel_out_prefix="$SRCROOT/"
+fi
+
+if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
+fi
+
+readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
+if [[ "$output_path" != "$absolute_bazel_out" ]]; then
+  # Use current path for bazel-out
+  # This fixes Index Build to use its version of generated files
+  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
+else
+  readonly roots=""
+fi
+
+cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
+{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
+EOF
+
+# Custom Swift toolchains
+
+if [[ -n "${TOOLCHAINS-}" ]]; then
+  toolchain="${TOOLCHAINS%% *}"
+  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+    unset toolchain
+  fi
+fi
+
+# Build
+
+# Ensure that our top-level cache buster `override_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
+readonly build_marker="$OBJROOT/bazel_build_start"
+touch "$build_marker"
+
+"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
+  "${bazel_cmd[@]}" \
+  build \
+  "${base_pre_config_flags[@]}" \
+  --config="$config" \
+  --color=yes \
+  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
+  "$output_groups_flag" \
+  "$GENERATOR_LABEL" \
+  2>&1
+
+# Check filelists
+
+indexstores_filelists=()
+for output_group in "${output_groups[@]}"; do
+  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
+  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
+  if [[ "$filelist" -ot "$build_marker" ]]; then
+    echo "error: Bazel didn't generate the correct files (it should have" \
+"generated outputs for output group \"$output_group\", but the timestamp for" \
+"\"$filelist\" was from before the build). Please regenerate the project to" \
+"fix this." >&2
+    echo "error: If your bazel version is less than 5.2, you may need to" \
+"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
+"generation." >&2
+    echo "error: If you are still getting this error after all of that," \
+"please file a bug report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+    exit 1
+  fi
+done
+readonly indexstores_filelists

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,23 +82,6 @@ else
   readonly labels
 fi
 
-output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
-readonly output_groups_flag
-
-# Set `bazel_cmd` for calling `bazel`
-
-bazelrcs=(
-  --noworkspace_rc
-  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
-)
-if [[ -s ".bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=.bazelrc")
-fi
-if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
-fi
-readonly bazelrcs
-
 # Set `output_base`
 
 # In `runner.template.sh` the generator has the build output base set inside
@@ -116,85 +99,6 @@ if [ "$ACTION" == "indexbuild" ]; then
   readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
-fi
-
-readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
-  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
-  "$BAZEL_PATH"
-
-  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
-  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
-
-  "${bazelrcs[@]}"
-
-  --output_base "$output_base"
-)
-
-readonly base_pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Work around https://github.com/bazelbuild/bazel/issues/8902
-  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
-  # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-)
-
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
-# Create VFS overlays
-
-# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
-if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
-  readonly bazel_out_prefix=
-else
-  readonly bazel_out_prefix="$SRCROOT/"
-fi
-
-if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$INTERNAL_DIR/create_xcode_overlay.sh"
-fi
-
-readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
-if [[ "$output_path" != "$absolute_bazel_out" ]]; then
-  # Use current path for bazel-out
-  # This fixes Index Build to use its version of generated files
-  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
-else
-  readonly roots=
-fi
-
-cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
-{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
-EOF
-
-# Custom Swift toolchains
-
-if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
-  fi
 fi
 
 # Build
@@ -226,58 +130,8 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# Ensure that our top-level cache buster `override_repository` is valid
-mkdir -p /tmp/rules_xcodeproj
-touch /tmp/rules_xcodeproj/WORKSPACE
-echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
-date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
-
-readonly build_marker="$OBJROOT/bazel_build_start"
-touch "$build_marker"
-
-# TODO: Include labels in some sort of BES metadata
-# See https://github.com/buildbuddy-io/rules_xcodeproj/issues/1224 for why we
-# don't set the labels in the target pattern
-"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
-  "${bazel_cmd[@]}" \
-  build \
-  "${base_pre_config_flags[@]}" \
-  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
-  --config="$config" \
-  --color=yes \
-  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  "$output_groups_flag" \
-  "$GENERATOR_LABEL" \
-  2>&1
-
-# Check filelists
-
-indexstores_filelists=()
-for output_group in "${output_groups[@]}"; do
-  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
-  filelist="${filelist/%/.filelist}"
-
-  if [[ "$output_group" =~ ^(xi|bi) ]]; then
-    indexstores_filelists+=("$filelist")
-  fi
-
-  if [[ "$filelist" -ot "$build_marker" ]]; then
-    echo "error: Bazel didn't generate the correct files (it should have" \
-"generated outputs for output group \"$output_group\", but the timestamp for" \
-"\"$filelist\" was from before the build). Please regenerate the project to" \
-"fix this." >&2
-    echo "error: If your bazel version is less than 5.2, you may need to" \
-"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
-"generation." >&2
-    echo "error: If you are still getting this error after all of that," \
-"please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
-  fi
-done
-readonly indexstores_filelists
+# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -1,0 +1,170 @@
+# It is assumed that this file is `source`ed from another script, with the following variable set:
+#
+# - BAZEL_CONFIG
+# - BAZEL_INTEGRATION_DIR
+# - BAZEL_OUT
+# - BAZEL_PATH
+# - DEVELOPER_DIR
+# - GENERATOR_LABEL
+# - GENERATOR_TARGET_NAME
+# - GENERATOR_PACKAGE_BIN_DIR
+# - HOME
+# - INTERNAL_DIR
+# - OBJROOT
+# - RULES_XCODEPROJ_BUILD_MODE
+# - SRCROOT
+# - TERM
+# - USER
+# - XCODE_PRODUCT_BUILD_VERSION
+# - (optional) build_pre_config_flags
+# - config
+# - (optional) labels
+# - output_base
+# - output_groups
+
+output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
+readonly output_groups_flag
+
+# Set `bazel_cmd` for calling `bazel`
+
+bazelrcs=(
+  --noworkspace_rc
+  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
+)
+if [[ -s ".bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=.bazelrc")
+fi
+if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
+fi
+readonly bazelrcs
+
+readonly bazel_cmd=(
+  env -i
+  DEVELOPER_DIR="$DEVELOPER_DIR"
+  HOME="$HOME"
+  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
+  USER="$USER"
+  "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
+  "${bazelrcs[@]}"
+
+  --output_base "$output_base"
+)
+
+readonly base_pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Work around https://github.com/bazelbuild/bazel/issues/8902
+  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
+  # re-evaluate the cc_toolchain for a different Xcode version
+  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
+  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+)
+
+# Determine Bazel output_path
+
+if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
+  readonly info_color=yes
+else
+  readonly info_color=no
+fi
+
+output_path=$("${bazel_cmd[@]}" \
+  info \
+  "${base_pre_config_flags[@]}" \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$info_color" \
+  output_path)
+readonly output_path
+
+# Create VFS overlays
+
+# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
+if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
+  readonly bazel_out_prefix=
+else
+  readonly bazel_out_prefix="$SRCROOT/"
+fi
+
+if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
+fi
+
+readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
+if [[ "$output_path" != "$absolute_bazel_out" ]]; then
+  # Use current path for bazel-out
+  # This fixes Index Build to use its version of generated files
+  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
+else
+  readonly roots=""
+fi
+
+cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
+{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
+EOF
+
+# Custom Swift toolchains
+
+if [[ -n "${TOOLCHAINS-}" ]]; then
+  toolchain="${TOOLCHAINS%% *}"
+  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+    unset toolchain
+  fi
+fi
+
+# Build
+
+# Ensure that our top-level cache buster `override_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
+readonly build_marker="$OBJROOT/bazel_build_start"
+touch "$build_marker"
+
+"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
+  "${bazel_cmd[@]}" \
+  build \
+  "${base_pre_config_flags[@]}" \
+  --config="$config" \
+  --color=yes \
+  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
+  "$output_groups_flag" \
+  "$GENERATOR_LABEL" \
+  2>&1
+
+# Check filelists
+
+indexstores_filelists=()
+for output_group in "${output_groups[@]}"; do
+  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
+  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
+  if [[ "$filelist" -ot "$build_marker" ]]; then
+    echo "error: Bazel didn't generate the correct files (it should have" \
+"generated outputs for output group \"$output_group\", but the timestamp for" \
+"\"$filelist\" was from before the build). Please regenerate the project to" \
+"fix this." >&2
+    echo "error: If your bazel version is less than 5.2, you may need to" \
+"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
+"generation." >&2
+    echo "error: If you are still getting this error after all of that," \
+"please file a bug report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+    exit 1
+  fi
+done
+readonly indexstores_filelists

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,23 +82,6 @@ else
   readonly labels
 fi
 
-output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
-readonly output_groups_flag
-
-# Set `bazel_cmd` for calling `bazel`
-
-bazelrcs=(
-  --noworkspace_rc
-  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
-)
-if [[ -s ".bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=.bazelrc")
-fi
-if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
-fi
-readonly bazelrcs
-
 # Set `output_base`
 
 # In `runner.template.sh` the generator has the build output base set inside
@@ -116,85 +99,6 @@ if [ "$ACTION" == "indexbuild" ]; then
   readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
-fi
-
-readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
-  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
-  "$BAZEL_PATH"
-
-  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
-  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
-
-  "${bazelrcs[@]}"
-
-  --output_base "$output_base"
-)
-
-readonly base_pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Work around https://github.com/bazelbuild/bazel/issues/8902
-  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
-  # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-)
-
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
-# Create VFS overlays
-
-# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
-if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
-  readonly bazel_out_prefix=
-else
-  readonly bazel_out_prefix="$SRCROOT/"
-fi
-
-if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$INTERNAL_DIR/create_xcode_overlay.sh"
-fi
-
-readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
-if [[ "$output_path" != "$absolute_bazel_out" ]]; then
-  # Use current path for bazel-out
-  # This fixes Index Build to use its version of generated files
-  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
-else
-  readonly roots=
-fi
-
-cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
-{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
-EOF
-
-# Custom Swift toolchains
-
-if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
-  fi
 fi
 
 # Build
@@ -226,58 +130,8 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# Ensure that our top-level cache buster `override_repository` is valid
-mkdir -p /tmp/rules_xcodeproj
-touch /tmp/rules_xcodeproj/WORKSPACE
-echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
-date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
-
-readonly build_marker="$OBJROOT/bazel_build_start"
-touch "$build_marker"
-
-# TODO: Include labels in some sort of BES metadata
-# See https://github.com/buildbuddy-io/rules_xcodeproj/issues/1224 for why we
-# don't set the labels in the target pattern
-"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
-  "${bazel_cmd[@]}" \
-  build \
-  "${base_pre_config_flags[@]}" \
-  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
-  --config="$config" \
-  --color=yes \
-  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  "$output_groups_flag" \
-  "$GENERATOR_LABEL" \
-  2>&1
-
-# Check filelists
-
-indexstores_filelists=()
-for output_group in "${output_groups[@]}"; do
-  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
-  filelist="${filelist/%/.filelist}"
-
-  if [[ "$output_group" =~ ^(xi|bi) ]]; then
-    indexstores_filelists+=("$filelist")
-  fi
-
-  if [[ "$filelist" -ot "$build_marker" ]]; then
-    echo "error: Bazel didn't generate the correct files (it should have" \
-"generated outputs for output group \"$output_group\", but the timestamp for" \
-"\"$filelist\" was from before the build). Please regenerate the project to" \
-"fix this." >&2
-    echo "error: If your bazel version is less than 5.2, you may need to" \
-"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
-"generation." >&2
-    echo "error: If you are still getting this error after all of that," \
-"please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
-  fi
-done
-readonly indexstores_filelists
+# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -1,0 +1,170 @@
+# It is assumed that this file is `source`ed from another script, with the following variable set:
+#
+# - BAZEL_CONFIG
+# - BAZEL_INTEGRATION_DIR
+# - BAZEL_OUT
+# - BAZEL_PATH
+# - DEVELOPER_DIR
+# - GENERATOR_LABEL
+# - GENERATOR_TARGET_NAME
+# - GENERATOR_PACKAGE_BIN_DIR
+# - HOME
+# - INTERNAL_DIR
+# - OBJROOT
+# - RULES_XCODEPROJ_BUILD_MODE
+# - SRCROOT
+# - TERM
+# - USER
+# - XCODE_PRODUCT_BUILD_VERSION
+# - (optional) build_pre_config_flags
+# - config
+# - (optional) labels
+# - output_base
+# - output_groups
+
+output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
+readonly output_groups_flag
+
+# Set `bazel_cmd` for calling `bazel`
+
+bazelrcs=(
+  --noworkspace_rc
+  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
+)
+if [[ -s ".bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=.bazelrc")
+fi
+if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
+fi
+readonly bazelrcs
+
+readonly bazel_cmd=(
+  env -i
+  DEVELOPER_DIR="$DEVELOPER_DIR"
+  HOME="$HOME"
+  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
+  USER="$USER"
+  "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
+  "${bazelrcs[@]}"
+
+  --output_base "$output_base"
+)
+
+readonly base_pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Work around https://github.com/bazelbuild/bazel/issues/8902
+  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
+  # re-evaluate the cc_toolchain for a different Xcode version
+  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
+  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+)
+
+# Determine Bazel output_path
+
+if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
+  readonly info_color=yes
+else
+  readonly info_color=no
+fi
+
+output_path=$("${bazel_cmd[@]}" \
+  info \
+  "${base_pre_config_flags[@]}" \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$info_color" \
+  output_path)
+readonly output_path
+
+# Create VFS overlays
+
+# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
+if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
+  readonly bazel_out_prefix=
+else
+  readonly bazel_out_prefix="$SRCROOT/"
+fi
+
+if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
+fi
+
+readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
+if [[ "$output_path" != "$absolute_bazel_out" ]]; then
+  # Use current path for bazel-out
+  # This fixes Index Build to use its version of generated files
+  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
+else
+  readonly roots=""
+fi
+
+cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
+{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
+EOF
+
+# Custom Swift toolchains
+
+if [[ -n "${TOOLCHAINS-}" ]]; then
+  toolchain="${TOOLCHAINS%% *}"
+  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+    unset toolchain
+  fi
+fi
+
+# Build
+
+# Ensure that our top-level cache buster `override_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
+readonly build_marker="$OBJROOT/bazel_build_start"
+touch "$build_marker"
+
+"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
+  "${bazel_cmd[@]}" \
+  build \
+  "${base_pre_config_flags[@]}" \
+  --config="$config" \
+  --color=yes \
+  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
+  "$output_groups_flag" \
+  "$GENERATOR_LABEL" \
+  2>&1
+
+# Check filelists
+
+indexstores_filelists=()
+for output_group in "${output_groups[@]}"; do
+  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
+  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
+  if [[ "$filelist" -ot "$build_marker" ]]; then
+    echo "error: Bazel didn't generate the correct files (it should have" \
+"generated outputs for output group \"$output_group\", but the timestamp for" \
+"\"$filelist\" was from before the build). Please regenerate the project to" \
+"fix this." >&2
+    echo "error: If your bazel version is less than 5.2, you may need to" \
+"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
+"generation." >&2
+    echo "error: If you are still getting this error after all of that," \
+"please file a bug report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+    exit 1
+  fi
+done
+readonly indexstores_filelists

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,23 +82,6 @@ else
   readonly labels
 fi
 
-output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
-readonly output_groups_flag
-
-# Set `bazel_cmd` for calling `bazel`
-
-bazelrcs=(
-  --noworkspace_rc
-  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
-)
-if [[ -s ".bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=.bazelrc")
-fi
-if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
-fi
-readonly bazelrcs
-
 # Set `output_base`
 
 # In `runner.template.sh` the generator has the build output base set inside
@@ -116,85 +99,6 @@ if [ "$ACTION" == "indexbuild" ]; then
   readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
-fi
-
-readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
-  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
-  "$BAZEL_PATH"
-
-  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
-  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
-
-  "${bazelrcs[@]}"
-
-  --output_base "$output_base"
-)
-
-readonly base_pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Work around https://github.com/bazelbuild/bazel/issues/8902
-  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
-  # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-)
-
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
-# Create VFS overlays
-
-# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
-if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
-  readonly bazel_out_prefix=
-else
-  readonly bazel_out_prefix="$SRCROOT/"
-fi
-
-if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$INTERNAL_DIR/create_xcode_overlay.sh"
-fi
-
-readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
-if [[ "$output_path" != "$absolute_bazel_out" ]]; then
-  # Use current path for bazel-out
-  # This fixes Index Build to use its version of generated files
-  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
-else
-  readonly roots=
-fi
-
-cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
-{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
-EOF
-
-# Custom Swift toolchains
-
-if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
-  fi
 fi
 
 # Build
@@ -226,58 +130,8 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# Ensure that our top-level cache buster `override_repository` is valid
-mkdir -p /tmp/rules_xcodeproj
-touch /tmp/rules_xcodeproj/WORKSPACE
-echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
-date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
-
-readonly build_marker="$OBJROOT/bazel_build_start"
-touch "$build_marker"
-
-# TODO: Include labels in some sort of BES metadata
-# See https://github.com/buildbuddy-io/rules_xcodeproj/issues/1224 for why we
-# don't set the labels in the target pattern
-"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
-  "${bazel_cmd[@]}" \
-  build \
-  "${base_pre_config_flags[@]}" \
-  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
-  --config="$config" \
-  --color=yes \
-  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  "$output_groups_flag" \
-  "$GENERATOR_LABEL" \
-  2>&1
-
-# Check filelists
-
-indexstores_filelists=()
-for output_group in "${output_groups[@]}"; do
-  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
-  filelist="${filelist/%/.filelist}"
-
-  if [[ "$output_group" =~ ^(xi|bi) ]]; then
-    indexstores_filelists+=("$filelist")
-  fi
-
-  if [[ "$filelist" -ot "$build_marker" ]]; then
-    echo "error: Bazel didn't generate the correct files (it should have" \
-"generated outputs for output group \"$output_group\", but the timestamp for" \
-"\"$filelist\" was from before the build). Please regenerate the project to" \
-"fix this." >&2
-    echo "error: If your bazel version is less than 5.2, you may need to" \
-"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
-"generation." >&2
-    echo "error: If you are still getting this error after all of that," \
-"please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
-  fi
-done
-readonly indexstores_filelists
+# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 

--- a/xcodeproj/internal/bazel_integration_files/BUILD
+++ b/xcodeproj/internal/bazel_integration_files/BUILD
@@ -1,4 +1,5 @@
 _BASE_FILES = [
+    "bazel_build.sh",
     "calculate_output_groups.py",
     "create_lldbinit.sh",
     "generate_bazel_dependencies.sh",

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -1,0 +1,170 @@
+# It is assumed that this file is `source`ed from another script, with the following variable set:
+#
+# - BAZEL_CONFIG
+# - BAZEL_INTEGRATION_DIR
+# - BAZEL_OUT
+# - BAZEL_PATH
+# - DEVELOPER_DIR
+# - GENERATOR_LABEL
+# - GENERATOR_TARGET_NAME
+# - GENERATOR_PACKAGE_BIN_DIR
+# - HOME
+# - INTERNAL_DIR
+# - OBJROOT
+# - RULES_XCODEPROJ_BUILD_MODE
+# - SRCROOT
+# - TERM
+# - USER
+# - XCODE_PRODUCT_BUILD_VERSION
+# - (optional) build_pre_config_flags
+# - config
+# - (optional) labels
+# - output_base
+# - output_groups
+
+output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
+readonly output_groups_flag
+
+# Set `bazel_cmd` for calling `bazel`
+
+bazelrcs=(
+  --noworkspace_rc
+  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
+)
+if [[ -s ".bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=.bazelrc")
+fi
+if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
+  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
+fi
+readonly bazelrcs
+
+readonly bazel_cmd=(
+  env -i
+  DEVELOPER_DIR="$DEVELOPER_DIR"
+  HOME="$HOME"
+  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  TERM="$TERM"
+  USER="$USER"
+  "$BAZEL_PATH"
+
+  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
+  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
+
+  "${bazelrcs[@]}"
+
+  --output_base "$output_base"
+)
+
+readonly base_pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Work around https://github.com/bazelbuild/bazel/issues/8902
+  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
+  # re-evaluate the cc_toolchain for a different Xcode version
+  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
+  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+)
+
+# Determine Bazel output_path
+
+if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
+  readonly info_color=yes
+else
+  readonly info_color=no
+fi
+
+output_path=$("${bazel_cmd[@]}" \
+  info \
+  "${base_pre_config_flags[@]}" \
+  --config="${BAZEL_CONFIG}_info" \
+  --color="$info_color" \
+  output_path)
+readonly output_path
+
+# Create VFS overlays
+
+# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
+if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
+  readonly bazel_out_prefix=
+else
+  readonly bazel_out_prefix="$SRCROOT/"
+fi
+
+if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
+  source "$INTERNAL_DIR/create_xcode_overlay.sh"
+fi
+
+readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
+if [[ "$output_path" != "$absolute_bazel_out" ]]; then
+  # Use current path for bazel-out
+  # This fixes Index Build to use its version of generated files
+  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
+else
+  readonly roots=""
+fi
+
+cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
+{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
+EOF
+
+# Custom Swift toolchains
+
+if [[ -n "${TOOLCHAINS-}" ]]; then
+  toolchain="${TOOLCHAINS%% *}"
+  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
+    unset toolchain
+  fi
+fi
+
+# Build
+
+# Ensure that our top-level cache buster `override_repository` is valid
+mkdir -p /tmp/rules_xcodeproj
+touch /tmp/rules_xcodeproj/WORKSPACE
+echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
+date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
+
+readonly build_marker="$OBJROOT/bazel_build_start"
+touch "$build_marker"
+
+"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
+  "${bazel_cmd[@]}" \
+  build \
+  "${base_pre_config_flags[@]}" \
+  --config="$config" \
+  --color=yes \
+  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
+  "$output_groups_flag" \
+  "$GENERATOR_LABEL" \
+  2>&1
+
+# Check filelists
+
+indexstores_filelists=()
+for output_group in "${output_groups[@]}"; do
+  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
+  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/%/.filelist}"
+
+  if [[ "$output_group" =~ ^(xi|bi) ]]; then
+    indexstores_filelists+=("$filelist")
+  fi
+
+  if [[ "$filelist" -ot "$build_marker" ]]; then
+    echo "error: Bazel didn't generate the correct files (it should have" \
+"generated outputs for output group \"$output_group\", but the timestamp for" \
+"\"$filelist\" was from before the build). Please regenerate the project to" \
+"fix this." >&2
+    echo "error: If your bazel version is less than 5.2, you may need to" \
+"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
+"generation." >&2
+    echo "error: If you are still getting this error after all of that," \
+"please file a bug report here:" \
+"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
+      >&2
+    exit 1
+  fi
+done
+readonly indexstores_filelists

--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -82,23 +82,6 @@ else
   readonly labels
 fi
 
-output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
-readonly output_groups_flag
-
-# Set `bazel_cmd` for calling `bazel`
-
-bazelrcs=(
-  --noworkspace_rc
-  "--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj.bazelrc"
-)
-if [[ -s ".bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=.bazelrc")
-fi
-if [[ -s "$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc" ]]; then
-  bazelrcs+=("--bazelrc=$BAZEL_INTEGRATION_DIR/xcodeproj_extra_flags.bazelrc")
-fi
-readonly bazelrcs
-
 # Set `output_base`
 
 # In `runner.template.sh` the generator has the build output base set inside
@@ -116,85 +99,6 @@ if [ "$ACTION" == "indexbuild" ]; then
   readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
 else
   readonly output_base="$build_output_base"
-fi
-
-readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
-  PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
-  "$BAZEL_PATH"
-
-  # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
-  "--host_jvm_args=-Xdock:name=$DEVELOPER_DIR"
-
-  "${bazelrcs[@]}"
-
-  --output_base "$output_base"
-)
-
-readonly base_pre_config_flags=(
-  # Be explicit about our desired Xcode version
-  "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Work around https://github.com/bazelbuild/bazel/issues/8902
-  # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
-  # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
-  "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-)
-
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
-# Create VFS overlays
-
-# `bazel_out_prefix` is used in `create_xcode_overlay.sh`
-if [[ "${BAZEL_OUT:0:1}" == '/' ]]; then
-  readonly bazel_out_prefix=
-else
-  readonly bazel_out_prefix="$SRCROOT/"
-fi
-
-if [[ "$RULES_XCODEPROJ_BUILD_MODE" == "xcode" ]]; then
-  source "$INTERNAL_DIR/create_xcode_overlay.sh"
-fi
-
-readonly absolute_bazel_out="${bazel_out_prefix}$BAZEL_OUT"
-if [[ "$output_path" != "$absolute_bazel_out" ]]; then
-  # Use current path for bazel-out
-  # This fixes Index Build to use its version of generated files
-  readonly roots="{\"external-contents\": \"$output_path\",\"name\": \"$absolute_bazel_out\",\"type\": \"directory-remap\"}"
-else
-  readonly roots=
-fi
-
-cat > "$OBJROOT/bazel-out-overlay.yaml" <<EOF
-{"case-sensitive": "false", "fallthrough": true, "roots": [$roots],"version": 0}
-EOF
-
-# Custom Swift toolchains
-
-if [[ -n "${TOOLCHAINS-}" ]]; then
-  toolchain="${TOOLCHAINS%% *}"
-  if [[ "$toolchain" == "com.apple.dt.toolchain.XcodeDefault" ]]; then
-    unset toolchain
-  fi
 fi
 
 # Build
@@ -226,58 +130,8 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# Ensure that our top-level cache buster `override_repository` is valid
-mkdir -p /tmp/rules_xcodeproj
-touch /tmp/rules_xcodeproj/WORKSPACE
-echo 'exports_files(["top_level_cache_buster"])' > /tmp/rules_xcodeproj/BUILD
-date +%s > "/tmp/rules_xcodeproj/top_level_cache_buster"
-
-readonly build_marker="$OBJROOT/bazel_build_start"
-touch "$build_marker"
-
-# TODO: Include labels in some sort of BES metadata
-# See https://github.com/buildbuddy-io/rules_xcodeproj/issues/1224 for why we
-# don't set the labels in the target pattern
-"$BAZEL_INTEGRATION_DIR/process_bazel_build_log.py" \
-  "${bazel_cmd[@]}" \
-  build \
-  "${base_pre_config_flags[@]}" \
-  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
-  --config="$config" \
-  --color=yes \
-  ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
-  "$output_groups_flag" \
-  "$GENERATOR_LABEL" \
-  2>&1
-
-# Check filelists
-
-indexstores_filelists=()
-for output_group in "${output_groups[@]}"; do
-  filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
-  filelist="${filelist/%/.filelist}"
-
-  if [[ "$output_group" =~ ^(xi|bi) ]]; then
-    indexstores_filelists+=("$filelist")
-  fi
-
-  if [[ "$filelist" -ot "$build_marker" ]]; then
-    echo "error: Bazel didn't generate the correct files (it should have" \
-"generated outputs for output group \"$output_group\", but the timestamp for" \
-"\"$filelist\" was from before the build). Please regenerate the project to" \
-"fix this." >&2
-    echo "error: If your bazel version is less than 5.2, you may need to" \
-"\`bazel clean\` and/or \`bazel shutdown\` to work around a bug in project" \
-"generation." >&2
-    echo "error: If you are still getting this error after all of that," \
-"please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
-  fi
-done
-readonly indexstores_filelists
+# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 


### PR DESCRIPTION
This extracts the core `bazel build` invocation logic from `generate_bazel_dependencies.sh`, which will allow it to be reused in a future `generate_index_build_bazel_dependencies.sh`.