### PR TITLE
Remove framework executable name from `xcode_generated_paths`

### DIFF
--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -375,8 +375,9 @@ def _set_search_paths(
 
     framework_build_setting_paths = {}
     for file in frameworks:
-        search_path = paths.dirname(file.dirname)
-        xcode_generated_path = xcode_generated_paths.get(file.path)
+        framework_path = file.dirname
+        search_path = paths.dirname(framework_path)
+        xcode_generated_path = xcode_generated_paths.get(framework_path)
         if xcode_generated_path:
             framework_build_setting_paths.setdefault(search_path, {})[True] = (
                 paths.dirname(xcode_generated_path)

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -739,7 +739,7 @@ def _process_xcode_generated_paths(
         for file in product.additional_product_files:
             xcode_generated_paths[file.path] = xcode_product_path
         for file in product.framework_files.to_list():
-            xcode_generated_paths[file.path] = (
+            xcode_generated_paths[file.dirname] = (
                 xcode_product_path
             )
 


### PR DESCRIPTION
This is just extra data we don't need to store, and it's also an incorrect mapping (executable -> framework). In the future we will map executable -> executable, so we want the mappings to be correct.