### PR TITLE
Inform the generator that it's creating a fixture

### DIFF
--- a/tools/generator/src/Generator/CreateProject.swift
+++ b/tools/generator/src/Generator/CreateProject.swift
@@ -8,6 +8,7 @@ extension Generator {
     /// `rootObject`.
     static func createProject(
         buildMode: BuildMode,
+        forFixtures: Bool,
         project: Project,
         directories: FilePathResolver.Directories
     ) -> PBXProj {

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -8,6 +8,7 @@ import XcodeProj
 struct Environment {
     let createProject: (
         _ buildMode: BuildMode,
+        _ forFixtures: Bool,
         _ project: Project,
         _ directories: FilePathResolver.Directories
     ) -> PBXProj

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -41,6 +41,7 @@ class Generator {
     /// Generates an Xcode project for a given `Project`.
     func generate(
         buildMode: BuildMode,
+        forFixtures: Bool,
         project: Project,
         xccurrentversions: [XCCurrentVersion],
         extensionPointIdentifiers: [TargetID: ExtensionPointIdentifier],
@@ -49,6 +50,7 @@ class Generator {
     ) throws {
         let pbxProj = environment.createProject(
             buildMode,
+            forFixtures,
             project,
             directories
         )

--- a/tools/generator/src/Generator/Main.swift
+++ b/tools/generator/src/Generator/Main.swift
@@ -30,6 +30,7 @@ extension Generator {
 
             try Generator(logger: logger).generate(
                 buildMode: arguments.buildMode,
+                forFixtures: arguments.forFixtures,
                 project: project,
                 xccurrentversions: xccurrentversions,
                 extensionPointIdentifiers: extensionPointIdentifiers,
@@ -52,15 +53,16 @@ extension Generator {
         let workspaceOutputPath: Path
         let projectRootDirectory: Path
         let buildMode: BuildMode
+        let forFixtures: Bool
     }
 
     static func parseArguments(_ arguments: [String]) throws -> Arguments {
-        guard arguments.count == 9 else {
+        guard arguments.count == 10 else {
             throw UsageError(message: """
 Usage: \(arguments[0]) <path/to/project.json> <path/to/root_dirs> \
 <path/to/xccurrentversions.json> <path/to/extensionPointIdentifiers.json> \
 <path/to/bazel/integration/dir> <path/to/output/project.xcodeproj> \
-<workspace/relative/output/path> (xcode|bazel)
+<workspace/relative/output/path> (xcode|bazel) <1 is for fixtures, otherwise 0>
 """)
         }
 
@@ -91,7 +93,8 @@ ERROR: build_mode wasn't one of the supported values: xcode, bazel
             outputPath: Path(arguments[6]),
             workspaceOutputPath: Path(workspaceOutput),
             projectRootDirectory: Path(projectRoot),
-            buildMode: buildMode
+            buildMode: buildMode,
+            forFixtures: arguments[9] == "1"
         )
     }
 

--- a/tools/generator/test/CreateProjectTests.swift
+++ b/tools/generator/test/CreateProjectTests.swift
@@ -117,6 +117,7 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)
 
         let createdPBXProj = Generator.createProject(
             buildMode: .xcode,
+            forFixtures: false,
             project: project,
             directories: directories
         )
@@ -248,6 +249,7 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)
 
         let createdPBXProj = Generator.createProject(
             buildMode: .bazel,
+            forFixtures: false,
             project: project,
             directories: directories
         )

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -253,6 +253,7 @@ final class GeneratorTests: XCTestCase {
         var createProjectCalled: [CreateProjectCalled] = []
         func createProject(
             buildMode: BuildMode,
+            _forFixtures: Bool,
             project: Project,
             directories: FilePathResolver.Directories
         ) -> PBXProj {
@@ -848,6 +849,7 @@ final class GeneratorTests: XCTestCase {
 
         try generator.generate(
             buildMode: buildMode,
+            forFixtures: false,
             project: project,
             xccurrentversions: xccurrentversions,
             extensionPointIdentifiers: extensionPointIdentifiers,

--- a/xcodeproj/internal/fixtures.bzl
+++ b/xcodeproj/internal/fixtures.bzl
@@ -131,6 +131,7 @@ def validate_fixtures(**kwargs):
     )
 
 _fixture_xcodeproj = make_xcodeproj_rule(
+    is_fixture = True,
     xcodeproj_transition = _fixtures_transition,
 )
 

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -733,7 +733,8 @@ def _write_xcodeproj(
         bazel_integration_files,
         xccurrentversions_file,
         extensionpointidentifiers_file,
-        build_mode):
+        build_mode,
+        is_fixture):
     xcodeproj = ctx.actions.declare_directory(
         "{}.xcodeproj".format(ctx.attr.name),
     )
@@ -752,6 +753,7 @@ def _write_xcodeproj(
     args.add(xcodeproj.path)
     args.add(install_path)
     args.add(build_mode)
+    args.add("1" if is_fixture else "0")
 
     ctx.actions.run(
         executable = ctx.attr._generator[DefaultInfo].files_to_run,
@@ -1000,6 +1002,7 @@ def _xcodeproj_impl(ctx):
         extensionpointidentifiers_file = extensionpointidentifiers_file,
         bazel_integration_files = bazel_integration_files,
         build_mode = ctx.attr.build_mode,
+        is_fixture = ctx.attr._is_fixture,
     )
     installer = _write_installer(
         ctx = ctx,
@@ -1054,7 +1057,7 @@ def _xcodeproj_impl(ctx):
         ),
     ]
 
-def make_xcodeproj_rule(*, xcodeproj_transition = None):
+def make_xcodeproj_rule(*, is_fixture = False, xcodeproj_transition = None):
     attrs = {
         "adjust_schemes_for_swiftui_previews": attr.bool(
             default = False,
@@ -1307,6 +1310,7 @@ transitive dependencies of the targets specified in the
             allow_single_file = True,
             default = Label("//xcodeproj/internal:installer.template.sh"),
         ),
+        "_is_fixture": attr.bool(default = is_fixture),
         "_swiftc_stub": attr.label(
             cfg = "exec",
             default = Label("//tools/swiftc_stub:universal_swiftc_stub"),


### PR DESCRIPTION
There are some things that we want to do differently when we generate a fixture based project. Mainly it's making paths relative, but in the future we might want to do more.