### PR TITLE
Fix lldb error when `module` is `None`

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -51,6 +51,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -51,6 +51,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -430,6 +430,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -51,6 +51,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -68,6 +68,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -51,6 +51,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -59,6 +59,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -51,6 +51,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -90,6 +90,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -90,6 +90,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -728,6 +728,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1168,6 +1168,9 @@ class StopHook:
     def handle_stop(self, exe_ctx, _stream):
         "Method that is called when the user stops in lldb."
         module = exe_ctx.frame.module
+        if not module:
+            return
+
         module_name = module.file.__get_fullpath__()
         target_triple = module.GetTriple()
         executable_path = _get_relative_executable_path(module_name)


### PR DESCRIPTION
I don't know why, but the module in lldb can sometimes not be set. Regardless, we can just not try to set settings if that is the case.