### PR TITLE
load rules_swift 1.3.0

### DIFF
--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -75,8 +75,8 @@ def xcodeproj_rules_dependencies(
     _maybe(
         http_archive,
         name = "build_bazel_rules_swift",
-        sha256 = "51efdaf85e04e51174de76ef563f255451d5a5cd24c61ad902feeadafc7046d9",
-        url = "https://github.com/bazelbuild/rules_swift/releases/download/1.2.0/rules_swift.1.2.0.tar.gz",
+        sha256 = "2ce874c8c34a03a0a33bfb0c8100f0be32279e0a40f5b794fd943f15441e034a",
+        url = "https://github.com/bazelbuild/rules_swift/releases/download/1.3.0/rules_swift.1.3.0.tar.gz",
         ignore_version_differences = ignore_version_differences,
     )
 


### PR DESCRIPTION
load rules_swift 1.3.0, and run the build `bazelisk build //iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests` to get below error

~/tinder/rules_xcodeproj/examples/integration/ [issue-933/duplicate_symbol_linker_error+*] bazelisk build //iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests

INFO: Analyzed target //iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests (101 packages loaded, 3393 targets configured).
INFO: Found 1 target...
INFO: From AssetCatalogCompile iOSApp/Source/iOSApp-intermediates/xcassets:
/* com.apple.actool.document.notices */
/Users/kaijing/tinder/rules_xcodeproj/examples/integration/iOSApp/Source/Assets.xcassets:./AppIcon.appiconset/[][iphone][57x57][][][2x][][][]: notice: 57x57@2x app icons only apply to iPhone apps targeting releases of iOS prior to 7.0
INFO: From MomCompile iOSApp/Source/iOSApp-intermediates/Model.momd:
/Users/kaijing/tinder/rules_xcodeproj/examples/integration/bazel-output-base/sandbox/darwin-sandbox/87/execroot/__main__/iOSApp/Source/Model.xcdatamodeld/Model2.xcdatamodel:Entity2.parent: warning: Entity2.parent should have an inverse [2]
ERROR: /Users/kaijing/tinder/rules_xcodeproj/examples/integration/iOSApp/Test/TestingUtils/BUILD:3:14: Compiling Swift module //iOSApp/Test/TestingUtils:TestingUtils failed: (Exit 1): worker failed: error executing command bazel-out/darwin_x86_64-opt-exec-BDE7E609-ST-53df4e45311b/bin/external/build_bazel_rules_swift/tools/worker/worker swiftc ... (remaining 1 argument skipped)
swift_worker: Could not copy bazel-out/ios-sim_arm64-min15.0-applebin_ios-ios_sim_arm64-fastbuild-ST-25e246568c54/bin/iOSApp/Test/TestingUtils/SwiftAPI/TestingUtils-Swift.h to bazel-out/ios-sim_arm64-min15.0-applebin_ios-ios_sim_arm64-fastbuild-ST-25e246568c54/bin/_swift_incremental/iOSApp/Test/TestingUtils/SwiftAPI/TestingUtils-Swift.h (No such file or directory)
Target //iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests failed to build
Use --verbose_failures to see the command lines of failed build steps.
ERROR: /Users/kaijing/tinder/rules_xcodeproj/examples/integration/iOSApp/Test/SwiftUnitTests/BUILD:17:14 Compiling Swift module //iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.library failed: (Exit 1): worker failed: error executing command bazel-out/darwin_x86_64-opt-exec-BDE7E609-ST-53df4e45311b/bin/external/build_bazel_rules_swift/tools/worker/worker swiftc ... (remaining 1 argument skipped)
INFO: Elapsed time: 18.991s, Critical Path: 7.56s
INFO: 299 processes: 199 internal, 86 darwin-sandbox, 12 local, 2 worker.
FAILED: Build did NOT complete successfully
