### PR TITLE
Exclude `*.framework/Module` from rsync

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -46,12 +46,21 @@ else
       cd "${BAZEL_OUTPUTS_PRODUCT%/*}"
     fi
 
+    # TODO: Create an exclude list for each wrapper type
+    if [[ -n "$exclude_list" ]]; then
+      readonly exclude_flags=(--exclude-from="$exclude_list")
+    else
+      readonly exclude_flags=(
+        --exclude='/*.framework/Modules/***'
+      )
+    fi
+
     rsync \
       --copy-links \
       --recursive \
       --times \
       --delete \
-      ${exclude_list:+--exclude-from="$exclude_list"} \
+      "${exclude_flags[@]}" \
       --chmod=u+w \
       --out-format="%n%L" \
       "$product_basename" \


### PR DESCRIPTION
Xcode messes with these, so reduce the churn.