### PR TITLE
Fix path references to `bazel-out` and `external` directories

### DIFF
--- a/examples/integration/CommandLine/CommandLineToolLib/BUILD
+++ b/examples/integration/CommandLine/CommandLineToolLib/BUILD
@@ -24,6 +24,12 @@ cc_library(
     name = "private_lib",
     srcs = ["private_lib.c"],
     hdrs = ["private_lib.h"],
+    copts = [
+        # This isn't needed bty anything, it's to exercise an edge case in
+        # `FilePath` detection.
+        "-Ibazel-out",
+        "-Iexternal",
+    ],
     tags = ["swift_module=_Lib"],
 )
 

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -7558,6 +7558,10 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
+				HEADER_SEARCH_PATHS = (
+					"$(BAZEL_OUT)",
+					"$(BAZEL_EXTERNAL)",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
@@ -9245,6 +9249,10 @@
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
 				);
+				HEADER_SEARCH_PATHS = (
+					"$(BAZEL_OUT)",
+					"$(BAZEL_EXTERNAL)",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
@@ -9970,6 +9978,10 @@
 					"__DATE__=\"redacted\"",
 					"__TIMESTAMP__=\"redacted\"",
 					"__TIME__=\"redacted\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(BAZEL_OUT)",
+					"$(BAZEL_EXTERNAL)",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -2053,6 +2053,10 @@
                 "__TIMESTAMP__=\"redacted\"",
                 "__TIME__=\"redacted\""
             ],
+            "HEADER_SEARCH_PATHS": [
+                "$(BAZEL_OUT)",
+                "$(BAZEL_EXTERNAL)"
+            ],
             "OTHER_CFLAGS": [
                 "-fstack-protector",
                 "-Wall",
@@ -2129,6 +2133,10 @@
                 "__TIMESTAMP__=\"redacted\"",
                 "__TIME__=\"redacted\""
             ],
+            "HEADER_SEARCH_PATHS": [
+                "$(BAZEL_OUT)",
+                "$(BAZEL_EXTERNAL)"
+            ],
             "OTHER_CFLAGS": [
                 "-fstack-protector",
                 "-Wall",
@@ -2204,6 +2212,10 @@
                 "__DATE__=\"redacted\"",
                 "__TIMESTAMP__=\"redacted\"",
                 "__TIME__=\"redacted\""
+            ],
+            "HEADER_SEARCH_PATHS": [
+                "$(BAZEL_OUT)",
+                "$(BAZEL_EXTERNAL)"
             ],
             "OTHER_CFLAGS": [
                 "-fstack-protector",

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -9977,6 +9977,10 @@
 					"__TIME__=\"redacted\"",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(BAZEL_OUT)",
+					"$(BAZEL_EXTERNAL)",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
@@ -10691,6 +10695,10 @@
 					"__TIME__=\"redacted\"",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(BAZEL_OUT)",
+					"$(BAZEL_EXTERNAL)",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
@@ -11803,6 +11811,10 @@
 					"__TIME__=\"redacted\"",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(BAZEL_OUT)",
+					"$(BAZEL_EXTERNAL)",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",

--- a/examples/integration/test/fixtures/bwx_targets_spec.json
+++ b/examples/integration/test/fixtures/bwx_targets_spec.json
@@ -1791,6 +1791,10 @@
                 "__TIMESTAMP__=\"redacted\"",
                 "__TIME__=\"redacted\""
             ],
+            "HEADER_SEARCH_PATHS": [
+                "$(BAZEL_OUT)",
+                "$(BAZEL_EXTERNAL)"
+            ],
             "OTHER_CFLAGS": [
                 "-fstack-protector",
                 "-Wall",
@@ -1867,6 +1871,10 @@
                 "__TIMESTAMP__=\"redacted\"",
                 "__TIME__=\"redacted\""
             ],
+            "HEADER_SEARCH_PATHS": [
+                "$(BAZEL_OUT)",
+                "$(BAZEL_EXTERNAL)"
+            ],
             "OTHER_CFLAGS": [
                 "-fstack-protector",
                 "-Wall",
@@ -1942,6 +1950,10 @@
                 "__DATE__=\"redacted\"",
                 "__TIMESTAMP__=\"redacted\"",
                 "__TIME__=\"redacted\""
+            ],
+            "HEADER_SEARCH_PATHS": [
+                "$(BAZEL_OUT)",
+                "$(BAZEL_EXTERNAL)"
             ],
             "OTHER_CFLAGS": [
                 "-fstack-protector",

--- a/tools/generator/src/FilePathResolver.swift
+++ b/tools/generator/src/FilePathResolver.swift
@@ -28,10 +28,16 @@ enum FilePathResolver {
     }
 
     static func resolveGenerated(_ path: Path) -> String {
+        // Technically we should handle when `path` == `.`, but we never
+        // reference anything that can be just `bazel-out` in the generator
+        // anymore
         return "$(BAZEL_OUT)/\(path)"
     }
 
     static func resolveInternal(_ path: Path) -> String {
+        // Technically we should handle when `path` == `.`, but we never
+        // reference anything that can be just `external` in the generator
+        // anymore
         return "$(INTERNAL_DIR)/\(path)"
     }
 }

--- a/xcodeproj/internal/files.bzl
+++ b/xcodeproj/internal/files.bzl
@@ -93,7 +93,11 @@ def build_setting_path(
     if type == "g":
         # Generated
         if use_build_dir:
-            build_setting = "$(BUILD_DIR)/{}".format(path)
+            if path:
+                build_setting = "$(BUILD_DIR)/{}".format(path)
+            else:
+                # Support directory reference
+                build_setting = "$(BUILD_DIR)"
         elif absolute_path:
             # Removing "bazel-out" prefix
             build_setting = "$(BAZEL_OUT){}".format(path[9:])
@@ -102,8 +106,12 @@ def build_setting_path(
     elif type == "e":
         # External
         if absolute_path:
-            # Removing "external" prefix
-            build_setting = "$(BAZEL_EXTERNAL){}".format(path[8:])
+            if path:
+                # Removing "external" prefix
+                build_setting = "$(BAZEL_EXTERNAL){}".format(path[8:])
+            else:
+                # Support directory reference
+                build_setting = "$(BAZEL_EXTERNAL)"
         else:
             build_setting = path
     else:
@@ -240,10 +248,10 @@ def generated_file_path(
     )
 
 def is_external_path(path):
-    return path.startswith("external/")
+    return path == "external" or path.startswith("external/")
 
 def is_generated_path(path):
-    return path.startswith("bazel-out/")
+    return path == "bazel-out" or path.startswith("bazel-out/")
 
 def is_generated_file_path(fp):
     return fp.type == "g"


### PR DESCRIPTION
For example, if a header search path was set like this `-Ibazel-out`, we would incorrectly detect that as rooted in `$SRCROOT`.