### PR TITLE
Remove `important_outputs` from BEP

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -51,6 +51,9 @@ build:rules_xcodeproj --features=swift.use_global_index_store
 # `swift.use_global_module_cache` drastically speeds up swift builds
 build:rules_xcodeproj --features=swift.use_global_module_cache
 
+# Removes potentially large unneeded event from the BEP
+build:rules_xcodeproj --nolegacy_important_outputs
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -51,6 +51,9 @@ build:rules_xcodeproj --features=swift.use_global_index_store
 # `swift.use_global_module_cache` drastically speeds up swift builds
 build:rules_xcodeproj --features=swift.use_global_module_cache
 
+# Removes potentially large unneeded event from the BEP
+build:rules_xcodeproj --nolegacy_important_outputs
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -51,6 +51,9 @@ build:rules_xcodeproj --features=swift.use_global_index_store
 # `swift.use_global_module_cache` drastically speeds up swift builds
 build:rules_xcodeproj --features=swift.use_global_module_cache
 
+# Removes potentially large unneeded event from the BEP
+build:rules_xcodeproj --nolegacy_important_outputs
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -51,6 +51,9 @@ build:rules_xcodeproj --features=swift.use_global_index_store
 # `swift.use_global_module_cache` drastically speeds up swift builds
 build:rules_xcodeproj --features=swift.use_global_module_cache
 
+# Removes potentially large unneeded event from the BEP
+build:rules_xcodeproj --nolegacy_important_outputs
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -51,6 +51,9 @@ build:rules_xcodeproj --features=swift.use_global_index_store
 # `swift.use_global_module_cache` drastically speeds up swift builds
 build:rules_xcodeproj --features=swift.use_global_module_cache
 
+# Removes potentially large unneeded event from the BEP
+build:rules_xcodeproj --nolegacy_important_outputs
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -51,6 +51,9 @@ build:rules_xcodeproj --features=swift.use_global_index_store
 # `swift.use_global_module_cache` drastically speeds up swift builds
 build:rules_xcodeproj --features=swift.use_global_module_cache
 
+# Removes potentially large unneeded event from the BEP
+build:rules_xcodeproj --nolegacy_important_outputs
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -51,6 +51,9 @@ build:rules_xcodeproj --features=swift.use_global_index_store
 # `swift.use_global_module_cache` drastically speeds up swift builds
 build:rules_xcodeproj --features=swift.use_global_module_cache
 
+# Removes potentially large unneeded event from the BEP
+build:rules_xcodeproj --nolegacy_important_outputs
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/simple/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -51,6 +51,9 @@ build:rules_xcodeproj --features=swift.use_global_index_store
 # `swift.use_global_module_cache` drastically speeds up swift builds
 build:rules_xcodeproj --features=swift.use_global_module_cache
 
+# Removes potentially large unneeded event from the BEP
+build:rules_xcodeproj --nolegacy_important_outputs
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -51,6 +51,9 @@ build:rules_xcodeproj --features=swift.use_global_index_store
 # `swift.use_global_module_cache` drastically speeds up swift builds
 build:rules_xcodeproj --features=swift.use_global_module_cache
 
+# Removes potentially large unneeded event from the BEP
+build:rules_xcodeproj --nolegacy_important_outputs
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -51,6 +51,9 @@ build:rules_xcodeproj --features=swift.use_global_index_store
 # `swift.use_global_module_cache` drastically speeds up swift builds
 build:rules_xcodeproj --features=swift.use_global_module_cache
 
+# Removes potentially large unneeded event from the BEP
+build:rules_xcodeproj --nolegacy_important_outputs
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -51,6 +51,9 @@ build:rules_xcodeproj --features=swift.use_global_index_store
 # `swift.use_global_module_cache` drastically speeds up swift builds
 build:rules_xcodeproj --features=swift.use_global_module_cache
 
+# Removes potentially large unneeded event from the BEP
+build:rules_xcodeproj --nolegacy_important_outputs
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0


### PR DESCRIPTION
This will normally half the number of paths output in the BEP.