### PR TITLE
Error in BwX mode if using VFS overlays

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -17,6 +17,7 @@ def _process_compiler_opts_test_impl(ctx):
         cxxopts = ctx.attr.cxxopts,
         full_swiftcopts = ctx.attr.full_swiftcopts,
         user_swiftcopts = ctx.attr.user_swiftcopts,
+        build_mode = ctx.attr.build_mode,
         compilation_mode = ctx.attr.compilation_mode,
         cpp_fragment = _cpp_fragment_stub(ctx.attr.cpp_fragment),
         objc_fragment = _objc_fragment_stub(ctx.attr.objc_fragment),
@@ -64,6 +65,7 @@ def _process_compiler_opts_test_impl(ctx):
 process_compiler_opts_test = unittest.make(
     impl = _process_compiler_opts_test_impl,
     attrs = {
+        "build_mode": attr.string(mandatory = True),
         "cc_info_defines": attr.string_list(default = []),
         "compilation_mode": attr.string(mandatory = True),
         "conlyopts": attr.string_list(mandatory = True),
@@ -138,6 +140,7 @@ def process_compiler_opts_test_suite(name):
             cxxopts = [],
             full_swiftcopts = [],
             user_swiftcopts = [],
+            build_mode = "bazel",
             compilation_mode = "dbg",
             cpp_fragment = None,
             objc_fragment = None,
@@ -150,6 +153,7 @@ def process_compiler_opts_test_suite(name):
             cxxopts = cxxopts,
             full_swiftcopts = full_swiftcopts,
             user_swiftcopts = user_swiftcopts,
+            build_mode = build_mode,
             compilation_mode = compilation_mode,
             cpp_fragment = cpp_fragment,
             objc_fragment = objc_fragment,

--- a/xcodeproj/internal/library_targets.bzl
+++ b/xcodeproj/internal/library_targets.bzl
@@ -29,6 +29,7 @@ load(":xcode_targets.bzl", "xcode_targets")
 def process_library_target(
         *,
         ctx,
+        build_mode,
         target,
         automatic_target_info,
         transitive_infos):
@@ -36,6 +37,7 @@ def process_library_target(
 
     Args:
         ctx: The aspect context.
+        build_mode: See `xcodeproj.build_mode`.
         target: The `Target` to process.
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
@@ -58,6 +60,7 @@ def process_library_target(
     )
     opts_search_paths = process_opts(
         ctx = ctx,
+        build_mode = build_mode,
         target = target,
         package_bin_dir = package_bin_dir,
         build_settings = build_settings,

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -165,6 +165,7 @@ def process_top_level_properties(
 def process_top_level_target(
         *,
         ctx,
+        build_mode,
         target,
         automatic_target_info,
         bundle_info,
@@ -173,6 +174,7 @@ def process_top_level_target(
 
     Args:
         ctx: The aspect context.
+        build_mode: See `xcodeproj.build_mode`.
         target: The `Target` to process.
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
@@ -312,6 +314,7 @@ def process_top_level_target(
     )
     opts_search_paths = process_opts(
         ctx = ctx,
+        build_mode = build_mode,
         target = target,
         package_bin_dir = package_bin_dir,
         build_settings = build_settings,

--- a/xcodeproj/internal/xcodeproj_aspect.bzl
+++ b/xcodeproj/internal/xcodeproj_aspect.bzl
@@ -55,6 +55,7 @@ def _xcodeproj_aspect_impl(target, ctx):
         # one
         info = create_xcodeprojinfo(
             ctx = ctx,
+            build_mode = ctx.attr._build_mode,
             target = target,
             transitive_infos = _transitive_infos(
                 ctx = ctx,

--- a/xcodeproj/internal/xcodeprojinfo.bzl
+++ b/xcodeproj/internal/xcodeprojinfo.bzl
@@ -364,6 +364,7 @@ def _create_envs_depset(*, ctx, id, automatic_target_info):
 def _create_xcodeprojinfo(
         *,
         ctx,
+        build_mode,
         target,
         transitive_infos,
         automatic_target_info):
@@ -371,6 +372,7 @@ def _create_xcodeprojinfo(
 
     Args:
         ctx: The aspect context.
+        build_mode: See `xcodeproj.build_mode`.
         target: The `Target` to process.
         automatic_target_info: The `XcodeProjAutomaticTargetProcessingInfo` for
             `target`.
@@ -400,6 +402,7 @@ def _create_xcodeprojinfo(
     elif AppleBundleInfo in target:
         processed_target = process_top_level_target(
             ctx = ctx,
+            build_mode = build_mode,
             target = target,
             automatic_target_info = automatic_target_info,
             bundle_info = target[AppleBundleInfo],
@@ -408,6 +411,7 @@ def _create_xcodeprojinfo(
     elif target[DefaultInfo].files_to_run.executable:
         processed_target = process_top_level_target(
             ctx = ctx,
+            build_mode = build_mode,
             target = target,
             automatic_target_info = automatic_target_info,
             bundle_info = None,
@@ -416,6 +420,7 @@ def _create_xcodeprojinfo(
     else:
         processed_target = process_library_target(
             ctx = ctx,
+            build_mode = build_mode,
             target = target,
             automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,
@@ -527,11 +532,12 @@ def _create_xcodeprojinfo(
 
 # API
 
-def create_xcodeprojinfo(*, ctx, target, transitive_infos):
+def create_xcodeprojinfo(*, ctx, build_mode, target, transitive_infos):
     """Creates an `XcodeProjInfo` for the given target.
 
     Args:
         ctx: The aspect context.
+        build_mode: See `xcodeproj.build_mode`.
         target: The `Target` to process.
         transitive_infos: A `list` of `XcodeProjInfo`s from the transitive
             dependencies of `target`.
@@ -558,6 +564,7 @@ def create_xcodeprojinfo(*, ctx, target, transitive_infos):
     else:
         info_fields = _create_xcodeprojinfo(
             ctx = ctx,
+            build_mode = build_mode,
             target = target,
             automatic_target_info = automatic_target_info,
             transitive_infos = transitive_infos,


### PR DESCRIPTION
Part of #715.

There is no real way to handle a VFS overlay in BwX mode, as the paths in it will all be Bazel execution root related.