### PR TITLE
Set `PREVIEW_FRAMEWORK_PATHS` in Starlark

### DIFF
--- a/examples/cc/test/fixtures/bwb_spec.json
+++ b/examples/cc/test/fixtures/bwb_spec.json
@@ -28,7 +28,6 @@
     "force_bazel_dependencies": false,
     "generator_label": "//test/fixtures:xcodeproj_bwb.generator",
     "index_import": "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import",
-    "linker_products_map": [],
     "name": "bwb",
     "post_build_script": null,
     "pre_build_script": null,

--- a/examples/cc/test/fixtures/bwx_spec.json
+++ b/examples/cc/test/fixtures/bwx_spec.json
@@ -28,7 +28,6 @@
     "force_bazel_dependencies": false,
     "generator_label": "//test/fixtures:xcodeproj_bwx.generator",
     "index_import": "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import",
-    "linker_products_map": [],
     "name": "bwx",
     "post_build_script": null,
     "pre_build_script": null,

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -392,168 +392,6 @@
     "force_bazel_dependencies": true,
     "generator_label": "//test/fixtures:xcodeproj_bwb.generator",
     "index_import": "$(BAZEL_OUT)/darwin_x86_64-opt-exec-BDE7E609-ST-87fb5cb17941/bin/external/rules_xcodeproj_index_import/index-import",
-    "linker_products_map": [
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/frameworks/LibFramework.iOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/LibFramework.iOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/UI/frameworks/UIFramework.iOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/UI/UIFramework.iOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/frameworks/LibFramework.watchOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/LibFramework.watchOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/UI/frameworks/UIFramework.watchOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/UI/UIFramework.watchOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/dist/dynamic/frameworks/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/dist/dynamic/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/dist/dynamic/frameworks/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/dist/dynamic/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/dist/dynamic/frameworks/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/dist/dynamic/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/frameworks/LibFramework.tvOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/LibFramework.tvOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/UI/frameworks/UIFramework.tvOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/UI/UIFramework.tvOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/frameworks/LibFramework.iOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/LibFramework.iOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/UI/frameworks/UIFramework.iOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/UI/UIFramework.iOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/frameworks/LibFramework.watchOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/LibFramework.watchOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/UI/frameworks/UIFramework.watchOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/UI/UIFramework.watchOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/dist/dynamic/frameworks/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/dist/dynamic/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/dist/dynamic/frameworks/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/dist/dynamic/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/dist/dynamic/frameworks/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/dist/dynamic/Lib.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/frameworks/LibFramework.tvOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/LibFramework.tvOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/UI/frameworks/UIFramework.tvOS.framework"
-        },
-        {
-            "t": "g",
-            "_": "applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/UI/UIFramework.tvOS.framework"
-        }
-    ],
     "name": "bwb",
     "post_build_script": null,
     "pre_build_script": null,
@@ -1908,6 +1746,9 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_STRICT_OBJC_MSGSEND": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -2035,6 +1876,9 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_STRICT_OBJC_MSGSEND": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -2162,6 +2006,9 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_STRICT_OBJC_MSGSEND": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -2288,6 +2135,9 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_STRICT_OBJC_MSGSEND": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -2414,6 +2264,9 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_STRICT_OBJC_MSGSEND": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -2540,6 +2393,9 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_STRICT_OBJC_MSGSEND": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -3122,6 +2978,9 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_STRICT_OBJC_MSGSEND": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -3248,6 +3107,9 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_STRICT_OBJC_MSGSEND": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -3374,6 +3236,9 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_STRICT_OBJC_MSGSEND": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -3500,6 +3365,9 @@
                 "ENABLE_BITCODE": false,
                 "ENABLE_STRICT_OBJC_MSGSEND": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
                 "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
@@ -3628,6 +3496,10 @@
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7 -static",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework\"",
+                    "\"$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/LibFramework.iOS.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.UIFramework",
                 "PRODUCT_MODULE_NAME": "UI",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -3820,6 +3692,10 @@
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator -static",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
+                    "\"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/LibFramework.iOS.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.UIFramework",
                 "PRODUCT_MODULE_NAME": "UI",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -4015,6 +3891,10 @@
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64 -static",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework\"",
+                    "\"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/LibFramework.tvOS.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.UIFramework",
                 "PRODUCT_MODULE_NAME": "UI",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -4207,6 +4087,10 @@
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator -static",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework\"",
+                    "\"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/LibFramework.tvOS.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.UIFramework",
                 "PRODUCT_MODULE_NAME": "UI",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -4399,6 +4283,10 @@
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k -static",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework\"",
+                    "\"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/LibFramework.watchOS.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.UIFramework",
                 "PRODUCT_MODULE_NAME": "UI",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -4591,6 +4479,10 @@
                 "ENABLE_TESTABILITY": true,
                 "GCC_OPTIMIZATION_LEVEL": "0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -fmodule-map-file=$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -Fexternal/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator -static",
+                "PREVIEW_FRAMEWORK_PATHS": [
+                    "\"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework\"",
+                    "\"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/LibFramework.watchOS.framework\""
+                ],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.UIFramework",
                 "PRODUCT_MODULE_NAME": "UI",
                 "SWIFT_ACTIVE_COMPILATION_CONDITIONS": "DEBUG",
@@ -5787,6 +5679,7 @@
                     "-fstack-protector",
                     "-fstack-protector-all"
                 ],
+                "PREVIEW_FRAMEWORK_PATHS": [],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.CoreUtilsObjC",
                 "PRODUCT_MODULE_NAME": "CoreUtils",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
@@ -5942,6 +5835,7 @@
                     "-fstack-protector",
                     "-fstack-protector-all"
                 ],
+                "PREVIEW_FRAMEWORK_PATHS": [],
                 "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.CoreUtilsObjC",
                 "PRODUCT_MODULE_NAME": "CoreUtils",
                 "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -315,7 +315,6 @@
     "force_bazel_dependencies": true,
     "generator_label": "//test/fixtures:xcodeproj_bwx.generator",
     "index_import": "$(BAZEL_OUT)/darwin_x86_64-opt-exec-BDE7E609-ST-87fb5cb17941/bin/external/rules_xcodeproj_index_import/index-import",
-    "linker_products_map": [],
     "name": "bwx",
     "post_build_script": null,
     "pre_build_script": null,

--- a/examples/sanitizers/test/fixtures/bwb_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_spec.json
@@ -84,7 +84,6 @@
     "force_bazel_dependencies": false,
     "generator_label": "//test/fixtures:xcodeproj_bwb.generator",
     "index_import": "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import",
-    "linker_products_map": [],
     "name": "bwb",
     "post_build_script": null,
     "pre_build_script": null,

--- a/examples/sanitizers/test/fixtures/bwx_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_spec.json
@@ -84,7 +84,6 @@
     "force_bazel_dependencies": false,
     "generator_label": "//test/fixtures:xcodeproj_bwx.generator",
     "index_import": "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import",
-    "linker_products_map": [],
     "name": "bwx",
     "post_build_script": null,
     "pre_build_script": null,

--- a/examples/simple/test/fixtures/bwb_spec.json
+++ b/examples/simple/test/fixtures/bwb_spec.json
@@ -21,7 +21,6 @@
     "force_bazel_dependencies": false,
     "generator_label": "//test/fixtures:xcodeproj_bwb.generator",
     "index_import": "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import",
-    "linker_products_map": [],
     "name": "bwb",
     "post_build_script": "\"$SRCROOT/post-build w spaces.sh\"\n",
     "pre_build_script": "echo 'Pre-building...'",

--- a/examples/simple/test/fixtures/bwx_spec.json
+++ b/examples/simple/test/fixtures/bwx_spec.json
@@ -21,7 +21,6 @@
     "force_bazel_dependencies": false,
     "generator_label": "//test/fixtures:xcodeproj_bwx.generator",
     "index_import": "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import",
-    "linker_products_map": [],
     "name": "bwx",
     "post_build_script": "\"$SRCROOT/post-build w spaces.sh\"\n",
     "pre_build_script": "echo 'Pre-building...'",

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -149,7 +149,6 @@
     "force_bazel_dependencies": true,
     "generator_label": "//test/fixtures/generator:xcodeproj_bwb.generator",
     "index_import": "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import",
-    "linker_products_map": [],
     "name": "bwb",
     "post_build_script": null,
     "pre_build_script": null,

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -149,7 +149,6 @@
     "force_bazel_dependencies": true,
     "generator_label": "//test/fixtures/generator:xcodeproj_bwx.generator",
     "index_import": "$(BAZEL_OUT)/darwin_x86_64-opt-exec-2B5CBBC6-ST-8b5ad9965560/bin/external/rules_xcodeproj_index_import/index-import",
-    "linker_products_map": [],
     "name": "bwx",
     "post_build_script": null,
     "pre_build_script": null,

--- a/tools/generator/src/DTO/Project.swift
+++ b/tools/generator/src/DTO/Project.swift
@@ -7,7 +7,6 @@ struct Project: Equatable, Decodable {
     let configuration: String
     let buildSettings: [String: BuildSetting]
     var targets: [TargetID: Target]
-    let linkerProductsMap: [FilePath: FilePath]
     let replacementLabels: [TargetID: BazelLabel]
     let targetHosts: [TargetID: [TargetID]]
     let envs: [TargetID: [String: String]]

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -91,7 +91,6 @@ struct Environment {
         _ pbxTargets: [ConsolidatedTarget.Key: PBXTarget],
         _ hostIDs: [TargetID: [TargetID]],
         _ hasBazelDependencies: Bool,
-        _ linkerProductsMap: [FilePath: FilePath],
         _ filePathResolver: FilePathResolver
     ) throws -> Void
 

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -141,7 +141,6 @@ class Generator {
             pbxTargets,
             project.targetHosts,
             bazelDependencies != nil,
-            project.linkerProductsMap,
             filePathResolver
         )
         try environment.setTargetDependencies(

--- a/tools/generator/src/Generator/SetTargetConfigurations.swift
+++ b/tools/generator/src/Generator/SetTargetConfigurations.swift
@@ -17,7 +17,6 @@ extension Generator {
         pbxTargets: [ConsolidatedTarget.Key: PBXTarget],
         hostIDs: [TargetID: [TargetID]],
         hasBazelDependencies: Bool,
-        linkerProductsMap: [FilePath: FilePath],
         filePathResolver: FilePathResolver
     ) throws {
         for (key, disambiguatedTarget) in disambiguatedTargets.targets {
@@ -42,7 +41,6 @@ Target "\(key)" not found in `pbxTargets`
                 targets: targets,
                 hostIDs: hostIDs,
                 hasBazelDependencies: hasBazelDependencies,
-                linkerProductsMap: linkerProductsMap,
                 filePathResolver: filePathResolver
             )
 
@@ -77,7 +75,6 @@ Target "\(key)" not found in `pbxTargets`
         targets: [TargetID: Target],
         hostIDs: [TargetID: [TargetID]],
         hasBazelDependencies: Bool,
-        linkerProductsMap: [FilePath: FilePath],
         filePathResolver: FilePathResolver
     ) throws -> [BuildSettingConditional: [String: BuildSetting]] {
         var anyBuildSettings: [String: BuildSetting] = [:]
@@ -93,7 +90,6 @@ Target "\(key)" not found in `pbxTargets`
                 hostIDs: hostIDs[id, default: []],
                 buildMode: buildMode,
                 hasBazelDependencies: hasBazelDependencies,
-                linkerProductsMap: linkerProductsMap,
                 filePathResolver: filePathResolver
             )
 
@@ -162,7 +158,6 @@ Target with id "\(id)" not found in `consolidatedTarget.uniqueFiles`
         hostIDs: [TargetID],
         buildMode: BuildMode,
         hasBazelDependencies: Bool,
-        linkerProductsMap: [FilePath: FilePath],
         filePathResolver: FilePathResolver
     ) throws -> [String: BuildSetting] {
         var buildSettings = target.buildSettings
@@ -448,19 +443,6 @@ $(CONFIGURATION_BUILD_DIR)
                     to: ldRunpathSearchPaths
                 )
             }
-        }
-
-        if buildMode != .xcode && target.product.type.isFramework {
-            buildSettings.set(
-                "PREVIEW_FRAMEWORK_PATHS",
-                to: target.linkerInputs.dynamicFrameworks.map { filePath in
-                    let filePath = linkerProductsMap[filePath] ?? filePath
-                    return #"""
-"\#(filePathResolver
-    .resolve(filePath, useBazelOut: true, forceFullBuildSettingPath: true))"
-"""#
-                }
-            )
         }
         
         // Set VFS overlays

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -18,9 +18,6 @@ enum Fixtures {
             "ONLY_ACTIVE_ARCH": .bool(true),
         ],
         targets: targets,
-        linkerProductsMap: [
-            .generated("a/frameworks/b.framework"): .generated("a/b.framework"),
-        ],
         replacementLabels: [:],
         targetHosts: [
             "W": ["I"],

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -18,7 +18,6 @@ final class GeneratorTests: XCTestCase {
             configuration: "abc123",
             buildSettings: [:],
             targets: Fixtures.targets,
-            linkerProductsMap: [:],
             replacementLabels: [:],
             targetHosts: [
                 "WKE": ["I 1", "I 2"],
@@ -531,7 +530,6 @@ final class GeneratorTests: XCTestCase {
             let pbxTargets: [ConsolidatedTarget.Key: PBXTarget]
             let hostIDs: [TargetID: [TargetID]]
             let hasBazelDependencies: Bool
-            let linkerProductsMap: [FilePath: FilePath]
         }
 
         var setTargetConfigurationsCalled: [SetTargetConfigurationsCalled] = []
@@ -543,7 +541,6 @@ final class GeneratorTests: XCTestCase {
             pbxTargets: [ConsolidatedTarget.Key: PBXTarget],
             hostIDs: [TargetID: [TargetID]],
             hasBazelDependencies: Bool,
-            linkerProductsMap: [FilePath: FilePath],
             filePathResolver: FilePathResolver
         ) {
             setTargetConfigurationsCalled.append(.init(
@@ -553,8 +550,7 @@ final class GeneratorTests: XCTestCase {
                 buildMode: buildMode,
                 pbxTargets: pbxTargets,
                 hostIDs: hostIDs,
-                hasBazelDependencies: hasBazelDependencies,
-                linkerProductsMap: linkerProductsMap
+                hasBazelDependencies: hasBazelDependencies
             ))
         }
 
@@ -566,8 +562,7 @@ final class GeneratorTests: XCTestCase {
                 buildMode: buildMode,
                 pbxTargets: pbxTargets,
                 hostIDs: project.targetHosts,
-                hasBazelDependencies: true,
-                linkerProductsMap: project.linkerProductsMap
+                hasBazelDependencies: true
             ),
         ]
 

--- a/tools/generator/test/SetTargetConfigurationsTests.swift
+++ b/tools/generator/test/SetTargetConfigurationsTests.swift
@@ -51,7 +51,6 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: Fixtures.project.targetHosts,
             hasBazelDependencies: true,
-            linkerProductsMap: Fixtures.project.linkerProductsMap,
             filePathResolver: filePathResolver
         )
 
@@ -181,7 +180,6 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: [:],
             hasBazelDependencies: false,
-            linkerProductsMap: [:],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -321,7 +319,6 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: [:],
             hasBazelDependencies: false,
-            linkerProductsMap: [:],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -415,7 +412,6 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: [:],
             hasBazelDependencies: false,
-            linkerProductsMap: [:],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -458,7 +454,6 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: [:],
             hasBazelDependencies: false,
-            linkerProductsMap: [:],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -512,7 +507,6 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: [:],
             hasBazelDependencies: false,
-            linkerProductsMap: [:],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -567,7 +561,6 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: [:],
             hasBazelDependencies: false,
-            linkerProductsMap: [:],
             filePathResolver: Self.filePathResolverFixture
         )
 
@@ -693,7 +686,6 @@ final class SetTargetConfigurationsTests: XCTestCase {
             pbxTargets: pbxTargets,
             hostIDs: [:],
             hasBazelDependencies: false,
-            linkerProductsMap: [:],
             filePathResolver: Self.filePathResolverFixture
         )
 

--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -81,8 +81,9 @@ def build_setting_path(
         fail("One of `file` or `path` must be specified.")
 
     if file:
-        path = file.path
         type = _file_type(file)
+        if not path:
+            path = file.path
     else:
         type = _parsed_path_type(path)
 

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -228,13 +228,11 @@ targets.
             product = xcode_target.product
             linker_files = product.linker_files.to_list()
             for file in linker_files:
-                linker_products_map[
-                    build_setting_path(
-                        file = file,
-                        path = file.dirname,
-                        quote = False,
-                    )
-                ] = build_setting_path(file = product.file, quote = False)
+                linker_products_map[build_setting_path(
+                    file = file,
+                    path = file.dirname,
+                    quote = False,
+                )] = build_setting_path(file = product.file, quote = False)
 
         label = replacement_labels.get(
             xcode_target.id,

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -12,7 +12,6 @@ load(
     "build_setting_path",
     "file_path",
     "file_path_to_dto",
-    "normalized_file_path",
     "parsed_file_path",
 )
 load(":flattened_key_values.bzl", "flattened_key_values")
@@ -221,19 +220,21 @@ targets.
     unfocused_libraries = sets.make(inputs.unfocused_libraries.to_list())
     has_focused_labels = sets.length(focused_labels) > 0
 
-    linker_products_flattened_map = []
+    linker_products_map = {}
     transitive_focused_targets = []
     unfocused_targets = {}
     for xcode_target in unprocessed_targets.values():
         if build_mode == "bazel":
             product = xcode_target.product
-            product_file_path_dto = file_path_to_dto(product.file_path)
             linker_files = product.linker_files.to_list()
             for file in linker_files:
-                linker_products_flattened_map.append(
-                    file_path_to_dto(normalized_file_path(file)),
-                )
-                linker_products_flattened_map.append(product_file_path_dto)
+                linker_products_map[
+                    build_setting_path(
+                        file = file,
+                        path = file.dirname,
+                        quote = False,
+                    )
+                ] = build_setting_path(file = product.file, quote = False)
 
         label = replacement_labels.get(
             xcode_target.id,
@@ -535,6 +536,7 @@ actual targets: {}
             build_mode = build_mode,
             include_lldb_context = include_lldb_context,
             is_unfocused_dependency = xcode_target.id in unfocused_dependencies,
+            linker_products_map = linker_products_map,
             should_include_outputs = should_include_outputs(build_mode),
             unfocused_targets = unfocused_targets,
             target_merges = target_merges,
@@ -612,7 +614,6 @@ actual targets: {}
         additional_outputs,
         has_unfocused_targets,
         focused_targets_extra_files,
-        linker_products_flattened_map,
         replacement_labels_by_label,
     )
 
@@ -631,7 +632,6 @@ def _write_json_spec(
         target_dtos,
         targets,
         has_unfocused_targets,
-        linker_products_flattened_map,
         replacement_labels,
         inputs,
         extra_files,
@@ -682,7 +682,6 @@ def _write_json_spec(
 "force_bazel_dependencies":{force_bazel_dependencies},\
 "generator_label":"{generator_label}",\
 "index_import":"{index_import}",\
-"linker_products_map":{linker_products_map},\
 "name":"{name}",\
 "post_build_script":{post_build_script},\
 "pre_build_script":{pre_build_script},\
@@ -709,7 +708,6 @@ def _write_json_spec(
             file = ctx.executable._index_import,
             quote = False,
         ),
-        linker_products_map = linker_products_flattened_map,
         name = project_name,
         post_build_script = post_build_script,
         pre_build_script = pre_build_script,
@@ -1071,7 +1069,6 @@ def _xcodeproj_impl(ctx):
         additional_outputs,
         has_unfocused_targets,
         focused_targets_extra_files,
-        linker_products_flattened_map,
         replacement_labels_by_label,
     ) = _process_targets(
         build_mode = build_mode,
@@ -1124,7 +1121,6 @@ def _xcodeproj_impl(ctx):
         targets = targets,
         target_dtos = target_dtos,
         has_unfocused_targets = has_unfocused_targets,
-        linker_products_flattened_map = linker_products_flattened_map,
         replacement_labels = replacement_labels,
         inputs = inputs,
         extra_files = extra_files,


### PR DESCRIPTION
This is progress towards moving all file path resolution into Starlark.

For now this makes the spec.json larger, but that can get reduced in the future by making `copy_outputs.sh` generated by Bazel with the paths directly embedded into it, on demand as part of the `bp` output group.