### PR TITLE
Set pre and post scripts to always be out of date by default

### DIFF
--- a/examples/simple/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/simple/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		};
 		3D71E6BCCD3DE986783AF2C9 /* Post-build Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -199,6 +200,7 @@
 		};
 		922073A986018654923053B1 /* Pre-build Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
+++ b/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
@@ -110,7 +110,8 @@ $(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py
             let script = createBuildScript(
                 in: pbxProj,
                 name: "Pre-build",
-                script: preBuildScript
+                script: preBuildScript,
+                alwaysOutOfDate: true
             )
             buildPhases.insert(script, at: 0)
         }
@@ -119,7 +120,8 @@ $(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py
             let script = createBuildScript(
                 in: pbxProj,
                 name: "Post-build",
-                script: postBuildScript
+                script: postBuildScript,
+                alwaysOutOfDate: true
             )
             buildPhases.append(script)
         }
@@ -211,12 +213,14 @@ perl -pe 's/\$(\()?([a-zA-Z_]\w*)(?(1)\))/$ENV{$2}/g' \
     private static func createBuildScript(
         in pbxProj: PBXProj,
         name: String,
-        script: String
+        script: String,
+        alwaysOutOfDate: Bool = false
     ) -> PBXShellScriptBuildPhase {
         let script = PBXShellScriptBuildPhase(
             name: "\(name) Run Script",
             shellScript: "\(script)\n",
-            showEnvVarsInLog: false
+            showEnvVarsInLog: false,
+            alwaysOutOfDate: alwaysOutOfDate
         )
         pbxProj.add(object: script)
 


### PR DESCRIPTION
This is already the case for the Bazel build script and removes the warning that Xcode throws due to the fact that inputs and outputs are not defined.