### PR TITLE
Remove a `bazel info` call

### DIFF
--- a/xcodeproj/internal/installer.template.sh
+++ b/xcodeproj/internal/installer.template.sh
@@ -34,6 +34,10 @@ while (("$#")); do
       dest="${2}"
       shift 2
       ;;
+    "--execution_root")
+      execution_root="${2}"
+      shift 2
+      ;;
     "--extra_flags_bazelrc")
       extra_flags_bazelrc="${2}"
       shift 2
@@ -50,6 +54,9 @@ done
 
 if [[ -z "${bazel_path:-}" ]]; then
   fail "Missing required argument: --bazel_path"
+fi
+if [[ -z "${execution_root:-}" ]]; then
+  fail "Missing required argument: --execution_root"
 fi
 
 # Resolve the inputs
@@ -164,7 +171,6 @@ plutil -replace IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded -bool fals
 if [[ -f "$dest/rules_xcodeproj/generated.xcfilelist" ]]; then
   cd "$BUILD_WORKSPACE_DIRECTORY"
 
-  execution_root=$("$bazel_path" info execution_root)
   readonly workspace_name="${execution_root##*/}"
   readonly output_base="${execution_root%/*/*}"
   readonly nested_output_base="$output_base/execroot/_rules_xcodeproj/build_output_base"

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -59,8 +59,10 @@ cd "$BUILD_WORKSPACE_DIRECTORY"
 bazel_path=$(which "%bazel_path%")
 installer_flags+=(--bazel_path "$bazel_path")
 
-output_base=$("$bazel_path" info output_base)
+execution_root=$("$bazel_path" info execution_root)
+installer_flags+=(--execution_root "$execution_root")
 
+readonly output_base="${execution_root%/*/*}"
 readonly nested_output_base_prefix="$output_base/execroot/_rules_xcodeproj"
 readonly nested_output_base="$nested_output_base_prefix/build_output_base"
 


### PR DESCRIPTION
We don't need to call `bazel info` in the installer script, since we already call it in the runner. Instead we can just pass the info from the runner to the installer.