### PR TITLE
Allow overriding `--show_result` in command-line API

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,15 +48,15 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
+# in the logs when generating, and all of the many outputs when building
+build:rules_xcodeproj --show_result=0
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
-
-# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
-# in the logs
-build:rules_xcodeproj_generator --show_result=0
 
 ### `--config=rules_xcodeproj_indexbuild`
 #

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,15 +48,15 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
+# in the logs when generating, and all of the many outputs when building
+build:rules_xcodeproj --show_result=0
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
-
-# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
-# in the logs
-build:rules_xcodeproj_generator --show_result=0
 
 ### `--config=rules_xcodeproj_indexbuild`
 #

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,15 +48,15 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
+# in the logs when generating, and all of the many outputs when building
+build:rules_xcodeproj --show_result=0
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
-
-# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
-# in the logs
-build:rules_xcodeproj_generator --show_result=0
 
 ### `--config=rules_xcodeproj_indexbuild`
 #

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,15 +48,15 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
+# in the logs when generating, and all of the many outputs when building
+build:rules_xcodeproj --show_result=0
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
-
-# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
-# in the logs
-build:rules_xcodeproj_generator --show_result=0
 
 ### `--config=rules_xcodeproj_indexbuild`
 #

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,15 +48,15 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
+# in the logs when generating, and all of the many outputs when building
+build:rules_xcodeproj --show_result=0
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
-
-# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
-# in the logs
-build:rules_xcodeproj_generator --show_result=0
 
 ### `--config=rules_xcodeproj_indexbuild`
 #

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,15 +48,15 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
+# in the logs when generating, and all of the many outputs when building
+build:rules_xcodeproj --show_result=0
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
-
-# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
-# in the logs
-build:rules_xcodeproj_generator --show_result=0
 
 ### `--config=rules_xcodeproj_indexbuild`
 #

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,15 +48,15 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
+# in the logs when generating, and all of the many outputs when building
+build:rules_xcodeproj --show_result=0
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
-
-# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
-# in the logs
-build:rules_xcodeproj_generator --show_result=0
 
 ### `--config=rules_xcodeproj_indexbuild`
 #

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,15 +48,15 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
+# in the logs when generating, and all of the many outputs when building
+build:rules_xcodeproj --show_result=0
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
-
-# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
-# in the logs
-build:rules_xcodeproj_generator --show_result=0
 
 ### `--config=rules_xcodeproj_indexbuild`
 #

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,15 +48,15 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
+# in the logs when generating, and all of the many outputs when building
+build:rules_xcodeproj --show_result=0
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
-
-# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
-# in the logs
-build:rules_xcodeproj_generator --show_result=0
 
 ### `--config=rules_xcodeproj_indexbuild`
 #

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,15 +48,15 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
+# in the logs when generating, and all of the many outputs when building
+build:rules_xcodeproj --show_result=0
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
-
-# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
-# in the logs
-build:rules_xcodeproj_generator --show_result=0
 
 ### `--config=rules_xcodeproj_indexbuild`
 #

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -62,9 +62,6 @@ readonly base_pre_config_flags=(
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
-
-  # Prevent filelist outputs from displaying in the logs
-  --show_result=0
 )
 
 # Custom Swift toolchains

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -152,11 +152,13 @@ else
     )
 
     # `--output_groups`
-    post_config_flags+=(
-      --show_result=0
+    post_config_flags=(
       --output_groups="$generator_output_groups"
+      "${cmd_args[@]:1}"
       "%generator_label%"
     )
+  else
+    post_config_flags=("${cmd_args[@]:1}")
   fi
 
   if [[ $verbose -eq 1 ]]; then

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -48,15 +48,15 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
+# in the logs when generating, and all of the many outputs when building
+build:rules_xcodeproj --show_result=0
+
 ### `--config=rules_xcodeproj_generator`
 #
 # Used when generating a project.
 
 build:rules_xcodeproj_generator --config=rules_xcodeproj
-
-# `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
-# in the logs
-build:rules_xcodeproj_generator --show_result=0
 
 ### `--config=rules_xcodeproj_indexbuild`
 #


### PR DESCRIPTION
Also fix use of `--` in the bazel command (e.g. `bazel run --config=cache //:xcodeproj -- --generator_output_groups=all_targets 'build --show_result=1 --'` now works).