### PR TITLE
Fix `local_repository` regression

### DIFF
--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -82,6 +82,7 @@ extension Generator {
     static func createFilesAndGroups(
         in pbxProj: PBXProj,
         buildMode: BuildMode,
+        forFixtures: Bool,
         forceBazelDependencies: Bool,
         targets: [TargetID: Target],
         extraFiles: Set<FilePath>,
@@ -118,7 +119,7 @@ extension Generator {
                 let workspaceDirectoryComponents = directories
                     .workspaceComponents
                 let symlinkComponents = symlinkDest.components
-                if symlinkComponents.starts(
+                if forFixtures && symlinkComponents.starts(
                     with: directories.workspaceComponents
                 ) {
                     let relativeComponents = symlinkComponents.suffix(

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -33,6 +33,7 @@ struct Environment {
     let createFilesAndGroups: (
         _ pbxProj: PBXProj,
         _ buildMode: BuildMode,
+        _ forFixtures: Bool,
         _ forceBazelDependencies: Bool,
         _ targets: [TargetID: Target],
         _ extraFiles: Set<FilePath>,

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -88,6 +88,7 @@ class Generator {
         ) = try environment.createFilesAndGroups(
             pbxProj,
             buildMode,
+            forFixtures,
             project.forceBazelDependencies,
             targets,
             project.extraFiles,

--- a/tools/generator/test/CreateFilesAndGroupsTests.swift
+++ b/tools/generator/test/CreateFilesAndGroupsTests.swift
@@ -65,6 +65,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             buildMode: .xcode,
+            forFixtures: false,
             forceBazelDependencies: false,
             targets: targets,
             extraFiles: extraFiles,
@@ -169,6 +170,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             buildMode: .xcode,
+            forFixtures: false,
             forceBazelDependencies: false,
             targets: targets,
             extraFiles: extraFiles,
@@ -283,6 +285,7 @@ final class CreateFilesAndGroupsTests: XCTestCase {
         ) = try Generator.createFilesAndGroups(
             in: pbxProj,
             buildMode: .bazel,
+            forFixtures: false,
             forceBazelDependencies: false,
             targets: targets,
             extraFiles: extraFiles,

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -340,6 +340,7 @@ final class GeneratorTests: XCTestCase {
         func createFilesAndGroups(
             in pbxProj: PBXProj,
             buildMode: BuildMode,
+            _forFixtures: Bool,
             forceBazelDependencies: Bool,
             targets: [TargetID: Target],
             extraFiles: Set<FilePath>,


### PR DESCRIPTION
Regressed with 5aec77f2831a70164406d461811bedab7a46e6aa.

`.srcRoot` now means Bazel's execution root. So just like `mainGroup`, we need this to be an absolute path all the time now.