### PR TITLE
Respect `absolute_path` for project files as well

### DIFF
--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -108,7 +108,10 @@ def build_setting_path(
             build_setting = path
     else:
         # Project
-        build_setting = "$(SRCROOT)/{}".format(path)
+        if absolute_path:
+            build_setting = "$(SRCROOT)/{}".format(path)
+        else:
+            build_setting = path
 
     return build_setting
 


### PR DESCRIPTION
The Bazel execution root has symlinks for project files.