### PR TITLE
Add support for additional include flag forms

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -911,6 +911,7 @@ $(PROJECT_DIR)/relative/Path.yaml \
         conlyopts = [
             "-iquote",
             "a/b/c",
+            "-iquotea/b/c/d",
             "-Ix/y/z",
             "-I",
             "1/2/3",
@@ -918,15 +919,18 @@ $(PROJECT_DIR)/relative/Path.yaml \
             "0/9",
             "-isystem",
             "s1/s2",
+            "-isystems1/s2/s3",
         ],
         cxxopts = [
             "-iquote",
             "y/z",
+            "-iquotey/z/1",
             "-Ix/y/z",
             "-I",
             "aa/bb",
             "-isystem",
             "s3/s4",
+            "-isystems3/s4/s5",
         ],
         user_swiftcopts = [
             "-Xcc",
@@ -942,8 +946,10 @@ $(PROJECT_DIR)/relative/Path.yaml \
         expected_search_paths = {
             "quote_includes": [
                 "a/b/c",
+                "a/b/c/d",
                 "0/9",
                 "y/z",
+                "y/z/1",
                 "4/5",
             ],
             "includes": [
@@ -954,7 +960,9 @@ $(PROJECT_DIR)/relative/Path.yaml \
             ],
             "system_includes": [
                 "s1/s2",
+                "s1/s2/s3",
                 "s3/s4",
+                "s3/s4/s5",
                 "s5/s6",
             ],
         },

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -379,6 +379,12 @@ def _process_conlyopts(opts, *, build_settings):
             return None
         if opt == "-I":
             return None
+        if opt.startswith("-isystem"):
+            system_includes.append(opt[8:])
+            return None
+        if opt.startswith("-iquote"):
+            quote_includes.append(opt[7:])
+            return None
         if opt.startswith("-I"):
             includes.append(opt[2:])
             return None
@@ -461,6 +467,12 @@ def _process_cxxopts(opts, *, build_settings):
         if opt == "-iquote":
             return None
         if opt == "-I":
+            return None
+        if opt.startswith("-isystem"):
+            system_includes.append(opt[8:])
+            return None
+        if opt.startswith("-iquote"):
+            quote_includes.append(opt[7:])
             return None
         if opt.startswith("-I"):
             includes.append(opt[2:])


### PR DESCRIPTION
We were correctly detecting these in the Swift `-Xcc` case, but not the normal C/C++ case.