### PR TITLE
Revert "Remove additional linker inputs processing  (#1448)"

### DIFF
--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -477,6 +477,7 @@
 		331C91FDCA4754A04846BCDA /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		34051E31629F66435DD61AF0 /* private_lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = private_lib.swift; sourceTree = "<group>"; };
 		3423B69557C97C31CE6F81A4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		36F9C2CDB719B34DA8EA894C /* Launchd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Launchd.plist; sourceTree = "<group>"; };
 		3744E81974720C3D4AA9563D /* MixedAnswer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAnswer.swift; sourceTree = "<group>"; };
 		38FCC9102767925CDBE87F57 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		399487B73A64195D5E0CEAF8 /* ios app.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "ios app.entitlements"; sourceTree = "<group>"; };
@@ -631,6 +632,7 @@
 		C454C50B0428F3DA857A8F1E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C7D6E9EA886ACE2FD42D136F /* lib.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = lib.m; sourceTree = "<group>"; };
 		C7F1D3B7505057A4744B13EC /* lib_impl.swift.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = lib_impl.swift.modulemap; sourceTree = "<group>"; };
+		C8C653DDACA7470FA8EAA0E4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C8DD100EC3FA656AEFE5A00B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C958AF1F0777021D72A8F6C1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C9C5A40EB514C4EC147C976B /* watchOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = watchOSApp.swift; sourceTree = "<group>"; };
@@ -723,6 +725,14 @@
 				C8DD100EC3FA656AEFE5A00B /* Info.plist */,
 			);
 			path = ExampleResources;
+			sourceTree = "<group>";
+		};
+		00FC4A8FD63090536A204ADB /* CommandLineTool.merged_infoplist-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				C8C653DDACA7470FA8EAA0E4 /* Info.plist */,
+			);
+			path = "CommandLineTool.merged_infoplist-intermediates";
 			sourceTree = "<group>";
 		};
 		0222AAF70FE98D940CE986B4 /* UI */ = {
@@ -1397,6 +1407,7 @@
 		447167F6AD8E43AE079610F7 /* CommandLine */ = {
 			isa = PBXGroup;
 			children = (
+				A94D0DC82AA39AC106F2A44B /* CommandLineTool */,
 				3848A16814B21E8D214F66D8 /* CommandLineToolLib */,
 			);
 			path = CommandLine;
@@ -1887,6 +1898,14 @@
 				11F7064CC3C63974356E95D6 /* AltIcon-60.alticon */,
 			);
 			path = AltIcons;
+			sourceTree = "<group>";
+		};
+		79EEA105FB86180784D602F1 /* CommandLineTool.merged_launchdplists-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				36F9C2CDB719B34DA8EA894C /* Launchd.plist */,
+			);
+			path = "CommandLineTool.merged_launchdplists-intermediates";
 			sourceTree = "<group>";
 		};
 		7A33A81C3EE67AB1CA6A2614 /* watchOSAppExtension */ = {
@@ -2454,6 +2473,15 @@
 				BEEA406D7D2D485AEDBB4F40 /* RealAnswer.h */,
 			);
 			path = CoreUtils;
+			sourceTree = "<group>";
+		};
+		A94D0DC82AA39AC106F2A44B /* CommandLineTool */ = {
+			isa = PBXGroup;
+			children = (
+				00FC4A8FD63090536A204ADB /* CommandLineTool.merged_infoplist-intermediates */,
+				79EEA105FB86180784D602F1 /* CommandLineTool.merged_launchdplists-intermediates */,
+			);
+			path = CommandLineTool;
 			sourceTree = "<group>";
 		};
 		A9A2A17A01D9534ACF8D6E8C /* SwiftUnitTests */ = {

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -68,6 +68,8 @@ $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/Utils.swift.modulemap
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/TestingUtils.swift
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/TestingUtils.swift.modulemap
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineTool/CommandLineTool.merged_infoplist-intermediates/Info.plist
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineTool/CommandLineTool.merged_launchdplists-intermediates/Launchd.plist
 $(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/lib_impl.swift.modulemap
 $(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/lib_swift.swift.modulemap
 $(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/private_lib.swift.modulemap

--- a/examples/integration/test/fixtures/bwb_spec.json
+++ b/examples/integration/test/fixtures/bwb_spec.json
@@ -299,6 +299,14 @@
         "CommandLine/CommandLineTool/Info.plist",
         "CommandLine/CommandLineTool/Launchd.plist",
         {
+            "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineTool/CommandLineTool.merged_infoplist-intermediates/Info.plist",
+            "t": "g"
+        },
+        {
+            "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineTool/CommandLineTool.merged_launchdplists-intermediates/Launchd.plist",
+            "t": "g"
+        },
+        {
             "_": "examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
             "t": "e"
         },

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -1235,6 +1235,7 @@
 		C74F0CE27C1BE62BAD492BC2 /* MixedAnswer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MixedAnswer.swift; sourceTree = "<group>"; };
 		C76EC49BB9C08D1023E0EEE7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C7AFD4E7FE44440D1A951A7F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		C809B802C65A75A451099BEB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C88E284E00547B4205F5A95B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		CA95EEF3FAE24FBB77E2EF38 /* Launchd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Launchd.plist; sourceTree = "<group>"; };
 		CB4A0FB26B6A160C6B667828 /* Nested */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Nested; sourceTree = "<group>"; };
@@ -1273,6 +1274,7 @@
 		E135F778E8931913A777DAC5 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
 		E1F8E96E36D76FC0FE607DFD /* libprivate_swift_lib.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = libprivate_swift_lib.a; path = "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		E23B060049E59E0D8A5A8798 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		E2A6BB353986B18FEDC56F0A /* Launchd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Launchd.plist; sourceTree = "<group>"; };
 		E543039CE72D7A78BE725EDA /* MixedAnswer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MixedAnswer.h; sourceTree = "<group>"; };
 		E6380838CC4C3E99F5C4215B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		E7B005556CA96365E4CD9D39 /* WatchOSAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchOSAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
@@ -2026,6 +2028,14 @@
 			path = bin;
 			sourceTree = "<group>";
 		};
+		3BF70867B1F7BAD947179081 /* CommandLineTool.merged_launchdplists-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				E2A6BB353986B18FEDC56F0A /* Launchd.plist */,
+			);
+			path = "CommandLineTool.merged_launchdplists-intermediates";
+			sourceTree = "<group>";
+		};
 		3D438CFF608DBEE795552CFD /* Lib */ = {
 			isa = PBXGroup;
 			children = (
@@ -2184,6 +2194,7 @@
 		52BF33991D0E63683C87BAEB /* CommandLine */ = {
 			isa = PBXGroup;
 			children = (
+				7A70932BEC64E72DEF0986E7 /* CommandLineTool */,
 				0D60346C1008212F5C4D68A4 /* CommandLineToolLib */,
 			);
 			path = CommandLine;
@@ -2620,6 +2631,15 @@
 				3B9C136F7B8D373BAA87EE5B /* UI */,
 			);
 			path = bin;
+			sourceTree = "<group>";
+		};
+		7A70932BEC64E72DEF0986E7 /* CommandLineTool */ = {
+			isa = PBXGroup;
+			children = (
+				B04BB5365AF466FC68462E69 /* CommandLineTool.merged_infoplist-intermediates */,
+				3BF70867B1F7BAD947179081 /* CommandLineTool.merged_launchdplists-intermediates */,
+			);
+			path = CommandLineTool;
 			sourceTree = "<group>";
 		};
 		7AB69A39C84E09E3EC4587C2 /* Source */ = {
@@ -3155,6 +3175,14 @@
 				6A49AEE1769DFD7A488B23CB /* GoogleMaps.bundle */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		B04BB5365AF466FC68462E69 /* CommandLineTool.merged_infoplist-intermediates */ = {
+			isa = PBXGroup;
+			children = (
+				C809B802C65A75A451099BEB /* Info.plist */,
+			);
+			path = "CommandLineTool.merged_infoplist-intermediates";
 			sourceTree = "<group>";
 		};
 		B1B351D10165A225FD5F8BCF /* Resources */ = {

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -70,6 +70,8 @@ $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Source/Utils/Utils.swift.modulemap
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/TestingUtils.swift
 $(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-ST-5e5f1c985307/bin/iOSApp/Test/TestingUtils/TestingUtils.swift.modulemap
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineTool/CommandLineTool.merged_infoplist-intermediates/Info.plist
+$(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineTool/CommandLineTool.merged_launchdplists-intermediates/Launchd.plist
 $(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/lib_impl.swift.modulemap
 $(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/lib_swift.swift.modulemap
 $(BAZEL_OUT)/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineToolLib/private_lib.swift.modulemap

--- a/examples/integration/test/fixtures/bwx_spec.json
+++ b/examples/integration/test/fixtures/bwx_spec.json
@@ -235,6 +235,14 @@
         "CommandLine/CommandLineTool/Info.plist",
         "CommandLine/CommandLineTool/Launchd.plist",
         {
+            "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineTool/CommandLineTool.merged_infoplist-intermediates/Info.plist",
+            "t": "g"
+        },
+        {
+            "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-ST-654a40ea2473/bin/CommandLine/CommandLineTool/CommandLineTool.merged_launchdplists-intermediates/Launchd.plist",
+            "t": "g"
+        },
+        {
             "_": "examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
             "t": "e"
         },


### PR DESCRIPTION
This reverts commit 3959deaea039ab46ed2bfcfaa2614ef23500b062.

In BwX mode we still need these in order to force Bazel to generate them for us.