### PR TITLE
Add BCR app config

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,0 +1,3 @@
+fixedReleaser:
+  login: BalestraPatrick
+  email: me@patrickbalestra.com

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,25 @@
+{
+    "homepage": "https://github.com/buildbuddy-io/rules_xcodeproj",
+    "maintainers": [
+        {
+            "email": "github@brentleyjones.com",
+            "github": "brentleyjones",
+            "name": "Jones Brentley"
+        },
+        {
+            "email": "me@patrickbalestra.com",
+            "github": "BalestraPatrick",
+            "name": "Patrick Balestra"
+        },
+        {
+            "email": "t@thi.im",
+            "github": "thii",
+            "name": "Thi Doãn"
+        }
+    ],
+    "repository": [
+        "github:buildbuddy-io/rules_xcodeproj"
+    ],
+    "versions": [],
+    "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,6 @@
+tasks:
+  verify_targets_macos:
+    name: Verify build targets
+    platform: macos
+    build_targets:
+    - "@rules_xcodeproj//tools/generator:xcodeproj"

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "",
+    "strip_prefix": "",
+    "url": "https://github.com/buildbuddy-io/rules_xcodeproj/releases/download/{TAG}/release.tar.gz"
+}


### PR DESCRIPTION
This PR adds the configuration files and templates necessary to get the [Publish To BCR](https://github.com/bazel-contrib/publish-to-bcr) GitHub app to work with rules_xcodeproj.

There are few steps to make sure this works correctly:
- [x] Approve my request to add the app to this repo.
- [x] Fork https://github.com/bazelbuild/bazel-central-registry under the account defined in `.bcr/config.yaml`. We can either remove the `fixedReleader` and have a fork of the BCR in the `buildbuddy-io` org, or we can use a personal fork. For example, for `rules_swift`, `rules_apple` and `apple_support` we're using [my own fork](https://github.com/balestrapatrick/bazel-central-registry) at the moment.
- [x] Test that the `.bcr/presubmit.yaml` is actually working. I think the first release should probably be checked-in manually to decide which targets to run as validation with bzlmod directly in the BCR.