### PR TITLE
Remove `bazel info` call from within Xcode

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -64,22 +64,6 @@ readonly base_pre_config_flags=(
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
 )
 
-# Determine Bazel output_path
-
-if [[ "${COLOR_DIAGNOSTICS:-NO}" == "YES" ]]; then
-  readonly info_color=yes
-else
-  readonly info_color=no
-fi
-
-output_path=$("${bazel_cmd[@]}" \
-  info \
-  "${base_pre_config_flags[@]}" \
-  --config="${BAZEL_CONFIG}_info" \
-  --color="$info_color" \
-  output_path)
-readonly output_path
-
 # Custom Swift toolchains
 
 if [[ -n "${TOOLCHAINS-}" ]]; then
@@ -116,7 +100,7 @@ for output_group in "${output_groups[@]}"; do
   fi
 
   filelist="$GENERATOR_TARGET_NAME-${output_group//\//_}"
-  filelist="${filelist/#/$output_path/$GENERATOR_PACKAGE_BIN_DIR/}"
+  filelist="${filelist/#/$BAZEL_OUT/$GENERATOR_PACKAGE_BIN_DIR/}"
   filelist="${filelist/%/.filelist}"
 
   if [[ ! -f "$filelist" ]]; then

--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -112,17 +112,15 @@ if [[ $apply_sanitizers -eq 1 ]]; then
 fi
 readonly build_pre_config_flags
 
-# `bazel_build.sh` sets `output_path` and `indexstores_filelists`
+# `bazel_build.sh` sets `indexstores_filelists`
 source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
 # Create `bazel.lldbinit``
 
-readonly execution_root="${output_path%/*}"
-
 if [[ "$ACTION" != "indexbuild" && "${ENABLE_PREVIEWS:-}" != "YES" ]]; then
   # shellcheck disable=SC2046
   "$BAZEL_INTEGRATION_DIR/create_lldbinit.sh" \
-    "$execution_root" \
+    "$PROJECT_DIR" \
     $(xargs -n1 <<< "${RESOLVED_EXTERNAL_REPOSITORIES:-}") \
     > "$BAZEL_LLDB_INIT"
 fi
@@ -151,7 +149,7 @@ done
 # Import indexes
 if [ -n "${indexstores_filelists:-}" ]; then
   "$BAZEL_INTEGRATION_DIR/import_indexstores.sh" \
-    "$execution_root" \
+    "$PROJECT_DIR" \
     "${indexstores_filelists[@]}" \
     >"$log_dir/import_indexstores.async.log" 2>&1 &
 fi


### PR DESCRIPTION
We have the output path in `$BAZEL_OUT` and the execution root in `$PROJECT_DIR`.