### PR TITLE
Be more specific with system framework search path filtering

### DIFF
--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -221,7 +221,9 @@ def _process_base_compiler_opts(
         if skip_next:
             skip_next -= 1
             continue
-        if (opt.startswith("-F__BAZEL_XCODE_") or
+        if (opt == "-F__BAZEL_XCODE_SDKROOT__/Developer/Library/Frameworks" or
+            opt == "-F__BAZEL_XCODE_SDKROOT__/System/Library/Frameworks" or
+            opt.startswith("-F__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/") or
             opt.startswith("-I__BAZEL_XCODE_DEVELOPER_DIR__/Platforms/")):
             # Theses options are already handled by Xcode
             continue


### PR DESCRIPTION
This tries to limit the filtering to allow other use copts to go through. We could remove the filtering altogether, but since these are set in the spec.json and the project.pbxproj, it can bloat projects with hundreds or thousands of targets.