### PR TITLE
Move `RESOLVED_EXTERNAL_REPOSITORIES` from `BazelDependencies` to project

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -830,7 +830,6 @@
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_DISABLE_SCRIPT_EXECUTION = YES;
 				INDEX_IMPORT = "fixture-index-import-path";
-				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_cc_external\" \"$(SRCROOT)/external\"";
 				SUPPORTED_PLATFORMS = macosx;
 				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = BazelDependencies;
@@ -1152,6 +1151,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
+				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_cc_external\" \"$(SRCROOT)/external\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -1146,7 +1146,6 @@
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_IMPORT = "fixture-index-import-path";
-				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_cc_external\" \"$(SRCROOT)/external\"";
 				SUPPORTED_PLATFORMS = macosx;
 				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = BazelDependencies;
@@ -1190,6 +1189,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_cc_external\" \"$(SRCROOT)/external\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -8867,7 +8867,6 @@
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_DISABLE_SCRIPT_EXECUTION = YES;
 				INDEX_IMPORT = "fixture-index-import-path";
-				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\"";
 				SUPPORTED_PLATFORMS = macosx;
 				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = BazelDependencies;
@@ -10058,6 +10057,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
+				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -10234,7 +10234,6 @@
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_IMPORT = "fixture-index-import-path";
-				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\"";
 				SUPPORTED_PLATFORMS = macosx;
 				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = BazelDependencies;
@@ -11648,6 +11647,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				RESOLVED_EXTERNAL_REPOSITORIES = "\"examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -732,7 +732,6 @@
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_DISABLE_SCRIPT_EXECUTION = YES;
 				INDEX_IMPORT = "fixture-index-import-path";
-				RESOLVED_EXTERNAL_REPOSITORIES = "";
 				SUPPORTED_PLATFORMS = iphonesimulator;
 				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = BazelDependencies;
@@ -782,6 +781,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
+				RESOLVED_EXTERNAL_REPOSITORIES = "";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -589,7 +589,6 @@
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_IMPORT = "fixture-index-import-path";
-				RESOLVED_EXTERNAL_REPOSITORIES = "";
 				SUPPORTED_PLATFORMS = iphonesimulator;
 				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = BazelDependencies;
@@ -784,6 +783,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				RESOLVED_EXTERNAL_REPOSITORIES = "";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		BECD01BA300E00331FACF49C /* _Hashtable+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11A5223CE3ED58001C49FE15 /* _Hashtable+Header.swift */; };
 		BFCCE08B291B40F8BCD53410 /* JSONSerialization.mm in Sources */ = {isa = PBXBuildFile; fileRef = 26A9188E264AA8D418D49A8D /* JSONSerialization.mm */; };
 		C06FFF6C987B8779D83AD76A /* Platform+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4B73BE1DC5509640DDCBCA /* Platform+Extensions.swift */; };
+		C1EF6F8745683EC239F07F31 /* SetAdditionalProjectConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AF120756CDFD2E4D366102 /* SetAdditionalProjectConfiguration.swift */; };
 		C41DDB4D3921E664100AA2B8 /* XCSchemeInfo+ProfileActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A5F8AA7804846155CFD79CC /* XCSchemeInfo+ProfileActionInfoTests.swift */; };
 		C68682DD3E215724587291ED /* XCSchemeInfo+PrePostActionInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1550104BA8818733ACC86 /* XCSchemeInfo+PrePostActionInfoTests.swift */; };
 		C6E6C91B5F999E68FBCF59D6 /* OrderedSet+Invariants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AB38800E4A200B1E17E4D0D /* OrderedSet+Invariants.swift */; };
@@ -639,6 +640,7 @@
 		A61F49C0EE9330580BB0169B /* ReferenceGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferenceGenerator.swift; sourceTree = "<group>"; };
 		A68A9610D685E01B9069236C /* XCCurrentVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCCurrentVersion.swift; sourceTree = "<group>"; };
 		A8A3E5A993AEE45CE7217367 /* PBXRezBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXRezBuildPhase.swift; sourceTree = "<group>"; };
+		A8AF120756CDFD2E4D366102 /* SetAdditionalProjectConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetAdditionalProjectConfiguration.swift; sourceTree = "<group>"; };
 		ABA94B592863254CECD2A4DE /* OrderedSet+Partial SetAlgebra+Predicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+Partial SetAlgebra+Predicates.swift"; sourceTree = "<group>"; };
 		AC9FD305C4225E40F5327120 /* XCSchemeInfo+TestActionInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCSchemeInfo+TestActionInfoTests.swift"; sourceTree = "<group>"; };
 		ACC4BE5749A2825648295DA0 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -843,6 +845,7 @@
 				B430E1F12A9EF757D481C28F /* PopulateMainGroup.swift */,
 				4764E4510BA9E11BFF455502 /* ProcessReplacementLabels.swift */,
 				4A56789CB89B52C6464FD38F /* SemanticVersion.swift */,
+				A8AF120756CDFD2E4D366102 /* SetAdditionalProjectConfiguration.swift */,
 				8C5CEE8583D6B165FACC19C7 /* SetTargetConfigurations.swift */,
 				57B67C14EB0479AEFAD69673 /* SetTargetDependencies.swift */,
 				B56516A0679CA62A37FD1F7E /* TargetResolver.swift */,
@@ -2546,6 +2549,7 @@
 				75CF813428759BDB21C4BE52 /* PopulateMainGroup.swift in Sources */,
 				03B10623A9F4A7ED4B9A454F /* ProcessReplacementLabels.swift in Sources */,
 				18E250500AF3F82A1FB26488 /* SemanticVersion.swift in Sources */,
+				C1EF6F8745683EC239F07F31 /* SetAdditionalProjectConfiguration.swift in Sources */,
 				09AA6FA25ABA47AC6A2B7806 /* SetTargetConfigurations.swift in Sources */,
 				947BA9361CB52508E27C5B7D /* SetTargetDependencies.swift in Sources */,
 				9462C7263DAD38C72797D3A8 /* TargetResolver.swift in Sources */,
@@ -2795,7 +2799,6 @@
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_DISABLE_SCRIPT_EXECUTION = YES;
 				INDEX_IMPORT = "fixture-index-import-path";
-				RESOLVED_EXTERNAL_REPOSITORIES = "";
 				SUPPORTED_PLATFORMS = macosx;
 				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = BazelDependencies;
@@ -3142,6 +3145,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
+				RESOLVED_EXTERNAL_REPOSITORIES = "";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/test/fixtures/generator/bwb_targets_spec.json
+++ b/test/fixtures/generator/bwb_targets_spec.json
@@ -534,6 +534,7 @@
                 "tools/generator/src/Generator/PopulateMainGroup.swift",
                 "tools/generator/src/Generator/ProcessReplacementLabels.swift",
                 "tools/generator/src/Generator/SemanticVersion.swift",
+                "tools/generator/src/Generator/SetAdditionalProjectConfiguration.swift",
                 "tools/generator/src/Generator/SetTargetConfigurations.swift",
                 "tools/generator/src/Generator/SetTargetDependencies.swift",
                 "tools/generator/src/Generator/TargetResolver.swift",

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		76F699267C0326C77D23C387 /* XCSchemeInfo+TargetInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 180BD33CC2B059C25C7DEC95 /* XCSchemeInfo+TargetInfoTests.swift */; };
 		7870FA6396BB71808E5A448A /* GameKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57CC919FE8B5CB6D2E8E2836 /* GameKit.swift */; };
 		78DCA0F4C4671D6F3FC4A6AE /* Array+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54068A8C12F0110E869B159F /* Array+Extensions.swift */; };
+		7B0123E90D4E3D2D8A228FED /* SetAdditionalProjectConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E94BCF4475CEF19121E416 /* SetAdditionalProjectConfiguration.swift */; };
 		7DD40282D119808407D2F5D3 /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = A761EF346DEF38694FBC490F /* PBXObject.swift */; };
 		7E15BA4BCA08762B90F7FDF3 /* Array+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31BA8BCB988172A766E60FE /* Array+Extras.swift */; };
 		7E449490609EDC218AFCB74D /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800E3E1F5EA50778894BF7FF /* Box.swift */; };
@@ -673,6 +674,7 @@
 		92D58BB1B65A4CE329A0ACE7 /* PBXProductType+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXProductType+Extensions.swift"; sourceTree = "<group>"; };
 		9336BBE76C331269E1912CB0 /* PBXBuildFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildFile.swift; sourceTree = "<group>"; };
 		93F0086B109A14B60823D214 /* PBXSourcesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXSourcesBuildPhase.swift; sourceTree = "<group>"; };
+		95E94BCF4475CEF19121E416 /* SetAdditionalProjectConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetAdditionalProjectConfiguration.swift; sourceTree = "<group>"; };
 		965C8301286D612C0D7514A2 /* OrderedDictionary+Partial RangeReplaceableCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedDictionary+Partial RangeReplaceableCollection.swift"; sourceTree = "<group>"; };
 		96978B78786FFB310C41DFDE /* XCWorkspaceDataFileRef.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataFileRef.swift; sourceTree = "<group>"; };
 		9704E0628AFD05B054DC1ED9 /* OrderedSet+UnstableInternals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderedSet+UnstableInternals.swift"; sourceTree = "<group>"; };
@@ -1621,6 +1623,7 @@
 				73F38515E87488039D5ED0EC /* PopulateMainGroup.swift */,
 				854528EA9A693DC32507798D /* ProcessReplacementLabels.swift */,
 				282A3E83DE16BD17AB4671BF /* SemanticVersion.swift */,
+				95E94BCF4475CEF19121E416 /* SetAdditionalProjectConfiguration.swift */,
 				10B1FC780D4BE80D1438FF83 /* SetTargetConfigurations.swift */,
 				FAA37BECE2AD8D399B416516 /* SetTargetDependencies.swift */,
 				E1C8EA74CBEA0685A0929665 /* TargetResolver.swift */,
@@ -2474,6 +2477,7 @@
 				EF6ED16BF041EA93A6117492 /* PopulateMainGroup.swift in Sources */,
 				F46DB512C166E7638F56E3FD /* ProcessReplacementLabels.swift in Sources */,
 				E66723DA3F69574220B61475 /* SemanticVersion.swift in Sources */,
+				7B0123E90D4E3D2D8A228FED /* SetAdditionalProjectConfiguration.swift in Sources */,
 				545AB8476A28E55F4E259413 /* SetTargetConfigurations.swift in Sources */,
 				1298717120FF78624A7BE2A7 /* SetTargetDependencies.swift in Sources */,
 				C05367CD225D44CFAE114A74 /* TargetResolver.swift in Sources */,
@@ -3039,7 +3043,6 @@
 				CALCULATE_OUTPUT_GROUPS_SCRIPT = "$(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py";
 				INDEX_DATA_STORE_DIR = "$(INDEX_DATA_STORE_DIR)";
 				INDEX_IMPORT = "fixture-index-import-path";
-				RESOLVED_EXTERNAL_REPOSITORIES = "";
 				SUPPORTED_PLATFORMS = macosx;
 				SUPPORTS_MACCATALYST = YES;
 				TARGET_NAME = BazelDependencies;
@@ -3354,6 +3357,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				RESOLVED_EXTERNAL_REPOSITORIES = "";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";
 				SRCROOT = ../../../../..;

--- a/test/fixtures/generator/bwx_targets_spec.json
+++ b/test/fixtures/generator/bwx_targets_spec.json
@@ -532,6 +532,7 @@
                 "tools/generator/src/Generator/PopulateMainGroup.swift",
                 "tools/generator/src/Generator/ProcessReplacementLabels.swift",
                 "tools/generator/src/Generator/SemanticVersion.swift",
+                "tools/generator/src/Generator/SetAdditionalProjectConfiguration.swift",
                 "tools/generator/src/Generator/SetTargetConfigurations.swift",
                 "tools/generator/src/Generator/SetTargetDependencies.swift",
                 "tools/generator/src/Generator/TargetResolver.swift",

--- a/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
+++ b/tools/generator/src/Generator/AddBazelDependenciesTarget.swift
@@ -26,7 +26,6 @@ extension Generator {
         minimumXcodeVersion: SemanticVersion,
         indexImport: String,
         files: [FilePath: File],
-        resolvedExternalRepositories: [(Path, Path)],
         bazelConfig: String,
         generatorLabel: BazelLabel,
         generatorConfiguration: String,
@@ -58,11 +57,6 @@ $(BAZEL_INTEGRATION_DIR)/calculate_output_groups.py
 """,
             "INDEX_DATA_STORE_DIR": "$(INDEX_DATA_STORE_DIR)",
             "INDEX_IMPORT": indexImport,
-            "RESOLVED_EXTERNAL_REPOSITORIES": resolvedExternalRepositories
-                // Sorted by length to ensure that subdirectories are listed first
-                .sorted { $0.0.string.count > $1.0.string.count }
-                .map { #""\#($0)" "\#($1)""# }
-                .joined(separator: " "),
             // We have to support only a single platform to prevent issues
             // with duplicated outputs during Index Build, but it also
             // has to be a platform that one of the targets uses, otherwise

--- a/tools/generator/src/Generator/Environment.swift
+++ b/tools/generator/src/Generator/Environment.swift
@@ -41,6 +41,11 @@ struct Environment {
         resolvedExternalRepositories: [(Path, Path)]
     )
 
+    let setAdditionalProjectConfiguration: (
+        _ pbxProj: PBXProj,
+        _ resolvedExternalRepositories: [(Path, Path)]
+    ) -> Void
+
     let createProducts: (
         _ pbxProj: PBXProj,
         _ consolidatedTargets: ConsolidatedTargets
@@ -64,7 +69,6 @@ struct Environment {
         _ minimumXcodeVersion: SemanticVersion,
         _ indexImport: String,
         _ files: [FilePath: File],
-        _ resolvedExternalRepositories: [(Path, Path)],
         _ bazelConfig: String,
         _ generatorLabel: BazelLabel,
         _ generatorConfiguration: String,

--- a/tools/generator/src/Generator/Generator.swift
+++ b/tools/generator/src/Generator/Generator.swift
@@ -12,6 +12,8 @@ class Generator {
         processReplacementLabels: Generator.processReplacementLabels,
         consolidateTargets: Generator.consolidateTargets,
         createFilesAndGroups: Generator.createFilesAndGroups,
+        setAdditionalProjectConfiguration:
+            Generator.setAdditionalProjectConfiguration,
         createProducts: Generator.createProducts,
         populateMainGroup: populateMainGroup,
         disambiguateTargets: Generator.disambiguateTargets,
@@ -90,6 +92,11 @@ class Generator {
             logger
         )
 
+        environment.setAdditionalProjectConfiguration(
+            pbxProj,
+            resolvedExternalRepositories
+        )
+
         let consolidatedTargets = try environment.consolidateTargets(
             targets,
             xcodeGeneratedFiles,
@@ -116,7 +123,6 @@ class Generator {
             project.minimumXcodeVersion,
             project.indexImport,
             files,
-            resolvedExternalRepositories,
             project.bazelConfig,
             project.generatorLabel,
             project.configuration,

--- a/tools/generator/src/Generator/SetAdditionalProjectConfiguration.swift
+++ b/tools/generator/src/Generator/SetAdditionalProjectConfiguration.swift
@@ -1,0 +1,20 @@
+import PathKit
+import XcodeProj
+
+extension Generator {
+    static func setAdditionalProjectConfiguration (
+        _ pbxProj: PBXProj,
+        _ resolvedExternalRepositories: [(Path, Path)]
+    ) {
+        let resolvedExternalRepositoriesString = resolvedExternalRepositories
+            // Sorted by length to ensure that subdirectories are listed first
+            .sorted { $0.0.string.count > $1.0.string.count }
+            .map { #""\#($0)" "\#($1)""# }
+            .joined(separator: " ")
+
+        for configuration in pbxProj.buildConfigurations {
+            configuration.buildSettings["RESOLVED_EXTERNAL_REPOSITORIES"] =
+            resolvedExternalRepositoriesString
+        }
+    }
+}

--- a/tools/generator/test/GeneratorTests.swift
+++ b/tools/generator/test/GeneratorTests.swift
@@ -318,6 +318,29 @@ final class GeneratorTests: XCTestCase {
             directories: directories
         )]
 
+        // MARK: setAdditionalProjectConfiguration()
+
+        struct SetAdditionalProjectConfigurationCalled: Equatable {
+            let pbxProj: PBXProj
+        }
+
+        var setAdditionalProjectConfigurationCalled:
+            [SetAdditionalProjectConfigurationCalled] = []
+        func setAdditionalProjectConfiguration(
+            in pbxProj: PBXProj,
+            resolvedExternalRepositories: [(Path, Path)]
+        ) {
+            setAdditionalProjectConfigurationCalled.append(.init(
+                pbxProj: pbxProj
+            ))
+        }
+
+        let expectedSetAdditionalProjectConfigurationCalled = [
+            SetAdditionalProjectConfigurationCalled(
+                pbxProj: pbxProj
+            ),
+        ]
+
         // MARK: consolidateTargets()
 
         struct ConsolidateTargetsCalled: Equatable {
@@ -444,7 +467,6 @@ final class GeneratorTests: XCTestCase {
             minimumXcodeVersion: SemanticVersion,
             indexImport: String,
             files: [FilePath: File],
-            resolvedExternalRepositories: [(Path, Path)],
             bazelConfig: String,
             generatorLabel: BazelLabel,
             generatorConfiguration: String,
@@ -761,6 +783,8 @@ final class GeneratorTests: XCTestCase {
             processReplacementLabels: processReplacementLabels,
             consolidateTargets: consolidateTargets,
             createFilesAndGroups: createFilesAndGroups,
+            setAdditionalProjectConfiguration:
+                setAdditionalProjectConfiguration,
             createProducts: createProducts,
             populateMainGroup: populateMainGroup,
             disambiguateTargets: disambiguateTargets,
@@ -810,6 +834,10 @@ final class GeneratorTests: XCTestCase {
         XCTAssertNoDifference(
             createFilesAndGroupsCalled,
             expectedCreateFilesAndGroupsCalled
+        )
+        XCTAssertNoDifference(
+            setAdditionalProjectConfigurationCalled,
+            expectedSetAdditionalProjectConfigurationCalled
         )
         XCTAssertNoDifference(
             createProductsCalled,


### PR DESCRIPTION
Fixes a regression introduced with 6934ecaf002828ab2487a079b5b8017a7046dc3b.