### PR TITLE
Add Mercari as a rules_xcodeproj user

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ rules.
 ## Projects using rules_xcodeproj
 
 - [Envoy Mobile](https://github.com/envoyproxy/envoy-mobile)
+- [Mercari](https://engineering.mercari.com/blog/entry/20221215-16cdd59909/)
 - Robinhood
 - Slack
 - Spotify


### PR DESCRIPTION
With a link to the blog post that mentions it.
