### PR TITLE
Use `CcInfo.compilation_context` to get proper header search paths

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -818,8 +818,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/examples_cc_external",
 					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;
@@ -1228,8 +1226,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/examples_cc_external",
 					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;
@@ -1362,8 +1358,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/examples_cc_external",
 					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;

--- a/examples/cc/test/fixtures/bwb_targets_spec.json
+++ b/examples/cc/test/fixtures/bwb_targets_spec.json
@@ -441,9 +441,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/examples_cc_external",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external"
             ]
         },
         "configuration": "darwin_x86_64-dbg-STABLE-1",
@@ -514,9 +512,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/examples_cc_external",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external"
             ]
         },
         "configuration": "darwin_x86_64-dbg-STABLE-1",
@@ -591,9 +587,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/examples_cc_external",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external"
             ]
         },
         "configuration": "darwin_x86_64-dbg-STABLE-1",

--- a/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -1266,8 +1266,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/examples_cc_external",
 					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;
@@ -1336,8 +1334,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/examples_cc_external",
 					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;
@@ -1490,8 +1486,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/examples_cc_external",
 					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;

--- a/examples/cc/test/fixtures/bwx_targets_spec.json
+++ b/examples/cc/test/fixtures/bwx_targets_spec.json
@@ -440,9 +440,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/examples_cc_external",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external"
             ]
         },
         "configuration": "darwin_x86_64-dbg-STABLE-1",
@@ -513,9 +511,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/examples_cc_external",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external"
             ]
         },
         "configuration": "darwin_x86_64-dbg-STABLE-1",
@@ -590,9 +586,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/examples_cc_external",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external"
             ]
         },
         "configuration": "darwin_x86_64-dbg-STABLE-1",

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -7388,18 +7388,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = iOS;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-7/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=iphoneos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-STABLE-8/bin",
-				);
 			};
 			name = Debug;
 		};
@@ -8045,18 +8033,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = tvOS;
 				TVOS_DEPLOYMENT_TARGET = 15.0;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=appletvos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin",
-				);
 			};
 			name = Debug;
 		};
@@ -8359,18 +8335,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = LibFramework.tvOS;
 				TVOS_DEPLOYMENT_TARGET = 15.0;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=appletvos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin",
-				);
 			};
 			name = Debug;
 		};
@@ -9056,18 +9020,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = watchOS;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin",
-				);
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};
 			name = Debug;
@@ -9473,18 +9425,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = LibFramework.watchOS;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin",
-				);
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};
 			name = Debug;
@@ -9966,10 +9906,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = iMessageApp;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-7/bin",
-				);
 			};
 			name = Debug;
 		};
@@ -10343,8 +10279,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/FXPageControl",
 					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;
@@ -10840,14 +10774,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = watchOSApp;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin",
-				);
 				WATCHOS_DEPLOYMENT_TARGET = 8.0;
 			};
 			name = Debug;

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -2754,13 +2754,7 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0",
-            "TARGETED_DEVICE_FAMILY": "1",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-STABLE-8/bin"
-            ]
+            "TARGETED_DEVICE_FAMILY": "1"
         },
         "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
         "dependencies": [
@@ -2856,13 +2850,7 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0",
-            "TARGETED_DEVICE_FAMILY": "1",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-7/bin"
-            ]
+            "TARGETED_DEVICE_FAMILY": "1"
         },
         "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
         "dependencies": [
@@ -2957,13 +2945,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
         "dependencies": [
@@ -3058,13 +3040,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
         "dependencies": [
@@ -3159,13 +3135,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
         "dependencies": [
@@ -3260,13 +3230,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
         "dependencies": [
@@ -3715,13 +3679,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
         "dependencies": [
@@ -3816,13 +3774,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
         "dependencies": [
@@ -3917,13 +3869,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
         "dependencies": [
@@ -4018,13 +3964,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
         "dependencies": [
@@ -5304,11 +5244,7 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0",
-            "TARGETED_DEVICE_FAMILY": "1",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-7/bin"
-            ]
+            "TARGETED_DEVICE_FAMILY": "1"
         },
         "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
         "dependencies": [
@@ -5346,7 +5282,7 @@
             "type": "com.apple.product-type.application.messages"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-STABLE-7",
@@ -8219,11 +8155,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12",
         "dependencies": [
@@ -8261,7 +8193,7 @@
             "type": "com.apple.product-type.application.watchapp2"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11",
@@ -8281,11 +8213,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-11",
         "dependencies": [
@@ -8323,7 +8251,7 @@
             "type": "com.apple.product-type.application.watchapp2"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-9",
@@ -8899,9 +8827,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/FXPageControl",
-                "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl"
             ]
         },
         "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -4422,7 +4422,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = AD31562E1C81A14E5AE6FF64 /* Build configuration list for PBXNativeTarget "watchOSApp" */;
 			buildPhases = (
-				2591DA2B1885CB84F32218A9 /* Create compiling dependencies */,
 				3F15C214513EBB6C3C513EB3 /* Resources */,
 				059251028EA368233C79DC18 /* Embed App Extensions */,
 			);
@@ -4651,7 +4650,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = EED69E6677FA4A1D173C9F27 /* Build configuration list for PBXNativeTarget "iMessageApp" */;
 			buildPhases = (
-				D111F89B8A7B7C15804685E1 /* Create compiling dependencies */,
 				72706C4746B792B0E3EA11B9 /* Resources */,
 				294721B38B8A22C3714E22A6 /* Embed App Extensions */,
 			);
@@ -6278,23 +6276,6 @@
 			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2591DA2B1885CB84F32218A9 /* Create compiling dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(BAZEL_INTEGRATION_DIR)/create_xcode_overlay.sh",
-			);
-			name = "Create compiling dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
 		2B3D36DE638238A881EB0F4D /* Create compiling dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -7304,23 +7285,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nperl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D111F89B8A7B7C15804685E1 /* Create compiling dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(BAZEL_INTEGRATION_DIR)/create_xcode_overlay.sh",
-			);
-			name = "Create compiling dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		DA9D59F71B3003C604D55396 /* Create linking dependencies */ = {
@@ -9508,13 +9472,9 @@
 				"INFOPLIST_FILE[sdk=watchos*]" = "$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist";
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
 					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
@@ -9526,14 +9486,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = watchOSApp;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin",
-				);
 				WATCHOS_DEPLOYMENT_TARGET = 8.0;
 			};
 			name = Debug;
@@ -9595,18 +9547,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = LibFramework.iOS;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-7/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=iphoneos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-STABLE-8/bin",
-				);
 			};
 			name = Debug;
 		};
@@ -9734,18 +9674,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = watchOS;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin",
-				);
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 				WATCHOS_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework";
 				WATCHSIMULATOR_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework";
@@ -9773,13 +9701,9 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
 					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
@@ -9793,10 +9717,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = iMessageApp;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-7/bin",
-				);
 			};
 			name = Debug;
 		};
@@ -10151,18 +10071,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = LibFramework.tvOS;
 				TVOS_DEPLOYMENT_TARGET = 15.0;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=appletvos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin",
-				);
 			};
 			name = Debug;
 		};
@@ -10354,8 +10262,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/FXPageControl",
 					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;
@@ -10666,18 +10572,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = tvOS;
 				TVOS_DEPLOYMENT_TARGET = 15.0;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=appletvos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin",
-				);
 			};
 			name = Debug;
 		};
@@ -11207,18 +11101,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				TARGET_NAME = iOS;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-7/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=iphoneos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-STABLE-8/bin",
-				);
 			};
 			name = Debug;
 		};
@@ -12127,18 +12009,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = LibFramework.watchOS;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin",
-				);
-				"USER_HEADER_SEARCH_PATHS[sdk=watchos*]" = (
-					"$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-					"$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/external/com_github_krzyzanowskim_cryptoswift",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin",
-				);
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 				WATCHOS_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework";
 				WATCHSIMULATOR_FILES = "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework";

--- a/examples/integration/test/fixtures/bwx_targets_spec.json
+++ b/examples/integration/test/fixtures/bwx_targets_spec.json
@@ -2425,13 +2425,7 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0",
-            "TARGETED_DEVICE_FAMILY": "1",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-STABLE-8/bin"
-            ]
+            "TARGETED_DEVICE_FAMILY": "1"
         },
         "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
         "dependencies": [
@@ -2510,13 +2504,7 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0",
-            "TARGETED_DEVICE_FAMILY": "1",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-7/bin"
-            ]
+            "TARGETED_DEVICE_FAMILY": "1"
         },
         "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
         "dependencies": [
@@ -2594,13 +2582,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
         "dependencies": [
@@ -2678,13 +2660,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
         "dependencies": [
@@ -2762,13 +2738,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
         "dependencies": [
@@ -2846,13 +2816,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
         "dependencies": [
@@ -3285,13 +3249,7 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0",
-            "TARGETED_DEVICE_FAMILY": "1",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_ios-ios_arm64-dbg-STABLE-8/bin"
-            ]
+            "TARGETED_DEVICE_FAMILY": "1"
         },
         "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
         "dependencies": [
@@ -3370,13 +3328,7 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0",
-            "TARGETED_DEVICE_FAMILY": "1",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-7/bin"
-            ]
+            "TARGETED_DEVICE_FAMILY": "1"
         },
         "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
         "dependencies": [
@@ -3454,13 +3406,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
         "dependencies": [
@@ -3538,13 +3484,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
         "dependencies": [
@@ -3622,13 +3562,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
         "dependencies": [
@@ -3706,13 +3640,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_krzyzanowskim_cryptoswift",
-                "$(BAZEL_OUT)/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/external/com_github_krzyzanowskim_cryptoswift",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
         "dependencies": [
@@ -4628,11 +4556,7 @@
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0",
-            "TARGETED_DEVICE_FAMILY": "1",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_ios-ios_x86_64-dbg-STABLE-7/bin"
-            ]
+            "TARGETED_DEVICE_FAMILY": "1"
         },
         "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
         "dependencies": [
@@ -4675,7 +4599,7 @@
             "type": "com.apple.product-type.application.messages"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-STABLE-7",
@@ -7061,11 +6985,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12",
         "dependencies": [
@@ -7108,7 +7028,7 @@
             "type": "com.apple.product-type.application.watchapp2"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11",
@@ -7123,11 +7043,7 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.buildbuddy.example.watch",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-11",
         "dependencies": [
@@ -7170,7 +7086,7 @@
             "type": "com.apple.product-type.application.watchapp2"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-9",
@@ -7551,9 +7467,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/FXPageControl",
-                "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl"
             ]
         },
         "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -2965,8 +2965,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter",
 					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;
@@ -3069,8 +3067,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily",
 					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;
@@ -3305,12 +3301,6 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				EXECUTABLE_EXTENSION = "";
 				GCC_OPTIMIZATION_LEVEL = 0;
-				HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include",
-					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include",
-				);
 				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwb.generator-params/generator.7.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_CFLAGS = (
@@ -3330,14 +3320,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = generator;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
-					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin",
-				);
 			};
 			name = Debug;
 		};

--- a/test/fixtures/generator/bwb_targets_spec.json
+++ b/test/fixtures/generator/bwb_targets_spec.json
@@ -315,23 +315,9 @@
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "GCC_OPTIMIZATION_LEVEL": "0",
-            "HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include",
-                "$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include"
-            ],
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
-                "$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
         "dependencies": [
@@ -485,7 +471,7 @@
             "type": "com.apple.product-type.tool"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
@@ -1092,9 +1078,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter"
             ]
         },
         "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
@@ -1297,9 +1281,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily"
             ]
         },
         "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -1833,7 +1833,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 098ECC207AD7CA38CAB13ADA /* Build configuration list for PBXNativeTarget "generator" */;
 			buildPhases = (
-				0526F613A0521424B1525042 /* Create compiling dependencies */,
 				2873C638E3CBD8B23D24AC62 /* Create linking dependencies */,
 				A20A184C7539826C418740CC /* Sources */,
 			);
@@ -2096,23 +2095,6 @@
 
 /* Begin PBXShellScriptBuildPhase section */
 		00C39D247C21E354CA493E9F /* Create compiling dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(BAZEL_INTEGRATION_DIR)/create_xcode_overlay.sh",
-			);
-			name = "Create compiling dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		0526F613A0521424B1525042 /* Create compiling dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3008,8 +2990,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily",
 					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;
@@ -3031,23 +3011,13 @@
 				EXECUTABLE_EXTENSION = "";
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include",
-					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include",
-				);
 				LINK_PARAMS_FILE = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwx.generator-params/generator.7.link.params";
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
 					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
@@ -3059,14 +3029,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = generator;
-				USER_HEADER_SEARCH_PATHS = (
-					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
-					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin",
-				);
 			};
 			name = Debug;
 		};
@@ -3215,8 +3177,6 @@
 				USER_HEADER_SEARCH_PATHS = (
 					"$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter",
 					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
-					"$(PROJECT_DIR)",
-					"$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin",
 				);
 			};
 			name = Debug;

--- a/test/fixtures/generator/bwx_targets_spec.json
+++ b/test/fixtures/generator/bwx_targets_spec.json
@@ -313,23 +313,9 @@
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "GCC_OPTIMIZATION_LEVEL": "0",
-            "HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/include",
-                "$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/include"
-            ],
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "USER_HEADER_SEARCH_PATHS": [
-                "$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
-                "$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin"
-            ]
+            "SWIFT_VERSION": "5.0"
         },
         "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
         "dependencies": [
@@ -483,7 +469,7 @@
             "type": "com.apple.product-type.tool"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
@@ -1089,9 +1075,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/com_github_michaeleisel_jjliso8601dateformatter",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter"
             ]
         },
         "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
@@ -1294,9 +1278,7 @@
             "SWIFT_VERSION": "5.0",
             "USER_HEADER_SEARCH_PATHS": [
                 "$(BAZEL_EXTERNAL)/com_github_michaeleisel_zippyjsoncfamily",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
-                "$(PROJECT_DIR)",
-                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin"
+                "$(BAZEL_OUT)/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily"
             ]
         },
         "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -105,6 +105,8 @@ def _get_unprocessed_compiler_opts(*, ctx, build_mode, target):
             swiftcopts = action.argv[2:]
 
     if not swiftcopts and CcInfo in target:
+        cc_info = target[CcInfo]
+        compilation_context = cc_info.compilation_context
         cc_toolchain = find_cpp_toolchain(ctx)
 
         feature_configuration = cc_common.configure_features(
@@ -122,6 +124,9 @@ def _get_unprocessed_compiler_opts(*, ctx, build_mode, target):
             feature_configuration = feature_configuration,
             cc_toolchain = cc_toolchain,
             user_compile_flags = [],
+            include_directories = compilation_context.includes,
+            quote_include_directories = compilation_context.quote_includes,
+            system_include_directories = compilation_context.system_includes,
         )
 
         is_objc = apple_common.Objc in target

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -918,25 +918,10 @@ def _search_paths_to_intermediate(search_paths, *, compile_target):
             cc_info = None
 
     if cc_info:
-        compilation_context = cc_info.compilation_context
         opts_search_paths = compile_search_paths._opts_search_paths
-
-        if opts_search_paths:
-            opts_includes = list(opts_search_paths.includes)
-            opts_quote_includes = list(opts_search_paths.quote_includes)
-            opts_system_includes = list(opts_search_paths.system_includes)
-        else:
-            opts_includes = []
-            opts_quote_includes = []
-            opts_system_includes = []
-
-        quote_includes = depset(
-            [".", compile_search_paths._bin_dir_path] + opts_quote_includes,
-            transitive = [compilation_context.quote_includes],
-        ).to_list()
-        includes = compilation_context.includes.to_list() + opts_includes
-        system_includes = (compilation_context.system_includes.to_list() +
-                           opts_system_includes)
+        includes = opts_search_paths.includes
+        quote_includes = opts_search_paths.quote_includes
+        system_includes = opts_search_paths.system_includes
     else:
         quote_includes = []
         includes = []


### PR DESCRIPTION
Added benefit is that Swift targets now correctly no longer have header search paths set.