### PR TITLE
Short-circuit some `XcodeProjInfo` creation

### DIFF
--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -77,12 +77,12 @@
         }
     ],
     "extra_files": [
-        "AppClip/BUILD",
         {
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
             "t": "e"
         },
         "Lib/BUILD",
+        "AppClip/BUILD",
         "iOSApp/BUILD",
         "AppClip/Entitlements.entitlements",
         "AppClip/Info.plist",
@@ -140,7 +140,6 @@
         "WidgetExtension/Assets.xcassets",
         "iOSApp/Source/CoreUtilsObjC/Info.plist",
         "UI/Info.plist",
-        "watchOSApp/BUILD",
         {
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
             "t": "e"
@@ -153,6 +152,7 @@
             "t": "g"
         },
         "watchOSAppExtension/Assets.xcassets",
+        "watchOSApp/BUILD",
         "watchOSApp/Info.plist",
         {
             "_": "applebin_watchos-watchos_x86_64-dbg-ST-826cd41ea091/bin/watchOSApp/Info.withbundleid.plist",
@@ -218,8 +218,8 @@
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
             "t": "e"
         },
-        "tvOSApp/Resources/BUILD",
         "tvOSApp/Source/BUILD",
+        "tvOSApp/Resources/BUILD",
         "tvOSApp/Source/Info.plist",
         "tvOSApp/Resources/PreviewContent/Preview Assets.xcassets",
         "tvOSApp/Resources/Assets.xcassets",
@@ -259,9 +259,9 @@
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-56c91ad57eeb/bin/iOSApp/Test/TestingUtils/TestingUtils.swift.modulemap",
             "t": "g"
         },
-        "macOSApp/Source/BUILD",
         "macOSApp/third_party/BUILD",
         "macOSApp/third_party/ExampleFramework.framework",
+        "macOSApp/Source/BUILD",
         "macOSApp/Source/Info.plist",
         "macOSApp/Source/PreviewContent/Preview Assets.xcassets",
         "macOSApp/Source/Assets.xcassets",

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -77,12 +77,12 @@
         }
     ],
     "extra_files": [
-        "AppClip/BUILD",
         {
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
             "t": "e"
         },
         "Lib/BUILD",
+        "AppClip/BUILD",
         "iOSApp/BUILD",
         "AppClip/Entitlements.entitlements",
         "AppClip/Info.plist",
@@ -137,7 +137,6 @@
         "iOSApp/Source/CoreUtilsObjC/Info.plist",
         "Lib/Info.plist",
         "UI/Info.plist",
-        "watchOSApp/BUILD",
         {
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
             "t": "e"
@@ -148,6 +147,7 @@
             "_": "applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/Info.withbundleid.plist",
             "t": "g"
         },
+        "watchOSApp/BUILD",
         "watchOSApp/Info.plist",
         {
             "_": "applebin_watchos-watchos_x86_64-dbg-ST-8330f5878aa5/bin/watchOSApp/Info.withbundleid.plist",
@@ -166,8 +166,8 @@
             "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
             "t": "e"
         },
-        "tvOSApp/Resources/BUILD",
         "tvOSApp/Source/BUILD",
+        "tvOSApp/Resources/BUILD",
         "tvOSApp/Source/Info.plist",
         "iOSApp/Resources/OnlyStructuredResources/BUILD",
         "iOSApp/Resources/OnlyStructuredResources/Info.plist",
@@ -197,9 +197,9 @@
             "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/TestingUtils.swift.modulemap",
             "t": "g"
         },
-        "macOSApp/Source/BUILD",
         "macOSApp/third_party/BUILD",
         "macOSApp/third_party/ExampleFramework.framework",
+        "macOSApp/Source/BUILD",
         "macOSApp/Source/Info.plist",
         "macOSApp/Test/UITests/BUILD",
         "tvOSApp/Test/UITests/BUILD",

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -359,6 +359,7 @@ def process_top_level_target(
         dep[XcodeProjInfo]
         for attr in automatic_target_info.deps
         for dep in getattr(ctx.rule.attr, attr, [])
+        if XcodeProjInfo in dep
     ]
 
     compilation_providers = comp_providers.merge(

--- a/xcodeproj/internal/xcodeproj_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_aspect.bzl
@@ -54,18 +54,18 @@ def _xcodeproj_aspect_impl(target, ctx):
     if XcodeProjInfo not in target:
         # Only create an `XcodeProjInfo` if the target hasn't already created
         # one
-        providers.append(
-            create_xcodeprojinfo(
+        info = create_xcodeprojinfo(
+            ctx = ctx,
+            target = target,
+            transitive_infos = _transitive_infos(
                 ctx = ctx,
-                target = target,
-                transitive_infos = _transitive_infos(
-                    ctx = ctx,
-                    automatic_target_info = (
-                        target[XcodeProjAutomaticTargetProcessingInfo]
-                    ),
+                automatic_target_info = (
+                    target[XcodeProjAutomaticTargetProcessingInfo]
                 ),
             ),
         )
+        if info:
+            providers.append(info)
 
     if XcodeProjProvisioningProfileInfo not in target:
         # Only create an `XcodeProjProvisioningProfileInfo` if the target hasn't


### PR DESCRIPTION
For targets that will always be private dependencies, and thus will be culled out later, we can detect some of them and don less work.