### PR TITLE
Fix BwX `.lldbinit` creation

### DIFF
--- a/examples/cc/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/tool.xcscheme
@@ -76,6 +76,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "EC6A68AC956C60AA25485960"
+                     BuildableName = "tool"
+                     BlueprintName = "tool"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/AppClip.xcscheme
@@ -76,6 +76,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2B369B164AB3542A258E8E5F"
+                     BuildableName = "AppClip.app"
+                     BlueprintName = "AppClip"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CommandLineTool.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CommandLineTool.xcscheme
@@ -76,6 +76,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "E569989878EC4D26C4EA6DD0"
+                     BuildableName = "CommandLineTool"
+                     BlueprintName = "CommandLineTool"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CommandLineToolTests.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/CommandLineToolTests.xcscheme
@@ -102,6 +102,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "8FA9DDD71D382CE2CA2EA479"
+                     BuildableName = "CommandLineToolTests.xctest"
+                     BlueprintName = "CommandLineToolTests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/UniversalCommandLineTool (arm64).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/UniversalCommandLineTool (arm64).xcscheme
@@ -76,6 +76,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "107286E146492760F22FBC44"
+                     BuildableName = "tool.binary"
+                     BlueprintName = "UniversalCommandLineTool (arm64)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/UniversalCommandLineTool (x86_64).xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/UniversalCommandLineTool (x86_64).xcscheme
@@ -76,6 +76,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "9CAD5D6707650AAEF4E3F2E1"
+                     BuildableName = "tool.binary"
+                     BlueprintName = "UniversalCommandLineTool (x86_64)"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/WidgetExtension.xcscheme
@@ -93,6 +93,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "2">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "EDF8F127D3EA3E7481E6D3D5"
+                     BuildableName = "WidgetExtension.appex"
+                     BlueprintName = "WidgetExtension"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <RemoteRunnable
          runnableDebuggingMode = "2"
          BundleIdentifier = "com.apple.springboard">

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/iMessageAppExtension.xcscheme
@@ -92,6 +92,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "2">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "FDA59F09C0DC31A1D18B6509"
+                     BuildableName = "iMessageAppExtension.appex"
+                     BlueprintName = "iMessageAppExtension"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <RemoteRunnable
          runnableDebuggingMode = "1"
          BundleIdentifier = "com.apple.MobileSMS">

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/iOSApp.xcscheme
@@ -76,6 +76,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "A6969986F4330BE56701A5EC"
+                     BuildableName = "iOSApp.app"
+                     BlueprintName = "iOSApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/iOSAppObjCUnitTests.xcscheme
@@ -107,6 +107,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "3CE6AD21A6E119583FB633F7"
+                     BuildableName = "iOSAppObjCUnitTests.xctest"
+                     BlueprintName = "iOSAppObjCUnitTests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/iOSAppSwiftUnitTests.xcscheme
@@ -107,6 +107,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "3BE6BBB59BF4F33150BA74CA"
+                     BuildableName = "iOSAppSwiftUnitTests.xctest"
+                     BlueprintName = "iOSAppSwiftUnitTests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/macOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/macOSApp.xcscheme
@@ -76,6 +76,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "C57AEABC99C185745155C88B"
+                     BuildableName = "macOSApp.app"
+                     BlueprintName = "macOSApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/macOSAppUITests.xcscheme
@@ -102,6 +102,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "D10ED04404B0870C2A77B187"
+                     BuildableName = "macOSAppUITests.xctest"
+                     BlueprintName = "macOSAppUITests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/tvOSApp.xcscheme
@@ -76,6 +76,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "F3451D8089613E01522F3373"
+                     BuildableName = "tvOSApp.app"
+                     BlueprintName = "tvOSApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/tvOSAppUITests.xcscheme
@@ -102,6 +102,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "F17532B236F0C0D5C4DE571E"
+                     BuildableName = "tvOSAppUITests.xctest"
+                     BlueprintName = "tvOSAppUITests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/tvOSAppUnitTests.xcscheme
@@ -102,6 +102,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "E9EB5E36CCE50C3C85A9B4C9"
+                     BuildableName = "tvOSAppUnitTests.xctest"
+                     BlueprintName = "tvOSAppUnitTests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/watchOSApp.xcscheme
@@ -76,6 +76,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "182B42EFE70A5561F1C023E5"
+                     BuildableName = "watchOSApp.app"
+                     BlueprintName = "watchOSApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/watchOSAppExtensionUnitTests.xcscheme
@@ -102,6 +102,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "5DC9876B9482A426EE1004BA"
+                     BuildableName = "watchOSAppExtensionUnitTests.xctest"
+                     BlueprintName = "watchOSAppExtensionUnitTests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/watchOSAppUITests.xcscheme
@@ -102,6 +102,24 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "467E28CECC74A90D0BF1F0D5"
+                     BuildableName = "watchOSAppUITests.xctest"
+                     BlueprintName = "watchOSAppUITests"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/AddressSanitizer.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/AddressSanitizer.xcscheme
@@ -77,6 +77,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       enableAddressSanitizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "3EAFF74229A8CE2544154BF9"
+                     BuildableName = "AddressSanitizerApp.app"
+                     BlueprintName = "AddressSanitizerApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ThreadSanitizer.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/ThreadSanitizer.xcscheme
@@ -77,6 +77,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       enableThreadSanitizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "E0A7BFDFC0C3D6AB230925A8"
+                     BuildableName = "ThreadSanitizerApp.app"
+                     BlueprintName = "ThreadSanitizerApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/UndefinedBehaviorSanitizer.xcscheme
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/xcshareddata/xcschemes/UndefinedBehaviorSanitizer.xcscheme
@@ -77,6 +77,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       enableUBSanitizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "5DDE2F008DF4134A31766B9F"
+                     BuildableName = "UndefinedBehaviorSanitizerApp.app"
+                     BlueprintName = "UndefinedBehaviorSanitizerApp"
+                     ReferencedContainer = "container:../../../../../test/fixtures/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -169,6 +169,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       enableAddressSanitizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "2FED647E7A6091DF616D345B"
+                     BuildableName = "generator"
+                     BlueprintName = "generator"
+                     ReferencedContainer = "container:../../../../../test/fixtures/generator/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/swiftc.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/swiftc.xcscheme
@@ -77,6 +77,24 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       enableAddressSanitizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Update .lldbinit"
+               scriptText = "&quot;$BAZEL_INTEGRATION_DIR/create_lldbinit.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "A4BAFFA66EE5607F05D752C1"
+                     BuildableName = "swiftc"
+                     BlueprintName = "swiftc"
+                     ReferencedContainer = "container:../../../../../test/fixtures/generator/bwx.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference

--- a/tools/generator/src/Extensions/XCScheme+Extensions.swift
+++ b/tools/generator/src/Extensions/XCScheme+Extensions.swift
@@ -65,15 +65,14 @@ extension XCScheme {
 
         let launchAction: XCScheme.LaunchAction
         if let launchActionInfo = schemeInfo.launchActionInfo {
-            var otherPreActions: [XCScheme.ExecutionAction] = []
-            if buildMode != .xcode {
-                otherPreActions.append(
-                    .createLLDBInit(
-                        buildableReference: launchActionInfo
-                            .targetInfo.buildableReference
-                    )
+            // TODO: Make this similar to `initBazelBuildOutputGroupsFile()`,
+            // instead of `otherPreActions`
+            let otherPreActions: [XCScheme.ExecutionAction] = [
+                .createLLDBInit(
+                    buildableReference: launchActionInfo
+                        .targetInfo.buildableReference
                 )
-            }
+            ]
             launchAction = try .init(
                 buildMode: buildMode,
                 launchActionInfo: launchActionInfo,


### PR DESCRIPTION
I keep forgetting that BwX mode needs `.lldbinit` for unfocused targets.