### PR TITLE
Create `bazel.lldbinit` in launch pre-action

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
@@ -92,6 +92,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "27EDD304E889980DC176FF62"
+                     BuildableName = "tool"
+                     BlueprintName = "tool"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
@@ -92,6 +92,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "13A68B4984727F4B3DAE6AFB"
+                     BuildableName = "AppClip.app"
+                     BlueprintName = "AppClip"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineTool.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineTool.xcscheme
@@ -92,6 +92,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "1A40783EF59C680645DD16E1"
+                     BuildableName = "CommandLineTool"
+                     BlueprintName = "CommandLineTool"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineToolTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/CommandLineToolTests.xcscheme
@@ -128,6 +128,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "5826810F86C049E80D55353A"
+                     BuildableName = "CommandLineToolTests.xctest"
+                     BlueprintName = "CommandLineToolTests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UniversalCommandLineTool (arm64).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UniversalCommandLineTool (arm64).xcscheme
@@ -92,6 +92,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2BF2C216789F6A1960CFC899"
+                     BuildableName = "tool.binary"
+                     BlueprintName = "UniversalCommandLineTool (arm64)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UniversalCommandLineTool (x86_64).xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UniversalCommandLineTool (x86_64).xcscheme
@@ -92,6 +92,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "D86CA50B6ABE0A52D2303BF4"
+                     BuildableName = "tool.binary"
+                     BlueprintName = "UniversalCommandLineTool (x86_64)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
@@ -109,6 +109,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "2">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "06E3C912B8DE52D274641347"
+                     BuildableName = "WidgetExtension.appex"
+                     BlueprintName = "WidgetExtension"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <RemoteRunnable
          runnableDebuggingMode = "2"
          BundleIdentifier = "com.apple.springboard">

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
@@ -108,6 +108,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "2">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2BECDF067E07C69468ED23A3"
+                     BuildableName = "iMessageAppExtension.appex"
+                     BlueprintName = "iMessageAppExtension"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <RemoteRunnable
          runnableDebuggingMode = "1"
          BundleIdentifier = "com.apple.MobileSMS">

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
@@ -134,6 +134,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "1765D91CC168F25A5BC51603"
+                     BuildableName = "iOSApp.app"
+                     BlueprintName = "iOSApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests.xcscheme
@@ -189,6 +189,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "41EA1ABC35FAFDF6B7FE0600"
+                     BuildableName = "iOSAppObjCUnitTests.xctest"
+                     BlueprintName = "iOSAppObjCUnitTests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
@@ -189,6 +189,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "D2B147BDA8E8FC10D91B53BB"
+                     BuildableName = "iOSAppSwiftUnitTests.xctest"
+                     BlueprintName = "iOSAppSwiftUnitTests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSApp.xcscheme
@@ -92,6 +92,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "AE02B41E521B2C6360C30D20"
+                     BuildableName = "macOSApp.app"
+                     BlueprintName = "macOSApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
@@ -142,6 +142,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "DBA520153E51B3D6E3103986"
+                     BuildableName = "macOSAppUITests.xctest"
+                     BlueprintName = "macOSAppUITests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
@@ -120,6 +120,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "ACEF2F653E0F6BEA37D2C7B6"
+                     BuildableName = "tvOSApp.app"
+                     BlueprintName = "tvOSApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
@@ -170,6 +170,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "53852A3B10D473B77DE57F4D"
+                     BuildableName = "tvOSAppUITests.xctest"
+                     BlueprintName = "tvOSAppUITests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
@@ -170,6 +170,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "76D3DE86C1DB5149A9A669ED"
+                     BuildableName = "tvOSAppUnitTests.xctest"
+                     BlueprintName = "tvOSAppUnitTests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
@@ -120,6 +120,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "632D255CE04E97FB997EBDD7"
+                     BuildableName = "watchOSApp.app"
+                     BlueprintName = "watchOSApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
@@ -156,6 +156,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "D72E91668AA84CA0E91BC0E9"
+                     BuildableName = "watchOSAppExtensionUnitTests.xctest"
+                     BlueprintName = "watchOSAppExtensionUnitTests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
@@ -156,6 +156,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "CA1F809431EBB13936399836"
+                     BuildableName = "watchOSAppUITests.xctest"
+                     BlueprintName = "watchOSAppUITests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AddressSanitizer.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/AddressSanitizer.xcscheme
@@ -93,6 +93,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       enableAddressSanitizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "469DDB537DCBED783EA330DB"
+                     BuildableName = "AddressSanitizerApp.app"
+                     BlueprintName = "AddressSanitizerApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ThreadSanitizer.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/ThreadSanitizer.xcscheme
@@ -93,6 +93,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       enableThreadSanitizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "ED825FF2BCA76CF484AE0486"
+                     BuildableName = "ThreadSanitizerApp.app"
+                     BlueprintName = "ThreadSanitizerApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UndefinedBehaviorSanitizer.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/xcshareddata/xcschemes/UndefinedBehaviorSanitizer.xcscheme
@@ -93,6 +93,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       enableUBSanitizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "BFCA7B92B9E6FD90B736F080"
+                     BuildableName = "UndefinedBehaviorSanitizerApp.app"
+                     BlueprintName = "UndefinedBehaviorSanitizerApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -195,6 +195,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       enableAddressSanitizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "85C876DB90D51CD225023BB2"
+                     BuildableName = "generator"
+                     BlueprintName = "generator"
+                     ReferencedContainer = "container:../../../../../test/fixtures/generator/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/swiftc.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/swiftc.xcscheme
@@ -93,6 +93,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       enableAddressSanitizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2CF4E33AE578202202C2EC87"
+                     BuildableName = "swiftc"
+                     BlueprintName = "swiftc"
+                     ReferencedContainer = "container:../../../../../test/fixtures/generator/bwb.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/tools/generator/test/XCScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XCScheme+ExtensionsTests.swift
@@ -244,7 +244,8 @@ extension XCSchemeExtensionsTests {
         let productType = launchActionInfo.targetInfo.productType
         let launchAction = try XCScheme.LaunchAction(
             buildMode: .xcode,
-            launchActionInfo: launchActionInfo
+            launchActionInfo: launchActionInfo,
+            otherPreActions: []
         )
         let expected = XCScheme.LaunchAction(
             runnable: launchActionInfo.runnable,
@@ -276,7 +277,8 @@ extension XCSchemeExtensionsTests {
         let productType = launchActionInfo.targetInfo.productType
         let launchAction = try XCScheme.LaunchAction(
             buildMode: .bazel,
-            launchActionInfo: launchActionInfo
+            launchActionInfo: launchActionInfo,
+            otherPreActions: []
         )
         let expected = XCScheme.LaunchAction(
             runnable: launchActionInfo.runnable,
@@ -312,7 +314,8 @@ extension XCSchemeExtensionsTests {
         let productType = launchActionInfo.targetInfo.productType
         let launchAction = try XCScheme.LaunchAction(
             buildMode: .bazel,
-            launchActionInfo: launchActionInfo
+            launchActionInfo: launchActionInfo,
+            otherPreActions: []
         )
         let expected = XCScheme.LaunchAction(
             runnable: launchActionInfo.runnable,
@@ -539,7 +542,8 @@ extension XCSchemeExtensionsTests {
         // when
         let launchAction = try XCScheme.LaunchAction(
             buildMode: .xcode,
-            launchActionInfo: launchActionInfo
+            launchActionInfo: launchActionInfo,
+            otherPreActions: []
         )
         
         // then

--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -119,13 +119,6 @@ readonly build_pre_config_flags
 # `bazel_build.sh` sets `indexstores_filelists`
 source "$BAZEL_INTEGRATION_DIR/bazel_build.sh"
 
-# Create `bazel.lldbinit``
-
-if [[ "$ACTION" != "indexbuild" && "${ENABLE_PREVIEWS:-}" != "YES" ]]; then
-  # shellcheck disable=SC2046
-  "$BAZEL_INTEGRATION_DIR/create_lldbinit.sh"
-fi
-
 # Async actions
 #
 # For these commands to run in the background, both stdout and stderr need to be


### PR DESCRIPTION
This will allow the script to customize based on the target being launched. It also ensures that the file is up to date on every launch, regardless if a build happened.