### PR TITLE
Adjust generator launch arguments

### DIFF
--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -207,19 +207,15 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "/tmp/spec.json"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
@@ -236,6 +232,42 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-project_spec.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.0.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.1.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.2.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.3.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.4.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.5.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.6.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.7.json"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/test/fixtures/generator/bwb_project_spec.json
+++ b/test/fixtures/generator/bwb_project_spec.json
@@ -44,14 +44,22 @@
             },
             "launch_action": {
                 "args": [
-                    "/tmp/spec.json",
-                    "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
-                    "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
-                    "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
                     "/tmp/out.xcodeproj",
                     "/tmp/out.final.xcodeproj",
                     "bazel",
-                    "0"
+                    "0",
+                    "/tmp/specs/xcodeproj.generator-project_spec.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.0.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.1.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.2.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.3.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.4.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.5.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.6.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.7.json"
                 ],
                 "build_configuration_name": "Debug",
                 "diagnostics": {

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -181,19 +181,15 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "/tmp/spec.json"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
@@ -210,6 +206,42 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "0"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-project_spec.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.0.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.1.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.2.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.3.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.4.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.5.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.6.json"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "/tmp/specs/xcodeproj.generator-targets_spec.7.json"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/test/fixtures/generator/bwx_project_spec.json
+++ b/test/fixtures/generator/bwx_project_spec.json
@@ -44,14 +44,22 @@
             },
             "launch_action": {
                 "args": [
-                    "/tmp/spec.json",
-                    "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
-                    "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
-                    "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
                     "/tmp/out.xcodeproj",
                     "/tmp/out.final.xcodeproj",
                     "bazel",
-                    "0"
+                    "0",
+                    "/tmp/specs/xcodeproj.generator-project_spec.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.0.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.1.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.2.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.3.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.4.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.5.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.6.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.7.json"
                 ],
                 "build_configuration_name": "Debug",
                 "diagnostics": {

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -63,14 +63,22 @@ def get_xcode_schemes():
             launch_action = xcode_schemes.launch_action(
                 _APP_TARGET,
                 args = [
-                    "/tmp/spec.json",
-                    "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
-                    "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
-                    "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
                     "/tmp/out.xcodeproj",
                     "/tmp/out.final.xcodeproj",
                     "bazel",
                     "0",
+                    "/tmp/specs/xcodeproj.generator-project_spec.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.0.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.1.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.2.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.3.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.4.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.5.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.6.json",
+                    "/tmp/specs/xcodeproj.generator-targets_spec.7.json",
                 ],
                 # This is not necessary for the generator. It is here to help
                 # verify that custom environment variables are passed along.


### PR DESCRIPTION
They now account for the new way that specs are passed, and default to `opt` to make it easier when adjusting for profiling.