### PR TITLE
Only set relative `projectDirPath` for fixtures

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -775,7 +775,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
-				SRCROOT = "$(_SRCROOT:standardizepath)";
+				SRCROOT = ../../../../../..;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EXEC = "$(BAZEL_INTEGRATION_DIR)/swiftc";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -784,7 +784,6 @@
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
 				_BAZEL_OUTPUT_BASE = "$(PROJECT_DIR)/../..";
-				_SRCROOT = "$(PROJECT_DIR)/../../../../../..";
 			};
 			name = Debug;
 		};

--- a/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -744,14 +744,13 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
-				SRCROOT = "$(_SRCROOT:standardizepath)";
+				SRCROOT = ../../../../../..;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)";
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
 				_BAZEL_OUTPUT_BASE = "$(PROJECT_DIR)/../..";
-				_SRCROOT = "$(PROJECT_DIR)/../../../../../..";
 			};
 			name = Debug;
 		};

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -8028,7 +8028,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
-				SRCROOT = "$(_SRCROOT:standardizepath)";
+				SRCROOT = ../../../../../..;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EXEC = "$(BAZEL_INTEGRATION_DIR)/swiftc";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -8037,7 +8037,6 @@
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
 				_BAZEL_OUTPUT_BASE = "$(PROJECT_DIR)/../..";
-				_SRCROOT = "$(PROJECT_DIR)/../../../../../..";
 			};
 			name = Debug;
 		};

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -9578,14 +9578,13 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
-				SRCROOT = "$(_SRCROOT:standardizepath)";
+				SRCROOT = ../../../../../..;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)";
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
 				_BAZEL_OUTPUT_BASE = "$(PROJECT_DIR)/../..";
-				_SRCROOT = "$(PROJECT_DIR)/../../../../../..";
 			};
 			name = Debug;
 		};

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -739,7 +739,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
-				SRCROOT = "$(_SRCROOT:standardizepath)";
+				SRCROOT = ../../../../../..;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EXEC = "$(BAZEL_INTEGRATION_DIR)/swiftc";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -748,7 +748,6 @@
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
 				_BAZEL_OUTPUT_BASE = "$(PROJECT_DIR)/../..";
-				_SRCROOT = "$(PROJECT_DIR)/../../../../../..";
 			};
 			name = Debug;
 		};

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -748,14 +748,13 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
-				SRCROOT = "$(_SRCROOT:standardizepath)";
+				SRCROOT = ../../../../../..;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)";
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
 				_BAZEL_OUTPUT_BASE = "$(PROJECT_DIR)/../..";
-				_SRCROOT = "$(PROJECT_DIR)/../../../../../..";
 			};
 			name = Debug;
 		};

--- a/examples/simple/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
-				SRCROOT = "$(_SRCROOT:standardizepath)";
+				SRCROOT = ../../../../../..;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EXEC = "$(BAZEL_INTEGRATION_DIR)/swiftc";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -373,7 +373,6 @@
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
 				_BAZEL_OUTPUT_BASE = "$(PROJECT_DIR)/../..";
-				_SRCROOT = "$(PROJECT_DIR)/../../../../../..";
 			};
 			name = Debug;
 		};

--- a/examples/simple/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -220,14 +220,13 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
-				SRCROOT = "$(_SRCROOT:standardizepath)";
+				SRCROOT = ../../../../../..;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)";
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
 				_BAZEL_OUTPUT_BASE = "$(PROJECT_DIR)/../..";
-				_SRCROOT = "$(PROJECT_DIR)/../../../../../..";
 			};
 			name = Debug;
 		};

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -2550,7 +2550,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
-				SRCROOT = "$(_SRCROOT:standardizepath)";
+				SRCROOT = ../../../../../..;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EXEC = "$(BAZEL_INTEGRATION_DIR)/swiftc";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -2559,7 +2559,6 @@
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
 				_BAZEL_OUTPUT_BASE = "$(PROJECT_DIR)/../..";
-				_SRCROOT = "$(PROJECT_DIR)/../../../../../..";
 			};
 			name = Debug;
 		};

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -2741,14 +2741,13 @@
 				ONLY_ACTIVE_ARCH = YES;
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
-				SRCROOT = "$(_SRCROOT:standardizepath)";
+				SRCROOT = ../../../../../..;
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				TARGET_TEMP_DIR = "$(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)";
 				USE_HEADERMAP = NO;
 				VALIDATE_WORKSPACE = NO;
 				_BAZEL_OUTPUT_BASE = "$(PROJECT_DIR)/../..";
-				_SRCROOT = "$(PROJECT_DIR)/../../../../../..";
 			};
 			name = Debug;
 		};


### PR DESCRIPTION
This is needed to support conditional `PROJECT_DIR` values. `SRCROOT` can't be relative to `PROJECT_DIR` in that case.