### PR TITLE
Remove some distinction of force_load static libraries

### DIFF
--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -231,11 +231,10 @@ def _extract_top_level_values(
     return struct(
         additional_input_files = tuple(additional_input_files),
         dynamic_frameworks = tuple(dynamic_frameworks),
-        force_load_libraries = tuple(force_load_libraries),
         link_args = link_args,
         link_args_inputs = link_args_inputs,
         static_frameworks = tuple(static_frameworks),
-        static_libraries = tuple(static_libraries),
+        static_libraries = tuple(static_libraries + force_load_libraries),
     )
 
 def _process_additional_inputs(files):
@@ -305,8 +304,7 @@ def _to_input_files(linker_inputs):
         top_level_values.static_frameworks,
     ) + [
         file
-        for file in (top_level_values.static_libraries +
-                     top_level_values.force_load_libraries)
+        for file in top_level_values.static_libraries
         if file.is_source
     ]
 

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -159,7 +159,6 @@ def _to_xcode_target_linker_inputs(linker_inputs):
 
     return struct(
         dynamic_frameworks = top_level_values.dynamic_frameworks,
-        force_load_libraries = top_level_values.force_load_libraries,
         link_args = top_level_values.link_args,
         link_args_inputs = top_level_values.link_args_inputs,
         static_libraries = top_level_values.static_libraries,
@@ -976,7 +975,7 @@ def _get_top_level_static_libraries(xcode_target):
         fail("""\
 Target '{}' requires `ObjcProvider` or `CcInfo`\
 """.format(xcode_target.label))
-    return linker_inputs.static_libraries + linker_inputs.force_load_libraries
+    return linker_inputs.static_libraries
 
 xcode_targets = struct(
     get_top_level_static_libraries = _get_top_level_static_libraries,


### PR DESCRIPTION
Since we no longer create the arguments ourselves, this is a step towards removing all tracking of static libraries.