### PR TITLE
Remove `xcodeproj_aspect` dependency on `//xcodeproj/internal:build_mode`

### DIFF
--- a/xcodeproj/internal/fixtures.bzl
+++ b/xcodeproj/internal/fixtures.bzl
@@ -130,7 +130,13 @@ def validate_fixtures(**kwargs):
         **kwargs
     )
 
-_fixture_xcodeproj = make_xcodeproj_rule(
+_bwx_fixture_xcodeproj = make_xcodeproj_rule(
+    build_mode = "xcode",
+    is_fixture = True,
+    xcodeproj_transition = _fixtures_transition,
+)
+_bwb_fixture_xcodeproj = make_xcodeproj_rule(
+    build_mode = "bazel",
     is_fixture = True,
     xcodeproj_transition = _fixtures_transition,
 )
@@ -191,6 +197,11 @@ def xcodeproj_fixture(
             visibility = ["//test:__subpackages__"],
         )
 
+        if mode == "bazel":
+            xcodeproj_rule = _bwb_fixture_xcodeproj
+        else:
+            xcodeproj_rule = _bwx_fixture_xcodeproj
+
         xcodeproj(
             name = fixture_name,
             associated_extra_files = associated_extra_files,
@@ -206,7 +217,7 @@ def xcodeproj_fixture(
             scheme_autogeneration_mode = scheme_autogeneration_mode,
             schemes = schemes,
             unfocused_targets = unfocused_targets,
-            xcodeproj_rule = _fixture_xcodeproj,
+            xcodeproj_rule = xcodeproj_rule,
             visibility = ["//test:__subpackages__"],
         )
 

--- a/xcodeproj/internal/target_properties.bzl
+++ b/xcodeproj/internal/target_properties.bzl
@@ -1,6 +1,5 @@
 """Functions for processing target properties"""
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":collections.bzl", "set_if_true", "uniq")
 load(
     ":files.bzl",
@@ -16,7 +15,7 @@ def should_bundle_resources(ctx):
     Returns:
         `True` if resources should be bundled, `False` otherwise.
     """
-    return ctx.attr._build_mode[BuildSettingInfo].value != "bazel"
+    return ctx.attr._build_mode != "bazel"
 
 def should_include_non_xcode_outputs(ctx):
     """Determines whether outputs of non Xcode targets should be included in \
@@ -29,7 +28,7 @@ def should_include_non_xcode_outputs(ctx):
         `True` if the outputs should be included, `False` otherwise. This will
         be `True` for modes that build primarily with Xcode.
     """
-    return ctx.attr._build_mode[BuildSettingInfo].value == "xcode"
+    return ctx.attr._build_mode == "xcode"
 
 def process_dependencies(*, automatic_target_info, transitive_infos):
     """Logic for processing target dependencies.

--- a/xcodeproj/internal/xcodeproj_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_aspect.bzl
@@ -1,6 +1,5 @@
 """Implementation of the `xcodeproj_aspect` aspect."""
 
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "use_cpp_toolchain")
 load(
     ":default_automatic_target_processing_aspect.bzl",
@@ -76,25 +75,23 @@ def _xcodeproj_aspect_impl(target, ctx):
 
     return providers
 
-xcodeproj_aspect = aspect(
-    implementation = _xcodeproj_aspect_impl,
-    attr_aspects = ["*"],
-    attrs = {
-        "_build_mode": attr.label(
-            default = Label("//xcodeproj/internal:build_mode"),
-            providers = [BuildSettingInfo],
-        ),
-        "_cc_toolchain": attr.label(default = Label(
-            "@bazel_tools//tools/cpp:current_cc_toolchain",
-        )),
-        "_xcode_config": attr.label(
-            default = configuration_field(
-                name = "xcode_config_label",
-                fragment = "apple",
+def make_xcodeproj_aspect(*, build_mode):
+    return aspect(
+        implementation = _xcodeproj_aspect_impl,
+        attr_aspects = ["*"],
+        attrs = {
+            "_build_mode": attr.string(default = build_mode),
+            "_cc_toolchain": attr.label(default = Label(
+                "@bazel_tools//tools/cpp:current_cc_toolchain",
+            )),
+            "_xcode_config": attr.label(
+                default = configuration_field(
+                    name = "xcode_config_label",
+                    fragment = "apple",
+                ),
             ),
-        ),
-    },
-    fragments = ["apple", "cpp", "objc"],
-    requires = [default_automatic_target_processing_aspect],
-    toolchains = use_cpp_toolchain(),
-)
+        },
+        fragments = ["apple", "cpp", "objc"],
+        requires = [default_automatic_target_processing_aspect],
+        toolchains = use_cpp_toolchain(),
+    )

--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -5,7 +5,7 @@ load(":bazel_labels.bzl", "bazel_labels")
 load(":logging.bzl", "warn")
 load(":top_level_target.bzl", "top_level_target")
 load(":xcode_schemes.bzl", "focus_schemes", "unfocus_schemes")
-load(":xcodeproj_rule.bzl", _xcodeproj = "xcodeproj")
+load(":xcodeproj_rule.bzl", "bwb_xcodeproj", "bwx_xcodeproj")
 load(":xcodeproj_runner.bzl", "xcodeproj_runner")
 
 def xcodeproj(
@@ -283,7 +283,12 @@ in your `.bazelrc` or `xcodeproj.bazelrc` file.""")
 
     generator_name = "{}.generator".format(name)
 
-    xcodeproj_rule = kwargs.pop("xcodeproj_rule", _xcodeproj)
+    xcodeproj_rule = kwargs.pop("xcodeproj_rule", None)
+    if not xcodeproj_rule:
+        if build_mode == "bazel":
+            xcodeproj_rule = bwb_xcodeproj
+        else:
+            xcodeproj_rule = bwx_xcodeproj
 
     tags = kwargs.pop("tags", [])
 

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -21,7 +21,7 @@ load(":platform.bzl", "platform_info")
 load(":providers.bzl", "XcodeProjInfo")
 load(":resource_target.bzl", "process_resource_bundles")
 load(":xcode_targets.bzl", "xcode_targets")
-load(":xcodeproj_aspect.bzl", "xcodeproj_aspect")
+load(":xcodeproj_aspect.bzl", "make_xcodeproj_aspect")
 
 # Utility
 
@@ -1177,7 +1177,20 @@ def _xcodeproj_impl(ctx):
         ),
     ]
 
-def make_xcodeproj_rule(*, is_fixture = False, xcodeproj_transition = None):
+bwx_xcodeproj_aspect = make_xcodeproj_aspect(build_mode = "xcode")
+bwb_xcodeproj_aspect = make_xcodeproj_aspect(build_mode = "bazel")
+
+# buildifier: disable=function-docstring
+def make_xcodeproj_rule(
+        *,
+        build_mode,
+        is_fixture = False,
+        xcodeproj_transition = None):
+    if build_mode == "bazel":
+        xcodeproj_aspect = bwb_xcodeproj_aspect
+    else:
+        xcodeproj_aspect = bwx_xcodeproj_aspect
+
     attrs = {
         "adjust_schemes_for_swiftui_previews": attr.bool(
             default = False,
@@ -1448,4 +1461,5 @@ transitive dependencies of the targets specified in the
         executable = True,
     )
 
-xcodeproj = make_xcodeproj_rule()
+bwx_xcodeproj = make_xcodeproj_rule(build_mode = "xcode")
+bwb_xcodeproj = make_xcodeproj_rule(build_mode = "bazel")


### PR DESCRIPTION
We get around this by creating two versions of the aspect, and two versions of `xcodeproj` rules (two use the different versions of the aspect). I'm choosing to do it this way , because some things are much more optimal being done at the aspect level instead of at the final rule level (e.g. unfocused Xcode targets require additional work in BwX mode that we don't do in BwB mode).