### PR TITLE
Remove env variable filtering

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -74,10 +74,12 @@ readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
   "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
 
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
+  "--repo_env=DEVELOPER_DIR=$developer_dir"
+
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -58,12 +58,8 @@ fi
 readonly bazelrcs
 
 readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
+  env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -74,10 +74,12 @@ readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
   "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
 
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
+  "--repo_env=DEVELOPER_DIR=$developer_dir"
+
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -58,12 +58,8 @@ fi
 readonly bazelrcs
 
 readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
+  env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -74,10 +74,12 @@ readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
   "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
 
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
+  "--repo_env=DEVELOPER_DIR=$developer_dir"
+
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -58,12 +58,8 @@ fi
 readonly bazelrcs
 
 readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
+  env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -74,10 +74,12 @@ readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
   "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
 
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
+  "--repo_env=DEVELOPER_DIR=$developer_dir"
+
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -58,12 +58,8 @@ fi
 readonly bazelrcs
 
 readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
+  env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -74,10 +74,12 @@ readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
   "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
 
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
+  "--repo_env=DEVELOPER_DIR=$developer_dir"
+
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -58,12 +58,8 @@ fi
 readonly bazelrcs
 
 readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
+  env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -74,10 +74,12 @@ readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
   "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
 
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
+  "--repo_env=DEVELOPER_DIR=$developer_dir"
+
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -58,12 +58,8 @@ fi
 readonly bazelrcs
 
 readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
+  env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -74,10 +74,12 @@ readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
   "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
 
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
+  "--repo_env=DEVELOPER_DIR=$developer_dir"
+
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -58,12 +58,8 @@ fi
 readonly bazelrcs
 
 readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
+  env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -74,10 +74,12 @@ readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
   "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
 
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
+  "--repo_env=DEVELOPER_DIR=$developer_dir"
+
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -58,12 +58,8 @@ fi
 readonly bazelrcs
 
 readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
+  env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -74,10 +74,12 @@ readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
   "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
 
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
+  "--repo_env=DEVELOPER_DIR=$developer_dir"
+
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -58,12 +58,8 @@ fi
 readonly bazelrcs
 
 readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
+  env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -74,10 +74,12 @@ readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
   "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
 
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
+  "--repo_env=DEVELOPER_DIR=$developer_dir"
+
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -58,12 +58,8 @@ fi
 readonly bazelrcs
 
 readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
+  env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -74,10 +74,12 @@ readonly base_pre_config_flags=(
   # Be explicit about our desired Xcode version
   "--xcode_version=$XCODE_PRODUCT_BUILD_VERSION"
 
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
+  "--repo_env=DEVELOPER_DIR=$developer_dir"
+
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=DEVELOPER_DIR=$DEVELOPER_DIR"
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -58,12 +58,8 @@ fi
 readonly bazelrcs
 
 readonly bazel_cmd=(
-  env -i
-  DEVELOPER_DIR="$DEVELOPER_DIR"
-  HOME="$HOME"
+  env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  TERM="$TERM"
-  USER="$USER"
   "$BAZEL_PATH"
 
   # Restart bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -62,7 +62,7 @@ fi
 developer_dir=$(xcode-select -p)
 xcode_build_version=$(/usr/bin/xcodebuild -version | tail -1 | cut -d " " -f3)
 pre_config_flags=(
-  # Set `DEVELOPER_DIR` in case a bazel wrapper filtered it
+  # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
   "--repo_env=DEVELOPER_DIR=$developer_dir"
 
   # Work around https://github.com/bazelbuild/bazel/issues/8902

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -41,9 +41,12 @@ done
 
 cd "$BUILD_WORKSPACE_DIRECTORY"
 
-installer_flags+=(--bazel_path "%bazel_path%")
+# Resolve path to bazel before changing the env variable. This allows bazelisk
+# downloaded bazel to be found.
+bazel_path=$(which "%bazel_path%")
+installer_flags+=(--bazel_path "$bazel_path")
 
-output_base=$("%bazel_path%" info output_base)
+output_base=$("$bazel_path" info output_base)
 
 readonly nested_output_base_prefix="$output_base/execroot/_rules_xcodeproj"
 readonly nested_output_base="$nested_output_base_prefix/build_output_base"
@@ -74,7 +77,7 @@ pre_config_flags=(
 readonly bazel_cmd=(
   env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  "%bazel_path%"
+  "$bazel_path"
 
   # Restart Bazel server if `DEVELOPER_DIR` changes to clear `developerDirCache`
   "--host_jvm_args=-Xdock:name=$developer_dir"


### PR DESCRIPTION
While people should filter env variables to make their builds as hermetic as possible, they can do it themselves in `tools/bazel` or `bazelw`. All that we really need to do is set a standard `PATH`, to ensure hits between the runner invoked build and the Xcode invoked build.