### PR TITLE
Add support for bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,22 @@
+module(
+    name = "rules_xcodeproj",
+    version = "0.11.0",
+    repo_name = "com_github_buildbuddy_io_rules_xcodeproj",
+    compatibility_level = 1,
+)
+bazel_dep(name = "bazel_skylib", version = "1.3.0")
+bazel_dep(name = "rules_swift", version = "1.5.1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_apple", version = "2.0.0", repo_name = "build_bazel_rules_apple")
+
+non_module_deps = use_extension("//xcodeproj:extensions.bzl", "non_module_deps")
+use_repo(
+    non_module_deps,
+    "rules_xcodeproj_index_import",
+    "com_github_kylef_pathkit",
+    "com_github_tadija_aexml",
+    "com_github_michaeleisel_jjliso8601dateformatter",
+    "com_github_michaeleisel_zippyjsoncfamily",
+    "com_github_michaeleisel_zippyjson",
+    "com_github_tuist_xcodeproj",
+    "com_github_apple_swift_collections",
+)

--- a/examples/cc/MODULE.bazel
+++ b/examples/cc/MODULE.bazel
@@ -1,0 +1,15 @@
+bazel_dep(name = "rules_apple", repo_name = "build_bazel_rules_apple", version = "2.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.3.0")
+bazel_dep(name = "rules_xcodeproj", repo_name = "com_github_buildbuddy_io_rules_xcodeproj", version = "0.0.0")
+bazel_dep(name = "rules_swift", repo_name = "build_bazel_rules_swift", version = "1.5.1")
+bazel_dep(name = "examples_cc_external", version = "0.0.1")
+
+local_path_override(
+    module_name = "rules_xcodeproj",
+    path = "../.."
+)
+
+local_path_override(
+    module_name = "examples_cc_external",
+    path = "external"
+)

--- a/examples/cc/external/MODULE.bazel
+++ b/examples/cc/external/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "examples_cc_external",
+    version = "0.0.1",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.3.0")

--- a/xcodeproj/extensions.bzl
+++ b/xcodeproj/extensions.bzl
@@ -1,0 +1,5 @@
+"""Module extension for loading dependencies not yet compatible with bzlmod."""
+
+load("//xcodeproj:repositories.bzl", "xcodeproj_rules_dependencies")
+
+non_module_deps = module_extension(implementation = lambda _: xcodeproj_rules_dependencies(include_bzlmod_ready_dependencies = False))


### PR DESCRIPTION
This PR adds initial support for bzlmod. I still have to test it with an example project, but the basic infrastructure should be ready.

bzlmod is only really ready to be used starting in Bazel 6.0. For this reason, the `MODULE.bazel` depends on rules_apple 2.0.0, which is also the release that requires Bazel 6. I will need to first check the newest version of rules_apple and rules_swift into the Bazel Central Registry, and then we can proceed testing the rules_xcodeproj integration.