### PR TITLE
Default Profile action's `customWorkingDirectory` based on Launch action

### DIFF
--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -293,7 +293,8 @@
       buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
-      useCustomWorkingDirectory = "NO"
+      useCustomWorkingDirectory = "YES"
+      customWorkingDirectory = "$(BUILD_WORKSPACE_DIRECTORY)"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -257,7 +257,8 @@
       buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
-      useCustomWorkingDirectory = "NO"
+      useCustomWorkingDirectory = "YES"
+      customWorkingDirectory = "$(BUILD_WORKSPACE_DIRECTORY)"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/tools/generator/src/DTO/XcodeScheme.swift
+++ b/tools/generator/src/DTO/XcodeScheme.swift
@@ -61,9 +61,9 @@ disabled, but the target is referenced in the scheme's \(keyPath.actionType) act
                 buildTargets[label] = buildTarget
             }
 
-            // Popuate the dictionary with any build targets that were explicitly specified.
-            // We are guaranteed not to have build targets with duplicate labels. So, we can just
-            // add these.
+            // Populate the dictionary with any build targets that were
+            // explicitly specified. We are guaranteed not to have build targets
+            // with duplicate labels. So, we can just add these.
             buildAction?.targets.forEach { buildTargets[$0.label] = $0 }
 
             // Default ProfileAction
@@ -75,7 +75,8 @@ disabled, but the target is referenced in the scheme's \(keyPath.actionType) act
             {
                 newProfileAction = .init(
                     target: launchAction.target,
-                    buildConfigurationName: launchAction.buildConfigurationName
+                    buildConfigurationName: launchAction.buildConfigurationName,
+                    workingDirectory: launchAction.workingDirectory
                 )
             } else {
                 newProfileAction = nil
@@ -406,13 +407,16 @@ extension XcodeScheme {
     struct ProfileAction: Equatable, Decodable {
         let buildConfigurationName: String
         let target: BazelLabel
+        let workingDirectory: String?
 
         init(
             target: BazelLabel,
-            buildConfigurationName: String = .defaultBuildConfigurationName
+            buildConfigurationName: String = .defaultBuildConfigurationName,
+            workingDirectory: String? = nil
         ) {
             self.target = target
             self.buildConfigurationName = buildConfigurationName
+            self.workingDirectory = workingDirectory
         }
     }
 }

--- a/tools/generator/src/Extensions/XCScheme+Extensions.swift
+++ b/tools/generator/src/Extensions/XCScheme+Extensions.swift
@@ -63,7 +63,7 @@ extension XCScheme {
             )
         }
 
-        let launchAction: XCScheme.LaunchAction?
+        let launchAction: XCScheme.LaunchAction
         if let launchActionInfo = schemeInfo.launchActionInfo {
             launchAction = try .init(buildMode: buildMode, launchActionInfo: launchActionInfo)
         } else {
@@ -273,7 +273,9 @@ extension XCScheme.ProfileAction {
     convenience init(profileActionInfo: XCSchemeInfo.ProfileActionInfo) {
         self.init(
             buildableProductRunnable: profileActionInfo.runnable,
-            buildConfiguration: profileActionInfo.buildConfigurationName
+            buildConfiguration: profileActionInfo.buildConfigurationName,
+            customWorkingDirectory: profileActionInfo.workingDirectory,
+            useCustomWorkingDirectory: profileActionInfo.workingDirectory != nil
         )
     }
 }

--- a/tools/generator/src/Generator/XCSchemeInfo+ProfileActionInfo.swift
+++ b/tools/generator/src/Generator/XCSchemeInfo+ProfileActionInfo.swift
@@ -4,6 +4,17 @@ extension XCSchemeInfo {
     struct ProfileActionInfo: Equatable {
         let buildConfigurationName: String
         let targetInfo: XCSchemeInfo.TargetInfo
+        let workingDirectory: String?
+
+        init(
+            buildConfigurationName: String,
+            targetInfo: XCSchemeInfo.TargetInfo,
+            workingDirectory: String? = nil
+        ) {
+            self.buildConfigurationName = buildConfigurationName
+            self.targetInfo = targetInfo
+            self.workingDirectory = workingDirectory
+        }
     }
 }
 
@@ -23,7 +34,8 @@ extension XCSchemeInfo.ProfileActionInfo {
             targetInfo: .init(
                 resolveHostFor: original.targetInfo,
                 topLevelTargetInfos: topLevelTargetInfos
-            )
+            ),
+            workingDirectory: original.workingDirectory
         )
     }
 }
@@ -59,7 +71,8 @@ extension XCSchemeInfo.ProfileActionInfo {
                     for: profileAction.target,
                     context: "creating a `ProfileActionInfo`"
                 )
-            )
+            ),
+            workingDirectory: profileAction.workingDirectory
         )
     }
 }


### PR DESCRIPTION
This way profiling works runs the same as launching, which is expected until we support custom `profile_action`s.