### PR TITLE
Revert "Revert "Parse compiler flags to determine `framework_includes` (#1584)" (#1591)"

### DIFF
--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -2818,7 +2818,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib/dist/dynamic:iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
@@ -2914,7 +2914,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib/dist/dynamic:tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
@@ -3009,7 +3009,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib/dist/dynamic:tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
@@ -3104,7 +3104,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib/dist/dynamic:watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
@@ -3199,7 +3199,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib/dist/dynamic:watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
@@ -3294,7 +3294,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
@@ -3743,7 +3743,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
@@ -3838,7 +3838,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
@@ -3933,7 +3933,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
@@ -4028,7 +4028,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//UI:UIFramework.iOS applebin_ios-ios_arm64-dbg-STABLE-8",

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -4440,7 +4440,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CE8EC23F8BA0F8067187BFCC /* Build configuration list for PBXNativeTarget "tvOS" */;
 			buildPhases = (
-				39D12E4B152047D1BD1E0352 /* Create compiling dependencies */,
 				70EC5FA6C0DE858D8B6B9D03 /* Create linking dependencies */,
 				35B1A496C141A511B68CD01C /* Sources */,
 				14EAA527ACD60CF941F8067F /* Resources */,
@@ -4810,7 +4809,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DE753F1584BAEEE9E9B3D961 /* Build configuration list for PBXNativeTarget "watchOS" */;
 			buildPhases = (
-				A50A81B5FDEDE5A2D01C0ADD /* Create compiling dependencies */,
 				38D23D8B1AAFCDF9FFBB24FF /* Create linking dependencies */,
 				5596CC0905ED033FAAB9CC5E /* Sources */,
 				E0E3499207E58E757421A8E3 /* Resources */,
@@ -4880,7 +4878,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = AE0571773EF9410BE199D216 /* Build configuration list for PBXNativeTarget "iOS" */;
 			buildPhases = (
-				5D05E62E3439F73AAF970359 /* Create compiling dependencies */,
 				94BB8CE548C9CEB38922293F /* Create linking dependencies */,
 				150ECE9B10A24EDCD68433E6 /* Sources */,
 				71069F15E90765B29EE0DB37 /* Resources */,
@@ -4916,7 +4913,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 03AE913C17EEF71D6B5750C0 /* Build configuration list for PBXNativeTarget "LibFramework.iOS" */;
 			buildPhases = (
-				BF0B59A38D7C23911E248719 /* Create compiling dependencies */,
 				6E34424248DBC273AB573C53 /* Create linking dependencies */,
 				72C05C54D2004F8886EDBB81 /* Sources */,
 				C75DDAD9B5747607C0104492 /* Resources */,
@@ -5288,7 +5284,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2C2259872DE0B8304500939E /* Build configuration list for PBXNativeTarget "LibFramework.tvOS" */;
 			buildPhases = (
-				9971185EB9A65D63D5198C27 /* Create compiling dependencies */,
 				027230613C505EE933350262 /* Create linking dependencies */,
 				A373CFAE1BBE832180746E37 /* Sources */,
 				43E9A189D5F0F26DFA8F01E5 /* Resources */,
@@ -5404,7 +5399,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D091FF3C234DBDF3E3287A5D /* Build configuration list for PBXNativeTarget "LibFramework.watchOS" */;
 			buildPhases = (
-				86F260C4472945B880AFA820 /* Create compiling dependencies */,
 				2E87C18EFCEF052665AC3147 /* Create linking dependencies */,
 				EAE6BB8CF20B0B9694FAD79B /* Sources */,
 				B3DA5EAAE6D1E354FD06A0C0 /* Resources */,
@@ -6346,23 +6340,6 @@
 			shellScript = "set -euo pipefail\n\nperl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n\ntouch \"$SCRIPT_OUTPUT_FILE_1\"\n";
 			showEnvVarsInLog = 0;
 		};
-		39D12E4B152047D1BD1E0352 /* Create compiling dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(BAZEL_INTEGRATION_DIR)/create_xcode_overlay.sh",
-			);
-			name = "Create compiling dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
 		3C0639924615EA9F3E740EB8 /* Create compiling dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -6483,23 +6460,6 @@
 			showEnvVarsInLog = 0;
 		};
 		50924B1B30D07B5082A4F739 /* Create compiling dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(BAZEL_INTEGRATION_DIR)/create_xcode_overlay.sh",
-			);
-			name = "Create compiling dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		5D05E62E3439F73AAF970359 /* Create compiling dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -6776,23 +6736,6 @@
 			shellScript = "if [[ -z \"${SWIFT_OBJC_INTERFACE_HEADER_NAME:-}\" ]]; then\n  exit 0\nfi\n\ncp \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		86F260C4472945B880AFA820 /* Create compiling dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(BAZEL_INTEGRATION_DIR)/create_xcode_overlay.sh",
-			);
-			name = "Create compiling dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
 		88A9F0ABA45AD0DEBC0B77B7 /* Create compiling dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -6896,23 +6839,6 @@
 			shellScript = "set -euo pipefail\n\nperl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
-		9971185EB9A65D63D5198C27 /* Create compiling dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(BAZEL_INTEGRATION_DIR)/create_xcode_overlay.sh",
-			);
-			name = "Create compiling dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
 		9AA3C6BB6A2C78549C071136 /* Create compiling dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -6982,23 +6908,6 @@
 			showEnvVarsInLog = 0;
 		};
 		9E588528644F5887C1B033F1 /* Create compiling dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(BAZEL_INTEGRATION_DIR)/create_xcode_overlay.sh",
-			);
-			name = "Create compiling dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A50A81B5FDEDE5A2D01C0ADD /* Create compiling dependencies */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -7115,23 +7024,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\n\nperl -pe 's/^(\"?)(.*\\$\\(.*\\).*?)(\"?)$/\"$2\"/ ; s/\\$(\\()?([a-zA-Z_]\\w*)(?(1)\\))/$ENV{$2}/g' \\\n  \"$SCRIPT_INPUT_FILE_0\" > \"$SCRIPT_OUTPUT_FILE_0\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BF0B59A38D7C23911E248719 /* Create compiling dependencies */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(BAZEL_INTEGRATION_DIR)/create_xcode_overlay.sh",
-			);
-			name = "Create compiling dependencies";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"$SCRIPT_INPUT_FILE_0\"\n";
 			showEnvVarsInLog = 0;
 		};
 		BFBEF6090107E1BB9D4CBE0A /* Create compiling dependencies */ = {
@@ -9525,13 +9417,9 @@
 				"LINK_PARAMS_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.iOS.65.link.params";
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
 					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
@@ -9649,13 +9537,9 @@
 				"LINK_PARAMS_FILE[sdk=watchos*]" = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOS.76.link.params";
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
 					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
@@ -10040,13 +9924,9 @@
 				"LINK_PARAMS_FILE[sdk=appletvos*]" = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.tvOS.77.link.params";
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
 					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
@@ -10524,13 +10404,9 @@
 				"LINK_PARAMS_FILE[sdk=appletvos*]" = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOS.75.link.params";
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
 					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
@@ -11049,13 +10925,9 @@
 				"LINK_PARAMS_FILE[sdk=iphoneos*]" = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOS.73.link.params";
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
 					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
@@ -11954,13 +11826,9 @@
 				"LINK_PARAMS_FILE[sdk=watchos*]" = "$(BAZEL_OUT)/darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.watchOS.68.link.params";
 				OTHER_CFLAGS = (
 					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
-					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
-					"-ivfsoverlay",
-					"$(DERIVED_FILE_DIR)/xcode-overlay.yaml",
 					"-ivfsoverlay",
 					"$(OBJROOT)/bazel-out-overlay.yaml",
 				);

--- a/examples/integration/test/fixtures/bwx_targets_spec.json
+++ b/examples/integration/test/fixtures/bwx_targets_spec.json
@@ -2488,7 +2488,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib/dist/dynamic:iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
@@ -2561,7 +2561,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib/dist/dynamic:tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
@@ -2633,7 +2633,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib/dist/dynamic:tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
@@ -2705,7 +2705,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib/dist/dynamic:watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
@@ -2777,7 +2777,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib/dist/dynamic:watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
@@ -2849,7 +2849,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
@@ -3276,7 +3276,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib:LibFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
@@ -3349,7 +3349,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
@@ -3421,7 +3421,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
@@ -3493,7 +3493,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
@@ -3565,7 +3565,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
@@ -3637,7 +3637,7 @@
             "type": "com.apple.product-type.framework"
         },
         "search_paths": {
-            "has_includes": true
+            "has_includes": false
         }
     },
     "//UI:UIFramework.iOS applebin_ios-ios_arm64-dbg-STABLE-8",

--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -99,6 +99,7 @@ def process_compiler_opts_test_suite(name):
                 "quote_includes": [],
                 "includes": [],
                 "system_includes": [],
+                "framework_includes": [],
             },
             conlyopts = [],
             cxxopts = [],
@@ -192,6 +193,7 @@ weird \
             ],
             "includes": [],
             "system_includes": [],
+            "framework_includes": [],
         },
     )
 
@@ -265,6 +267,7 @@ weird \
             ],
             "includes": [],
             "system_includes": [],
+            "framework_includes": [],
         },
     )
 
@@ -454,6 +457,7 @@ $(PROJECT_DIR)/relative/Path.yaml \
             "quote_includes": [],
             "includes": ["__BAZEL_XCODE_SOMETHING_/path", "__BAZEL_XCODE_BOSS_"],
             "system_includes": [],
+            "framework_includes": [],
         },
     )
 
@@ -573,6 +577,7 @@ $(PROJECT_DIR)/relative/Path.yaml \
             "quote_includes": [],
             "includes": ["__BAZEL_XCODE_SOMETHING_/path", "__BAZEL_XCODE_BOSS_"],
             "system_includes": [],
+            "framework_includes": [],
         },
     )
 
@@ -962,6 +967,7 @@ $(PROJECT_DIR)/relative/Path.yaml \
                 "s3/s4/s5",
                 "s5/s6",
             ],
+            "framework_includes": [],
         },
     )
 

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -273,7 +273,12 @@ def _process_base_compiler_opts(
 
     return processed_opts
 
-def create_opts_search_paths(quote_includes, includes, system_includes):
+def create_opts_search_paths(
+        *,
+        quote_includes,
+        includes,
+        system_includes,
+        framework_includes):
     """Creates a value representing search paths of a target.
 
     Args:
@@ -281,15 +286,19 @@ def create_opts_search_paths(quote_includes, includes, system_includes):
         includes: A `list` of include paths (i.e. `-I` values).
         system_includes: A `list` of system include paths (i.e. `-isystem`
             values).
+        framework_includes: A `list` of framework include paths (i.e. `-F`
+            values).
 
     Returns:
         A `struct` containing the `quote_includes`, `includes`, and
-        `system_includes` fields provided as arguments.
+        `system_includes`, and `framework_includes` fields provided as
+        arguments.
     """
     return struct(
         quote_includes = tuple(quote_includes),
         includes = tuple(includes),
         system_includes = tuple(system_includes),
+        framework_includes = tuple(framework_includes),
     )
 
 def merge_opts_search_paths(search_paths):
@@ -307,16 +316,19 @@ def merge_opts_search_paths(search_paths):
     quote_includes = []
     includes = []
     system_includes = []
+    framework_includes = []
 
     for search_path in search_paths:
         quote_includes.extend(search_path.quote_includes)
         includes.extend(search_path.includes)
         system_includes.extend(search_path.system_includes)
+        framework_includes.extend(search_path.framework_includes)
 
     return create_opts_search_paths(
         quote_includes = uniq(quote_includes),
         includes = uniq(includes),
         system_includes = uniq(system_includes),
+        framework_includes = uniq(framework_includes),
     )
 
 def _process_conlyopts(opts, *, build_settings):
@@ -342,6 +354,7 @@ def _process_conlyopts(opts, *, build_settings):
     quote_includes = []
     includes = []
     system_includes = []
+    framework_includes = []
     has_debug_info = {}
 
     def process(opt, previous_opt):
@@ -379,6 +392,9 @@ def _process_conlyopts(opts, *, build_settings):
         if opt.startswith("-I"):
             includes.append(opt[2:])
             return None
+        if opt.startswith("-F"):
+            framework_includes.append(opt[2:])
+            return opt
         if opt.startswith("-D"):
             value = opt[2:]
             if value.startswith("OBJC_OLD_DISPATCH_PROTOTYPES"):
@@ -404,6 +420,7 @@ def _process_conlyopts(opts, *, build_settings):
         quote_includes = uniq(quote_includes),
         includes = uniq(includes),
         system_includes = uniq(system_includes),
+        framework_includes = uniq(framework_includes),
     )
 
     return processed_opts, defines, optimizations, search_paths, has_debug_info
@@ -431,6 +448,7 @@ def _process_cxxopts(opts, *, build_settings):
     quote_includes = []
     includes = []
     system_includes = []
+    framework_includes = []
     has_debug_info = {}
 
     def process(opt, previous_opt):
@@ -468,6 +486,9 @@ def _process_cxxopts(opts, *, build_settings):
         if opt.startswith("-I"):
             includes.append(opt[2:])
             return None
+        if opt.startswith("-F"):
+            framework_includes.append(opt[2:])
+            return opt
         if opt.startswith("-D"):
             value = opt[2:]
             if value.startswith("OBJC_OLD_DISPATCH_PROTOTYPES"):
@@ -491,6 +512,7 @@ def _process_cxxopts(opts, *, build_settings):
         quote_includes = uniq(quote_includes),
         includes = uniq(includes),
         system_includes = uniq(system_includes),
+        framework_includes = uniq(framework_includes),
     )
 
     return processed_opts, defines, optimizations, search_paths, has_debug_info
@@ -616,6 +638,7 @@ def _process_swiftcopts(
     quote_includes = []
     includes = []
     system_includes = []
+    framework_includes = []
     has_debug_info = {}
 
     def process(opt, previous_opt):
@@ -649,6 +672,9 @@ def _process_swiftcopts(
             if (build_mode == "xcode" and path != "." and
                 not path.startswith("/")):
                 return "-fmodule-map-file=$(PROJECT_DIR)/" + path
+            return opt
+        if opt.startswith("-F"):
+            framework_includes.append(opt[2:])
             return opt
         if previous_opt == "-Xcc":
             # We do this check here, to prevent the `-O` and `-D` logic below
@@ -725,6 +751,7 @@ Using VFS overlays with `build_mode = "xcode"` is unsupported.
         quote_includes = uniq(quote_includes),
         includes = uniq(includes),
         system_includes = uniq(system_includes),
+        framework_includes = uniq(framework_includes),
     )
 
     set_if_true(

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -473,7 +473,7 @@ def _generated_framework_search_paths(
 
     ordered_framework_search_paths = {}
     for search_path in search_paths_intermediate.framework_includes:
-        search_paths = framework_search_paths.get(search_path)
+        search_paths = framework_search_paths.pop(search_path, None)
         if search_paths:
             ordered_framework_search_paths[search_path] = search_paths
             continue
@@ -482,6 +482,10 @@ def _generated_framework_search_paths(
         ordered_framework_search_paths.setdefault(search_path, {})["b"] = (
             build_setting_path(path = search_path)
         )
+
+    # Add remaining items from `framework_search_paths`, for linker only paths
+    for search_path, search_paths in framework_search_paths.items():
+        ordered_framework_search_paths[search_path] = search_paths
 
     return ordered_framework_search_paths
 
@@ -879,10 +883,8 @@ def _search_paths_to_intermediate(search_paths, *, compile_target):
 
     if compilation_providers:
         cc_info = compilation_providers._cc_info
-        objc = compilation_providers._objc
     else:
         cc_info = None
-        objc = None
 
     if compile_target:
         compile_search_paths = compile_target._search_paths
@@ -899,19 +901,11 @@ def _search_paths_to_intermediate(search_paths, *, compile_target):
         includes = opts_search_paths.includes
         quote_includes = opts_search_paths.quote_includes
         system_includes = opts_search_paths.system_includes
+        framework_includes = opts_search_paths.framework_includes
     else:
         quote_includes = []
         includes = []
         system_includes = []
-
-    if objc:
-        framework_includes = depset(
-            transitive = [
-                objc.static_framework_paths,
-                objc.dynamic_framework_paths,
-            ],
-        ).to_list()
-    else:
         framework_includes = []
 
     return struct(


### PR DESCRIPTION
This reverts commit 788fa50135dc8d822347fab9e9b767cdf6788a1d.

We now add the remaining paths in `framework_search_paths` to `ordered_framework_search_paths`, to account for paths that are link-only.