### PR TITLE
Stop writing linkopts for fixtures

### DIFF
--- a/examples/cc/test/fixtures/bwb_targets_spec.json
+++ b/examples/cc/test/fixtures/bwb_targets_spec.json
@@ -377,14 +377,8 @@
         "label": "//tool:tool",
         "linker_inputs": {
             "linkopts": [
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-lc++",
-                "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib2/liblib_impl.a",
-                "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external/liblib_impl.a",
-                "-force_load",
-                "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib/liblib_impl.lo"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "tool",

--- a/examples/cc/test/fixtures/bwx_targets_spec.json
+++ b/examples/cc/test/fixtures/bwx_targets_spec.json
@@ -376,14 +376,8 @@
         "label": "//tool:tool",
         "linker_inputs": {
             "linkopts": [
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-lc++",
-                "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib2/liblib_impl.a",
-                "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external/liblib_impl.a",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib/liblib_impl.lo"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "tool",

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -65,24 +65,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/AppClip/AppClip.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -231,24 +215,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/AppClip/AppClip.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -439,36 +407,8 @@
         "label": "//CommandLine/CommandLineTool:CommandLineTool",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "ExternalFramework",
-                "-weak_framework",
-                "SwiftUI",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
-                "-Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-Wl,-sectcreate,__TEXT,__launchd_plist,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineTool/CommandLineTool.merged_launchdplists-intermediates/Launchd.plist",
-                "-Wl,-dead_strip",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-Wl,-exported_symbols_list,CommandLine/CommandLineTool/export_symbol_list.exp",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/swift_c_module/libc_lib.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                "-force_load",
-                "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -648,26 +588,8 @@
         "label": "//CommandLine/CommandLineTool:tool.binary",
         "linker_inputs": {
             "linkopts": [
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "ExternalFramework",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-L/usr/lib/swift",
-                "-ObjC",
-                "-no-canonical-prefixes",
-                "-lc++",
-                "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/swift_c_module/libc_lib.a",
-                "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                "-force_load",
-                "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -869,26 +791,8 @@
         "label": "//CommandLine/CommandLineTool:tool.binary",
         "linker_inputs": {
             "linkopts": [
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "ExternalFramework",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-L/usr/lib/swift",
-                "-ObjC",
-                "-no-canonical-prefixes",
-                "-lc++",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/swift_c_module/libc_lib.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                "-force_load",
-                "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -2597,37 +2501,8 @@
         "label": "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "ExternalFramework",
-                "-weak_framework",
-                "SwiftUI",
-                "-L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule",
-                "-Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/swift_c_module/libc_lib.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                "-force_load",
-                "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -3009,23 +2884,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -3129,23 +2989,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -3248,23 +3093,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -3367,23 +3197,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -3486,23 +3301,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -3605,23 +3405,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -4132,23 +3917,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -4251,23 +4021,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -4370,23 +4125,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -4489,23 +4229,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -4635,24 +4360,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.iOS",
-                "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -4812,24 +4521,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.iOS",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -4989,24 +4682,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.tvOS",
-                "-Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -5166,24 +4843,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.tvOS",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -5343,24 +5004,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.watchOS",
-                "-Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -5520,24 +5165,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.watchOS",
-                "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -5690,24 +5319,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/WidgetExtension/WidgetExtension.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -5855,24 +5468,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/WidgetExtension/WidgetExtension.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -6075,24 +5672,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iMessageApp/iMessageAppExtension.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -6620,15 +6201,8 @@
         "label": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-lc++",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "FrameworkCoreUtilsObjC",
@@ -6776,15 +6350,8 @@
         "label": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-lc++",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "FrameworkCoreUtilsObjC",
@@ -7046,47 +6613,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "SystemConfiguration",
-                "-framework",
-                "CoreLocation",
-                "-framework",
-                "CoreTelephony",
-                "-framework",
-                "GoogleMaps",
-                "-framework",
-                "GoogleMapsCore",
-                "-framework",
-                "GoogleMapsBase",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "CoreUtilsObjC",
-                "-framework",
-                "UIFramework.iOS",
-                "-framework",
-                "LibFramework.iOS",
-                "-lc++",
-                "-lz",
-                "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/iOSApp.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule",
-                "--ld-path=external/rules_apple_linker_lld/ld64.lld",
-                "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
-                "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -7321,47 +6849,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "SystemConfiguration",
-                "-framework",
-                "CoreLocation",
-                "-framework",
-                "CoreTelephony",
-                "-framework",
-                "GoogleMaps",
-                "-framework",
-                "GoogleMapsCore",
-                "-framework",
-                "GoogleMapsBase",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "CoreUtilsObjC",
-                "-framework",
-                "UIFramework.iOS",
-                "-framework",
-                "LibFramework.iOS",
-                "-lc++",
-                "-lz",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/iOSApp.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule",
-                "--ld-path=external/rules_apple_linker_lld/ld64.lld",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -7644,48 +7133,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "SystemConfiguration",
-                "-framework",
-                "CoreLocation",
-                "-framework",
-                "CoreTelephony",
-                "-framework",
-                "CoreGraphics",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "CoreUtilsObjC",
-                "-framework",
-                "UIFramework.iOS",
-                "-framework",
-                "LibFramework.iOS",
-                "-lc++",
-                "-lz",
-                "-L$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/TestingUtils.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/iOSApp.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule",
-                "--ld-path=external/rules_apple_linker_lld/ld64.lld",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/Utils/libUtils.a",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl/libFXPageControl.a",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -7922,49 +7371,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "SystemConfiguration",
-                "-framework",
-                "CoreLocation",
-                "-framework",
-                "CoreTelephony",
-                "-framework",
-                "CoreGraphics",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "CoreUtilsObjC",
-                "-framework",
-                "UIFramework.iOS",
-                "-framework",
-                "LibFramework.iOS",
-                "-lc++",
-                "-lz",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.swiftmodule",
-                "-L$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/TestingUtils.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/iOSApp.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule",
-                "--ld-path=external/rules_apple_linker_lld/ld64.lld",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/Utils/libUtils.a",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl/libFXPageControl.a",
-                "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -8264,21 +7672,8 @@
                 "macOSApp/third_party/ExampleFramework.framework"
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "ExampleFramework",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15/bin/macOSApp/Source/macOSApp.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "Cocoa"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -8391,20 +7786,8 @@
         "label": "//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15/bin/macOSApp/Test/UITests/macOSAppUITests.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -8535,27 +7918,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.tvOS",
-                "-framework",
-                "LibFramework.tvOS",
-                "-Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/tvOSApp/Source/tvOSApp.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -8730,27 +8094,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.tvOS",
-                "-framework",
-                "LibFramework.tvOS",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/tvOSApp/Source/tvOSApp.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -8905,22 +8250,8 @@
         "label": "//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-L$(DEVELOPER_DIR)/Platforms/AppleTVSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/tvOSApp/Test/UITests/tvOSAppUITests.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -9052,31 +8383,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.tvOS",
-                "-framework",
-                "LibFramework.tvOS",
-                "-L$(DEVELOPER_DIR)/Platforms/AppleTVSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/tvOSApp/Source/tvOSApp.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -9249,22 +8557,8 @@
         "label": "//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-L$(DEVELOPER_DIR)/Platforms/WatchSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/watchOSApp/Test/UITests/watchOSAppUITestsLibrary.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -9520,30 +8814,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.watchOS",
-                "-framework",
-                "LibFramework.watchOS",
-                "-L$(DEVELOPER_DIR)/Platforms/WatchSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTestsLibrary.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -9720,27 +8992,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.watchOS",
-                "-framework",
-                "LibFramework.watchOS",
-                "-Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -9916,27 +9169,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.watchOS",
-                "-framework",
-                "LibFramework.watchOS",
-                "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/UI/UI.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {

--- a/examples/integration/test/fixtures/bwx_targets_spec.json
+++ b/examples/integration/test/fixtures/bwx_targets_spec.json
@@ -69,24 +69,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip/AppClip.swiftmodule/arm64-apple-ios.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "AppClip",
@@ -195,24 +179,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip/AppClip.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "AppClip",
@@ -358,36 +326,8 @@
         "label": "//CommandLine/CommandLineTool:CommandLineTool",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "ExternalFramework",
-                "-weak_framework",
-                "SwiftUI",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-Wl,-sectcreate,__TEXT,__launchd_plist,bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineTool/CommandLineTool.merged_launchdplists-intermediates/Launchd.plist",
-                "-Wl,-dead_strip",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-Wl,-exported_symbols_list,CommandLine/CommandLineTool/export_symbol_list.exp",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/swift_c_module/libc_lib.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                "-force_load",
-                "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "CommandLineTool",
@@ -521,26 +461,8 @@
         "label": "//CommandLine/CommandLineTool:tool.binary",
         "linker_inputs": {
             "linkopts": [
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "ExternalFramework",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-L/usr/lib/swift",
-                "-ObjC",
-                "-no-canonical-prefixes",
-                "-lc++",
-                "$(BUILD_DIR)/bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                "$(BUILD_DIR)/bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/swift_c_module/libc_lib.a",
-                "$(BUILD_DIR)/bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                "$(BUILD_DIR)/bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                "$(BUILD_DIR)/bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                "-force_load",
-                "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "tool.binary",
@@ -674,26 +596,8 @@
         "label": "//CommandLine/CommandLineTool:tool.binary",
         "linker_inputs": {
             "linkopts": [
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "ExternalFramework",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-L/usr/lib/swift",
-                "-ObjC",
-                "-no-canonical-prefixes",
-                "-lc++",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/swift_c_module/libc_lib.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                "-force_load",
-                "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "tool.binary",
@@ -2334,37 +2238,8 @@
         "label": "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "ExternalFramework",
-                "-weak_framework",
-                "SwiftUI",
-                "-L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests/LibSwiftTestsLib.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/LibSwift.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,external/examples_command_line_external/ExternalFramework.framework/Modules/ExternalFramework.swiftmodule/x86_64.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/swift_c_module/libc_lib.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
-                "external/examples_command_line_external/ImportableLibrary/libImportableLibrary.a",
-                "-force_load",
-                "external/examples_command_line_external/ExternalFramework.framework/ExternalFramework"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "CommandLineToolTests.__internal__.__test_bundle",
@@ -2679,23 +2554,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "iOS",
@@ -2776,23 +2636,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "iOS",
@@ -2872,23 +2717,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "tvOS",
@@ -2968,23 +2798,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "tvOS",
@@ -3064,23 +2879,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "watchOS",
@@ -3160,23 +2960,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "watchOS",
@@ -3665,23 +3450,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "LibFramework.iOS",
@@ -3762,23 +3532,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "LibFramework.iOS",
@@ -3858,23 +3613,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "LibFramework.tvOS",
@@ -3954,23 +3694,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "LibFramework.tvOS",
@@ -4050,23 +3775,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "LibFramework.watchOS",
@@ -4146,23 +3856,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "LibFramework.watchOS",
@@ -4264,24 +3959,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.iOS",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/UIFramework.iOS.framework/Modules/UI.swiftmodule/arm64-apple-ios.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "UIFramework.iOS",
@@ -4393,24 +4072,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.iOS",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/UIFramework.iOS.framework/Modules/UI.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "UIFramework.iOS",
@@ -4518,24 +4181,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.tvOS",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/UIFramework.tvOS.framework/Modules/UI.swiftmodule/arm64-apple-tvos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "UIFramework.tvOS",
@@ -4643,24 +4290,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.tvOS",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/UIFramework.tvOS.framework/Modules/UI.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "UIFramework.tvOS",
@@ -4768,24 +4399,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.watchOS",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/UIFramework.watchOS.framework/Modules/UI.swiftmodule/arm64_32-apple-watchos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "UIFramework.watchOS",
@@ -4893,24 +4508,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "LibFramework.watchOS",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/UIFramework.watchOS.framework/Modules/UI.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "UIFramework.watchOS",
@@ -5022,24 +4621,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension/WidgetExtension.swiftmodule/arm64-apple-ios.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "WidgetExtension",
@@ -5146,24 +4729,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension/WidgetExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "WidgetExtension",
@@ -5330,24 +4897,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/iMessageAppExtension.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "-force_load",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/libLib.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "iMessageAppExtension",
@@ -6073,15 +5624,8 @@
         "label": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-lc++",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "FrameworkCoreUtilsObjC",
@@ -6227,15 +5771,8 @@
         "label": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-lc++",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "FrameworkCoreUtilsObjC",
@@ -6515,47 +6052,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "SystemConfiguration",
-                "-framework",
-                "CoreLocation",
-                "-framework",
-                "CoreTelephony",
-                "-framework",
-                "GoogleMaps",
-                "-framework",
-                "GoogleMapsCore",
-                "-framework",
-                "GoogleMapsBase",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "CoreUtilsObjC",
-                "-framework",
-                "UIFramework.iOS",
-                "-framework",
-                "LibFramework.iOS",
-                "-lc++",
-                "-lz",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/iOSApp.swiftmodule/arm64-apple-ios.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule/arm64-apple-ios.swiftmodule",
-                "--ld-path=external/rules_apple_linker_lld/ld64.lld",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/UIFramework.iOS.framework/Modules/UI.swiftmodule/arm64-apple-ios.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule/arm64-apple-ios.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
-                "$(BUILD_DIR)/bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "iOSApp",
@@ -6721,47 +6219,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "SystemConfiguration",
-                "-framework",
-                "CoreLocation",
-                "-framework",
-                "CoreTelephony",
-                "-framework",
-                "GoogleMaps",
-                "-framework",
-                "GoogleMapsCore",
-                "-framework",
-                "GoogleMapsBase",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "CoreUtilsObjC",
-                "-framework",
-                "UIFramework.iOS",
-                "-framework",
-                "LibFramework.iOS",
-                "-lc++",
-                "-lz",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/iOSApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "--ld-path=external/rules_apple_linker_lld/ld64.lld",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/UIFramework.iOS.framework/Modules/UI.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "iOSApp",
@@ -6958,48 +6417,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "SystemConfiguration",
-                "-framework",
-                "CoreLocation",
-                "-framework",
-                "CoreTelephony",
-                "-framework",
-                "CoreGraphics",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "CoreUtilsObjC",
-                "-framework",
-                "UIFramework.iOS",
-                "-framework",
-                "LibFramework.iOS",
-                "-lc++",
-                "-lz",
-                "-L$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/TestingUtils.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/iOSApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "--ld-path=external/rules_apple_linker_lld/ld64.lld",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/UIFramework.iOS.framework/Modules/UI.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/Utils/libUtils.a",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl/libFXPageControl.a",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "iOSAppObjCUnitTests.__internal__.__test_bundle",
@@ -7137,49 +6556,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "SystemConfiguration",
-                "-framework",
-                "CoreLocation",
-                "-framework",
-                "CoreTelephony",
-                "-framework",
-                "CoreGraphics",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "CoreUtilsObjC",
-                "-framework",
-                "UIFramework.iOS",
-                "-framework",
-                "LibFramework.iOS",
-                "-lc++",
-                "-lz",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-L$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/TestingUtils.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/iOSApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "--ld-path=external/rules_apple_linker_lld/ld64.lld",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/UIFramework.iOS.framework/Modules/UI.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/Utils/libUtils.a",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl/libFXPageControl.a",
-                "$(BUILD_DIR)/bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/libTestingUtils.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "iOSAppSwiftUnitTests.__internal__.__test_bundle",
@@ -7340,21 +6718,8 @@
                 "macOSApp/third_party/ExampleFramework.framework"
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "ExampleFramework",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source/macOSApp.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "Cocoa"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "macOSApp",
@@ -7441,20 +6806,8 @@
         "label": "//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests/macOSAppUITests.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "macOSAppUITests.__internal__.__test_bundle",
@@ -7568,27 +6921,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.tvOS",
-                "-framework",
-                "LibFramework.tvOS",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source/tvOSApp.swiftmodule/arm64-apple-tvos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/UIFramework.tvOS.framework/Modules/UI.swiftmodule/arm64-apple-tvos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swiftmodule/arm64-apple-tvos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "tvOSApp",
@@ -7700,27 +7034,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.tvOS",
-                "-framework",
-                "LibFramework.tvOS",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source/tvOSApp.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/UIFramework.tvOS.framework/Modules/UI.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "tvOSApp",
@@ -7807,22 +7122,8 @@
         "label": "//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-L$(DEVELOPER_DIR)/Platforms/AppleTVSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests/tvOSAppUITests.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "tvOSAppUITests.__internal__.__test_bundle",
@@ -7932,31 +7233,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.tvOS",
-                "-framework",
-                "LibFramework.tvOS",
-                "-L$(DEVELOPER_DIR)/Platforms/AppleTVSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source/tvOSApp.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/UIFramework.tvOS.framework/Modules/UI.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule/x86_64-apple-tvos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/appletvsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "tvOSAppUnitTests.__internal__.__test_bundle",
@@ -8044,22 +7322,8 @@
         "label": "//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-L$(DEVELOPER_DIR)/Platforms/WatchSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests/watchOSAppUITestsLibrary.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "watchOSAppUITests.__internal__.__test_bundle",
@@ -8294,30 +7558,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.watchOS",
-                "-framework",
-                "LibFramework.watchOS",
-                "-L$(DEVELOPER_DIR)/Platforms/WatchSimulator.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTestsLibrary.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/UIFramework.watchOS.framework/Modules/UI.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "watchOSAppExtensionUnitTests.__internal__.__test_bundle",
@@ -8430,27 +7672,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.watchOS",
-                "-framework",
-                "LibFramework.watchOS",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule/arm64_32-apple-watchos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/UIFramework.watchOS.framework/Modules/UI.swiftmodule/arm64_32-apple-watchos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swiftmodule/arm64_32-apple-watchos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchos",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "watchOSAppExtension",
@@ -8562,27 +7785,8 @@
                 }
             ],
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "CryptoSwift",
-                "-framework",
-                "UIFramework.watchOS",
-                "-framework",
-                "LibFramework.watchOS",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/watchOSAppExtension.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/UIFramework.watchOS.framework/Modules/UI.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule/x86_64-apple-watchos-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/watchsimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "watchOSAppExtension",

--- a/examples/sanitizers/test/fixtures/bwb_targets_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_targets_spec.json
@@ -45,19 +45,8 @@
         "label": "//AddressSanitizerApp:AddressSanitizerApp",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/AddressSanitizerApp/AddressSanitizerApp.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -159,19 +148,8 @@
         "label": "//ThreadSanitizerApp:ThreadSanitizerApp",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-Wl,-add_ast_path,bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/ThreadSanitizerApp/ThreadSanitizerApp.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -327,16 +305,8 @@
         "label": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "UIKit",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "UndefinedBehaviorSanitizerApp",

--- a/examples/sanitizers/test/fixtures/bwx_targets_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_targets_spec.json
@@ -44,19 +44,8 @@
         "label": "//AddressSanitizerApp:AddressSanitizerApp",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp/AddressSanitizerApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "AddressSanitizerApp",
@@ -141,19 +130,8 @@
         "label": "//ThreadSanitizerApp:ThreadSanitizerApp",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp/ThreadSanitizerApp.swiftmodule/x86_64-apple-ios-simulator.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphonesimulator",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "ThreadSanitizerApp",
@@ -292,16 +270,8 @@
         "label": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-framework",
-                "UIKit",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "-framework",
-                "UIKit"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "UndefinedBehaviorSanitizerApp",

--- a/examples/simple/test/fixtures/bwb_targets_spec.json
+++ b/examples/simple/test/fixtures/bwb_targets_spec.json
@@ -28,8 +28,8 @@
         "label": "//:SwiftBin",
         "linker_inputs": {
             "linkopts": [
-                "-D",
-                "-no_warning_for_no_symbols"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {

--- a/examples/simple/test/fixtures/bwx_targets_spec.json
+++ b/examples/simple/test/fixtures/bwx_targets_spec.json
@@ -27,8 +27,8 @@
         "label": "//:SwiftBin",
         "linker_inputs": {
             "linkopts": [
-                "-D",
-                "-no_warning_for_no_symbols"
+                "fixture",
+                "linkopts"
             ]
         },
         "name": "SwiftBin",

--- a/test/fixtures/generator/bwb_targets_spec.json
+++ b/test/fixtures/generator/bwb_targets_spec.json
@@ -105,38 +105,8 @@
         "label": "//tools/generator/test:tests.__internal__.__test_bundle",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/test/tests.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/generator.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/libgenerator.library.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml/libAEXML.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/libPathKit.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -374,30 +344,8 @@
         "label": "//tools/generator:generator",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/generator.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/libgenerator.library.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml/libAEXML.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/libPathKit.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -714,17 +662,8 @@
         "label": "//tools/swiftc_stub:swiftc",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub/tools_swiftc_stub_swiftc_stub_library.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {

--- a/test/fixtures/generator/bwx_targets_spec.json
+++ b/test/fixtures/generator/bwx_targets_spec.json
@@ -104,38 +104,8 @@
         "label": "//tools/generator/test:tests.__internal__.__test_bundle",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-L$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/usr/lib",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test/tests.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/generator.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-framework",
-                "XCTest",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/libgenerator.library.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml/libAEXML.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/libPathKit.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -372,30 +342,8 @@
         "label": "//tools/generator:generator",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/generator.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-Wl,-add_ast_path,bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml/AEXML.swiftmodule",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/libgenerator.library.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
-                "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tadija_aexml/libAEXML.a",
-                "$(BUILD_DIR)/bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/libPathKit.a"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {
@@ -711,17 +659,8 @@
         "label": "//tools/swiftc_stub:swiftc",
         "linker_inputs": {
             "linkopts": [
-                "-ObjC",
-                "-Wl,-add_ast_path,$(BUILD_DIR)/bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/swiftc_stub/rules_xcodeproj/swiftc/tools_swiftc_stub_swiftc_stub_library.swiftmodule/x86_64-apple-macos.swiftmodule",
-                "-ObjC",
-                "-L/usr/lib/swift",
-                "-L$(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx",
-                "-Wl,-rpath,/usr/lib/swift",
-                "-lc++",
-                "-headerpad_max_install_names",
-                "-no-canonical-prefixes",
-                "-framework",
-                "Foundation"
+                "fixture",
+                "linkopts"
             ]
         },
         "lldb_context": {

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -822,7 +822,6 @@ def _linker_inputs_to_dto(
         linkopts.append("-force_load")
         linkopts.append(quote_if_needed(path))
 
-
     if is_fixture and linkopts:
         # We don't write the linkopts for fixtures
         linkopts = ["fixture", "linkopts"]

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -518,6 +518,7 @@ def _xcode_target_to_dto(
         additional_scheme_target_ids = None,
         build_mode,
         include_lldb_context,
+        is_fixture,
         is_unfocused_dependency = False,
         linker_products_map,
         should_include_outputs,
@@ -607,6 +608,7 @@ def _xcode_target_to_dto(
         dto,
         "linker_inputs",
         _linker_inputs_to_dto(
+            is_fixture = is_fixture,
             linker_inputs = xcode_target.linker_inputs,
             compile_target = xcode_target._compile_target,
             platform = xcode_target.platform,
@@ -758,6 +760,7 @@ def _linker_inputs_to_dto(
         linker_inputs,
         *,
         compile_target,
+        is_fixture,
         platform,
         xcode_generated_paths):
     if not linker_inputs:
@@ -818,6 +821,11 @@ def _linker_inputs_to_dto(
         path = xcode_generated_paths.get(path, path)
         linkopts.append("-force_load")
         linkopts.append(quote_if_needed(path))
+
+
+    if is_fixture and linkopts:
+        # We don't write the linkopts for fixtures
+        linkopts = ["fixture", "linkopts"]
 
     set_if_true(ret, "linkopts", linkopts)
 

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -639,6 +639,7 @@ actual targets: {}
 
         dto, replaced_dependencies = xcode_targets.to_dto(
             xcode_target = xcode_target,
+            is_fixture = is_fixture,
             additional_scheme_target_ids = additional_scheme_target_ids,
             build_mode = build_mode,
             include_lldb_context = include_lldb_context,


### PR DESCRIPTION
Soon we will generate the `link.params` file on the fly, and the linkopts won't be in the spec at all. Until then though, we need to remove these from the spec to allow for Bazel 5 and 6 to generate the same fixtures.