### PR TITLE
Set `--features=swift.use_global_module_cache`

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,6 +48,9 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `swift.use_global_module_cache` drastically speeds up swift builds
+build:rules_xcodeproj --features=swift.use_global_module_cache
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,6 +48,9 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `swift.use_global_module_cache` drastically speeds up swift builds
+build:rules_xcodeproj --features=swift.use_global_module_cache
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,6 +48,9 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `swift.use_global_module_cache` drastically speeds up swift builds
+build:rules_xcodeproj --features=swift.use_global_module_cache
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,6 +48,9 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `swift.use_global_module_cache` drastically speeds up swift builds
+build:rules_xcodeproj --features=swift.use_global_module_cache
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,6 +48,9 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `swift.use_global_module_cache` drastically speeds up swift builds
+build:rules_xcodeproj --features=swift.use_global_module_cache
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,6 +48,9 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `swift.use_global_module_cache` drastically speeds up swift builds
+build:rules_xcodeproj --features=swift.use_global_module_cache
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,6 +48,9 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `swift.use_global_module_cache` drastically speeds up swift builds
+build:rules_xcodeproj --features=swift.use_global_module_cache
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,6 +48,9 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `swift.use_global_module_cache` drastically speeds up swift builds
+build:rules_xcodeproj --features=swift.use_global_module_cache
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -1,5 +1,6 @@
 build --incompatible_disallow_empty_glob
 build --experimental_convenience_symlinks=ignore
+build --features=swift.use_global_module_cache
 
 # Work around https://github.com/bazelbuild/bazel/issues/13912
 build --experimental_action_cache_store_output_metadata

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,6 +48,9 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `swift.use_global_module_cache` drastically speeds up swift builds
+build:rules_xcodeproj --features=swift.use_global_module_cache
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -48,6 +48,9 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `swift.use_global_module_cache` drastically speeds up swift builds
+build:rules_xcodeproj --features=swift.use_global_module_cache
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -39,6 +39,7 @@ _SWIFTC_SKIP_OPTS = {
     "-gline-tables-only": 1,
     "-index-ignore-system-modules": 1,
     "-index-store-path": 2,
+    "-module-cache-path": 2,
     "-module-name": 2,
     "-num-threads": 2,
     "-output-file-map": 2,

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -48,6 +48,9 @@ build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 build:rules_xcodeproj --features=swift.index_while_building
 build:rules_xcodeproj --features=swift.use_global_index_store
 
+# `swift.use_global_module_cache` drastically speeds up swift builds
+build:rules_xcodeproj --features=swift.use_global_module_cache
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0


### PR DESCRIPTION
I personally believe this should be enabled by default in rules_swift, but until then we can do it.

Also ignore `-module-cache-path` in copts.