### PR TITLE
Set `--incompatible_unambiguous_label_stringification=false` for fixtures

### DIFF
--- a/xcodeproj/internal/fixtures.bzl
+++ b/xcodeproj/internal/fixtures.bzl
@@ -211,6 +211,7 @@ def xcodeproj_fixture(
             config = config,
             extra_files = extra_files,
             focused_targets = focused_targets,
+            is_fixture = True,
             minimum_xcode_version = _MINIMUM_XCODE_VERSION,
             post_build = post_build,
             pre_build = pre_build,

--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -110,6 +110,15 @@ pre_config_flags=(
   "--repo_env=USE_CLANG_CL=$xcode_build_version"
 )
 
+if [[ %is_fixture% -eq 1 ]]; then
+  if [[ %is_bazel_6% -eq 1 ]]; then
+    pre_config_flags+=(
+      # Until we stop testing Bazel 5, we want the strings to format the same
+      "--incompatible_unambiguous_label_stringification=false"
+    )
+  fi
+fi
+
 readonly bazel_cmd=(
   env
   PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"

--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -290,6 +290,8 @@ in your `.bazelrc` or `xcodeproj.bazelrc` file.""")
 
     generator_name = "{}.generator".format(name)
 
+    is_fixture = kwargs.pop("is_fixture", False)
+
     xcodeproj_rule = kwargs.pop("xcodeproj_rule", None)
     if not xcodeproj_rule:
         if build_mode == "bazel":
@@ -341,6 +343,7 @@ in your `.bazelrc` or `xcodeproj.bazelrc` file.""")
         name = name,
         bazel_path = bazel_path,
         config = config,
+        is_fixture = is_fixture,
         project_name = project_name,
         tags = tags,
         testonly = testonly,

--- a/xcodeproj/internal/xcodeproj_runner.bzl
+++ b/xcodeproj/internal/xcodeproj_runner.bzl
@@ -97,11 +97,14 @@ def _write_runner(
         extra_flags_bazelrc,
         extra_generator_flags,
         generator_label,
+        is_fixture,
         project_name,
         runner_label,
         template,
         xcodeproj_bazelrc):
     output = actions.declare_file("{}-runner.sh".format(name))
+
+    is_bazel_6 = hasattr(apple_common, "link_multi_arch_static_library")
 
     actions.expand_template(
         template = template,
@@ -113,6 +116,8 @@ def _write_runner(
             "%extra_flags_bazelrc%": extra_flags_bazelrc.short_path,
             "%extra_generator_flags%": extra_generator_flags,
             "%generator_label%": generator_label,
+            "%is_bazel_6%": "1" if is_bazel_6 else "0",
+            "%is_fixture%": "1" if is_fixture else "0",
             "%project_name%": project_name,
             "%runner_label%": runner_label,
             "%xcodeproj_bazelrc%": xcodeproj_bazelrc.short_path,
@@ -148,6 +153,7 @@ def _xcodeproj_runner_impl(ctx):
             ctx.attr._extra_generator_flags[BuildSettingInfo].value
         ),
         generator_label = ctx.attr.xcodeproj_target,
+        is_fixture = ctx.attr.is_fixture,
         project_name = project_name,
         runner_label = str(ctx.label),
         template = ctx.file._runner_template,
@@ -177,6 +183,9 @@ xcodeproj_runner = rule(
             mandatory = True,
         ),
         "config": attr.string(
+            mandatory = True,
+        ),
+        "is_fixture": attr.bool(
             mandatory = True,
         ),
         "project_name": attr.string(


### PR DESCRIPTION
This is to make the difference between Bazel 5 and 6 less noisy.