### PR TITLE
Optimize away some `build_setting_path` usage

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -8752,7 +8752,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/macOSApp/third_party";
+				FRAMEWORK_SEARCH_PATHS = macOSApp/third_party;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-ST-5a457b91a60a/bin/macOSApp/Source/rules_xcodeproj/macOSApp/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -7172,7 +7172,7 @@
                 "ENABLE_STRICT_OBJC_MSGSEND": true,
                 "ENABLE_TESTABILITY": true,
                 "FRAMEWORK_SEARCH_PATHS": [
-                    "$(SRCROOT)/macOSApp/third_party"
+                    "macOSApp/third_party"
                 ],
                 "GCC_OPTIMIZATION_LEVEL": "0",
                 "OTHER_SWIFT_FLAGS": "-Xcc -fmodule-map-file=$(SRCROOT)/macOSApp/third_party/ExampleFramework.framework/Modules/module.modulemap -Xcc -O0 -Xcc -DDEBUG=1 -Xcc -fstack-protector -Xcc -fstack-protector-all -FmacOSApp/third_party -static",

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -334,10 +334,7 @@ def _set_bazel_outputs_product(
     if not file:
         return
 
-    build_settings["BAZEL_OUTPUTS_PRODUCT"] = build_setting_path(
-        file = file,
-        absolute_path = False,
-    )
+    build_settings["BAZEL_OUTPUTS_PRODUCT"] = file.path
 
 def _set_search_paths(
         *,
@@ -392,7 +389,6 @@ def _set_search_paths(
                 bs_path = build_setting_path(
                     file = file,
                     path = search_path,
-                    absolute_path = True,
                 )
             else:
                 bs_path = search_path
@@ -404,12 +400,10 @@ def _set_search_paths(
     for path in search_paths_intermediate.framework_includes:
         search_paths = framework_build_setting_paths.get(path)
         if not search_paths:
-            framework_search_paths.append(
-                build_setting_path(
-                    path = path,
-                    absolute_path = build_mode == "xcode",
-                ),
-            )
+            if build_mode == "xcode":
+                framework_search_paths.append(build_setting_path(path = path))
+            else:
+                framework_search_paths.append(path)
             continue
 
         xcode_path = search_paths.get(True)
@@ -491,11 +485,7 @@ def _set_swift_include_paths(
         path = file.path
         bs_path = xcode_generated_paths.get(path)
         if not bs_path:
-            bs_path = build_setting_path(
-                file = file,
-                path = path,
-                absolute_path = False,
-            )
+            bs_path = path
         include_path = paths.dirname(bs_path)
 
         if include_path.find(" ") != -1:


### PR DESCRIPTION
When `absolute_path = False` and `use_build_dir = False`, there is no need to sue the function (expect for header search paths, to get the `.` -> `$(PROJECT_DIR)` behavior).