### PR TITLE
Fix BwB SwiftUI Previews framework symlink error

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -73,6 +73,10 @@ build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=
 
 build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 
+# Allow frameworks to find framework dependencies when running a preview
+# See `$PROJECT_FILE_PATH/rules_xcodeproj/bazel/copy_outputs.sh` for more info
+build:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
+
 # `swiftc` flags needed for SwiftUI Previews
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -73,6 +73,10 @@ build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=
 
 build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 
+# Allow frameworks to find framework dependencies when running a preview
+# See `$PROJECT_FILE_PATH/rules_xcodeproj/bazel/copy_outputs.sh` for more info
+build:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
+
 # `swiftc` flags needed for SwiftUI Previews
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -73,6 +73,10 @@ build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=
 
 build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 
+# Allow frameworks to find framework dependencies when running a preview
+# See `$PROJECT_FILE_PATH/rules_xcodeproj/bazel/copy_outputs.sh` for more info
+build:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
+
 # `swiftc` flags needed for SwiftUI Previews
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -73,6 +73,10 @@ build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=
 
 build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 
+# Allow frameworks to find framework dependencies when running a preview
+# See `$PROJECT_FILE_PATH/rules_xcodeproj/bazel/copy_outputs.sh` for more info
+build:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
+
 # `swiftc` flags needed for SwiftUI Previews
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -73,6 +73,10 @@ build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=
 
 build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 
+# Allow frameworks to find framework dependencies when running a preview
+# See `$PROJECT_FILE_PATH/rules_xcodeproj/bazel/copy_outputs.sh` for more info
+build:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
+
 # `swiftc` flags needed for SwiftUI Previews
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -73,6 +73,10 @@ build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=
 
 build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 
+# Allow frameworks to find framework dependencies when running a preview
+# See `$PROJECT_FILE_PATH/rules_xcodeproj/bazel/copy_outputs.sh` for more info
+build:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
+
 # `swiftc` flags needed for SwiftUI Previews
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -73,6 +73,10 @@ build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=
 
 build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 
+# Allow frameworks to find framework dependencies when running a preview
+# See `$PROJECT_FILE_PATH/rules_xcodeproj/bazel/copy_outputs.sh` for more info
+build:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
+
 # `swiftc` flags needed for SwiftUI Previews
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -73,6 +73,10 @@ build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=
 
 build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 
+# Allow frameworks to find framework dependencies when running a preview
+# See `$PROJECT_FILE_PATH/rules_xcodeproj/bazel/copy_outputs.sh` for more info
+build:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
+
 # `swiftc` flags needed for SwiftUI Previews
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -73,6 +73,10 @@ build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=
 
 build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 
+# Allow frameworks to find framework dependencies when running a preview
+# See `$PROJECT_FILE_PATH/rules_xcodeproj/bazel/copy_outputs.sh` for more info
+build:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
+
 # `swiftc` flags needed for SwiftUI Previews
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -73,6 +73,10 @@ build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=
 
 build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 
+# Allow frameworks to find framework dependencies when running a preview
+# See `$PROJECT_FILE_PATH/rules_xcodeproj/bazel/copy_outputs.sh` for more info
+build:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
+
 # `swiftc` flags needed for SwiftUI Previews
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports

--- a/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_outputs.sh
@@ -52,6 +52,7 @@ else
     else
       readonly exclude_flags=(
         --exclude='/*.framework/Modules/***'
+        --exclude='/*.framework/SwiftUIPreviewsFrameworks/***'
       )
     fi
 
@@ -67,10 +68,15 @@ else
       "$TARGET_BUILD_DIR"
 
     # SwiftUI Previews has a hard time finding frameworks (`@rpath`) when using
-    # framework schemes, so let's symlink them into `$BUILD_DIR`
+    # framework schemes, so let's symlink them into
+    # `$TARGET_BUILD_DIR` (since we modify `@rpath` to always include
+    # `@loader_path/SwiftUIPreviewsFrameworks`)
     if [[ "${ENABLE_PREVIEWS:-}" == "YES" && \
           -n "${PREVIEW_FRAMEWORK_PATHS:-}" ]]; then
-      cd "$BUILD_DIR"
+      mkdir -p "$TARGET_BUILD_DIR/$WRAPPER_NAME/SwiftUIPreviewsFrameworks"
+      cd "$TARGET_BUILD_DIR/$WRAPPER_NAME/SwiftUIPreviewsFrameworks"
+
+      # shellcheck disable=SC2016
       xargs -n1 sh -c 'ln -shfF "$1" $(basename "$1")' _ \
         <<< "$PREVIEW_FRAMEWORK_PATHS"
     fi

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -73,6 +73,10 @@ build:rules_xcodeproj_indexbuild --bes_backend= --bes_results_url=
 
 build:rules_xcodeproj_swiftuipreviews --config=rules_xcodeproj
 
+# Allow frameworks to find framework dependencies when running a preview
+# See `$PROJECT_FILE_PATH/rules_xcodeproj/bazel/copy_outputs.sh` for more info
+build:rules_xcodeproj_swiftuipreviews --linkopt="-Wl,-rpath,@loader_path/SwiftUIPreviewsFrameworks"
+
 # `swiftc` flags needed for SwiftUI Previews
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-implicit-dynamic
 build:rules_xcodeproj_swiftuipreviews --swiftcopt=-Xfrontend --swiftcopt=-enable-private-imports


### PR DESCRIPTION
When multiple frameworks try to symlink their dependency frameworks into `$BUILD_DIR`, `ln` can error out. To work around this we add `@loader_path/SwiftUIPreviewsFrameworks` to the `@rpath` when building for previews, and then create the symlinks at `$TARGET_BUILD_DIR/$WRAPPER_NAME/SwiftUIPreviewsFrameworks`.