### PR TITLE
Move "should include outputs in DTO" decision up to the `xcodeproj` rule

### DIFF
--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -23,7 +23,6 @@ load(
     "process_modulemaps",
     "process_swiftmodules",
     "should_bundle_resources",
-    "should_include_outputs",
     "should_include_outputs_output_groups",
 )
 load(":xcode_targets.bzl", "xcode_targets")
@@ -131,7 +130,6 @@ def process_library_target(
         id = id,
         swift_info = swift_info,
         transitive_infos = transitive_infos,
-        should_produce_dto = should_include_outputs(ctx = ctx),
         should_produce_output_groups = should_include_outputs_output_groups(
             ctx = ctx,
         ),

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -240,7 +240,7 @@ def _collect_output_files(
         bwx_infoplist = None,
         bwb_infoplist = None,
         transitive_infos,
-        should_produce_dto,
+        should_produce_dto = True,
         should_produce_output_groups):
     """Collects the outputs of a target.
 

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -18,19 +18,6 @@ def should_bundle_resources(ctx):
     """
     return ctx.attr._build_mode[BuildSettingInfo].value != "bazel"
 
-def should_include_outputs(ctx):
-    """Determines whether outputs should be included in the generated project.
-
-    Args:
-        ctx: The aspect context.
-
-    Returns:
-        `True` if outputs should be included, `False` otherwise. This will be
-        `True` if the generator can use the output files (e.g. not Build with
-        Bazel via Proxy).
-    """
-    return ctx.attr._build_mode[BuildSettingInfo].value != "bazel_via_proxy"
-
 def should_include_outputs_output_groups(ctx):
     """Determines whether outputs output groups should be created.
 

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -32,7 +32,6 @@ load(
     "process_modulemaps",
     "process_swiftmodules",
     "should_bundle_resources",
-    "should_include_outputs",
     "should_include_outputs_output_groups",
 )
 load(":target_search_paths.bzl", "target_search_paths")
@@ -411,7 +410,6 @@ def process_top_level_target(
         bwx_infoplist = bwx_infoplist,
         bwb_infoplist = bwb_infoplist,
         transitive_infos = transitive_infos,
-        should_produce_dto = should_include_outputs(ctx = ctx),
         should_produce_output_groups = should_include_outputs_output_groups(
             ctx = ctx,
         ),

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -270,6 +270,7 @@ def _xcode_target_to_dto(
         build_mode,
         include_lldb_context,
         is_unfocused_dependency = False,
+        should_include_outputs,
         unfocused_targets = {},
         target_merges = {}):
     inputs = xcode_target.inputs
@@ -369,7 +370,9 @@ def _xcode_target_to_dto(
             if id not in unfocused_targets
         ],
     )
-    set_if_true(dto, "outputs", _outputs_to_dto(xcode_target.outputs))
+
+    if should_include_outputs:
+        set_if_true(dto, "outputs", _outputs_to_dto(xcode_target.outputs))
 
     if build_mode == "xcode":
         infoplist = xcode_target.outputs.bwx_infoplist

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -538,6 +538,7 @@ actual targets: {}
             build_mode = build_mode,
             include_lldb_context = include_lldb_context,
             is_unfocused_dependency = xcode_target.id in unfocused_dependencies,
+            should_include_outputs = should_include_outputs(build_mode),
             unfocused_targets = unfocused_targets,
             target_merges = target_merges,
         )
@@ -617,6 +618,9 @@ actual targets: {}
         linker_products_flattened_map,
         replacement_labels_by_label,
     )
+
+def should_include_outputs(build_mode):
+    return build_mode != "bazel_via_proxy"
 
 # Actions
 


### PR DESCRIPTION
This removes another use of the `//xcodeproj/internal:build_mode` build setting.