### PR TITLE
Use `--remote_download_outputs=toplevel` for projects

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -62,21 +62,6 @@ build:rules_xcodeproj --show_result=0
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
 
-# Work around https://github.com/bazelbuild/bazel/issues/11920
-#
-# If you see a warning like:
-#
-#  WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source $WORKSPACE/.bazelrc) and option '--config=rules_xcodeproj_generator' (source command line options)
-#
-# Then you should change your use of `--remote_download_minimal` to these
-# individual flags:
-#
-#  --nobuild_runfile_links (don't set this one if using `--remote_download_toplevel`)
-#  --experimental_inmemory_jdeps_files
-#  --experimental_inmemory_dotd_files
-#
-run:rules_xcodeproj_generator --remote_download_outputs=all
-
 ### `--config=rules_xcodeproj_info`
 #
 # Used when querying `bazel info`.

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -62,21 +62,6 @@ build:rules_xcodeproj --show_result=0
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
 
-# Work around https://github.com/bazelbuild/bazel/issues/11920
-#
-# If you see a warning like:
-#
-#  WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source $WORKSPACE/.bazelrc) and option '--config=rules_xcodeproj_generator' (source command line options)
-#
-# Then you should change your use of `--remote_download_minimal` to these
-# individual flags:
-#
-#  --nobuild_runfile_links (don't set this one if using `--remote_download_toplevel`)
-#  --experimental_inmemory_jdeps_files
-#  --experimental_inmemory_dotd_files
-#
-run:rules_xcodeproj_generator --remote_download_outputs=all
-
 ### `--config=rules_xcodeproj_info`
 #
 # Used when querying `bazel info`.

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -62,21 +62,6 @@ build:rules_xcodeproj --show_result=0
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
 
-# Work around https://github.com/bazelbuild/bazel/issues/11920
-#
-# If you see a warning like:
-#
-#  WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source $WORKSPACE/.bazelrc) and option '--config=rules_xcodeproj_generator' (source command line options)
-#
-# Then you should change your use of `--remote_download_minimal` to these
-# individual flags:
-#
-#  --nobuild_runfile_links (don't set this one if using `--remote_download_toplevel`)
-#  --experimental_inmemory_jdeps_files
-#  --experimental_inmemory_dotd_files
-#
-run:rules_xcodeproj_generator --remote_download_outputs=all
-
 ### `--config=rules_xcodeproj_info`
 #
 # Used when querying `bazel info`.

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -62,21 +62,6 @@ build:rules_xcodeproj --show_result=0
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
 
-# Work around https://github.com/bazelbuild/bazel/issues/11920
-#
-# If you see a warning like:
-#
-#  WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source $WORKSPACE/.bazelrc) and option '--config=rules_xcodeproj_generator' (source command line options)
-#
-# Then you should change your use of `--remote_download_minimal` to these
-# individual flags:
-#
-#  --nobuild_runfile_links (don't set this one if using `--remote_download_toplevel`)
-#  --experimental_inmemory_jdeps_files
-#  --experimental_inmemory_dotd_files
-#
-run:rules_xcodeproj_generator --remote_download_outputs=all
-
 ### `--config=rules_xcodeproj_info`
 #
 # Used when querying `bazel info`.

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -62,21 +62,6 @@ build:rules_xcodeproj --show_result=0
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
 
-# Work around https://github.com/bazelbuild/bazel/issues/11920
-#
-# If you see a warning like:
-#
-#  WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source $WORKSPACE/.bazelrc) and option '--config=rules_xcodeproj_generator' (source command line options)
-#
-# Then you should change your use of `--remote_download_minimal` to these
-# individual flags:
-#
-#  --nobuild_runfile_links (don't set this one if using `--remote_download_toplevel`)
-#  --experimental_inmemory_jdeps_files
-#  --experimental_inmemory_dotd_files
-#
-run:rules_xcodeproj_generator --remote_download_outputs=all
-
 ### `--config=rules_xcodeproj_info`
 #
 # Used when querying `bazel info`.

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -62,21 +62,6 @@ build:rules_xcodeproj --show_result=0
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
 
-# Work around https://github.com/bazelbuild/bazel/issues/11920
-#
-# If you see a warning like:
-#
-#  WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source $WORKSPACE/.bazelrc) and option '--config=rules_xcodeproj_generator' (source command line options)
-#
-# Then you should change your use of `--remote_download_minimal` to these
-# individual flags:
-#
-#  --nobuild_runfile_links (don't set this one if using `--remote_download_toplevel`)
-#  --experimental_inmemory_jdeps_files
-#  --experimental_inmemory_dotd_files
-#
-run:rules_xcodeproj_generator --remote_download_outputs=all
-
 ### `--config=rules_xcodeproj_info`
 #
 # Used when querying `bazel info`.

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -62,21 +62,6 @@ build:rules_xcodeproj --show_result=0
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
 
-# Work around https://github.com/bazelbuild/bazel/issues/11920
-#
-# If you see a warning like:
-#
-#  WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source $WORKSPACE/.bazelrc) and option '--config=rules_xcodeproj_generator' (source command line options)
-#
-# Then you should change your use of `--remote_download_minimal` to these
-# individual flags:
-#
-#  --nobuild_runfile_links (don't set this one if using `--remote_download_toplevel`)
-#  --experimental_inmemory_jdeps_files
-#  --experimental_inmemory_dotd_files
-#
-run:rules_xcodeproj_generator --remote_download_outputs=all
-
 ### `--config=rules_xcodeproj_info`
 #
 # Used when querying `bazel info`.

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -62,21 +62,6 @@ build:rules_xcodeproj --show_result=0
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
 
-# Work around https://github.com/bazelbuild/bazel/issues/11920
-#
-# If you see a warning like:
-#
-#  WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source $WORKSPACE/.bazelrc) and option '--config=rules_xcodeproj_generator' (source command line options)
-#
-# Then you should change your use of `--remote_download_minimal` to these
-# individual flags:
-#
-#  --nobuild_runfile_links (don't set this one if using `--remote_download_toplevel`)
-#  --experimental_inmemory_jdeps_files
-#  --experimental_inmemory_dotd_files
-#
-run:rules_xcodeproj_generator --remote_download_outputs=all
-
 ### `--config=rules_xcodeproj_info`
 #
 # Used when querying `bazel info`.

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -10,11 +10,18 @@ build --remote_default_exec_properties=cache_bust=macOS_12.0/3
 # In-repo output_base makes fixtures relative
 startup --output_base=bazel-output-base
 
+# Ensure we work with BwtB
 build --nobuild_runfile_links
 build --experimental_inmemory_jdeps_files
 build --experimental_inmemory_dotd_files
 build --remote_download_outputs=minimal
 test --remote_download_outputs=toplevel
+
+# Work around https://github.com/bazelbuild/bazel/issues/11920
+run --remote_download_outputs=all
+
+# rules_xcodeproj needs toplevel to download needed outputs
+build:rules_xcodeproj --remote_download_outputs=toplevel
 
 # Build with --config=cache to use BuildBuddy Remote Cache
 build:cache --bes_backend=grpcs://remote.buildbuddy.io

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -62,21 +62,6 @@ build:rules_xcodeproj --show_result=0
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
 
-# Work around https://github.com/bazelbuild/bazel/issues/11920
-#
-# If you see a warning like:
-#
-#  WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source $WORKSPACE/.bazelrc) and option '--config=rules_xcodeproj_generator' (source command line options)
-#
-# Then you should change your use of `--remote_download_minimal` to these
-# individual flags:
-#
-#  --nobuild_runfile_links (don't set this one if using `--remote_download_toplevel`)
-#  --experimental_inmemory_jdeps_files
-#  --experimental_inmemory_dotd_files
-#
-run:rules_xcodeproj_generator --remote_download_outputs=all
-
 ### `--config=rules_xcodeproj_info`
 #
 # Used when querying `bazel info`.

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -62,21 +62,6 @@ build:rules_xcodeproj --show_result=0
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
 
-# Work around https://github.com/bazelbuild/bazel/issues/11920
-#
-# If you see a warning like:
-#
-#  WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source $WORKSPACE/.bazelrc) and option '--config=rules_xcodeproj_generator' (source command line options)
-#
-# Then you should change your use of `--remote_download_minimal` to these
-# individual flags:
-#
-#  --nobuild_runfile_links (don't set this one if using `--remote_download_toplevel`)
-#  --experimental_inmemory_jdeps_files
-#  --experimental_inmemory_dotd_files
-#
-run:rules_xcodeproj_generator --remote_download_outputs=all
-
 ### `--config=rules_xcodeproj_info`
 #
 # Used when querying `bazel info`.

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -62,21 +62,6 @@ build:rules_xcodeproj --show_result=0
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
 
-# Work around https://github.com/bazelbuild/bazel/issues/11920
-#
-# If you see a warning like:
-#
-#  WARNING: option '--remote_download_outputs' was expanded to from both option '--remote_download_minimal' (source $WORKSPACE/.bazelrc) and option '--config=rules_xcodeproj_generator' (source command line options)
-#
-# Then you should change your use of `--remote_download_minimal` to these
-# individual flags:
-#
-#  --nobuild_runfile_links (don't set this one if using `--remote_download_toplevel`)
-#  --experimental_inmemory_jdeps_files
-#  --experimental_inmemory_dotd_files
-#
-run:rules_xcodeproj_generator --remote_download_outputs=all
-
 ### `--config=rules_xcodeproj_info`
 #
 # Used when querying `bazel info`.


### PR DESCRIPTION
Also stop setting `run:rules_xcodeproj_generator --remote_download_outputs=all`. This leads to warnings if people set BwtB settings themselves. They will just have to work around https://github.com/bazelbuild/bazel/issues/11920 on their own. This also allows us to immediately benefit if that is eventually fixed.