### PR TITLE
Stop including `CcInfo` headers in `srcs`

### DIFF
--- a/examples/cc/test/fixtures/bwb_project_spec.json
+++ b/examples/cc/test/fixtures/bwb_project_spec.json
@@ -16,8 +16,14 @@
     "custom_xcode_schemes": [],
     "envs": [],
     "extra_files": [
+        {
+            "_": "examples_cc_external/lib.h",
+            "t": "e"
+        },
         "lib/BUILD",
+        "lib/lib.h",
         "lib2/BUILD",
+        "lib2/includes/lib.h",
         "test/fixtures/BUILD",
         "tool/BUILD"
     ],

--- a/examples/cc/test/fixtures/bwb_targets_spec.json
+++ b/examples/cc/test/fixtures/bwb_targets_spec.json
@@ -50,8 +50,7 @@
         "configuration": "darwin_x86_64-dbg-STABLE-1",
         "inputs": {
             "srcs": [
-                "lib2/lib.c",
-                "lib2/includes/lib.h"
+                "lib2/lib.c"
             ]
         },
         "is_swift": false,
@@ -199,11 +198,6 @@
         "dependencies": [
             "//lib:lib_defines darwin_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
-                "lib/lib.h"
-            ]
-        },
         "is_swift": false,
         "label": "//lib:lib_headers",
         "name": "lib_headers",
@@ -529,14 +523,6 @@
         "dependencies": [
             "@examples_cc_external//:lib_defines darwin_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
-                {
-                    "_": "examples_cc_external/lib.h",
-                    "t": "e"
-                }
-            ]
-        },
         "is_swift": false,
         "label": "@examples_cc_external//:lib_headers",
         "name": "lib_headers",

--- a/examples/cc/test/fixtures/bwx_project_spec.json
+++ b/examples/cc/test/fixtures/bwx_project_spec.json
@@ -16,8 +16,14 @@
     "custom_xcode_schemes": [],
     "envs": [],
     "extra_files": [
+        {
+            "_": "examples_cc_external/lib.h",
+            "t": "e"
+        },
         "lib/BUILD",
+        "lib/lib.h",
         "lib2/BUILD",
+        "lib2/includes/lib.h",
         "test/fixtures/BUILD",
         "tool/BUILD"
     ],

--- a/examples/cc/test/fixtures/bwx_targets_spec.json
+++ b/examples/cc/test/fixtures/bwx_targets_spec.json
@@ -50,8 +50,7 @@
         "configuration": "darwin_x86_64-dbg-STABLE-1",
         "inputs": {
             "srcs": [
-                "lib2/lib.c",
-                "lib2/includes/lib.h"
+                "lib2/lib.c"
             ]
         },
         "is_swift": false,
@@ -199,11 +198,6 @@
         "dependencies": [
             "//lib:lib_defines darwin_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
-                "lib/lib.h"
-            ]
-        },
         "is_swift": false,
         "label": "//lib:lib_headers",
         "name": "lib_headers",
@@ -528,14 +522,6 @@
         "dependencies": [
             "@examples_cc_external//:lib_defines darwin_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
-                {
-                    "_": "examples_cc_external/lib.h",
-                    "t": "e"
-                }
-            ]
-        },
         "is_swift": false,
         "label": "@examples_cc_external//:lib_headers",
         "name": "lib_headers",

--- a/examples/integration/test/fixtures/bwb_project_spec.json
+++ b/examples/integration/test/fixtures/bwb_project_spec.json
@@ -105,6 +105,10 @@
     ],
     "extra_files": [
         {
+            "_": "FXPageControl/FXPageControl/FXPageControl.h",
+            "t": "e"
+        },
+        {
             "_": "build_bazel_rules_apple/apple/testing/DefaultTestBundle.plist",
             "t": "e"
         },
@@ -266,8 +270,11 @@
         "CommandLine/CommandLineTool/Launchd.plist",
         "CommandLine/CommandLineTool/export_symbol_list.exp",
         "CommandLine/CommandLineToolLib/BUILD",
+        "CommandLine/CommandLineToolLib/dir with space/lib.h",
+        "CommandLine/CommandLineToolLib/private_lib.h",
         "CommandLine/Tests/BUILD",
         "CommandLine/swift_c_module/BUILD",
+        "CommandLine/swift_c_module/c_lib.h",
         "Lib/BUILD",
         "Lib/Info.plist",
         "Lib/README.md",
@@ -326,6 +333,8 @@
         "iOSApp/Source/Model.xcdatamodeld/Model2.xcdatamodel/contents",
         "iOSApp/Source/PreviewContent/Preview Assets.xcassets",
         "iOSApp/Source/Utils/BUILD",
+        "iOSApp/Source/Utils/Foo.h",
+        "iOSApp/Source/Utils/Utils.h",
         "iOSApp/Source/en.lproj/Localizable.strings",
         "iOSApp/Source/en.lproj/unprocessed.json",
         "iOSApp/Source/es.lproj/Localizable.strings",

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -1251,11 +1251,6 @@
         "dependencies": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18"
         ],
-        "inputs": {
-            "srcs": [
-                "CommandLine/CommandLineToolLib/dir with space/lib.h"
-            ]
-        },
         "is_swift": false,
         "label": "//CommandLine/CommandLineToolLib:lib_headers",
         "name": "lib_headers",
@@ -1363,11 +1358,6 @@
         "dependencies": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "inputs": {
-            "srcs": [
-                "CommandLine/CommandLineToolLib/dir with space/lib.h"
-            ]
-        },
         "is_swift": false,
         "label": "//CommandLine/CommandLineToolLib:lib_headers",
         "name": "lib_headers",
@@ -1475,11 +1465,6 @@
         "dependencies": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19"
         ],
-        "inputs": {
-            "srcs": [
-                "CommandLine/CommandLineToolLib/dir with space/lib.h"
-            ]
-        },
         "is_swift": false,
         "label": "//CommandLine/CommandLineToolLib:lib_headers",
         "name": "lib_headers",
@@ -2090,8 +2075,7 @@
         "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
         "inputs": {
             "srcs": [
-                "CommandLine/CommandLineToolLib/private_lib.c",
-                "CommandLine/CommandLineToolLib/private_lib.h"
+                "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
         "is_swift": false,
@@ -2170,8 +2154,7 @@
         "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
         "inputs": {
             "srcs": [
-                "CommandLine/CommandLineToolLib/private_lib.c",
-                "CommandLine/CommandLineToolLib/private_lib.h"
+                "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
         "is_swift": false,
@@ -2250,8 +2233,7 @@
         "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
         "inputs": {
             "srcs": [
-                "CommandLine/CommandLineToolLib/private_lib.c",
-                "CommandLine/CommandLineToolLib/private_lib.h"
+                "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
         "is_swift": false,
@@ -2661,8 +2643,7 @@
         "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
         "inputs": {
             "srcs": [
-                "CommandLine/swift_c_module/c_lib.c",
-                "CommandLine/swift_c_module/c_lib.h"
+                "CommandLine/swift_c_module/c_lib.c"
             ]
         },
         "is_swift": false,
@@ -2737,8 +2718,7 @@
         "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
         "inputs": {
             "srcs": [
-                "CommandLine/swift_c_module/c_lib.c",
-                "CommandLine/swift_c_module/c_lib.h"
+                "CommandLine/swift_c_module/c_lib.c"
             ]
         },
         "is_swift": false,
@@ -2813,8 +2793,7 @@
         "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
         "inputs": {
             "srcs": [
-                "CommandLine/swift_c_module/c_lib.c",
-                "CommandLine/swift_c_module/c_lib.h"
+                "CommandLine/swift_c_module/c_lib.c"
             ]
         },
         "is_swift": false,
@@ -5838,8 +5817,7 @@
         ],
         "inputs": {
             "srcs": [
-                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m",
-                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h"
+                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m"
             ]
         },
         "is_swift": false,
@@ -5952,8 +5930,7 @@
         ],
         "inputs": {
             "srcs": [
-                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m",
-                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h"
+                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m"
             ]
         },
         "is_swift": false,
@@ -6479,9 +6456,7 @@
         ],
         "inputs": {
             "srcs": [
-                "iOSApp/Source/Utils/Foo.m",
-                "iOSApp/Source/Utils/Utils.h",
-                "iOSApp/Source/Utils/Foo.h"
+                "iOSApp/Source/Utils/Foo.m"
             ]
         },
         "is_swift": false,
@@ -9350,10 +9325,6 @@
             "srcs": [
                 {
                     "_": "FXPageControl/FXPageControl/FXPageControl.m",
-                    "t": "e"
-                },
-                {
-                    "_": "FXPageControl/FXPageControl/FXPageControl.h",
                     "t": "e"
                 }
             ]

--- a/examples/integration/test/fixtures/bwx_project_spec.json
+++ b/examples/integration/test/fixtures/bwx_project_spec.json
@@ -105,6 +105,10 @@
     ],
     "extra_files": [
         {
+            "_": "FXPageControl/FXPageControl/FXPageControl.h",
+            "t": "e"
+        },
+        {
             "_": "build_bazel_rules_apple/apple/testing/DefaultTestBundle.plist",
             "t": "e"
         },
@@ -234,8 +238,11 @@
         "CommandLine/CommandLineTool/Launchd.plist",
         "CommandLine/CommandLineTool/export_symbol_list.exp",
         "CommandLine/CommandLineToolLib/BUILD",
+        "CommandLine/CommandLineToolLib/dir with space/lib.h",
+        "CommandLine/CommandLineToolLib/private_lib.h",
         "CommandLine/Tests/BUILD",
         "CommandLine/swift_c_module/BUILD",
+        "CommandLine/swift_c_module/c_lib.h",
         "Lib/BUILD",
         "Lib/Info.plist",
         "Lib/README.md",
@@ -265,6 +272,8 @@
         "iOSApp/Source/CoreUtilsObjC/Info.plist",
         "iOSApp/Source/Info.plist",
         "iOSApp/Source/Utils/BUILD",
+        "iOSApp/Source/Utils/Foo.h",
+        "iOSApp/Source/Utils/Utils.h",
         "iOSApp/Test/ObjCUnitTests/BUILD",
         "iOSApp/Test/SwiftUnitTests/BUILD",
         "iOSApp/Test/TestingUtils/Answer.swift.stencil",

--- a/examples/integration/test/fixtures/bwx_targets_spec.json
+++ b/examples/integration/test/fixtures/bwx_targets_spec.json
@@ -989,11 +989,6 @@
         "dependencies": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18"
         ],
-        "inputs": {
-            "srcs": [
-                "CommandLine/CommandLineToolLib/dir with space/lib.h"
-            ]
-        },
         "is_swift": false,
         "label": "//CommandLine/CommandLineToolLib:lib_headers",
         "name": "lib_headers",
@@ -1101,11 +1096,6 @@
         "dependencies": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "inputs": {
-            "srcs": [
-                "CommandLine/CommandLineToolLib/dir with space/lib.h"
-            ]
-        },
         "is_swift": false,
         "label": "//CommandLine/CommandLineToolLib:lib_headers",
         "name": "lib_headers",
@@ -1213,11 +1203,6 @@
         "dependencies": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19"
         ],
-        "inputs": {
-            "srcs": [
-                "CommandLine/CommandLineToolLib/dir with space/lib.h"
-            ]
-        },
         "is_swift": false,
         "label": "//CommandLine/CommandLineToolLib:lib_headers",
         "name": "lib_headers",
@@ -1828,8 +1813,7 @@
         "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
         "inputs": {
             "srcs": [
-                "CommandLine/CommandLineToolLib/private_lib.c",
-                "CommandLine/CommandLineToolLib/private_lib.h"
+                "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
         "is_swift": false,
@@ -1908,8 +1892,7 @@
         "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
         "inputs": {
             "srcs": [
-                "CommandLine/CommandLineToolLib/private_lib.c",
-                "CommandLine/CommandLineToolLib/private_lib.h"
+                "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
         "is_swift": false,
@@ -1988,8 +1971,7 @@
         "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
         "inputs": {
             "srcs": [
-                "CommandLine/CommandLineToolLib/private_lib.c",
-                "CommandLine/CommandLineToolLib/private_lib.h"
+                "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
         "is_swift": false,
@@ -2330,8 +2312,7 @@
         "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
         "inputs": {
             "srcs": [
-                "CommandLine/swift_c_module/c_lib.c",
-                "CommandLine/swift_c_module/c_lib.h"
+                "CommandLine/swift_c_module/c_lib.c"
             ]
         },
         "is_swift": false,
@@ -2406,8 +2387,7 @@
         "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
         "inputs": {
             "srcs": [
-                "CommandLine/swift_c_module/c_lib.c",
-                "CommandLine/swift_c_module/c_lib.h"
+                "CommandLine/swift_c_module/c_lib.c"
             ]
         },
         "is_swift": false,
@@ -2482,8 +2462,7 @@
         "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
         "inputs": {
             "srcs": [
-                "CommandLine/swift_c_module/c_lib.c",
-                "CommandLine/swift_c_module/c_lib.h"
+                "CommandLine/swift_c_module/c_lib.c"
             ]
         },
         "is_swift": false,
@@ -5263,8 +5242,7 @@
         ],
         "inputs": {
             "srcs": [
-                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m",
-                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h"
+                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m"
             ]
         },
         "is_swift": false,
@@ -5377,8 +5355,7 @@
         ],
         "inputs": {
             "srcs": [
-                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m",
-                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.h"
+                "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m"
             ]
         },
         "is_swift": false,
@@ -5900,9 +5877,7 @@
         ],
         "inputs": {
             "srcs": [
-                "iOSApp/Source/Utils/Foo.m",
-                "iOSApp/Source/Utils/Utils.h",
-                "iOSApp/Source/Utils/Foo.h"
+                "iOSApp/Source/Utils/Foo.m"
             ]
         },
         "is_swift": false,
@@ -7904,10 +7879,6 @@
             "srcs": [
                 {
                     "_": "FXPageControl/FXPageControl/FXPageControl.m",
-                    "t": "e"
-                },
-                {
-                    "_": "FXPageControl/FXPageControl/FXPageControl.h",
                     "t": "e"
                 }
             ]

--- a/xcodeproj/internal/input_files.bzl
+++ b/xcodeproj/internal/input_files.bzl
@@ -83,16 +83,18 @@ def _is_categorized_attr(attr, *, automatic_target_info):
     else:
         return False
 
-def _process_cc_info_headers(headers, *, output_files, pch, generated):
+def _process_cc_info_headers(headers, *, output_files, pch, srcs, generated):
     def _process_header(header):
         if not header.is_source:
             generated.append(header)
-        return header
+        return normalized_file_path(header)
 
     return [
         _process_header(header)
         for header in headers
-        if header not in pch and header not in output_files
+        if (header not in pch and
+            header not in output_files and
+            header not in srcs)
     ]
 
 # API
@@ -360,12 +362,13 @@ def _collect_input_files(
     # headers from `objc_import` and the like.
     if CcInfo in target:
         compilation_context = target[CcInfo].compilation_context
-        srcs.extend(_process_cc_info_headers(
+        extra_files.extend(_process_cc_info_headers(
             (compilation_context.direct_private_headers +
              compilation_context.direct_public_headers +
              compilation_context.direct_textual_headers),
             output_files = output_files,
             pch = pch,
+            srcs = srcs,
             generated = generated,
         ))
 


### PR DESCRIPTION
We don't use them as sources in the generator. We still want them in the project navigator for easy editing though, so we are adding them to `extra_files` instead.