### PR TITLE
Adjust expansion of `build_pre_config_flags`

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -133,12 +133,12 @@ touch "$build_marker"
   "${bazel_cmd[@]}" \
   build \
   "${base_pre_config_flags[@]}" \
+  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
-  ${build_pre_config_flags:-} \
   2>&1
 
 # Check filelists

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -133,12 +133,12 @@ touch "$build_marker"
   "${bazel_cmd[@]}" \
   build \
   "${base_pre_config_flags[@]}" \
+  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
-  ${build_pre_config_flags:-} \
   2>&1
 
 # Check filelists

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -133,12 +133,12 @@ touch "$build_marker"
   "${bazel_cmd[@]}" \
   build \
   "${base_pre_config_flags[@]}" \
+  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
-  ${build_pre_config_flags:-} \
   2>&1
 
 # Check filelists

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -133,12 +133,12 @@ touch "$build_marker"
   "${bazel_cmd[@]}" \
   build \
   "${base_pre_config_flags[@]}" \
+  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
-  ${build_pre_config_flags:-} \
   2>&1
 
 # Check filelists

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -133,12 +133,12 @@ touch "$build_marker"
   "${bazel_cmd[@]}" \
   build \
   "${base_pre_config_flags[@]}" \
+  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
-  ${build_pre_config_flags:-} \
   2>&1
 
 # Check filelists

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -133,12 +133,12 @@ touch "$build_marker"
   "${bazel_cmd[@]}" \
   build \
   "${base_pre_config_flags[@]}" \
+  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
-  ${build_pre_config_flags:-} \
   2>&1
 
 # Check filelists

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -133,12 +133,12 @@ touch "$build_marker"
   "${bazel_cmd[@]}" \
   build \
   "${base_pre_config_flags[@]}" \
+  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
-  ${build_pre_config_flags:-} \
   2>&1
 
 # Check filelists

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -133,12 +133,12 @@ touch "$build_marker"
   "${bazel_cmd[@]}" \
   build \
   "${base_pre_config_flags[@]}" \
+  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
-  ${build_pre_config_flags:-} \
   2>&1
 
 # Check filelists

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -133,12 +133,12 @@ touch "$build_marker"
   "${bazel_cmd[@]}" \
   build \
   "${base_pre_config_flags[@]}" \
+  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
-  ${build_pre_config_flags:-} \
   2>&1
 
 # Check filelists

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -133,12 +133,12 @@ touch "$build_marker"
   "${bazel_cmd[@]}" \
   build \
   "${base_pre_config_flags[@]}" \
+  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
-  ${build_pre_config_flags:-} \
   2>&1
 
 # Check filelists

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -133,12 +133,12 @@ touch "$build_marker"
   "${bazel_cmd[@]}" \
   build \
   "${base_pre_config_flags[@]}" \
+  ${build_pre_config_flags:+"${build_pre_config_flags[@]}"} \
   --config="$config" \
   --color=yes \
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
-  ${build_pre_config_flags:-} \
   2>&1
 
 # Check filelists


### PR DESCRIPTION
If they ever have inclosed whitespace, this different expansion is needed. We also want them set before `--config`, to allow that to override them.