### PR TITLE
Add pre_post_actions to TestActions

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -295,7 +295,8 @@ A `struct` representing a launch action.
 ## xcode_schemes.test_action
 
 <pre>
-xcode_schemes.test_action(<a href="#xcode_schemes.test_action-targets">targets</a>, <a href="#xcode_schemes.test_action-args">args</a>, <a href="#xcode_schemes.test_action-diagnostics">diagnostics</a>, <a href="#xcode_schemes.test_action-env">env</a>, <a href="#xcode_schemes.test_action-expand_variables_based_on">expand_variables_based_on</a>)
+xcode_schemes.test_action(<a href="#xcode_schemes.test_action-targets">targets</a>, <a href="#xcode_schemes.test_action-args">args</a>, <a href="#xcode_schemes.test_action-diagnostics">diagnostics</a>, <a href="#xcode_schemes.test_action-env">env</a>, <a href="#xcode_schemes.test_action-expand_variables_based_on">expand_variables_based_on</a>, <a href="#xcode_schemes.test_action-pre_actions">pre_actions</a>,
+                          <a href="#xcode_schemes.test_action-post_actions">post_actions</a>)
 </pre>
 
 Constructs a test action for an Xcode scheme.
@@ -310,6 +311,8 @@ Constructs a test action for an Xcode scheme.
 | <a id="xcode_schemes.test_action-diagnostics"></a>diagnostics |  Optional. A value returned by <code>xcode_schemes.diagnostics</code>.   |  <code>None</code> |
 | <a id="xcode_schemes.test_action-env"></a>env |  Optional. A <code>dict</code> of <code>string</code> values that will be set as environment variables when the target is executed.   |  <code>None</code> |
 | <a id="xcode_schemes.test_action-expand_variables_based_on"></a>expand_variables_based_on |  Optional. One of the specified test target labels. If no value is provided, one of the test targets will be selected. If no expansion context is desired, use the <code>string</code> value <code>none</code>.   |  <code>None</code> |
+| <a id="xcode_schemes.test_action-pre_actions"></a>pre_actions |  A <code>sequence</code> of <code>struct</code> values as created by <code>xcode_schemes.pre_action</code>.   |  <code>[]</code> |
+| <a id="xcode_schemes.test_action-post_actions"></a>post_actions |  A <code>sequence</code> of <code>struct</code> values as created by <code>xcode_schemes.post_action</code>.   |  <code>[]</code> |
 
 **RETURNS**
 

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -311,8 +311,8 @@ Constructs a test action for an Xcode scheme.
 | <a id="xcode_schemes.test_action-diagnostics"></a>diagnostics |  Optional. A value returned by <code>xcode_schemes.diagnostics</code>.   |  <code>None</code> |
 | <a id="xcode_schemes.test_action-env"></a>env |  Optional. A <code>dict</code> of <code>string</code> values that will be set as environment variables when the target is executed.   |  <code>None</code> |
 | <a id="xcode_schemes.test_action-expand_variables_based_on"></a>expand_variables_based_on |  Optional. One of the specified test target labels. If no value is provided, one of the test targets will be selected. If no expansion context is desired, use the <code>string</code> value <code>none</code>.   |  <code>None</code> |
-| <a id="xcode_schemes.test_action-pre_actions"></a>pre_actions |  A <code>sequence</code> of <code>struct</code> values as created by <code>xcode_schemes.pre_action</code>.   |  <code>[]</code> |
-| <a id="xcode_schemes.test_action-post_actions"></a>post_actions |  A <code>sequence</code> of <code>struct</code> values as created by <code>xcode_schemes.post_action</code>.   |  <code>[]</code> |
+| <a id="xcode_schemes.test_action-pre_actions"></a>pre_actions |  Optional. A <code>sequence</code> of <code>struct</code> values as created by <code>xcode_schemes.pre_post_action</code>.   |  <code>[]</code> |
+| <a id="xcode_schemes.test_action-post_actions"></a>post_actions |  Optional. A <code>sequence</code> of <code>struct</code> values as created by <code>xcode_schemes.pre_post_action</code>.   |  <code>[]</code> |
 
 **RETURNS**
 

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
@@ -164,6 +164,24 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
       shouldUseLaunchSchemeArgsEnv = "NO">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run After Tests"
+               scriptText = "echo &quot;Hi&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "D2B147BDA8E8FC10D91B53BB"
+                     BuildableName = "iOSAppSwiftUnitTests.xctest"
+                     BlueprintName = "iOSAppSwiftUnitTests"
+                     ReferencedContainer = "container:../../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -25,6 +25,14 @@
                     "IOSAPPSWIFTUNITTESTS_CUSTOMSCHEMEVAR": "TRUE"
                 },
                 "expand_variables_based_on": null,
+                "post_actions": [
+                    {
+                        "expand_variables_based_on": "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
+                        "name": "Run After Tests",
+                        "script": "echo \"Hi\""
+                    }
+                ],
+                "pre_actions": [],
                 "targets": [
                     "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
                     "@//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/iOSAppUnitTests_Scheme.xcscheme
@@ -92,6 +92,24 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       customLLDBInitFile = "$(BAZEL_LLDB_INIT)"
       shouldUseLaunchSchemeArgsEnv = "NO">
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run After Tests"
+               scriptText = "echo &quot;Hi&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "3BE6BBB59BF4F33150BA74CA"
+                     BuildableName = "iOSAppSwiftUnitTests.xctest"
+                     BlueprintName = "iOSAppSwiftUnitTests"
+                     ReferencedContainer = "container:../../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -25,6 +25,14 @@
                     "IOSAPPSWIFTUNITTESTS_CUSTOMSCHEMEVAR": "TRUE"
                 },
                 "expand_variables_based_on": null,
+                "post_actions": [
+                    {
+                        "expand_variables_based_on": "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
+                        "name": "Run After Tests",
+                        "script": "echo \"Hi\""
+                    }
+                ],
+                "pre_actions": [],
                 "targets": [
                     "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
                     "@//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests"

--- a/examples/integration/xcodeproj_targets.bzl
+++ b/examples/integration/xcodeproj_targets.bzl
@@ -73,6 +73,13 @@ def get_xcode_schemes():
                     "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
                     "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests",
                 ],
+                post_actions = [
+                    xcode_schemes.pre_post_action(
+                        name = "Run After Tests",
+                        script = "echo \"Hi\"",
+                        expand_variables_based_on = "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests"
+                    ),
+                ]
             ),
         ),
     ]

--- a/examples/integration/xcodeproj_targets.bzl
+++ b/examples/integration/xcodeproj_targets.bzl
@@ -77,9 +77,9 @@ def get_xcode_schemes():
                     xcode_schemes.pre_post_action(
                         name = "Run After Tests",
                         script = "echo \"Hi\"",
-                        expand_variables_based_on = "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests"
+                        expand_variables_based_on = "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
                     ),
-                ]
+                ],
             ),
         ),
     ]

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -83,6 +83,8 @@
                     "CUSTOM_ENV_VAR": "goodbye"
                 },
                 "expand_variables_based_on": null,
+                "post_actions": [],
+                "pre_actions": [],
                 "targets": [
                     "@//tools/generator/test:tests"
                 ]

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -83,6 +83,8 @@
                     "CUSTOM_ENV_VAR": "goodbye"
                 },
                 "expand_variables_based_on": null,
+                "post_actions": [],
+                "pre_actions": [],
                 "targets": [
                     "@//tools/generator/test:tests"
                 ]

--- a/test/internal/xcode_schemes/model_tests.bzl
+++ b/test/internal/xcode_schemes/model_tests.bzl
@@ -164,6 +164,8 @@ def _test_action_test(ctx):
         diagnostics = None,
         env = {},
         expand_variables_based_on = None,
+        pre_actions = [],
+        post_actions = [],
     )
     asserts.equals(env, expected, actual, "no custom values")
 
@@ -179,6 +181,8 @@ def _test_action_test(ctx):
         diagnostics = None,
         env = custom_env,
         expand_variables_based_on = None,
+        pre_actions = [],
+        post_actions = [],
     )
     asserts.equals(env, expected, actual, "with custom values")
 
@@ -195,6 +199,8 @@ def _test_action_test(ctx):
         diagnostics = None,
         env = {},
         expand_variables_based_on = "none",
+        pre_actions = [],
+        post_actions = [],
     )
     asserts.equals(
         env,
@@ -216,6 +222,8 @@ def _test_action_test(ctx):
         diagnostics = None,
         env = {},
         expand_variables_based_on = bazel_labels.normalize(targets[0]),
+        pre_actions = [],
+        post_actions = [],
     )
     asserts.equals(
         env,

--- a/tools/generator/src/DTO/XcodeScheme.swift
+++ b/tools/generator/src/DTO/XcodeScheme.swift
@@ -273,13 +273,11 @@ extension XcodeScheme.TestAction: Decodable {
                 [XcodeScheme.PrePostAction].self,
                 forKey: .preActions
             ) ?? []
-        print(preActions)
         postActions = try container
             .decodeIfPresent(
                 [XcodeScheme.PrePostAction].self,
                 forKey: .postActions
             ) ?? []
-        print(postActions)
     }
 }
 

--- a/tools/generator/src/DTO/XcodeScheme.swift
+++ b/tools/generator/src/DTO/XcodeScheme.swift
@@ -203,6 +203,8 @@ extension XcodeScheme {
         let diagnostics: Diagnostics
         let env: [String: String]
         let expandVariablesBasedOn: BazelLabel?
+        let preActions: [PrePostAction]
+        let postActions: [PrePostAction]
 
         init<Targets: Sequence>(
             targets: Targets,
@@ -210,7 +212,9 @@ extension XcodeScheme {
             args: [String] = [],
             diagnostics: Diagnostics = .init(),
             env: [String: String] = [:],
-            expandVariablesBasedOn: BazelLabel? = nil
+            expandVariablesBasedOn: BazelLabel? = nil,
+            preActions: [PrePostAction] = [],
+            postActions: [PrePostAction] = []
         ) throws where Targets.Element == BazelLabel {
             self.targets = Set(targets)
             self.buildConfigurationName = buildConfigurationName
@@ -218,6 +222,8 @@ extension XcodeScheme {
             self.diagnostics = diagnostics
             self.env = env
             self.expandVariablesBasedOn = expandVariablesBasedOn
+            self.preActions = preActions
+            self.postActions = postActions
 
             guard !self.targets.isEmpty else {
                 throw PreconditionError(message: """
@@ -236,6 +242,8 @@ extension XcodeScheme.TestAction: Decodable {
         case diagnostics
         case env
         case expandVariablesBasedOn
+        case preActions
+        case postActions
     }
 
     init(from decoder: Decoder) throws {
@@ -260,6 +268,18 @@ extension XcodeScheme.TestAction: Decodable {
                 BazelLabel.self,
                 forKey: .expandVariablesBasedOn
             )
+        preActions = try container
+            .decodeIfPresent(
+                [XcodeScheme.PrePostAction].self,
+                forKey: .preActions
+            ) ?? []
+        print(preActions)
+        postActions = try container
+            .decodeIfPresent(
+                [XcodeScheme.PrePostAction].self,
+                forKey: .postActions
+            ) ?? []
+        print(postActions)
     }
 }
 

--- a/tools/generator/src/Extensions/XCScheme+Extensions.swift
+++ b/tools/generator/src/Extensions/XCScheme+Extensions.swift
@@ -220,6 +220,8 @@ extension XCScheme.TestAction {
                 .filter(\.pbxTarget.isTestable)
                 .sortedLocalizedStandard(\.pbxTarget.name)
                 .map { .init(skipped: false, buildableReference: $0.buildableReference) },
+            preActions: testActionInfo.preActions.map(\.executionAction),
+            postActions: testActionInfo.postActions.map(\.executionAction),
             shouldUseLaunchSchemeArgsEnv: shouldUseLaunchSchemeArgsEnv,
             enableAddressSanitizer: testActionInfo.diagnostics.sanitizers
                 .address,

--- a/tools/generator/src/Extensions/XcodeScheme+Extensions.swift
+++ b/tools/generator/src/Extensions/XcodeScheme+Extensions.swift
@@ -178,6 +178,12 @@ extension XcodeScheme {
         }
         if let testAction = testAction {
             labels.formUnion(testAction.targets)
+            labels.formUnion(testAction.preActions.compactMap(
+                \.expandVariablesBasedOn
+            ))
+            labels.formUnion(testAction.postActions.compactMap(
+                \.expandVariablesBasedOn
+            ))
         }
         if let launchAction = launchAction {
             labels.update(with: launchAction.target)

--- a/tools/generator/test/XCScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XCScheme+ExtensionsTests.swift
@@ -115,7 +115,9 @@ extension XCSchemeExtensionsTests {
         let testActionInfo = try XCSchemeInfo.TestActionInfo(
             resolveHostsFor: .init(
                 buildConfigurationName: buildConfigurationName,
-                targetInfos: [unitTestTargetInfo, uiTestTargetInfo]
+                targetInfos: [unitTestTargetInfo, uiTestTargetInfo],
+                preActions: [.init(name: "Custom Pre Script", expandVariablesBasedOn: nil, script: "exit 0")],
+                postActions: [.init(name: "Custom Post Script", expandVariablesBasedOn: libraryTargetInfo, script: "exit 1")]
             ),
             topLevelTargetInfos: []
         ).orThrow()
@@ -126,6 +128,12 @@ extension XCSchemeExtensionsTests {
             testables: [
                 .init(skipped: false, buildableReference: unitTestTargetInfo.buildableReference),
                 .init(skipped: false, buildableReference: uiTestTargetInfo.buildableReference),
+            ],
+            preActions: [
+                .init(scriptText: "exit 0", title: "Custom Pre Script", environmentBuildable: nil)
+            ],
+            postActions: [
+                .init(scriptText: "exit 1", title: "Custom Post Script", environmentBuildable: libraryTargetInfo.buildableReference)
             ],
             shouldUseLaunchSchemeArgsEnv: true,
             customLLDBInitFile: XCSchemeConstants.customLLDBInitFile

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -413,10 +413,10 @@ def make_xcode_schemes(bazel_labels):
                 target labels. If no value is provided, one of the test targets
                 will be selected. If no expansion context is desired, use the
                 `string` value `none`.
-            pre_actions: A `sequence` of `struct` values as created by
-                `xcode_schemes.pre_action`.
-            post_actions: A `sequence` of `struct` values as created by
-                `xcode_schemes.post_action`.
+            pre_actions: Optional. A `sequence` of `struct` values as created by
+                `xcode_schemes.pre_post_action`.
+            post_actions: Optional. A `sequence` of `struct` values as created by
+                `xcode_schemes.pre_post_action`.
 
         Returns:
             A `struct` representing a test action.

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -397,7 +397,7 @@ def make_xcode_schemes(bazel_labels):
             diagnostics = None,
             env = None,
             expand_variables_based_on = None,
-            pre_actions = [], 
+            pre_actions = [],
             post_actions = []):
         """Constructs a test action for an Xcode scheme.
 

--- a/xcodeproj/internal/xcode_schemes_internal.bzl
+++ b/xcodeproj/internal/xcode_schemes_internal.bzl
@@ -122,7 +122,7 @@ def _test_action(
         diagnostics = None,
         env = None,
         expand_variables_based_on = None,
-        pre_actions = [], 
+        pre_actions = [],
         post_actions = []):
     """Constructs a test action for an Xcode scheme.
 

--- a/xcodeproj/internal/xcode_schemes_internal.bzl
+++ b/xcodeproj/internal/xcode_schemes_internal.bzl
@@ -138,9 +138,9 @@ def _test_action(
         expand_variables_based_on: Optional. One of the specified test target labels.
             If no value is provided, one of the test targets will be selected.
             If no expansion context is desired, use the `string` value `none`.
-        pre_actions: A `sequence` of `struct` values as created by
+        pre_actions: Optional. A `sequence` of `struct` values as created by
             `xcode_schemes.pre_post_action`.
-        post_actions: A `sequence` of `struct` values as created by
+        post_actions: Optional. A `sequence` of `struct` values as created by
             `xcode_schemes.pre_post_action`.
 
     Returns:

--- a/xcodeproj/internal/xcode_schemes_internal.bzl
+++ b/xcodeproj/internal/xcode_schemes_internal.bzl
@@ -121,7 +121,9 @@ def _test_action(
         args = None,
         diagnostics = None,
         env = None,
-        expand_variables_based_on = None):
+        expand_variables_based_on = None,
+        pre_actions = [], 
+        post_actions = []):
     """Constructs a test action for an Xcode scheme.
 
     Args:
@@ -136,6 +138,10 @@ def _test_action(
         expand_variables_based_on: Optional. One of the specified test target labels.
             If no value is provided, one of the test targets will be selected.
             If no expansion context is desired, use the `string` value `none`.
+        pre_actions: A `sequence` of `struct` values as created by
+            `xcode_schemes.pre_post_action`.
+        post_actions: A `sequence` of `struct` values as created by
+            `xcode_schemes.pre_post_action`.
 
     Returns:
         A `struct` representing a test action.
@@ -159,6 +165,8 @@ or one of the test targets.
         diagnostics = diagnostics,
         env = env if env != None else {},
         expand_variables_based_on = expand_variables_based_on,
+        pre_actions = pre_actions,
+        post_actions = post_actions,
     )
 
 def _launch_action(


### PR DESCRIPTION
Adds pre_post_action attributes to `test_action` for custom actions run on the test scheme.