### PR TITLE
Remove `link.params` `-L__BAZEL_XCODE_` filter

### DIFF
--- a/tools/params_processors/link_params_processor.py
+++ b/tools/params_processors/link_params_processor.py
@@ -123,10 +123,6 @@ def _process_linkopts(
         if opt.endswith(".o"):
             return None
 
-        # Xcode adds system library search paths
-        if opt.startswith("-L__BAZEL_XCODE_"):
-            return None
-
         if opt.startswith("-F"):
             path = opt[2:]
             search_paths = generated_framework_search_paths.get(path)


### PR DESCRIPTION
This will result in slight duplication, but since these files are generated on the fly, that is fine, and it lowers the chance of filtering something incorrect.