### PR TITLE
Stop filtering static library paths in linkopts

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-3688109ddba2/tool/tool.link.params
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-3688109ddba2/tool/tool.link.params
@@ -1,8 +1,7 @@
 -lc++
+-Wl,-force_load,bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo
+bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a
+bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a
-bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a
--force_load
-bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo

--- a/examples/cc/test/fixtures/bwb_spec.json
+++ b/examples/cc/test/fixtures/bwb_spec.json
@@ -268,13 +268,12 @@
             "linker_inputs": {
                 "linkopts": [
                     "-lc++",
-                    "-headerpad_max_install_names",
-                    "-no-canonical-prefixes",
-                    "-lc++",
+                    "-Wl,-force_load,bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo",
                     "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a",
                     "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a",
-                    "-force_load",
-                    "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo"
+                    "-headerpad_max_install_names",
+                    "-no-canonical-prefixes",
+                    "-lc++"
                 ]
             },
             "name": "tool",

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-3688109ddba2/tool/tool.link.params
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-3688109ddba2/tool/tool.link.params
@@ -1,8 +1,7 @@
 -lc++
+-Wl,-force_load,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a
--force_load
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo

--- a/examples/cc/test/fixtures/bwx_spec.json
+++ b/examples/cc/test/fixtures/bwx_spec.json
@@ -267,13 +267,12 @@
             "linker_inputs": {
                 "linkopts": [
                     "-lc++",
-                    "-headerpad_max_install_names",
-                    "-no-canonical-prefixes",
-                    "-lc++",
+                    "-Wl,-force_load,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo",
                     "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a",
                     "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo"
+                    "-headerpad_max_install_names",
+                    "-no-canonical-prefixes",
+                    "-lc++"
                 ]
             },
             "name": "tool",

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/AppClip/AppClip.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftmodule
 -Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule
 -ObjC
@@ -14,5 +16,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/dist/dynamic/iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/dist/dynamic/iOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/WidgetExtension/WidgetExtension.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftmodule
 -Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule
 -ObjC
@@ -14,5 +16,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/iOSApp/Source/iOSApp.link.params
@@ -37,5 +37,3 @@ LibFramework.iOS
 Foundation
 -framework
 UIKit
-bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a
-bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/AppClip/AppClip.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftmodule
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule
 -ObjC
@@ -14,5 +16,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/dist/dynamic/iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/dist/dynamic/iOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/WidgetExtension/WidgetExtension.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftmodule
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule
 -ObjC
@@ -14,5 +16,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iMessageApp/iMessageAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iMessageApp/iMessageAppExtension.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftmodule
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule
 -ObjC
@@ -14,5 +16,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Source/iOSApp.link.params
@@ -37,5 +37,3 @@ LibFramework.iOS
 Foundation
 -framework
 UIKit
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.link.params
@@ -37,6 +37,3 @@ XCTest
 Foundation
 -framework
 UIKit
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.link.params
@@ -38,6 +38,3 @@ XCTest
 Foundation
 -framework
 UIKit
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/CommandLineTool/CommandLineTool.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/CommandLineTool/CommandLineTool.link.params
@@ -5,6 +5,8 @@ Foundation
 ExternalFramework
 -weak_framework
 SwiftUI
+-force_load
+external/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule
 -Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule
 -Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule
@@ -20,11 +22,3 @@ SwiftUI
 -no-canonical-prefixes
 -framework
 Foundation
-bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a
-bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a
-bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a
-bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a
-bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a
-external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
--force_load
-external/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/Tests/CommandLineToolTests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/Tests/CommandLineToolTests.link.params
@@ -5,6 +5,8 @@ Foundation
 ExternalFramework
 -weak_framework
 SwiftUI
+-force_load
+external/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib
 -Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule
 -Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule
@@ -21,11 +23,3 @@ XCTest
 -no-canonical-prefixes
 -framework
 Foundation
-bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a
-bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a
-bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a
-bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a
-bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a
-external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
--force_load
-external/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/LibFramework.tvOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/dist/dynamic/tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/dist/dynamic/tvOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/LibFramework.tvOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/dist/dynamic/tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/dist/dynamic/tvOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/LibFramework.watchOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/dist/dynamic/watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/dist/dynamic/watchOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/LibFramework.watchOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/dist/dynamic/watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/dist/dynamic/watchOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -511,6 +511,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
@@ -523,9 +525,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -682,6 +682,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
@@ -694,9 +696,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -900,6 +900,8 @@
                     "ExternalFramework",
                     "-weak_framework",
                     "SwiftUI",
+                    "-force_load",
+                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework",
                     "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
                     "-Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule",
@@ -914,15 +916,7 @@
                     "-Wl,-exported_symbols_list,CommandLine/CommandLineTool/export_symbol_list.exp",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation",
-                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a",
-                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                    "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                    "-force_load",
-                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                    "Foundation"
                 ],
                 "static_frameworks": [
                     {
@@ -1397,6 +1391,8 @@
                     "ExternalFramework",
                     "-weak_framework",
                     "SwiftUI",
+                    "-force_load",
+                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework",
                     "-L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib",
                     "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule",
@@ -1412,15 +1408,7 @@
                     "XCTest",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation",
-                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a",
-                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                    "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                    "-force_load",
-                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                    "Foundation"
                 ],
                 "static_frameworks": [
                     {
@@ -1678,6 +1666,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1689,9 +1679,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -1798,6 +1786,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1809,9 +1799,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -1917,6 +1905,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1928,9 +1918,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -2036,6 +2024,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2047,9 +2037,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -2155,6 +2143,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2166,9 +2156,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -2274,6 +2262,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2285,9 +2275,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -2831,6 +2819,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2842,9 +2832,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -2950,6 +2938,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2961,9 +2951,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -3069,6 +3057,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -3080,9 +3070,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -3188,6 +3176,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -3199,9 +3189,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -4418,6 +4406,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
@@ -4430,9 +4420,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -4588,6 +4576,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
@@ -4600,9 +4590,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -4813,6 +4801,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
@@ -4825,9 +4815,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -5824,9 +5812,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
-                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
+                    "UIKit"
                 ],
                 "static_frameworks": [
                     {
@@ -6146,9 +6132,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
+                    "UIKit"
                 ],
                 "static_frameworks": [
                     {
@@ -6517,10 +6501,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {
@@ -6795,10 +6776,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
+                    "UIKit"
                 ]
             },
             "lldb_context": {

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/AppClip/AppClip.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftmodule/arm64-apple-ios.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
@@ -14,5 +16,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/LibFramework.iOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/dist/dynamic/iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/dist/dynamic/iOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/WidgetExtension/WidgetExtension.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftmodule/arm64-apple-ios.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
@@ -14,5 +16,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/iOSApp/Source/iOSApp.link.params
@@ -37,5 +37,3 @@ LibFramework.iOS
 Foundation
 -framework
 UIKit
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/AppClip/AppClip.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
@@ -14,5 +16,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/LibFramework.iOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/dist/dynamic/iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/dist/dynamic/iOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/WidgetExtension/WidgetExtension.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
@@ -14,5 +16,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iMessageApp/iMessageAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iMessageApp/iMessageAppExtension.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
@@ -14,5 +16,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Source/iOSApp.link.params
@@ -37,5 +37,3 @@ LibFramework.iOS
 Foundation
 -framework
 UIKit
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.link.params
@@ -37,6 +37,3 @@ XCTest
 Foundation
 -framework
 UIKit
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.link.params
@@ -38,6 +38,3 @@ XCTest
 Foundation
 -framework
 UIKit
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/CommandLineTool/CommandLineTool.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/CommandLineTool/CommandLineTool.link.params
@@ -5,6 +5,8 @@ Foundation
 ExternalFramework
 -weak_framework
 SwiftUI
+-force_load
+external/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule/x86_64-apple-macos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule/x86_64-apple-macos.swiftmodule
 -Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule
@@ -20,11 +22,3 @@ SwiftUI
 -no-canonical-prefixes
 -framework
 Foundation
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a
-external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
--force_load
-external/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/Tests/CommandLineToolTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/Tests/CommandLineToolTests.link.params
@@ -5,6 +5,8 @@ Foundation
 ExternalFramework
 -weak_framework
 SwiftUI
+-force_load
+external/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule/x86_64-apple-macos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule/x86_64-apple-macos.swiftmodule
@@ -21,11 +23,3 @@ XCTest
 -no-canonical-prefixes
 -framework
 Foundation
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a
-external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
--force_load
-external/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/LibFramework.tvOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/dist/dynamic/tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/dist/dynamic/tvOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/LibFramework.tvOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/dist/dynamic/tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/dist/dynamic/tvOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/LibFramework.watchOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/dist/dynamic/watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/dist/dynamic/watchOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/LibFramework.watchOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/dist/dynamic/watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/dist/dynamic/watchOS.link.params
@@ -1,6 +1,8 @@
 -ObjC
 -framework
 CryptoSwift
+-force_load
+$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -13,5 +15,3 @@ CryptoSwift
 Foundation
 -framework
 UIKit
--force_load
-$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -438,6 +438,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-ObjC",
@@ -450,9 +452,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "modulemaps": [
@@ -569,6 +569,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-ObjC",
@@ -581,9 +583,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "modulemaps": [
@@ -742,6 +742,8 @@
                     "ExternalFramework",
                     "-weak_framework",
                     "SwiftUI",
+                    "-force_load",
+                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule/x86_64-apple-macos.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule/x86_64-apple-macos.swiftmodule",
                     "-Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule",
@@ -756,15 +758,7 @@
                     "-Wl,-exported_symbols_list,CommandLine/CommandLineTool/export_symbol_list.exp",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                    "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                    "-force_load",
-                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                    "Foundation"
                 ],
                 "static_frameworks": [
                     {
@@ -1193,6 +1187,8 @@
                     "ExternalFramework",
                     "-weak_framework",
                     "SwiftUI",
+                    "-force_load",
+                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework",
                     "-L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule/x86_64-apple-macos.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule/x86_64-apple-macos.swiftmodule",
@@ -1208,15 +1204,7 @@
                     "XCTest",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                    "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                    "-force_load",
-                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                    "Foundation"
                 ],
                 "static_frameworks": [
                     {
@@ -1407,6 +1395,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1418,9 +1408,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "iOS",
@@ -1504,6 +1492,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1515,9 +1505,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "iOS",
@@ -1600,6 +1588,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1611,9 +1601,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "tvOS",
@@ -1696,6 +1684,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1707,9 +1697,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "tvOS",
@@ -1792,6 +1780,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1803,9 +1793,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "watchOS",
@@ -1888,6 +1876,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1899,9 +1889,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "watchOS",
@@ -2423,6 +2411,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2434,9 +2424,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "LibFramework.iOS",
@@ -2520,6 +2508,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2531,9 +2521,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "LibFramework.iOS",
@@ -2616,6 +2604,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2627,9 +2617,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "LibFramework.tvOS",
@@ -2712,6 +2700,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2723,9 +2713,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "LibFramework.tvOS",
@@ -2808,6 +2796,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2819,9 +2809,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "LibFramework.watchOS",
@@ -2904,6 +2892,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2915,9 +2905,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "name": "LibFramework.watchOS",
@@ -3809,6 +3797,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-ObjC",
@@ -3821,9 +3811,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "modulemaps": [
@@ -3938,6 +3926,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-ObjC",
@@ -3950,9 +3940,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "modulemaps": [
@@ -4127,6 +4115,8 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-ObjC",
@@ -4139,9 +4129,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
+                    "UIKit"
                 ]
             },
             "modulemaps": [
@@ -5352,9 +5340,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
-                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
+                    "UIKit"
                 ],
                 "static_frameworks": [
                     {
@@ -5605,9 +5591,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
+                    "UIKit"
                 ],
                 "static_frameworks": [
                     {
@@ -5890,10 +5874,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
+                    "UIKit"
                 ]
             },
             "name": "iOSAppObjCUnitTests.__internal__.__test_bundle",
@@ -6069,10 +6050,7 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
+                    "UIKit"
                 ]
             },
             "modulemaps": [

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/generator.link.params
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/generator.link.params
@@ -14,11 +14,3 @@
 -no-canonical-prefixes
 -framework
 Foundation
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/test/tests.link.params
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/test/tests.link.params
@@ -20,13 +20,3 @@ XCTest
 -no-canonical-prefixes
 -framework
 Foundation
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -286,17 +286,7 @@
                     "XCTest",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a"
+                    "Foundation"
                 ]
             },
             "lldb_context": {
@@ -559,15 +549,7 @@
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a"
+                    "Foundation"
                 ]
             },
             "lldb_context": {

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/generator.link.params
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/generator.link.params
@@ -14,11 +14,3 @@
 -no-canonical-prefixes
 -framework
 Foundation
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/test/tests.link.params
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/test/tests.link.params
@@ -20,13 +20,3 @@ XCTest
 -no-canonical-prefixes
 -framework
 Foundation
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
-bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
-$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -285,17 +285,7 @@
                     "XCTest",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a"
+                    "Foundation"
                 ]
             },
             "lldb_context": {
@@ -557,15 +547,7 @@
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
-                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a",
-                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a"
+                    "Foundation"
                 ]
             },
             "lldb_context": {

--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -18,9 +18,6 @@ _LD_SKIP_OPTS = {
     "-o": 2,
     "-static": 1,
     "-target": 2,
-
-    # TODO: Remove this filter once we move path logic out of the generator
-    "-force_load": 2,
 }
 
 _SKIP_INPUT_EXTENSIONS = {
@@ -353,8 +350,6 @@ def _process_linkopt(linkopt):
     if linkopt.startswith("-Wl,-install_name,"):
         return None
     if linkopt.startswith("@"):
-        return None
-    if linkopt.endswith(".a") or linkopt.endswith(".lo"):
         return None
 
     # Use Xcode set `DEVELOPER_DIR`


### PR DESCRIPTION
These values are now dictated by Bazel. This fixes a couple incorrect links we were doing.