### PR TITLE
Set pattern override for BuildBuddy

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -144,6 +144,7 @@ touch "$build_marker"
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
+  ${labels:+"--build_metadata=PATTERN=${labels[*]}"} \
   2>&1
 
 # Collect indexstore filelists

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -144,6 +144,7 @@ touch "$build_marker"
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
+  ${labels:+"--build_metadata=PATTERN=${labels[*]}"} \
   2>&1
 
 # Collect indexstore filelists

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -144,6 +144,7 @@ touch "$build_marker"
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
+  ${labels:+"--build_metadata=PATTERN=${labels[*]}"} \
   2>&1
 
 # Collect indexstore filelists

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -144,6 +144,7 @@ touch "$build_marker"
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
+  ${labels:+"--build_metadata=PATTERN=${labels[*]}"} \
   2>&1
 
 # Collect indexstore filelists

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -144,6 +144,7 @@ touch "$build_marker"
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
+  ${labels:+"--build_metadata=PATTERN=${labels[*]}"} \
   2>&1
 
 # Collect indexstore filelists

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -144,6 +144,7 @@ touch "$build_marker"
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
+  ${labels:+"--build_metadata=PATTERN=${labels[*]}"} \
   2>&1
 
 # Collect indexstore filelists

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -144,6 +144,7 @@ touch "$build_marker"
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
+  ${labels:+"--build_metadata=PATTERN=${labels[*]}"} \
   2>&1
 
 # Collect indexstore filelists

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -144,6 +144,7 @@ touch "$build_marker"
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
+  ${labels:+"--build_metadata=PATTERN=${labels[*]}"} \
   2>&1
 
 # Collect indexstore filelists

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -144,6 +144,7 @@ touch "$build_marker"
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
+  ${labels:+"--build_metadata=PATTERN=${labels[*]}"} \
   2>&1
 
 # Collect indexstore filelists

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/bazel_build.sh
@@ -144,6 +144,7 @@ touch "$build_marker"
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
+  ${labels:+"--build_metadata=PATTERN=${labels[*]}"} \
   2>&1
 
 # Collect indexstore filelists

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -144,6 +144,7 @@ touch "$build_marker"
   ${toolchain:+--define=SWIFT_CUSTOM_TOOLCHAIN="$toolchain"} \
   "$output_groups_flag" \
   "$GENERATOR_LABEL" \
+  ${labels:+"--build_metadata=PATTERN=${labels[*]}"} \
   2>&1
 
 # Collect indexstore filelists


### PR DESCRIPTION
Example (notice the pattern in the header doesn't say `//tools/generator:xcodeproj.generator`): https://app.buildbuddy.io/invocation/94d67a3c-eb20-4894-9eb3-ea3895e083db

Re-implements #1131.