### PR TITLE
Revert "Stop filtering static library paths in linkopts (#1441)"

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-3688109ddba2/tool/tool.link.params
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-3688109ddba2/tool/tool.link.params
@@ -1,7 +1,8 @@
 -lc++
--Wl,-force_load,bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo
-bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a
-bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a
+bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a
+-force_load
+bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo

--- a/examples/cc/test/fixtures/bwb_spec.json
+++ b/examples/cc/test/fixtures/bwb_spec.json
@@ -268,12 +268,13 @@
             "linker_inputs": {
                 "linkopts": [
                     "-lc++",
-                    "-Wl,-force_load,bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo",
-                    "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a",
-                    "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
-                    "-lc++"
+                    "-lc++",
+                    "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a",
+                    "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a",
+                    "-force_load",
+                    "bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo"
                 ]
             },
             "name": "tool",

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-3688109ddba2/tool/tool.link.params
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/darwin_x86_64-dbg-ST-3688109ddba2/tool/tool.link.params
@@ -1,7 +1,8 @@
 -lc++
--Wl,-force_load,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a
-$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a
 -headerpad_max_install_names
 -no-canonical-prefixes
 -lc++
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a
+-force_load
+$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo

--- a/examples/cc/test/fixtures/bwx_spec.json
+++ b/examples/cc/test/fixtures/bwx_spec.json
@@ -267,12 +267,13 @@
             "linker_inputs": {
                 "linkopts": [
                     "-lc++",
-                    "-Wl,-force_load,$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo",
-                    "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a",
-                    "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a",
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
-                    "-lc++"
+                    "-lc++",
+                    "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib2/liblib_impl.a",
+                    "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/external/examples_cc_external/liblib_impl.a",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-ST-3688109ddba2/bin/lib/liblib_impl.lo"
                 ]
             },
             "name": "tool",

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/AppClip/AppClip.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftmodule
 -Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule
 -ObjC
@@ -16,3 +14,5 @@ bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/l
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/dist/dynamic/iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/dist/dynamic/iOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/l
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/WidgetExtension/WidgetExtension.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftmodule
 -Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule
 -ObjC
@@ -16,3 +14,5 @@ bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/l
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/iOSApp/Source/iOSApp.link.params
@@ -37,3 +37,5 @@ LibFramework.iOS
 Foundation
 -framework
 UIKit
+bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a
+bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/AppClip/AppClip.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftmodule
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule
 -ObjC
@@ -16,3 +14,5 @@ bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/dist/dynamic/iOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/dist/dynamic/iOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/WidgetExtension/WidgetExtension.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftmodule
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule
 -ObjC
@@ -16,3 +14,5 @@ bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iMessageApp/iMessageAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iMessageApp/iMessageAppExtension.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftmodule
 -Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule
 -ObjC
@@ -16,3 +14,5 @@ bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Source/iOSApp.link.params
@@ -37,3 +37,5 @@ LibFramework.iOS
 Foundation
 -framework
 UIKit
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.link.params
@@ -37,3 +37,6 @@ XCTest
 Foundation
 -framework
 UIKit
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.link.params
@@ -38,3 +38,6 @@ XCTest
 Foundation
 -framework
 UIKit
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a
+bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/CommandLineTool/CommandLineTool.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/CommandLineTool/CommandLineTool.link.params
@@ -5,8 +5,6 @@ Foundation
 ExternalFramework
 -weak_framework
 SwiftUI
--force_load
-external/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule
 -Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule
 -Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule
@@ -22,3 +20,11 @@ external/examples_command_line_external/ExternalFramework.framework/ExternalFram
 -no-canonical-prefixes
 -framework
 Foundation
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a
+external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
+-force_load
+external/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/Tests/CommandLineToolTests.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/Tests/CommandLineToolTests.link.params
@@ -5,8 +5,6 @@ Foundation
 ExternalFramework
 -weak_framework
 SwiftUI
--force_load
-external/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib
 -Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule
 -Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule
@@ -23,3 +21,11 @@ XCTest
 -no-canonical-prefixes
 -framework
 Foundation
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a
+bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a
+external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
+-force_load
+external/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/LibFramework.tvOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Li
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/dist/dynamic/tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/dist/dynamic/tvOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Li
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/LibFramework.tvOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/dist/dynamic/tvOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/dist/dynamic/tvOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/LibFramework.watchOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/dist/dynamic/watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/dist/dynamic/watchOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/LibFramework.watchOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/dist/dynamic/watchOS.link.params
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/dist/dynamic/watchOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a
 -Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3
 Foundation
 -framework
 UIKit
+-force_load
+bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -511,8 +511,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
@@ -525,7 +523,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -682,8 +682,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
@@ -696,7 +694,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -900,8 +900,6 @@
                     "ExternalFramework",
                     "-weak_framework",
                     "SwiftUI",
-                    "-force_load",
-                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework",
                     "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
                     "-Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule",
@@ -916,7 +914,15 @@
                     "-Wl,-exported_symbols_list,CommandLine/CommandLineTool/export_symbol_list.exp",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation"
+                    "Foundation",
+                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
+                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a",
+                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
+                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
+                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
+                    "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
+                    "-force_load",
+                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
                 ]
             },
             "lldb_context": {
@@ -1385,8 +1391,6 @@
                     "ExternalFramework",
                     "-weak_framework",
                     "SwiftUI",
-                    "-force_load",
-                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework",
                     "-L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib",
                     "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule",
@@ -1402,7 +1406,15 @@
                     "XCTest",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation"
+                    "Foundation",
+                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
+                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a",
+                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
+                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
+                    "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
+                    "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
+                    "-force_load",
+                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
                 ]
             },
             "lldb_context": {
@@ -1654,8 +1666,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1667,7 +1677,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -1774,8 +1786,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1787,7 +1797,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -1893,8 +1905,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1906,7 +1916,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -2012,8 +2024,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2025,7 +2035,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -2131,8 +2143,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2144,7 +2154,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -2250,8 +2262,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2263,7 +2273,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -2807,8 +2819,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2820,7 +2830,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -2926,8 +2938,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2939,7 +2949,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -3045,8 +3057,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -3058,7 +3068,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -3164,8 +3176,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -3177,7 +3187,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -4394,8 +4406,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
@@ -4408,7 +4418,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -4564,8 +4576,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
@@ -4578,7 +4588,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -4789,8 +4801,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftmodule",
                     "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule",
                     "-ObjC",
@@ -4803,7 +4813,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
                 ]
             },
             "lldb_context": {
@@ -5800,7 +5812,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
+                    "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
                 ]
             },
             "lldb_context": {
@@ -6106,7 +6120,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
                 ]
             },
             "lldb_context": {
@@ -6461,7 +6477,10 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
                 ]
             },
             "lldb_context": {
@@ -6736,7 +6755,10 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a",
+                    "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
                 ]
             },
             "lldb_context": {

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/AppClip/AppClip.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftmodule/arm64-apple-ios.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
@@ -16,3 +14,5 @@ $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/LibFramework.iOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/dist/dynamic/iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/Lib/dist/dynamic/iOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/WidgetExtension/WidgetExtension.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftmodule/arm64-apple-ios.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule
 -ObjC
@@ -16,3 +14,5 @@ $(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/iOSApp/Source/iOSApp.link.params
@@ -37,3 +37,5 @@ LibFramework.iOS
 Foundation
 -framework
 UIKit
+$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a
+$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/AppClip/AppClip.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/AppClip/AppClip.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
@@ -16,3 +14,5 @@ $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c9
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/LibFramework.iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/LibFramework.iOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c9
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/dist/dynamic/iOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/Lib/dist/dynamic/iOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c9
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/WidgetExtension/WidgetExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/WidgetExtension/WidgetExtension.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
@@ -16,3 +14,5 @@ $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c9
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iMessageApp/iMessageAppExtension.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iMessageApp/iMessageAppExtension.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
 -ObjC
@@ -16,3 +14,5 @@ $(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c9
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Source/iOSApp.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Source/iOSApp.link.params
@@ -37,3 +37,5 @@ LibFramework.iOS
 Foundation
 -framework
 UIKit
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.link.params
@@ -37,3 +37,6 @@ XCTest
 Foundation
 -framework
 UIKit
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.link.params
@@ -38,3 +38,6 @@ XCTest
 Foundation
 -framework
 UIKit
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a
+$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/CommandLineTool/CommandLineTool.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/CommandLineTool/CommandLineTool.link.params
@@ -5,8 +5,6 @@ Foundation
 ExternalFramework
 -weak_framework
 SwiftUI
--force_load
-external/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule/x86_64-apple-macos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule/x86_64-apple-macos.swiftmodule
 -Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule
@@ -22,3 +20,11 @@ external/examples_command_line_external/ExternalFramework.framework/ExternalFram
 -no-canonical-prefixes
 -framework
 Foundation
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a
+external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
+-force_load
+external/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/Tests/CommandLineToolTests.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/CommandLine/Tests/CommandLineToolTests.link.params
@@ -5,8 +5,6 @@ Foundation
 ExternalFramework
 -weak_framework
 SwiftUI
--force_load
-external/examples_command_line_external/ExternalFramework.framework/ExternalFramework
 -L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule/x86_64-apple-macos.swiftmodule
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule/x86_64-apple-macos.swiftmodule
@@ -23,3 +21,11 @@ XCTest
 -no-canonical-prefixes
 -framework
 Foundation
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a
+external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a
+-force_load
+external/examples_command_line_external/ExternalFramework.framework/ExternalFramework

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/LibFramework.tvOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-410448
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/dist/dynamic/tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/Lib/dist/dynamic/tvOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-410448
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/LibFramework.tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/LibFramework.tvOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/dist/dynamic/tvOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/Lib/dist/dynamic/tvOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/LibFramework.watchOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/dist/dynamic/watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/Lib/dist/dynamic/watchOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/LibFramework.watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/LibFramework.watchOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/dist/dynamic/watchOS.link.params
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/targets/applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/Lib/dist/dynamic/watchOS.link.params
@@ -1,8 +1,6 @@
 -ObjC
 -framework
 CryptoSwift
--force_load
-$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a
 -Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule
 -ObjC
 -L/usr/lib/swift
@@ -15,3 +13,5 @@ $(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg
 Foundation
 -framework
 UIKit
+-force_load
+$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -438,8 +438,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/AppClip/AppClip.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-ObjC",
@@ -452,7 +450,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
                 ]
             },
             "modulemaps": [
@@ -569,8 +569,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/AppClip/AppClip.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-ObjC",
@@ -583,7 +581,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
                 ]
             },
             "modulemaps": [
@@ -742,8 +742,6 @@
                     "ExternalFramework",
                     "-weak_framework",
                     "SwiftUI",
-                    "-force_load",
-                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule/x86_64-apple-macos.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule/x86_64-apple-macos.swiftmodule",
                     "-Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule",
@@ -758,7 +756,15 @@
                     "-Wl,-exported_symbols_list,CommandLine/CommandLineTool/export_symbol_list.exp",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation"
+                    "Foundation",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
+                    "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
+                    "-force_load",
+                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
                 ]
             },
             "name": "CommandLineTool",
@@ -1181,8 +1187,6 @@
                     "ExternalFramework",
                     "-weak_framework",
                     "SwiftUI",
-                    "-force_load",
-                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework",
                     "-L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule/x86_64-apple-macos.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule/x86_64-apple-macos.swiftmodule",
@@ -1198,7 +1202,15 @@
                     "XCTest",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation"
+                    "Foundation",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/swift_c_module/libc_lib.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
+                    "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
+                    "-force_load",
+                    "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
                 ]
             },
             "modulemaps": [
@@ -1383,8 +1395,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1396,7 +1406,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
                 ]
             },
             "name": "iOS",
@@ -1480,8 +1492,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1493,7 +1503,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
                 ]
             },
             "name": "iOS",
@@ -1576,8 +1588,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1589,7 +1599,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a"
                 ]
             },
             "name": "tvOS",
@@ -1672,8 +1684,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1685,7 +1695,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a"
                 ]
             },
             "name": "tvOS",
@@ -1768,8 +1780,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1781,7 +1791,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a"
                 ]
             },
             "name": "watchOS",
@@ -1864,8 +1876,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -1877,7 +1887,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a"
                 ]
             },
             "name": "watchOS",
@@ -2399,8 +2411,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2412,7 +2422,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
                 ]
             },
             "name": "LibFramework.iOS",
@@ -2496,8 +2508,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2509,7 +2519,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
                 ]
             },
             "name": "LibFramework.iOS",
@@ -2592,8 +2604,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2605,7 +2615,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-ST-4104480a806c/bin/Lib/libLib.a"
                 ]
             },
             "name": "LibFramework.tvOS",
@@ -2688,8 +2700,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2701,7 +2711,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-ST-c922fa386514/bin/Lib/libLib.a"
                 ]
             },
             "name": "LibFramework.tvOS",
@@ -2784,8 +2796,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2797,7 +2807,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-ST-f389b73ae0f8/bin/Lib/libLib.a"
                 ]
             },
             "name": "LibFramework.watchOS",
@@ -2880,8 +2892,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
                     "-ObjC",
                     "-L/usr/lib/swift",
@@ -2893,7 +2903,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-ST-7b12038e3673/bin/Lib/libLib.a"
                 ]
             },
             "name": "LibFramework.watchOS",
@@ -3785,8 +3797,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/WidgetExtension/WidgetExtension.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
                     "-ObjC",
@@ -3799,7 +3809,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/Lib/libLib.a"
                 ]
             },
             "modulemaps": [
@@ -3914,8 +3926,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/WidgetExtension/WidgetExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-ObjC",
@@ -3928,7 +3938,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
                 ]
             },
             "modulemaps": [
@@ -4103,8 +4115,6 @@
                     "-ObjC",
                     "-framework",
                     "CryptoSwift",
-                    "-force_load",
-                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iMessageApp/iMessageAppExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
                     "-ObjC",
@@ -4117,7 +4127,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "-force_load",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/Lib/libLib.a"
                 ]
             },
             "modulemaps": [
@@ -5328,7 +5340,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
+                    "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-ST-a79bc2d21871/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
                 ]
             },
             "modulemaps": [
@@ -5565,7 +5579,9 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
                 ]
             },
             "modulemaps": [
@@ -5834,7 +5850,10 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
                 ]
             },
             "name": "iOSAppObjCUnitTests.__internal__.__test_bundle",
@@ -6010,7 +6029,10 @@
                     "-framework",
                     "Foundation",
                     "-framework",
-                    "UIKit"
+                    "UIKit",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/libUtils.a",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/external/FXPageControl/libFXPageControl.a",
+                    "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
                 ]
             },
             "modulemaps": [

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/generator.link.params
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/generator.link.params
@@ -14,3 +14,11 @@
 -no-canonical-prefixes
 -framework
 Foundation
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/test/tests.link.params
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/test/tests.link.params
@@ -20,3 +20,13 @@ XCTest
 -no-canonical-prefixes
 -framework
 Foundation
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a

--- a/test/fixtures/generator/bwb_spec.json
+++ b/test/fixtures/generator/bwb_spec.json
@@ -286,7 +286,17 @@
                     "XCTest",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation"
+                    "Foundation",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a"
                 ]
             },
             "lldb_context": {
@@ -549,7 +559,15 @@
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation"
+                    "Foundation",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a"
                 ]
             },
             "lldb_context": {

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/generator.link.params
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/generator.link.params
@@ -14,3 +14,11 @@
 -no-canonical-prefixes
 -framework
 Foundation
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/test/tests.link.params
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/targets/applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/tools/generator/test/tests.link.params
@@ -20,3 +20,13 @@ XCTest
 -no-canonical-prefixes
 -framework
 Foundation
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a
+bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a
+$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a

--- a/test/fixtures/generator/bwx_spec.json
+++ b/test/fixtures/generator/bwx_spec.json
@@ -285,7 +285,17 @@
                     "XCTest",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation"
+                    "Foundation",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a"
                 ]
             },
             "lldb_context": {
@@ -547,7 +557,15 @@
                     "-headerpad_max_install_names",
                     "-no-canonical-prefixes",
                     "-framework",
-                    "Foundation"
+                    "Foundation",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/tools/generator/libgenerator.library.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
+                    "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_tadija_aexml/libAEXML.a",
+                    "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-0c83c5e59889/bin/external/com_github_kylef_pathkit/libPathKit.a"
                 ]
             },
             "lldb_context": {

--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -18,6 +18,9 @@ _LD_SKIP_OPTS = {
     "-o": 2,
     "-static": 1,
     "-target": 2,
+
+    # TODO: Remove this filter once we move path logic out of the generator
+    "-force_load": 2,
 }
 
 _SKIP_INPUT_EXTENSIONS = {
@@ -350,6 +353,8 @@ def _process_linkopt(linkopt):
     if linkopt.startswith("-Wl,-install_name,"):
         return None
     if linkopt.startswith("@"):
+        return None
+    if linkopt.endswith(".a") or linkopt.endswith(".lo"):
         return None
 
     # Use Xcode set `DEVELOPER_DIR`

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -778,48 +778,46 @@ def _linker_inputs_to_dto(
         ],
     )
 
-    avoid_library_path = avoid_library.path if avoid_library else None
-    swift_triple = platform_info.to_swift_triple(platform)
+    if xcode_generated_paths:
+        swift_triple = platform_info.to_swift_triple(platform)
 
-    def _process_linkopt_value(value):
-        if value == avoid_library_path:
-            return None
+        def _process_linkopt_value(value):
+            xcode_path = xcode_generated_paths.get(value)
+            if not xcode_path:
+                return value
+            if paths.split_extension(xcode_path)[1] != ".swiftmodule":
+                return xcode_path
+            return "{}/{}.swiftmodule".format(xcode_path, swift_triple)
 
-        xcode_path = xcode_generated_paths.get(value)
-        if not xcode_path:
-            return value
-        if paths.split_extension(xcode_path)[1] != ".swiftmodule":
-            return xcode_path
-        return "{}/{}.swiftmodule".format(xcode_path, swift_triple)
+        def _process_linkopt_component(component):
+            prefix, sep, suffix = component.partition("=")
+            if not sep:
+                return _process_linkopt_value(component)
+            return "{}={}".format(prefix, _process_linkopt_value(suffix))
 
-    def _process_linkopt_component(component):
-        prefix, sep, suffix = component.partition("=")
-        if not sep:
-            return _process_linkopt_value(component)
-        value = _process_linkopt_value(suffix)
-        if not value:
-            return None
-        return "{}={}".format(prefix, value)
+        def _process_linkopt(linkopt):
+            return ",".join([
+                _process_linkopt_component(component)
+                for component in linkopt.split(",")
+            ])
 
-    def _process_linkopt(linkopt):
-        components = []
-        for component in linkopt.split(","):
-            component = _process_linkopt_component(component)
-            if not component:
-                return None
-            components.append(component)
-        return ",".join(components)
+        linkopts = [_process_linkopt(opt) for opt in linker_inputs.linkopts]
+    else:
+        linkopts = list(linker_inputs.linkopts)
 
-    linkopts = []
-    for opt in linker_inputs.linkopts:
-        opt = _process_linkopt(opt)
-        if not opt:
-            if linkopts and linkopts[-1] == "-force_load":
-                # We only skip linkopts for libraries, so we need to check if
-                # the previous linkopt was "-force_load" and remove it
-                linkopts.pop()
+    linkopts.extend([
+        quote_if_needed(xcode_generated_paths.get(file.path, file.path))
+        for file in linker_inputs.static_libraries
+        if file != avoid_library
+    ])
+
+    for file in linker_inputs.force_load_libraries:
+        if file == avoid_library:
             continue
-        linkopts.append(opt)
+        path = file.path
+        path = xcode_generated_paths.get(path, path)
+        linkopts.append("-force_load")
+        linkopts.append(quote_if_needed(path))
 
     set_if_true(ret, "linkopts", linkopts)
 


### PR DESCRIPTION
This reverts commit fe061c2a15f0e000b0619dd357cb807d9fdae9fc.

For us to properly do this, we need to parse any `-filelist`, filter out `.o` (leaving `.a` and `.lo`), and include them in this file. We can tackle that as part of making the `link.params` file lazy.