### PR TITLE
Fix horrible BwX `FilePathResolver` performance

### DIFF
--- a/tools/generator/src/FilePathResolver.swift
+++ b/tools/generator/src/FilePathResolver.swift
@@ -1,24 +1,13 @@
 import PathKit
 
-// TODO: Make thread safe if we ever go concurrent
-var memoizedPaths: [MemoizationKey: Path] = [:]
-
-struct MemoizationKey: Equatable, Hashable {
-    let filePath: FilePath
-    let transformedFilePath: FilePath
-    let useBazelOut: Bool?
-    let forceFullBuildSettingPath: Bool
-    let mode: FilePathResolver.Mode
-}
-
-struct FilePathResolver: Equatable, Hashable {
+final class FilePathResolver {
     enum Mode {
         case buildSetting
         case script
         case srcRoot
     }
 
-    struct Directories: Equatable, Hashable {
+    struct Directories: Equatable {
         let workspace: Path
         let workspaceComponents: [String]
         let workspaceOutput: Path
@@ -57,6 +46,17 @@ struct FilePathResolver: Equatable, Hashable {
             }
         }
     }
+
+    struct MemoizationKey: Equatable, Hashable {
+        let filePath: FilePath
+        let transformedFilePath: FilePath
+        let useBazelOut: Bool?
+        let forceFullBuildSettingPath: Bool
+        let mode: FilePathResolver.Mode
+    }
+
+    // TODO: Make thread safe if we ever go concurrent
+    private var memoizedPaths: [MemoizationKey: Path] = [:]
 
     private let directories: Directories
 

--- a/tools/generator/src/FilePathResolver.swift
+++ b/tools/generator/src/FilePathResolver.swift
@@ -4,7 +4,6 @@ import PathKit
 var memoizedPaths: [MemoizationKey: Path] = [:]
 
 struct MemoizationKey: Equatable, Hashable {
-    let resolver: FilePathResolver
     let filePath: FilePath
     let transformedFilePath: FilePath
     let useBazelOut: Bool?
@@ -99,7 +98,6 @@ container:\(workspace + directories.workspaceOutput)
     ) throws -> Path {
         func memoizationKey(_ transformedFilePath: FilePath) -> MemoizationKey {
             return .init(
-                resolver: self,
                 filePath: filePath,
                 transformedFilePath: transformedFilePath,
                 useBazelOut: useBazelOut,

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -489,7 +489,6 @@ final class GeneratorTests: XCTestCase {
             let forceBazelDependencies: Bool
             let indexImport: FilePath
             let files: [FilePath: File]
-            let filePathResolver: FilePathResolver
             let bazelConfig: String
             let generatorLabel: BazelLabel
             let generatorConfiguration: String
@@ -521,7 +520,6 @@ final class GeneratorTests: XCTestCase {
                 forceBazelDependencies: forceBazelDependencies,
                 indexImport: indexImport,
                 files: files,
-                filePathResolver: filePathResolver,
                 bazelConfig: bazelConfig,
                 generatorLabel: generatorLabel,
                 generatorConfiguration: generatorConfiguration,
@@ -539,7 +537,6 @@ final class GeneratorTests: XCTestCase {
                 forceBazelDependencies: project.forceBazelDependencies,
                 indexImport: project.indexImport,
                 files: files,
-                filePathResolver: filePathResolver,
                 bazelConfig: project.bazelConfig,
                 generatorLabel: project.generatorLabel,
                 generatorConfiguration: project.configuration,
@@ -557,7 +554,6 @@ final class GeneratorTests: XCTestCase {
             let buildMode: BuildMode
             let products: Products
             let files: [FilePath: File]
-            let filePathResolver: FilePathResolver
             let bazelDependenciesTarget: PBXAggregateTarget?
         }
 
@@ -577,7 +573,6 @@ final class GeneratorTests: XCTestCase {
                 buildMode: buildMode,
                 products: products,
                 files: files,
-                filePathResolver: filePathResolver,
                 bazelDependenciesTarget: bazelDependenciesTarget
             ))
             return pbxTargets
@@ -589,7 +584,6 @@ final class GeneratorTests: XCTestCase {
             buildMode: buildMode,
             products: products,
             files: files,
-            filePathResolver: filePathResolver,
             bazelDependenciesTarget: bazelDependenciesTarget
         )]
 
@@ -604,7 +598,6 @@ final class GeneratorTests: XCTestCase {
             let hostIDs: [TargetID: [TargetID]]
             let hasBazelDependencies: Bool
             let bazelRemappedFiles: [FilePath: FilePath]
-            let filePathResolver: FilePathResolver
         }
 
         var setTargetConfigurationsCalled: [SetTargetConfigurationsCalled] = []
@@ -627,8 +620,7 @@ final class GeneratorTests: XCTestCase {
                 pbxTargets: pbxTargets,
                 hostIDs: hostIDs,
                 hasBazelDependencies: hasBazelDependencies,
-                bazelRemappedFiles: bazelRemappedFiles,
-                filePathResolver: filePathResolver
+                bazelRemappedFiles: bazelRemappedFiles
             ))
         }
 
@@ -641,8 +633,7 @@ final class GeneratorTests: XCTestCase {
                 pbxTargets: pbxTargets,
                 hostIDs: project.targetHosts,
                 hasBazelDependencies: true,
-                bazelRemappedFiles: bazelRemappedFiles,
-                filePathResolver: filePathResolver
+                bazelRemappedFiles: bazelRemappedFiles
             ),
         ]
 


### PR DESCRIPTION
Fixes #1359.

Regressed with 5febe757f6c771e32b82bf640f3db5b2f65d34ab.

We were hashing `FilePathResolver` as part of `MemoizationKey`, to ensure that if there were multiple versions of `FilePathResolver` then the values wouldn't conflict. That itself isn't much of an issue, except in BwX mode that would include a large `xcodeGeneratedFiles` dictionary. Changing `FilePathResolver` to a class and embedding the memoization into the instance side-steps this issue. In the future `FilePathResolver` will be in Starlark, removing all of this anyway...