### PR TITLE
Make BES upload async inside of Xcode

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -86,6 +86,9 @@ readonly base_pre_config_flags=(
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
   "--repo_env=USE_CLANG_CL=$XCODE_PRODUCT_BUILD_VERSION"
+
+  # Don't block the end of the build for BES upload (artifacts OR events)
+  "--bes_upload_mode=NOWAIT_FOR_UPLOAD_COMPLETE"
 )
 
 # Create VFS overlay


### PR DESCRIPTION
For builds with lots of outputs, they may have hundreds of `namedSetsOfFiles` events. This can take a couple seconds to send to a BES service. We shouldn't hold up the build to send these events.