### PR TITLE
Remove unused swift outputs from spec.json

### DIFF
--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -742,16 +742,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -936,16 +928,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1403,20 +1387,12 @@
             "name": "lib_swift",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftdoc",
-                        "t": "g"
-                    },
                     "h": {
                         "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/private/LibSwift-Swift.h",
                         "t": "g"
                     },
                     "m": {
                         "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1560,16 +1536,8 @@
             "name": "private_swift_lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1809,16 +1777,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2738,16 +2698,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2822,16 +2774,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2906,16 +2850,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2990,16 +2926,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -3074,16 +3002,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -3158,16 +3078,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -3843,16 +3755,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -4043,16 +3947,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -4243,16 +4139,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -4443,16 +4331,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -4643,16 +4523,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -4843,16 +4715,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -5045,16 +4909,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -5238,16 +5094,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -5486,16 +5334,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -5788,20 +5628,12 @@
             "name": "MixedAnswerLib_Swift",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftdoc",
-                        "t": "g"
-                    },
                     "h": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
                         "t": "g"
                     },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -5857,20 +5689,12 @@
             "name": "MixedAnswerLib_Swift",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftdoc",
-                        "t": "g"
-                    },
                     "h": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
                         "t": "g"
                     },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -6624,16 +6448,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/iOSApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/iOSApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/iOSApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -7014,16 +6830,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/iOSApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/iOSApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/iOSApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -7843,16 +7651,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -7970,20 +7770,12 @@
             "name": "TestingUtils",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/TestingUtils.swiftdoc",
-                        "t": "g"
-                    },
                     "h": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/SwiftAPI/TestingUtils-Swift.h",
                         "t": "g"
                     },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/TestingUtils.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/TestingUtils.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -8100,16 +7892,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Source/macOSApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Source/macOSApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Source/macOSApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -8227,16 +8011,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Test/UITests/macOSAppUITests.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Test/UITests/macOSAppUITests.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Test/UITests/macOSAppUITests.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -8437,16 +8213,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/tvOSApp/Source/tvOSApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/tvOSApp/Source/tvOSApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/tvOSApp/Source/tvOSApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -8669,16 +8437,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Source/tvOSApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Source/tvOSApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Source/tvOSApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -8821,16 +8581,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UITests/tvOSAppUITests.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UITests/tvOSAppUITests.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UITests/tvOSAppUITests.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -9057,16 +8809,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -9213,16 +8957,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSApp/Test/UITests/watchOSAppUITestsLibrary.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSApp/Test/UITests/watchOSAppUITestsLibrary.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSApp/Test/UITests/watchOSAppUITestsLibrary.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -9551,16 +9287,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTestsLibrary.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTestsLibrary.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTestsLibrary.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -9785,16 +9513,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/watchOSAppExtension/watchOSAppExtension.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/watchOSAppExtension/watchOSAppExtension.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -10018,16 +9738,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/watchOSAppExtension.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/watchOSAppExtension.swiftsourceinfo",
                         "t": "g"
                     }
                 }

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -458,16 +458,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -606,16 +598,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1021,20 +1005,12 @@
             "name": "lib_swift",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftdoc",
-                        "t": "g"
-                    },
                     "h": {
                         "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/private/LibSwift-Swift.h",
                         "t": "g"
                     },
                     "m": {
                         "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1178,16 +1154,8 @@
             "name": "private_swift_lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1348,16 +1316,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2139,16 +2099,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2223,16 +2175,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2307,16 +2251,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2391,16 +2327,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2475,16 +2403,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2559,16 +2479,8 @@
             "name": "Lib",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -3310,16 +3222,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -3460,16 +3364,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -3606,16 +3502,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -3752,16 +3640,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -3898,16 +3778,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -4044,16 +3916,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/UI/UI.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/UI/UI.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/UI/UI.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -4199,16 +4063,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -4345,16 +4201,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -4551,16 +4399,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -5097,20 +4937,12 @@
             "name": "MixedAnswerLib_Swift",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftdoc",
-                        "t": "g"
-                    },
                     "h": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
                         "t": "g"
                     },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -5166,20 +4998,12 @@
             "name": "MixedAnswerLib_Swift",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftdoc",
-                        "t": "g"
-                    },
                     "h": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
                         "t": "g"
                     },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -5837,16 +5661,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/iOSApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/iOSApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/iOSApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -6137,16 +5953,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/iOSApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/iOSApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/iOSApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -6682,16 +6490,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -6809,20 +6609,12 @@
             "name": "TestingUtils",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/TestingUtils.swiftdoc",
-                        "t": "g"
-                    },
                     "h": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/SwiftAPI/TestingUtils-Swift.h",
                         "t": "g"
                     },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/TestingUtils.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/TestingUtils.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -6920,16 +6712,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Source/macOSApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Source/macOSApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Source/macOSApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -7027,16 +6811,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Test/UITests/macOSAppUITests.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Test/UITests/macOSAppUITests.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Test/UITests/macOSAppUITests.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -7165,16 +6941,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/tvOSApp/Source/tvOSApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/tvOSApp/Source/tvOSApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/tvOSApp/Source/tvOSApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -7325,16 +7093,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Source/tvOSApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Source/tvOSApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Source/tvOSApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -7455,16 +7215,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UITests/tvOSAppUITests.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UITests/tvOSAppUITests.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UITests/tvOSAppUITests.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -7593,16 +7345,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -7728,16 +7472,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSApp/Test/UITests/watchOSAppUITestsLibrary.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSApp/Test/UITests/watchOSAppUITestsLibrary.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSApp/Test/UITests/watchOSAppUITestsLibrary.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -7990,16 +7726,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTestsLibrary.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTestsLibrary.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTestsLibrary.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -8151,16 +7879,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/watchOSAppExtension/watchOSAppExtension.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/watchOSAppExtension/watchOSAppExtension.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -8311,16 +8031,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/watchOSAppExtension.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/watchOSAppExtension/watchOSAppExtension.swiftsourceinfo",
                         "t": "g"
                     }
                 }

--- a/examples/sanitizers/test/fixtures/bwb_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_spec.json
@@ -170,16 +170,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -288,16 +280,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/ThreadSanitizerApp/ThreadSanitizerApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/ThreadSanitizerApp/ThreadSanitizerApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/ThreadSanitizerApp/ThreadSanitizerApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }

--- a/examples/sanitizers/test/fixtures/bwx_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_spec.json
@@ -153,16 +153,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/AddressSanitizerApp/AddressSanitizerApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -254,16 +246,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/ThreadSanitizerApp/ThreadSanitizerApp.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/ThreadSanitizerApp/ThreadSanitizerApp.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-7aac51e4b353/bin/ThreadSanitizerApp/ThreadSanitizerApp.swiftsourceinfo",
                         "t": "g"
                     }
                 }

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -530,16 +530,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/test/tests.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/test/tests.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/test/tests.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -967,16 +959,8 @@
             "name": "generator.library",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/generator.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/generator.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/generator.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1091,16 +1075,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/swiftc_stub/tools_swiftc_stub_swiftc_stub_library.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/swiftc_stub/tools_swiftc_stub_swiftc_stub_library.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/swiftc_stub/tools_swiftc_stub_swiftc_stub_library.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1360,16 +1336,8 @@
             "name": "OrderedCollections",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1428,16 +1396,8 @@
             "name": "PathKit",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/PathKit.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/PathKit.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1664,16 +1624,8 @@
             "name": "ZippyJSON",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1962,16 +1914,8 @@
             "name": "CustomDump",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2036,16 +1980,8 @@
             "name": "XCTestDynamicOverlay",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2483,16 +2419,8 @@
             "name": "XcodeProj",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftsourceinfo",
                         "t": "g"
                     }
                 }

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -529,16 +529,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/test/tests.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/test/tests.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/test/tests.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -965,16 +957,8 @@
             "name": "generator.library",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/generator.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/generator.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/generator.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1088,16 +1072,8 @@
             "outputs": {
                 "p": true,
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/swiftc_stub/tools_swiftc_stub_swiftc_stub_library.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/swiftc_stub/tools_swiftc_stub_swiftc_stub_library.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/swiftc_stub/tools_swiftc_stub_swiftc_stub_library.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1357,16 +1333,8 @@
             "name": "OrderedCollections",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1425,16 +1393,8 @@
             "name": "PathKit",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/PathKit.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/PathKit.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1661,16 +1621,8 @@
             "name": "ZippyJSON",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -1959,16 +1911,8 @@
             "name": "CustomDump",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2033,16 +1977,8 @@
             "name": "XCTestDynamicOverlay",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftsourceinfo",
                         "t": "g"
                     }
                 }
@@ -2480,16 +2416,8 @@
             "name": "XcodeProj",
             "outputs": {
                 "s": {
-                    "d": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftdoc",
-                        "t": "g"
-                    },
                     "m": {
                         "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
-                        "t": "g"
-                    },
-                    "s": {
-                        "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftsourceinfo",
                         "t": "g"
                     }
                 }

--- a/tools/generator/src/DTO/Outputs.swift
+++ b/tools/generator/src/DTO/Outputs.swift
@@ -1,28 +1,19 @@
 struct Outputs: Equatable {
     struct Swift: Equatable {
         let module: FilePath
-        let doc: FilePath
-        let sourceInfo: FilePath?
-        let interface: FilePath?
         let generatedHeader: FilePath?
 
         init(
             module: FilePath,
-            doc: FilePath,
-            sourceInfo: FilePath? = nil,
-            interface: FilePath? = nil,
             generatedHeader: FilePath? = nil
         ) {
             self.module = module
-            self.doc = doc
-            self.sourceInfo = sourceInfo
-            self.interface = interface
             self.generatedHeader = generatedHeader
         }
     }
 
-    let hasProductOutput: Bool
     var swift: Swift?
+    let hasProductOutput: Bool
 
     init(hasProductOutput: Bool = false, swift: Swift? = nil) {
         self.hasProductOutput = hasProductOutput
@@ -70,9 +61,6 @@ extension Outputs: Decodable {
 extension Outputs.Swift: Decodable {
     enum CodingKeys: String, CodingKey {
         case module = "m"
-        case doc = "d"
-        case sourceinfo = "s"
-        case interface = "i"
         case generatedHeader = "h"
     }
 
@@ -80,15 +68,6 @@ extension Outputs.Swift: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         module = try container.decode(FilePath.self, forKey: .module)
-        doc = try container.decode(FilePath.self, forKey: .doc)
-        sourceInfo = try container.decodeIfPresent(
-            FilePath.self,
-            forKey: .sourceinfo
-        )
-        interface = try container.decodeIfPresent(
-            FilePath.self,
-            forKey: .interface
-        )
         generatedHeader = try container.decodeIfPresent(
             FilePath.self,
             forKey: .generatedHeader

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -81,8 +81,6 @@ enum Fixtures {
             outputs: .init(
                 swift: .init(
                     module: .generated("x/y.swiftmodule"),
-                    doc: .generated("x/y.swiftdoc"),
-                    sourceInfo: .generated("x/y.swiftsourceinfo"),
                     generatedHeader: .generated("x/y-Swift.h")
                 )
             )
@@ -127,9 +125,7 @@ enum Fixtures {
             dependencies: ["C 1", "A 1", "R 1"],
             outputs: .init(
                 swift: .init(
-                    module: .generated("x/A.swiftmodule"),
-                    doc: .generated("x/A.swiftdoc"),
-                    sourceInfo: .generated("x/A.swiftsourceinfo")
+                    module: .generated("x/A.swiftmodule")
                 )
             )
         ),
@@ -231,9 +227,7 @@ enum Fixtures {
             inputs: .init(srcs: [.external("a_repo/a.swift")]),
             outputs: .init(
               swift: .init(
-                  module: .generated("x/E.swiftmodule"),
-                  doc: .generated("x/E.swiftdoc"),
-                  sourceInfo: .generated("x/E.swiftsourceinfo")
+                  module: .generated("x/E.swiftmodule")
               )
             )
         ),

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -728,12 +728,7 @@ def _swift_to_dto(swift):
     module = swift.module
     dto = {
         "m": file_path_to_dto(file_path(module.swiftmodule)),
-        "s": file_path_to_dto(file_path(module.swiftsourceinfo)),
-        "d": file_path_to_dto(file_path(module.swiftdoc)),
     }
-
-    if module.swiftinterface:
-        dto["i"] = file_path_to_dto(file_path(module.swiftinterface))
 
     if swift.generated_header:
         dto["h"] = file_path_to_dto(file_path(swift.generated_header))


### PR DESCRIPTION
Only the module and generated header paths are needed by the generator.