### PR TITLE
Repro: Unable to use swiftUI previews

### DIFF
--- a/examples/integration/.bazelrc
+++ b/examples/integration/.bazelrc
@@ -12,5 +12,9 @@ build:rules_xcodeproj_integration --define=foo=bar
 
 build --test_env=INTEGRATION_TEST_ENV_VAR=TRUE
 
+build --ios_minimum_os=14.0
+build --features apple.arm64_simulator_use_device_deps
+build --features=swift.vfsoverlay
+
 # Use a user.bazelrc if it exists
 try-import %workspace%/user.bazelrc

--- a/examples/integration/SwiftUIIssues/SomeModule/BUILD
+++ b/examples/integration/SwiftUIIssues/SomeModule/BUILD
@@ -1,0 +1,35 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_test")
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_framework", "ios_unit_test")
+
+swift_library(
+    name = "SomeModule",
+    srcs = ["somemodule.swift"],
+    module_name = "SomeModule",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "SomeModuleTestsLib",
+    srcs = ["test_somemodule.swift"],
+    tags = ["manual"],
+    deps = [":SomeModule"],
+    testonly = True,
+)
+
+ios_unit_test(
+    name = "SomeModuleTests",
+    deps = [":SomeModuleTestsLib"],
+    minimum_os_version = "14.0",
+    visibility = ["//visibility:public"]
+)
+
+ios_framework(
+    name = "SomeModuleFramework.iOS",
+    bundle_id = "io.budilebuddy.UIFramework",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    minimum_os_version = "14.0",
+    visibility = ["//visibility:public"],
+    deps = [":SomeModule"],
+)

--- a/examples/integration/SwiftUIIssues/SomeModule/Info.plist
+++ b/examples/integration/SwiftUIIssues/SomeModule/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+</dict>
+</plist>

--- a/examples/integration/SwiftUIIssues/SomeModule/somemodule.swift
+++ b/examples/integration/SwiftUIIssues/SomeModule/somemodule.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+public struct ContentView: View {
+    public init() {}
+
+    public var body: some View {
+        Text("test")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/examples/integration/SwiftUIIssues/SomeModule/test_somemodule.swift
+++ b/examples/integration/SwiftUIIssues/SomeModule/test_somemodule.swift
@@ -1,0 +1,1 @@
+import SomeModule

--- a/examples/integration/xcodeproj_targets.bzl
+++ b/examples/integration/xcodeproj_targets.bzl
@@ -50,6 +50,8 @@ XCODEPROJ_TARGETS = [
     "//tvOSApp/Test/UnitTests:tvOSAppUnitTests",
     "//watchOSApp/Test/UITests:watchOSAppUITests",
     "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests",
+    "//SwiftUIIssues/SomeModule:SomeModuleFramework.iOS",
+    "//SwiftUIIssues/SomeModule:SomeModuleTests"
 ]
 
 IOS_BUNDLE_ID = "io.buildbuddy.example"
@@ -59,7 +61,7 @@ APP_CLIP_BUNDLE_ID = "{}.app-clip".format(IOS_BUNDLE_ID)
 TVOS_BUNDLE_ID = IOS_BUNDLE_ID
 WATCHOS_BUNDLE_ID = "{}.watch".format(IOS_BUNDLE_ID)
 
-SCHEME_AUTOGENERATION_MODE = "all"
+SCHEME_AUTOGENERATION_MODE = "auto"
 
 def get_xcode_schemes():
     return [
@@ -75,4 +77,17 @@ def get_xcode_schemes():
                 ],
             ),
         ),
+        xcode_schemes.scheme(
+            name = "SomeModule_Scheme",
+            build_action = xcode_schemes.build_action(
+                targets = [
+                    "//SwiftUIIssues/SomeModule:SomeModuleFramework.iOS"
+                ]
+            ),
+            test_action = xcode_schemes.test_action(
+                targets = [
+                    "//SwiftUIIssues/SomeModule:SomeModuleTests"
+                ]
+            )
+        )
     ]


### PR DESCRIPTION
This reproducer highlights a potential issue when
using swiftUI for a target that shares a scheme
with a unit test target for the same underlying
target.

Removing the test target from the scheme fixes the issue and allows swiftuI to work:

xcode log:

```terminal
UnsupportedProductTypeError: Previews not supported for SomeModule

Previews can be defined in applications, frameworks, Swift packages, or dynamic libraries, but not in static libraries

productType = com.apple.product-type.library.static
buildable = SomeModule
```