### PR TITLE
Slightly optimize `_transitive_infos`

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -461,10 +461,10 @@ rules, then you will use these providers to communicate between them.
 ## XcodeProjAutomaticTargetProcessingInfo
 
 <pre>
-XcodeProjAutomaticTargetProcessingInfo(<a href="#XcodeProjAutomaticTargetProcessingInfo-alternate_icons">alternate_icons</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-app_icons">app_icons</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-bazel_build_mode_error">bazel_build_mode_error</a>,
-                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-bundle_id">bundle_id</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-codesignopts">codesignopts</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-deps">deps</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-entitlements">entitlements</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-env">env</a>,
-                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-exported_symbols_lists">exported_symbols_lists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-hdrs">hdrs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-infoplists">infoplists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-launchdplists">launchdplists</a>,
-                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-non_arc_srcs">non_arc_srcs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-pch">pch</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-provisioning_profile">provisioning_profile</a>,
+XcodeProjAutomaticTargetProcessingInfo(<a href="#XcodeProjAutomaticTargetProcessingInfo-all_attrs">all_attrs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-alternate_icons">alternate_icons</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-app_icons">app_icons</a>,
+                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-bazel_build_mode_error">bazel_build_mode_error</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-bundle_id">bundle_id</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-codesignopts">codesignopts</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-deps">deps</a>,
+                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-entitlements">entitlements</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-env">env</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-exported_symbols_lists">exported_symbols_lists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-hdrs">hdrs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-infoplists">infoplists</a>,
+                                       <a href="#XcodeProjAutomaticTargetProcessingInfo-launchdplists">launchdplists</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-non_arc_srcs">non_arc_srcs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-pch">pch</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-provisioning_profile">provisioning_profile</a>,
                                        <a href="#XcodeProjAutomaticTargetProcessingInfo-should_generate_target">should_generate_target</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-srcs">srcs</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-target_type">target_type</a>, <a href="#XcodeProjAutomaticTargetProcessingInfo-xcode_targets">xcode_targets</a>)
 </pre>
 
@@ -480,6 +480,7 @@ return a `XcodeProjInfo` provider instance instead.
 
 | Name  | Description |
 | :------------- | :------------- |
+| <a id="XcodeProjAutomaticTargetProcessingInfo-all_attrs"></a>all_attrs |  -    |
 | <a id="XcodeProjAutomaticTargetProcessingInfo-alternate_icons"></a>alternate_icons |  An attribute name (or <code>None</code>) to collect the application alternate icons.    |
 | <a id="XcodeProjAutomaticTargetProcessingInfo-app_icons"></a>app_icons |  An attribute name (or <code>None</code>) to collect the application icons.    |
 | <a id="XcodeProjAutomaticTargetProcessingInfo-bazel_build_mode_error"></a>bazel_build_mode_error |  If <code>build_mode = "bazel"</code>, then if this is non-<code>None</code>, it will be raised as an error during analysis.    |

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -185,6 +185,7 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
 
     return [
         XcodeProjAutomaticTargetProcessingInfo(
+            all_attrs = attrs,
             alternate_icons = alternate_icons,
             app_icons = app_icons,
             bazel_build_mode_error = bazel_build_mode_error,

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -9,6 +9,7 @@ If you need more control over how a target or its dependencies are processed,
 return a `XcodeProjInfo` provider instance instead.
 """,
     fields = {
+        "all_attrs": "",
         "alternate_icons": """\
 An attribute name (or `None`) to collect the application alternate icons.
 """,

--- a/xcodeproj/internal/xcodeproj_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_aspect.bzl
@@ -27,6 +27,7 @@ def _should_ignore_attr(attr):
 
 def _transitive_infos(*, ctx, automatic_target_info):
     transitive_infos = []
+
     # TODO: Have `XcodeProjAutomaticTargetProcessingInfo` tell us which
     # attributes to look at. About 7% of an example pprof trace is spent on
     # `_should_ignore_attr` and the type checks below. If we had a list of


### PR DESCRIPTION
This removes lots of `dir(ctx.rule.attr)` calls. I added a TODO to do even better in the future.