### PR TITLE
Unset iOS app as watchOS app host target

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -8807,9 +8807,6 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=watchos*]" = arm64_32;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				BAZEL_HOST_LABEL_0 = "@//iOSApp/Source:iOSApp";
-				BAZEL_HOST_TARGET_ID_0 = "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56";
-				"BAZEL_HOST_TARGET_ID_0[sdk=watchos*]" = "//iOSApp/Source:iOSApp applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00";
 				BAZEL_LABEL = "@//watchOSApp:watchOSApp";
 				BAZEL_OUTPUTS_PRODUCT = "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-3df60cf154e9/bin/watchOSApp/watchOSApp.app";
 				"BAZEL_OUTPUTS_PRODUCT[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-56a8163e2aa7/bin/watchOSApp/watchOSApp.app";

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Set Bazel Build Output Groups for watchOSApp"
-               scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;echo &quot;$BAZEL_HOST_LABEL_0,$BAZEL_HOST_TARGET_ID_0&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
+               scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -56,20 +56,6 @@
          </ExecutionAction>
       </PreActions>
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1765D91CC168F25A5BC51603"
-               BuildableName = "iOSApp.app"
-               BlueprintName = "iOSApp"
-               ReferencedContainer = "container:../../../../../../test/fixtures/bwb.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -380,14 +380,6 @@
         [
             "//iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56"
         ],
-        "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-56a8163e2aa7",
-        [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_arm64-dbg-ST-b625d7c0bd00"
-        ],
-        "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-3df60cf154e9",
-        [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-ST-9fcfb6a7af56"
-        ],
         "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-ST-3f6925aafe90",
         [
             "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-56a8163e2aa7"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -7321,9 +7321,6 @@
 				ARCHS = x86_64;
 				"ARCHS[sdk=watchos*]" = arm64_32;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				BAZEL_HOST_LABEL_0 = "@//iOSApp/Source:iOSApp";
-				BAZEL_HOST_TARGET_ID_0 = "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353";
-				"BAZEL_HOST_TARGET_ID_0[sdk=watchos*]" = "//iOSApp/Source:iOSApp applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd";
 				BAZEL_LABEL = "@//watchOSApp:watchOSApp";
 				BAZEL_PACKAGE_BIN_DIR = "bazel-out/applebin_watchos-watchos_x86_64-dbg-ST-2f849b1d5a93/bin/watchOSApp";
 				"BAZEL_PACKAGE_BIN_DIR[sdk=watchos*]" = "bazel-out/applebin_watchos-watchos_arm64_32-dbg-ST-8e65bd00489d/bin/watchOSApp";

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
@@ -26,7 +26,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Set Bazel Build Output Groups for watchOSApp"
-               scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;echo &quot;$BAZEL_HOST_LABEL_0,$BAZEL_HOST_TARGET_ID_0&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
+               scriptText = "echo &quot;$BAZEL_LABEL,$BAZEL_TARGET_ID&quot; &gt;&gt; &quot;$SCHEME_TARGET_IDS_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
@@ -40,20 +40,6 @@
          </ExecutionAction>
       </PreActions>
       <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "A6969986F4330BE56701A5EC"
-               BuildableName = "iOSApp.app"
-               BlueprintName = "iOSApp"
-               ReferencedContainer = "container:../../../../../../test/fixtures/bwx.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -304,14 +304,6 @@
         [
             "//iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353"
         ],
-        "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-8e65bd00489d",
-        [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_arm64-dbg-ST-3a05e106c3dd"
-        ],
-        "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-ST-2f849b1d5a93",
-        [
-            "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353"
-        ],
         "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-ST-899e4c5ca1ae",
         [
             "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-ST-8e65bd00489d"

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -234,15 +234,12 @@ def process_top_level_target(
     ]
     extensions = [info.xcode_target.id for info in extension_target_infos]
 
-    hosted_target_infos = extension_target_infos
-    if watch_app_target_info:
-        hosted_target_infos.append(watch_app_target_info)
     hosted_targets = [
         struct(
             host = id,
             hosted = info.xcode_target.id,
         )
-        for info in hosted_target_infos
+        for info in extension_target_infos
     ]
 
     additional_files = []


### PR DESCRIPTION
Similar to an App Clip, a watchOS app does not need to build the hosting app. This makes a future BwB optimization easier.