### PR TITLE
Rename internal Starlark functions for easier profiling

### DIFF
--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -1,6 +1,6 @@
 """Module for propagating compilation providers."""
 
-def _collect(*, cc_info, objc, swift_info, is_xcode_target):
+def _collect_compilation_providers(*, cc_info, objc, swift_info, is_xcode_target):
     """Collects compilation providers for a non top-level target.
 
     Args:
@@ -26,7 +26,7 @@ def _collect(*, cc_info, objc, swift_info, is_xcode_target):
         _transitive_compilation_providers = (),
     )
 
-def _merge(
+def _merge_compilation_providers(
         *,
         apple_dynamic_framework_info = None,
         cc_info = None,
@@ -137,7 +137,7 @@ def _get_xcode_library_targets(*, compilation_providers):
     ]
 
 compilation_providers = struct(
-    collect = _collect,
+    collect = _collect_compilation_providers,
     get_xcode_library_targets = _get_xcode_library_targets,
-    merge = _merge,
+    merge = _merge_compilation_providers,
 )

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -57,7 +57,7 @@ def _collect_transitive_uncategorized(info):
         return depset()
     return info.inputs.uncategorized
 
-def _should_ignore_attr(attr):
+def _should_ignore_input_attr(attr):
     return (
         # We don't want to include implicit dependencies
         attr.startswith("_") or
@@ -99,7 +99,7 @@ def _process_cc_info_headers(headers, *, output_files, pch, generated):
 
 # API
 
-def _collect(
+def _collect_input_files(
         *,
         ctx,
         target,
@@ -240,18 +240,18 @@ def _collect(
         transitive_extra_files.append(dep[XcodeProjInfo].inputs.uncategorized)
 
     for attr in dir(ctx.rule.files):
-        if _should_ignore_attr(attr):
+        if _should_ignore_input_attr(attr):
             continue
         for file in getattr(ctx.rule.files, attr):
             _handle_file(file, attr = attr)
 
     for attr in dir(ctx.rule.file):
-        if _should_ignore_attr(attr):
+        if _should_ignore_input_attr(attr):
             continue
         _handle_file(getattr(ctx.rule.file, attr), attr = attr)
 
     for attr in dir(ctx.rule.attr):
-        if _should_ignore_attr(attr):
+        if _should_ignore_input_attr(attr):
             continue
         dep = getattr(ctx.rule.attr, attr, None)
         if type(dep) == "Target":
@@ -669,7 +669,7 @@ def _from_resource_bundle(bundle):
         linking_output_group_name = None,
     )
 
-def _merge(*, transitive_infos, extra_generated = None):
+def _merge_input_files(*, transitive_infos, extra_generated = None):
     """Creates merged inputs.
 
     Args:
@@ -782,7 +782,7 @@ def _merge(*, transitive_infos, extra_generated = None):
         linking_output_group_name = None,
     )
 
-def _to_dto(inputs):
+def _input_files_to_dto(inputs):
     """Generates a target DTO value for inputs.
 
     Args:
@@ -916,9 +916,9 @@ def _to_output_groups_fields(
     return output_groups
 
 input_files = struct(
-    collect = _collect,
+    collect = _collect_input_files,
     from_resource_bundle = _from_resource_bundle,
-    merge = _merge,
-    to_dto = _to_dto,
+    merge = _merge_input_files,
+    to_dto = _input_files_to_dto,
     to_output_groups_fields = _to_output_groups_fields,
 )

--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -35,7 +35,7 @@ _SKIP_INPUT_EXTENSIONS = {
     "xctest": None,
 }
 
-def _collect(
+def _collect_linker_inputs(
         *,
         target,
         compilation_providers,
@@ -87,8 +87,8 @@ def _collect(
         _top_level_values = top_level_values,
     )
 
-def _merge(*, compilation_providers):
-    return _collect(
+def _merge_linker_inputs(*, compilation_providers):
+    return _collect_linker_inputs(
         target = None,
         compilation_providers = compilation_providers,
     )
@@ -382,7 +382,7 @@ def _process_linkopt(linkopt):
 
     return linkopt
 
-def _to_dto(linker_inputs):
+def _linker_inputs_to_dto(linker_inputs):
     """Generates a target DTO for linker inputs.
 
     Args:
@@ -468,12 +468,12 @@ def _get_primary_static_library(linker_inputs):
     return linker_inputs._primary_static_library
 
 linker_input_files = struct(
-    collect = _collect,
-    merge = _merge,
+    collect = _collect_linker_inputs,
+    merge = _merge_linker_inputs,
     get_library_static_libraries = _get_library_static_libraries,
     get_primary_static_library = _get_primary_static_library,
     get_top_level_static_libraries = _get_top_level_static_libraries,
     get_transitive_static_libraries = _get_transitive_static_libraries,
-    to_dto = _to_dto,
+    to_dto = _linker_inputs_to_dto,
     to_input_files = _to_input_files,
 )

--- a/xcodeproj/internal/lldb_contexts.bzl
+++ b/xcodeproj/internal/lldb_contexts.bzl
@@ -9,7 +9,7 @@ load(
 )
 load(":opts.bzl", "swift_pcm_copts")
 
-def _collect(
+def _collect_lldb_context(
         *,
         compilation_mode = None,
         objc_fragment = None,
@@ -89,7 +89,7 @@ def _collect(
         ),
     )
 
-def _to_dto(lldb_context):
+def _lldb_context_to_dto(lldb_context):
     if not lldb_context:
         return {}
 
@@ -183,6 +183,6 @@ def _to_dto(lldb_context):
     return dto
 
 lldb_contexts = struct(
-    collect = _collect,
-    to_dto = _to_dto,
+    collect = _collect_lldb_context,
+    to_dto = _lldb_context_to_dto,
 )

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -232,7 +232,7 @@ def _swift_to_dto(swift):
 
 # API
 
-def _collect(
+def _collect_output_files(
         *,
         id,
         swift_info,
@@ -277,7 +277,7 @@ def _collect(
         transitive_infos = transitive_infos,
     )
 
-def _merge(*, automatic_target_info, transitive_infos):
+def _merge_output_files(*, automatic_target_info, transitive_infos):
     """Creates merged outputs.
 
     Args:
@@ -298,7 +298,7 @@ def _merge(*, automatic_target_info, transitive_infos):
         should_produce_output_groups = False,
     )
 
-def _to_dto(outputs):
+def _outputs_files_to_dto(outputs):
     direct_outputs = outputs._direct_outputs
     if not direct_outputs:
         return {}
@@ -439,8 +439,8 @@ def swift_to_outputs(swift):
     return (compiled, getattr(module, "indexstore", None))
 
 output_files = struct(
-    collect = _collect,
-    merge = _merge,
-    to_dto = _to_dto,
+    collect = _collect_output_files,
+    merge = _merge_output_files,
+    to_dto = _outputs_files_to_dto,
     to_output_groups_fields = _to_output_groups_fields,
 )

--- a/xcodeproj/internal/platform.bzl
+++ b/xcodeproj/internal/platform.bzl
@@ -10,7 +10,7 @@ _PLATFORM_NAME = {
     apple_common.platform.watchos_simulator: "watchsimulator",
 }
 
-def _collect(*, ctx):
+def _collect_platform(*, ctx):
     """Collects information about a target's platform.
 
     Args:
@@ -36,7 +36,7 @@ def _is_same_type(lhs, rhs):
     """Returns whether two platforms are the same platform type."""
     return lhs._platform.platform_type == rhs._platform.platform_type
 
-def _to_dto(platform):
+def _platform_to_dto(platform):
     """Generates a target DTO value for a platform.
 
     Args:
@@ -55,7 +55,7 @@ def _to_dto(platform):
     return dto
 
 platform_info = struct(
-    collect = _collect,
+    collect = _collect_platform,
     is_same_type = _is_same_type,
-    to_dto = _to_dto,
+    to_dto = _platform_to_dto,
 )

--- a/xcodeproj/internal/target_search_paths.bzl
+++ b/xcodeproj/internal/target_search_paths.bzl
@@ -7,7 +7,7 @@ load(
     "parsed_file_path",
 )
 
-def _make(*, compilation_providers, bin_dir_path, opts_search_paths = None):
+def _make_search_paths(*, compilation_providers, bin_dir_path, opts_search_paths = None):
     """Creates the internal data structure of the `target_search_paths` module.
 
     Args:
@@ -27,7 +27,7 @@ def _make(*, compilation_providers, bin_dir_path, opts_search_paths = None):
         _opts_search_paths = opts_search_paths,
     )
 
-def _to_dto(search_paths):
+def _search_paths_to_dto(search_paths):
     if not search_paths:
         return {}
 
@@ -109,6 +109,6 @@ def _to_dto(search_paths):
     return dto
 
 target_search_paths = struct(
-    make = _make,
-    to_dto = _to_dto,
+    make = _make_search_paths,
+    to_dto = _search_paths_to_dto,
 )

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -10,7 +10,7 @@ load(":platform.bzl", "platform_info")
 load(":product.bzl", "product_to_dto")
 load(":target_search_paths.bzl", "target_search_paths")
 
-def _make(
+def _make_xcode_target(
         *,
         id,
         name,
@@ -112,7 +112,7 @@ def _make(
         xcode_required_targets = xcode_required_targets,
     )
 
-def _to_dto(
+def _xcode_target_to_dto(
         xcode_target,
         *,
         additional_scheme_target_ids,
@@ -226,6 +226,6 @@ def _to_dto(
     return dto
 
 xcode_targets = struct(
-    make = _make,
-    to_dto = _to_dto,
+    make = _make_xcode_target,
+    to_dto = _xcode_target_to_dto,
 )


### PR DESCRIPTION
When using `--starlark_cpu_profile`/`pprof` same named functions, even internal ones, are seen as the same function. By giving them unique names it makes the statistics easier to read.