### PR TITLE
Move `output_base` calculation into `bazel_build.sh`

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -19,11 +19,29 @@
 # - (optional) build_pre_config_flags
 # - config
 # - (optional) labels
-# - output_base
 # - output_groups
 
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
+
+# Set `output_base`
+
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_base="$build_output_base/../.."
+
+if [ "$ACTION" == "indexbuild" ]; then
+  # We use a different output base for Index Build to prevent normal builds and
+  # indexing waiting on bazel locks from the other. We nest it inside of the
+  # normal output base directory so that it's not cleaned up when running
+  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
+  # Xcode behavior of not cleaning the Index Build outputs by default.
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
+fi
 
 # Set `bazel_cmd` for calling `bazel`
 

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,25 +82,6 @@ else
   readonly labels
 fi
 
-# Set `output_base`
-
-# In `runner.template.sh` the generator has the build output base set inside
-# of the outer bazel's output path (`bazel-out/`). So here we need to make
-# our output base changes relative to that changed path.
-readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_base="$build_output_base/../.."
-
-if [ "$ACTION" == "indexbuild" ]; then
-  # We use a different output base for Index Build to prevent normal builds and
-  # indexing waiting on bazel locks from the other. We nest it inside of the
-  # normal output base directory so that it's not cleaned up when running
-  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
-  # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
-else
-  readonly output_base="$build_output_base"
-fi
-
 # Build
 
 apply_sanitizers=1

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -19,11 +19,29 @@
 # - (optional) build_pre_config_flags
 # - config
 # - (optional) labels
-# - output_base
 # - output_groups
 
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
+
+# Set `output_base`
+
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_base="$build_output_base/../.."
+
+if [ "$ACTION" == "indexbuild" ]; then
+  # We use a different output base for Index Build to prevent normal builds and
+  # indexing waiting on bazel locks from the other. We nest it inside of the
+  # normal output base directory so that it's not cleaned up when running
+  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
+  # Xcode behavior of not cleaning the Index Build outputs by default.
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
+fi
 
 # Set `bazel_cmd` for calling `bazel`
 

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,25 +82,6 @@ else
   readonly labels
 fi
 
-# Set `output_base`
-
-# In `runner.template.sh` the generator has the build output base set inside
-# of the outer bazel's output path (`bazel-out/`). So here we need to make
-# our output base changes relative to that changed path.
-readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_base="$build_output_base/../.."
-
-if [ "$ACTION" == "indexbuild" ]; then
-  # We use a different output base for Index Build to prevent normal builds and
-  # indexing waiting on bazel locks from the other. We nest it inside of the
-  # normal output base directory so that it's not cleaned up when running
-  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
-  # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
-else
-  readonly output_base="$build_output_base"
-fi
-
 # Build
 
 apply_sanitizers=1

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -19,11 +19,29 @@
 # - (optional) build_pre_config_flags
 # - config
 # - (optional) labels
-# - output_base
 # - output_groups
 
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
+
+# Set `output_base`
+
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_base="$build_output_base/../.."
+
+if [ "$ACTION" == "indexbuild" ]; then
+  # We use a different output base for Index Build to prevent normal builds and
+  # indexing waiting on bazel locks from the other. We nest it inside of the
+  # normal output base directory so that it's not cleaned up when running
+  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
+  # Xcode behavior of not cleaning the Index Build outputs by default.
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
+fi
 
 # Set `bazel_cmd` for calling `bazel`
 

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,25 +82,6 @@ else
   readonly labels
 fi
 
-# Set `output_base`
-
-# In `runner.template.sh` the generator has the build output base set inside
-# of the outer bazel's output path (`bazel-out/`). So here we need to make
-# our output base changes relative to that changed path.
-readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_base="$build_output_base/../.."
-
-if [ "$ACTION" == "indexbuild" ]; then
-  # We use a different output base for Index Build to prevent normal builds and
-  # indexing waiting on bazel locks from the other. We nest it inside of the
-  # normal output base directory so that it's not cleaned up when running
-  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
-  # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
-else
-  readonly output_base="$build_output_base"
-fi
-
 # Build
 
 apply_sanitizers=1

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -19,11 +19,29 @@
 # - (optional) build_pre_config_flags
 # - config
 # - (optional) labels
-# - output_base
 # - output_groups
 
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
+
+# Set `output_base`
+
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_base="$build_output_base/../.."
+
+if [ "$ACTION" == "indexbuild" ]; then
+  # We use a different output base for Index Build to prevent normal builds and
+  # indexing waiting on bazel locks from the other. We nest it inside of the
+  # normal output base directory so that it's not cleaned up when running
+  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
+  # Xcode behavior of not cleaning the Index Build outputs by default.
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
+fi
 
 # Set `bazel_cmd` for calling `bazel`
 

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,25 +82,6 @@ else
   readonly labels
 fi
 
-# Set `output_base`
-
-# In `runner.template.sh` the generator has the build output base set inside
-# of the outer bazel's output path (`bazel-out/`). So here we need to make
-# our output base changes relative to that changed path.
-readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_base="$build_output_base/../.."
-
-if [ "$ACTION" == "indexbuild" ]; then
-  # We use a different output base for Index Build to prevent normal builds and
-  # indexing waiting on bazel locks from the other. We nest it inside of the
-  # normal output base directory so that it's not cleaned up when running
-  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
-  # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
-else
-  readonly output_base="$build_output_base"
-fi
-
 # Build
 
 apply_sanitizers=1

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -19,11 +19,29 @@
 # - (optional) build_pre_config_flags
 # - config
 # - (optional) labels
-# - output_base
 # - output_groups
 
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
+
+# Set `output_base`
+
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_base="$build_output_base/../.."
+
+if [ "$ACTION" == "indexbuild" ]; then
+  # We use a different output base for Index Build to prevent normal builds and
+  # indexing waiting on bazel locks from the other. We nest it inside of the
+  # normal output base directory so that it's not cleaned up when running
+  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
+  # Xcode behavior of not cleaning the Index Build outputs by default.
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
+fi
 
 # Set `bazel_cmd` for calling `bazel`
 

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,25 +82,6 @@ else
   readonly labels
 fi
 
-# Set `output_base`
-
-# In `runner.template.sh` the generator has the build output base set inside
-# of the outer bazel's output path (`bazel-out/`). So here we need to make
-# our output base changes relative to that changed path.
-readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_base="$build_output_base/../.."
-
-if [ "$ACTION" == "indexbuild" ]; then
-  # We use a different output base for Index Build to prevent normal builds and
-  # indexing waiting on bazel locks from the other. We nest it inside of the
-  # normal output base directory so that it's not cleaned up when running
-  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
-  # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
-else
-  readonly output_base="$build_output_base"
-fi
-
 # Build
 
 apply_sanitizers=1

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -19,11 +19,29 @@
 # - (optional) build_pre_config_flags
 # - config
 # - (optional) labels
-# - output_base
 # - output_groups
 
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
+
+# Set `output_base`
+
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_base="$build_output_base/../.."
+
+if [ "$ACTION" == "indexbuild" ]; then
+  # We use a different output base for Index Build to prevent normal builds and
+  # indexing waiting on bazel locks from the other. We nest it inside of the
+  # normal output base directory so that it's not cleaned up when running
+  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
+  # Xcode behavior of not cleaning the Index Build outputs by default.
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
+fi
 
 # Set `bazel_cmd` for calling `bazel`
 

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,25 +82,6 @@ else
   readonly labels
 fi
 
-# Set `output_base`
-
-# In `runner.template.sh` the generator has the build output base set inside
-# of the outer bazel's output path (`bazel-out/`). So here we need to make
-# our output base changes relative to that changed path.
-readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_base="$build_output_base/../.."
-
-if [ "$ACTION" == "indexbuild" ]; then
-  # We use a different output base for Index Build to prevent normal builds and
-  # indexing waiting on bazel locks from the other. We nest it inside of the
-  # normal output base directory so that it's not cleaned up when running
-  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
-  # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
-else
-  readonly output_base="$build_output_base"
-fi
-
 # Build
 
 apply_sanitizers=1

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -19,11 +19,29 @@
 # - (optional) build_pre_config_flags
 # - config
 # - (optional) labels
-# - output_base
 # - output_groups
 
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
+
+# Set `output_base`
+
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_base="$build_output_base/../.."
+
+if [ "$ACTION" == "indexbuild" ]; then
+  # We use a different output base for Index Build to prevent normal builds and
+  # indexing waiting on bazel locks from the other. We nest it inside of the
+  # normal output base directory so that it's not cleaned up when running
+  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
+  # Xcode behavior of not cleaning the Index Build outputs by default.
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
+fi
 
 # Set `bazel_cmd` for calling `bazel`
 

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,25 +82,6 @@ else
   readonly labels
 fi
 
-# Set `output_base`
-
-# In `runner.template.sh` the generator has the build output base set inside
-# of the outer bazel's output path (`bazel-out/`). So here we need to make
-# our output base changes relative to that changed path.
-readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_base="$build_output_base/../.."
-
-if [ "$ACTION" == "indexbuild" ]; then
-  # We use a different output base for Index Build to prevent normal builds and
-  # indexing waiting on bazel locks from the other. We nest it inside of the
-  # normal output base directory so that it's not cleaned up when running
-  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
-  # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
-else
-  readonly output_base="$build_output_base"
-fi
-
 # Build
 
 apply_sanitizers=1

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -19,11 +19,29 @@
 # - (optional) build_pre_config_flags
 # - config
 # - (optional) labels
-# - output_base
 # - output_groups
 
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
+
+# Set `output_base`
+
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_base="$build_output_base/../.."
+
+if [ "$ACTION" == "indexbuild" ]; then
+  # We use a different output base for Index Build to prevent normal builds and
+  # indexing waiting on bazel locks from the other. We nest it inside of the
+  # normal output base directory so that it's not cleaned up when running
+  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
+  # Xcode behavior of not cleaning the Index Build outputs by default.
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
+fi
 
 # Set `bazel_cmd` for calling `bazel`
 

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,25 +82,6 @@ else
   readonly labels
 fi
 
-# Set `output_base`
-
-# In `runner.template.sh` the generator has the build output base set inside
-# of the outer bazel's output path (`bazel-out/`). So here we need to make
-# our output base changes relative to that changed path.
-readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_base="$build_output_base/../.."
-
-if [ "$ACTION" == "indexbuild" ]; then
-  # We use a different output base for Index Build to prevent normal builds and
-  # indexing waiting on bazel locks from the other. We nest it inside of the
-  # normal output base directory so that it's not cleaned up when running
-  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
-  # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
-else
-  readonly output_base="$build_output_base"
-fi
-
 # Build
 
 apply_sanitizers=1

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -19,11 +19,29 @@
 # - (optional) build_pre_config_flags
 # - config
 # - (optional) labels
-# - output_base
 # - output_groups
 
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
+
+# Set `output_base`
+
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_base="$build_output_base/../.."
+
+if [ "$ACTION" == "indexbuild" ]; then
+  # We use a different output base for Index Build to prevent normal builds and
+  # indexing waiting on bazel locks from the other. We nest it inside of the
+  # normal output base directory so that it's not cleaned up when running
+  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
+  # Xcode behavior of not cleaning the Index Build outputs by default.
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
+fi
 
 # Set `bazel_cmd` for calling `bazel`
 

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,25 +82,6 @@ else
   readonly labels
 fi
 
-# Set `output_base`
-
-# In `runner.template.sh` the generator has the build output base set inside
-# of the outer bazel's output path (`bazel-out/`). So here we need to make
-# our output base changes relative to that changed path.
-readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_base="$build_output_base/../.."
-
-if [ "$ACTION" == "indexbuild" ]; then
-  # We use a different output base for Index Build to prevent normal builds and
-  # indexing waiting on bazel locks from the other. We nest it inside of the
-  # normal output base directory so that it's not cleaned up when running
-  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
-  # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
-else
-  readonly output_base="$build_output_base"
-fi
-
 # Build
 
 apply_sanitizers=1

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -19,11 +19,29 @@
 # - (optional) build_pre_config_flags
 # - config
 # - (optional) labels
-# - output_base
 # - output_groups
 
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
+
+# Set `output_base`
+
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_base="$build_output_base/../.."
+
+if [ "$ACTION" == "indexbuild" ]; then
+  # We use a different output base for Index Build to prevent normal builds and
+  # indexing waiting on bazel locks from the other. We nest it inside of the
+  # normal output base directory so that it's not cleaned up when running
+  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
+  # Xcode behavior of not cleaning the Index Build outputs by default.
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
+fi
 
 # Set `bazel_cmd` for calling `bazel`
 

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/generate_bazel_dependencies.sh
@@ -82,25 +82,6 @@ else
   readonly labels
 fi
 
-# Set `output_base`
-
-# In `runner.template.sh` the generator has the build output base set inside
-# of the outer bazel's output path (`bazel-out/`). So here we need to make
-# our output base changes relative to that changed path.
-readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_base="$build_output_base/../.."
-
-if [ "$ACTION" == "indexbuild" ]; then
-  # We use a different output base for Index Build to prevent normal builds and
-  # indexing waiting on bazel locks from the other. We nest it inside of the
-  # normal output base directory so that it's not cleaned up when running
-  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
-  # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
-else
-  readonly output_base="$build_output_base"
-fi
-
 # Build
 
 apply_sanitizers=1

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -19,11 +19,29 @@
 # - (optional) build_pre_config_flags
 # - config
 # - (optional) labels
-# - output_base
 # - output_groups
 
 output_groups_flag="--output_groups=$(IFS=, ; echo "${output_groups[*]}")"
 readonly output_groups_flag
+
+# Set `output_base`
+
+# In `runner.template.sh` the generator has the build output base set inside
+# of the outer bazel's output path (`bazel-out/`). So here we need to make
+# our output base changes relative to that changed path.
+readonly build_output_base="$BAZEL_OUT/../../.."
+readonly outer_output_base="$build_output_base/../.."
+
+if [ "$ACTION" == "indexbuild" ]; then
+  # We use a different output base for Index Build to prevent normal builds and
+  # indexing waiting on bazel locks from the other. We nest it inside of the
+  # normal output base directory so that it's not cleaned up when running
+  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
+  # Xcode behavior of not cleaning the Index Build outputs by default.
+  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
+else
+  readonly output_base="$build_output_base"
+fi
 
 # Set `bazel_cmd` for calling `bazel`
 

--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -82,25 +82,6 @@ else
   readonly labels
 fi
 
-# Set `output_base`
-
-# In `runner.template.sh` the generator has the build output base set inside
-# of the outer bazel's output path (`bazel-out/`). So here we need to make
-# our output base changes relative to that changed path.
-readonly build_output_base="$BAZEL_OUT/../../.."
-readonly outer_output_base="$build_output_base/../.."
-
-if [ "$ACTION" == "indexbuild" ]; then
-  # We use a different output base for Index Build to prevent normal builds and
-  # indexing waiting on bazel locks from the other. We nest it inside of the
-  # normal output base directory so that it's not cleaned up when running
-  # `bazel clean`, but is when running `bazel clean --expunge`. This matches
-  # Xcode behavior of not cleaning the Index Build outputs by default.
-  readonly output_base="$outer_output_base/rules_xcodeproj/indexbuild_output_base"
-else
-  readonly output_base="$build_output_base"
-fi
-
 # Build
 
 apply_sanitizers=1


### PR DESCRIPTION
Even when we add `generate_index_build_bazel_dependencies.sh`, we will share some of this logic.