### PR TITLE
Move "should include BwB output groups" decision up to the `xcodeproj` rule

### DIFF
--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -23,7 +23,6 @@ load(
     "process_modulemaps",
     "process_swiftmodules",
     "should_bundle_resources",
-    "should_include_outputs_output_groups",
 )
 load(":xcode_targets.bzl", "xcode_targets")
 
@@ -130,9 +129,6 @@ def process_library_target(
         id = id,
         swift_info = swift_info,
         transitive_infos = transitive_infos,
-        should_produce_output_groups = should_include_outputs_output_groups(
-            ctx = ctx,
-        ),
     )
 
     process_defines(

--- a/xcodeproj/internal/output_files.bzl
+++ b/xcodeproj/internal/output_files.bzl
@@ -241,7 +241,7 @@ def _collect_output_files(
         bwb_infoplist = None,
         transitive_infos,
         should_produce_dto = True,
-        should_produce_output_groups):
+        should_produce_output_groups = True):
     """Collects the outputs of a target.
 
     Args:

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -18,18 +18,6 @@ def should_bundle_resources(ctx):
     """
     return ctx.attr._build_mode[BuildSettingInfo].value != "bazel"
 
-def should_include_outputs_output_groups(ctx):
-    """Determines whether outputs output groups should be created.
-
-    Args:
-        ctx: The aspect context.
-
-    Returns:
-        `True` if outputs should be included, `False` otherwise. This will be
-        `True` for modes that build primarily with Bazel.
-    """
-    return ctx.attr._build_mode[BuildSettingInfo].value != "xcode"
-
 def should_include_non_xcode_outputs(ctx):
     """Determines whether outputs of non Xcode targets should be included in \
     output groups.

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -32,7 +32,6 @@ load(
     "process_modulemaps",
     "process_swiftmodules",
     "should_bundle_resources",
-    "should_include_outputs_output_groups",
 )
 load(":target_search_paths.bzl", "target_search_paths")
 load(":xcode_targets.bzl", "xcode_targets")
@@ -410,9 +409,6 @@ def process_top_level_target(
         bwx_infoplist = bwx_infoplist,
         bwb_infoplist = bwb_infoplist,
         transitive_infos = transitive_infos,
-        should_produce_output_groups = should_include_outputs_output_groups(
-            ctx = ctx,
-        ),
     )
 
     if not inputs.srcs:

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -1132,26 +1132,27 @@ def _xcodeproj_impl(ctx):
         xcodeproj = xcodeproj,
     )
 
-    input_files_output_groups = input_files.to_output_groups_fields(
-        ctx = ctx,
-        inputs = inputs,
-        additional_generated = additional_generated,
-        index_import = ctx.executable._index_import,
-    )
-    output_files_output_groups = output_files.to_output_groups_fields(
-        ctx = ctx,
-        outputs = outputs,
-        additional_outputs = additional_outputs,
-        index_import = ctx.executable._index_import,
-    )
-
     if build_mode == "xcode":
+        input_files_output_groups = input_files.to_output_groups_fields(
+            ctx = ctx,
+            inputs = inputs,
+            additional_generated = additional_generated,
+            index_import = ctx.executable._index_import,
+        )
+        output_files_output_groups = {}
         all_targets_files = [
             input_files_output_groups["all_xc"],
             input_files_output_groups["all_xi"],
             input_files_output_groups["all_xl"],
         ]
     else:
+        input_files_output_groups = {}
+        output_files_output_groups = output_files.to_output_groups_fields(
+            ctx = ctx,
+            outputs = outputs,
+            additional_outputs = additional_outputs,
+            index_import = ctx.executable._index_import,
+        )
         all_targets_files = [output_files_output_groups["all_b"]]
 
     return [


### PR DESCRIPTION
This removes another use of the `//xcodeproj/internal:build_mode` build setting.