### PR TITLE
Include all transitive Info.plist

### DIFF
--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -39,9 +39,6 @@ def _create(
     direct_compiles = []
     indexstore = None
 
-    if infoplist:
-        direct_products.append(infoplist)
-
     if direct_outputs:
         swift = direct_outputs.swift
         if swift:
@@ -80,6 +77,18 @@ def _create(
         [indexstore] if indexstore else None,
         transitive = [
             info.outputs._transitive_indexestores
+            for attr, info in transitive_infos
+            if (not automatic_target_info or
+                info.target_type in automatic_target_info.xcode_targets.get(
+                    attr,
+                    [None],
+                ))
+        ],
+    )
+    transitive_infoplists = depset(
+        [infoplist] if infoplist else None,
+        transitive = [
+            info.outputs.transitive_infoplists
             for attr, info in transitive_infos
             if (not automatic_target_info or
                 info.target_type in automatic_target_info.xcode_targets.get(
@@ -146,6 +155,7 @@ def _create(
         _transitive_products = transitive_products,
         _transitive_swift = transitive_swift,
         products_output_group_name = products_output_group_name,
+        transitive_infoplists = transitive_infoplists,
     )
 
 def _get_outputs(*, id, product, swift_info):

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -228,7 +228,7 @@ targets.
         if sets.contains(unfocused_labels, label_str):
             sets.remove(unfocused_labels, label_str)
 
-        infoplist = xcode_target.infoplist
+        infoplist = xcode_target.outputs.transitive_infoplists
         if infoplist:
             infoplists.setdefault(label, []).append(infoplist)
 
@@ -345,14 +345,13 @@ targets.
         )
         target_infoplists = infoplists.get(label)
         if target_infoplists:
-            infoplists_depset = depset(target_infoplists)
-            additional_linking_files.append(infoplists_depset)
+            additional_linking_files.extend(target_infoplists)
             products_output_group_name = (
                 xcode_target.outputs.products_output_group_name
             )
             if products_output_group_name:
                 additional_outputs[products_output_group_name] = (
-                    [infoplists_depset]
+                    target_infoplists
                 )
 
         linking_output_group_name = (


### PR DESCRIPTION
Before this change, when building an App, only the App's various versions of Info.plist would be generated. The original intent was that all versions of every transitive dependency would be generated.