### PR TITLE
Simplify `FilePathResolver` more

### DIFF
--- a/tools/generator/src/Generator/AddTargets.swift
+++ b/tools/generator/src/Generator/AddTargets.swift
@@ -8,7 +8,6 @@ extension Generator {
         buildMode: BuildMode,
         products: Products,
         files: [FilePath: File],
-        filePathResolver: FilePathResolver,
         bazelDependenciesTarget: PBXAggregateTarget?
     ) throws -> [ConsolidatedTarget.Key: PBXTarget] {
         let pbxProject = pbxProj.rootObject!
@@ -45,15 +44,13 @@ Product for target "\(key)" not found in `products`
                     buildMode: buildMode,
                     productType: productType,
                     productBasename: target.product.basename,
-                    outputs: outputs,
-                    filePathResolver: filePathResolver
+                    outputs: outputs
                 ),
                 try createCompilingDependenciesScript(
                     in: pbxProj,
                     buildMode: buildMode,
                     hasClangSearchPaths: target.hasClangSearchPaths,
-                    files: files,
-                    filePathResolver: filePathResolver
+                    files: files
                 ),
                 try createLinkingDependenciesScript(
                     in: pbxProj,
@@ -142,8 +139,7 @@ Product for target "\(key)" not found in `products`
         buildMode: BuildMode,
         productType: PBXProductType,
         productBasename: String,
-        outputs: ConsolidatedTargetOutputs,
-        filePathResolver: FilePathResolver
+        outputs: ConsolidatedTargetOutputs
     ) throws -> PBXShellScriptBuildPhase? {
         guard buildMode.usesBazelModeBuildScripts else {
             return nil
@@ -200,8 +196,7 @@ Copy Bazel Outputs / Generate Bazel Dependencies (Index Build)
         in pbxProj: PBXProj,
         buildMode: BuildMode,
         hasClangSearchPaths: Bool,
-        files: [FilePath: File],
-        filePathResolver: FilePathResolver
+        files: [FilePath: File]
     ) throws -> PBXShellScriptBuildPhase? {
         guard buildMode == .xcode, hasClangSearchPaths else {
             return  nil

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -590,13 +590,13 @@ already was set to `\(existingValue)`.
 
         let externalPaths = fileListFileFilePaths
             .filter { $0.type == .external }
-            .map { filePathResolver.resolve($0) }
+            .map { FilePathResolver.resolveExternal($0.path) }
 
         let generatedFilePaths = fileListFileFilePaths
             .filter { $0.type == .generated && !$0.isFolder } + nonIncludedFiles
 
         let generatedPaths = generatedFilePaths
-            .map { filePathResolver.resolve($0) }
+            .map { FilePathResolver.resolveGenerated($0.path) }
 
         func addXCFileList(_ path: Path, paths: [String]) {
             guard !paths.isEmpty else {
@@ -657,7 +657,6 @@ already was set to `\(existingValue)`.
                     return clang.toClangExtraArgs(
                         buildMode: buildMode,
                         hasBazelDependencies: hasBazelDependencies,
-                        filePathResolver: filePathResolver,
                         oncePaths: &oncePaths,
                         onceOtherFlags: &onceOtherFlags
                     )
@@ -930,7 +929,6 @@ private extension LLDBContext.Clang {
     func toClangExtraArgs(
         buildMode: BuildMode,
         hasBazelDependencies: Bool,
-        filePathResolver: FilePathResolver,
         oncePaths: inout Set<String>,
         onceOtherFlags: inout Set<String>
     ) -> String {

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -63,7 +63,6 @@ struct Environment {
         _ forceBazelDependencies: Bool,
         _ indexImport: String,
         _ files: [FilePath: File],
-        _ filePathResolver: FilePathResolver,
         _ resolvedExternalRepositories: [(Path, Path)],
         _ bazelConfig: String,
         _ generatorLabel: BazelLabel,
@@ -79,7 +78,6 @@ struct Environment {
         _ buildMode: BuildMode,
         _ products: Products,
         _ files: [FilePath: File],
-        _ filePathResolver: FilePathResolver,
         _ bazelDependenciesTarget: PBXAggregateTarget?
     ) throws -> [ConsolidatedTarget.Key: PBXTarget]
 
@@ -90,8 +88,7 @@ struct Environment {
         _ buildMode: BuildMode,
         _ pbxTargets: [ConsolidatedTarget.Key: PBXTarget],
         _ hostIDs: [TargetID: [TargetID]],
-        _ hasBazelDependencies: Bool,
-        _ filePathResolver: FilePathResolver
+        _ hasBazelDependencies: Bool
     ) throws -> Void
 
     let setTargetDependencies: (

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -115,7 +115,6 @@ class Generator {
             project.forceBazelDependencies,
             project.indexImport,
             files,
-            filePathResolver,
             resolvedExternalRepositories,
             project.bazelConfig,
             project.generatorLabel,
@@ -130,7 +129,6 @@ class Generator {
             buildMode,
             products,
             files,
-            filePathResolver,
             bazelDependencies
         )
         try environment.setTargetConfigurations(
@@ -140,8 +138,7 @@ class Generator {
             buildMode,
             pbxTargets,
             project.targetHosts,
-            bazelDependencies != nil,
-            filePathResolver
+            bazelDependencies != nil
         )
         try environment.setTargetDependencies(
             buildMode,

--- a/tools/generator/test/AddTargetsTests.swift
+++ b/tools/generator/test/AddTargetsTests.swift
@@ -32,9 +32,6 @@ final class AddTargetsTests: XCTestCase {
             internalDirectoryName: internalDirectoryName,
             workspaceOutput: workspaceOutputPath
         )
-        let filePathResolver = FilePathResolver(
-            directories: directories
-        )
 
         let (files, _, _, _) = Fixtures.files(
             in: pbxProj,
@@ -85,7 +82,6 @@ final class AddTargetsTests: XCTestCase {
             buildMode: .xcode,
             products: products,
             files: files,
-            filePathResolver: filePathResolver,
             bazelDependenciesTarget: bazelDependenciesTarget
         )
 

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -438,7 +438,6 @@ final class GeneratorTests: XCTestCase {
             forceBazelDependencies: Bool,
             indexImport: String,
             files: [FilePath: File],
-            filePathResolver: FilePathResolver,
             resolvedExternalRepositories: [(Path, Path)],
             bazelConfig: String,
             generatorLabel: BazelLabel,
@@ -497,7 +496,6 @@ final class GeneratorTests: XCTestCase {
             buildMode: BuildMode,
             products: Products,
             files: [FilePath: File],
-            filePathResolver: FilePathResolver,
             bazelDependenciesTarget: PBXAggregateTarget?
         ) throws -> [ConsolidatedTarget.Key: PBXTarget] {
             addTargetsCalled.append(.init(
@@ -540,8 +538,7 @@ final class GeneratorTests: XCTestCase {
             buildMode: BuildMode,
             pbxTargets: [ConsolidatedTarget.Key: PBXTarget],
             hostIDs: [TargetID: [TargetID]],
-            hasBazelDependencies: Bool,
-            filePathResolver: FilePathResolver
+            hasBazelDependencies: Bool
         ) {
             setTargetConfigurationsCalled.append(.init(
                 pbxProj: pbxProj,

--- a/tools/generator/test/SetTargetConfigurationsTests.swift
+++ b/tools/generator/test/SetTargetConfigurationsTests.swift
@@ -29,7 +29,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
         let (
             pbxTargets,
             disambiguatedTargets,
-            filePathResolver
+            _
         ) = Fixtures.pbxTargets(
             in: pbxProj,
             directories: Self.directories,
@@ -50,8 +50,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .xcode,
             pbxTargets: pbxTargets,
             hostIDs: Fixtures.project.targetHosts,
-            hasBazelDependencies: true,
-            filePathResolver: filePathResolver
+            hasBazelDependencies: true
         )
 
         try pbxProj.fixReferences()
@@ -179,8 +178,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .xcode,
             pbxTargets: pbxTargets,
             hostIDs: [:],
-            hasBazelDependencies: false,
-            filePathResolver: Self.filePathResolverFixture
+            hasBazelDependencies: false
         )
 
         let ldRunpathSearchPaths: [ConsolidatedTarget.Key: [String: [String]]] =
@@ -318,8 +316,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .bazel,
             pbxTargets: pbxTargets,
             hostIDs: [:],
-            hasBazelDependencies: false,
-            filePathResolver: Self.filePathResolverFixture
+            hasBazelDependencies: false
         )
 
         let ldRunpathSearchPaths: [ConsolidatedTarget.Key: [String: [String]]] =
@@ -411,8 +408,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .xcode,
             pbxTargets: pbxTargets,
             hostIDs: [:],
-            hasBazelDependencies: false,
-            filePathResolver: Self.filePathResolverFixture
+            hasBazelDependencies: false
         )
 
         let previewsLdRunpathSearchPaths: [
@@ -453,8 +449,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .bazel,
             pbxTargets: pbxTargets,
             hostIDs: [:],
-            hasBazelDependencies: false,
-            filePathResolver: Self.filePathResolverFixture
+            hasBazelDependencies: false
         )
 
         let previewsLdRunpathSearchPaths: [
@@ -506,8 +501,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .xcode,
             pbxTargets: pbxTargets,
             hostIDs: [:],
-            hasBazelDependencies: false,
-            filePathResolver: Self.filePathResolverFixture
+            hasBazelDependencies: false
         )
 
         let sdkRoots: [ConsolidatedTarget.Key: [String: String]] =
@@ -560,8 +554,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .xcode,
             pbxTargets: pbxTargets,
             hostIDs: [:],
-            hasBazelDependencies: false,
-            filePathResolver: Self.filePathResolverFixture
+            hasBazelDependencies: false
         )
 
         let supportedPlatforms: [ConsolidatedTarget.Key: [String: String]] =
@@ -685,8 +678,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
             buildMode: .xcode,
             pbxTargets: pbxTargets,
             hostIDs: [:],
-            hasBazelDependencies: false,
-            filePathResolver: Self.filePathResolverFixture
+            hasBazelDependencies: false
         )
 
         var buildSettings: [ConsolidatedTarget.Key: [String: String]] = [:]


### PR DESCRIPTION
It's only static functions now. A followup change will change it to a namespace (decoupling the instance properties).