### PR TITLE
Fix label and path handling when bzlmod is enabled

### DIFF
--- a/examples/cc/test/fixtures/bwb_project_spec.json
+++ b/examples/cc/test/fixtures/bwb_project_spec.json
@@ -34,7 +34,7 @@
     "post_build_script": null,
     "pre_build_script": null,
     "replacement_labels": [],
-    "runner_label": "@//test/fixtures:xcodeproj_bwb",
+    "runner_label": "//test/fixtures:xcodeproj_bwb",
     "scheme_autogeneration_mode": "auto",
     "target_hosts": []
 }

--- a/examples/cc/test/fixtures/bwx_project_spec.json
+++ b/examples/cc/test/fixtures/bwx_project_spec.json
@@ -34,7 +34,7 @@
     "post_build_script": null,
     "pre_build_script": null,
     "replacement_labels": [],
-    "runner_label": "@//test/fixtures:xcodeproj_bwx",
+    "runner_label": "//test/fixtures:xcodeproj_bwx",
     "scheme_autogeneration_mode": "auto",
     "target_hosts": []
 }

--- a/examples/integration/test/fixtures/bwb_project_spec.json
+++ b/examples/integration/test/fixtures/bwb_project_spec.json
@@ -32,15 +32,15 @@
                 "expand_variables_based_on": null,
                 "post_actions": [
                     {
-                        "expand_variables_based_on": "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
+                        "expand_variables_based_on": "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
                         "name": "Run After Tests",
                         "script": "echo \"Hi\""
                     }
                 ],
                 "pre_actions": [],
                 "targets": [
-                    "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
-                    "@//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests"
+                    "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
+                    "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests"
                 ]
             }
         },
@@ -61,7 +61,7 @@
                 "post_actions": [],
                 "pre_actions": [],
                 "targets": [
-                    "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests"
+                    "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests"
                 ]
             }
         }
@@ -392,27 +392,27 @@
     "pre_build_script": null,
     "replacement_labels": [
         "//CommandLine/CommandLineTool:tool.binary macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "@//CommandLine/CommandLineTool:UniversalCommandLineTool",
+        "//CommandLine/CommandLineTool:UniversalCommandLineTool",
         "//CommandLine/CommandLineTool:tool.binary macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "@//CommandLine/CommandLineTool:UniversalCommandLineTool",
+        "//CommandLine/CommandLineTool:UniversalCommandLineTool",
         "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-20",
-        "@//CommandLine/Tests:CommandLineToolTests",
+        "//CommandLine/Tests:CommandLineToolTests",
         "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "@//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests",
+        "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests",
         "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
+        "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
         "//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-16",
-        "@//macOSApp/Test/UITests:macOSAppUITests",
+        "//macOSApp/Test/UITests:macOSAppUITests",
         "//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "@//tvOSApp/Test/UITests:tvOSAppUITests",
+        "//tvOSApp/Test/UITests:tvOSAppUITests",
         "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "@//tvOSApp/Test/UnitTests:tvOSAppUnitTests",
+        "//tvOSApp/Test/UnitTests:tvOSAppUnitTests",
         "//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "@//watchOSApp/Test/UITests:watchOSAppUITests",
+        "//watchOSApp/Test/UITests:watchOSAppUITests",
         "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "@//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests"
+        "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests"
     ],
-    "runner_label": "@//test/fixtures:xcodeproj_bwb",
+    "runner_label": "//test/fixtures:xcodeproj_bwb",
     "scheme_autogeneration_mode": "all",
     "target_hosts": [
         "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-8",

--- a/examples/integration/test/fixtures/bwx_project_spec.json
+++ b/examples/integration/test/fixtures/bwx_project_spec.json
@@ -32,15 +32,15 @@
                 "expand_variables_based_on": null,
                 "post_actions": [
                     {
-                        "expand_variables_based_on": "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
+                        "expand_variables_based_on": "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
                         "name": "Run After Tests",
                         "script": "echo \"Hi\""
                     }
                 ],
                 "pre_actions": [],
                 "targets": [
-                    "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
-                    "@//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests"
+                    "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
+                    "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests"
                 ]
             }
         },
@@ -61,7 +61,7 @@
                 "post_actions": [],
                 "pre_actions": [],
                 "targets": [
-                    "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests"
+                    "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests"
                 ]
             }
         }
@@ -315,27 +315,27 @@
     "pre_build_script": null,
     "replacement_labels": [
         "//CommandLine/CommandLineTool:tool.binary macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "@//CommandLine/CommandLineTool:UniversalCommandLineTool",
+        "//CommandLine/CommandLineTool:UniversalCommandLineTool",
         "//CommandLine/CommandLineTool:tool.binary macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "@//CommandLine/CommandLineTool:UniversalCommandLineTool",
+        "//CommandLine/CommandLineTool:UniversalCommandLineTool",
         "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-20",
-        "@//CommandLine/Tests:CommandLineToolTests",
+        "//CommandLine/Tests:CommandLineToolTests",
         "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "@//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests",
+        "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests",
         "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "@//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
+        "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests",
         "//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-16",
-        "@//macOSApp/Test/UITests:macOSAppUITests",
+        "//macOSApp/Test/UITests:macOSAppUITests",
         "//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "@//tvOSApp/Test/UITests:tvOSAppUITests",
+        "//tvOSApp/Test/UITests:tvOSAppUITests",
         "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "@//tvOSApp/Test/UnitTests:tvOSAppUnitTests",
+        "//tvOSApp/Test/UnitTests:tvOSAppUnitTests",
         "//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "@//watchOSApp/Test/UITests:watchOSAppUITests",
+        "//watchOSApp/Test/UITests:watchOSAppUITests",
         "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "@//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests"
+        "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests"
     ],
-    "runner_label": "@//test/fixtures:xcodeproj_bwx",
+    "runner_label": "//test/fixtures:xcodeproj_bwx",
     "scheme_autogeneration_mode": "all",
     "target_hosts": [
         "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-8",

--- a/examples/sanitizers/test/fixtures/bwb_project_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_project_spec.json
@@ -26,7 +26,7 @@
                     }
                 },
                 "env": {},
-                "target": "@//AddressSanitizerApp:AddressSanitizerApp",
+                "target": "//AddressSanitizerApp:AddressSanitizerApp",
                 "working_directory": null
             },
             "name": "AddressSanitizer",
@@ -45,7 +45,7 @@
                     }
                 },
                 "env": {},
-                "target": "@//ThreadSanitizerApp:ThreadSanitizerApp",
+                "target": "//ThreadSanitizerApp:ThreadSanitizerApp",
                 "working_directory": null
             },
             "name": "ThreadSanitizer",
@@ -64,7 +64,7 @@
                     }
                 },
                 "env": {},
-                "target": "@//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
+                "target": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
                 "working_directory": null
             },
             "name": "UndefinedBehaviorSanitizer",
@@ -89,7 +89,7 @@
     "post_build_script": null,
     "pre_build_script": null,
     "replacement_labels": [],
-    "runner_label": "@//test/fixtures:xcodeproj_bwb",
+    "runner_label": "//test/fixtures:xcodeproj_bwb",
     "scheme_autogeneration_mode": "none",
     "target_hosts": []
 }

--- a/examples/sanitizers/test/fixtures/bwx_project_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_project_spec.json
@@ -26,7 +26,7 @@
                     }
                 },
                 "env": {},
-                "target": "@//AddressSanitizerApp:AddressSanitizerApp",
+                "target": "//AddressSanitizerApp:AddressSanitizerApp",
                 "working_directory": null
             },
             "name": "AddressSanitizer",
@@ -45,7 +45,7 @@
                     }
                 },
                 "env": {},
-                "target": "@//ThreadSanitizerApp:ThreadSanitizerApp",
+                "target": "//ThreadSanitizerApp:ThreadSanitizerApp",
                 "working_directory": null
             },
             "name": "ThreadSanitizer",
@@ -64,7 +64,7 @@
                     }
                 },
                 "env": {},
-                "target": "@//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
+                "target": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
                 "working_directory": null
             },
             "name": "UndefinedBehaviorSanitizer",
@@ -89,7 +89,7 @@
     "post_build_script": null,
     "pre_build_script": null,
     "replacement_labels": [],
-    "runner_label": "@//test/fixtures:xcodeproj_bwx",
+    "runner_label": "//test/fixtures:xcodeproj_bwx",
     "scheme_autogeneration_mode": "none",
     "target_hosts": []
 }

--- a/test/fixtures/generator/bwb_project_spec.json
+++ b/test/fixtures/generator/bwb_project_spec.json
@@ -17,14 +17,14 @@
             "build_action": {
                 "post_actions": [
                     {
-                        "expand_variables_based_on": "@//tools/generator:generator",
+                        "expand_variables_based_on": "//tools/generator:generator",
                         "name": "Example: Stop build time tracking...",
                         "script": "echo 'Completed Building target: generator'"
                     }
                 ],
                 "pre_actions": [
                     {
-                        "expand_variables_based_on": "@//tools/generator:generator",
+                        "expand_variables_based_on": "//tools/generator:generator",
                         "name": "Example: Start build time tracking...",
                         "script": "echo 'Building target: generator'"
                     }
@@ -38,7 +38,7 @@
                             "running": "unspecified",
                             "testing": "unspecified"
                         },
-                        "label": "@//tools/generator:generator"
+                        "label": "//tools/generator:generator"
                     }
                 ]
             },
@@ -72,7 +72,7 @@
                 "env": {
                     "CUSTOM_ENV_VAR": "hello"
                 },
-                "target": "@//tools/generator:generator",
+                "target": "//tools/generator:generator",
                 "working_directory": "$(BUILD_WORKSPACE_DIRECTORY)"
             },
             "name": "generator",
@@ -93,7 +93,7 @@
                 "post_actions": [],
                 "pre_actions": [],
                 "targets": [
-                    "@//tools/generator/test:tests"
+                    "//tools/generator/test:tests"
                 ]
             }
         },
@@ -110,7 +110,7 @@
                             "running": "enabled",
                             "testing": "enabled"
                         },
-                        "label": "@//tools/swiftc_stub:swiftc"
+                        "label": "//tools/swiftc_stub:swiftc"
                     }
                 ]
             },
@@ -125,7 +125,7 @@
                     }
                 },
                 "env": {},
-                "target": "@//tools/swiftc_stub:swiftc",
+                "target": "//tools/swiftc_stub:swiftc",
                 "working_directory": null
             },
             "name": "swiftc",
@@ -155,9 +155,9 @@
     "pre_build_script": null,
     "replacement_labels": [
         "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-2",
-        "@//tools/generator/test:tests"
+        "//tools/generator/test:tests"
     ],
-    "runner_label": "@//test/fixtures/generator:xcodeproj_bwb",
+    "runner_label": "//test/fixtures/generator:xcodeproj_bwb",
     "scheme_autogeneration_mode": "none",
     "target_hosts": []
 }

--- a/test/fixtures/generator/bwx_project_spec.json
+++ b/test/fixtures/generator/bwx_project_spec.json
@@ -17,14 +17,14 @@
             "build_action": {
                 "post_actions": [
                     {
-                        "expand_variables_based_on": "@//tools/generator:generator",
+                        "expand_variables_based_on": "//tools/generator:generator",
                         "name": "Example: Stop build time tracking...",
                         "script": "echo 'Completed Building target: generator'"
                     }
                 ],
                 "pre_actions": [
                     {
-                        "expand_variables_based_on": "@//tools/generator:generator",
+                        "expand_variables_based_on": "//tools/generator:generator",
                         "name": "Example: Start build time tracking...",
                         "script": "echo 'Building target: generator'"
                     }
@@ -38,7 +38,7 @@
                             "running": "unspecified",
                             "testing": "unspecified"
                         },
-                        "label": "@//tools/generator:generator"
+                        "label": "//tools/generator:generator"
                     }
                 ]
             },
@@ -72,7 +72,7 @@
                 "env": {
                     "CUSTOM_ENV_VAR": "hello"
                 },
-                "target": "@//tools/generator:generator",
+                "target": "//tools/generator:generator",
                 "working_directory": "$(BUILD_WORKSPACE_DIRECTORY)"
             },
             "name": "generator",
@@ -93,7 +93,7 @@
                 "post_actions": [],
                 "pre_actions": [],
                 "targets": [
-                    "@//tools/generator/test:tests"
+                    "//tools/generator/test:tests"
                 ]
             }
         },
@@ -110,7 +110,7 @@
                             "running": "enabled",
                             "testing": "enabled"
                         },
-                        "label": "@//tools/swiftc_stub:swiftc"
+                        "label": "//tools/swiftc_stub:swiftc"
                     }
                 ]
             },
@@ -125,7 +125,7 @@
                     }
                 },
                 "env": {},
-                "target": "@//tools/swiftc_stub:swiftc",
+                "target": "//tools/swiftc_stub:swiftc",
                 "working_directory": null
             },
             "name": "swiftc",
@@ -155,9 +155,9 @@
     "pre_build_script": null,
     "replacement_labels": [
         "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-2",
-        "@//tools/generator/test:tests"
+        "//tools/generator/test:tests"
     ],
-    "runner_label": "@//test/fixtures/generator:xcodeproj_bwx",
+    "runner_label": "//test/fixtures/generator:xcodeproj_bwx",
     "scheme_autogeneration_mode": "none",
     "target_hosts": []
 }

--- a/test/internal/bazel_labels/normalize_tests.bzl
+++ b/test/internal/bazel_labels/normalize_tests.bzl
@@ -21,12 +21,19 @@ bazel_labels = make_bazel_labels(
     ),
 )
 
+def _repo_prefix():
+    is_bazel_6 = hasattr(apple_common, "link_multi_arch_static_library")
+    if is_bazel_6:
+        return "@"
+    else:
+        return ""
+
 def _relative_label_test(ctx):
     env = unittest.begin(ctx)
 
     value = ":chicken"
     actual = bazel_labels.normalize(value)
-    expected = "@//Sources/Foo:chicken"
+    expected = _repo_prefix() + "//Sources/Foo:chicken"
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)
@@ -50,7 +57,7 @@ def _absolute_label_without_repo_name_test(ctx):
 
     value = "//Sources/Foo:chicken"
     actual = bazel_labels.normalize(value)
-    expected = "@//Sources/Foo:chicken"
+    expected = _repo_prefix() + "//Sources/Foo:chicken"
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)

--- a/xcodeproj/internal/bazel_integration_files/bazel_build.sh
+++ b/xcodeproj/internal/bazel_integration_files/bazel_build.sh
@@ -138,6 +138,10 @@ for output_group in "${output_groups[@]}"; do
     fi
 
     repo="${BASH_REMATCH[2]}"
+    if [[ "$repo" == "@" ]]; then
+      repo=""
+    fi
+
     package="${BASH_REMATCH[3]}"
     target="${BASH_REMATCH[4]}"
     configuration="${BASH_REMATCH[5]}"

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -88,23 +88,24 @@ def make_bazel_labels(workspace_name_resolvers = workspace_name_resolvers):
 
     def _normalize(value):
         if type(value) == "Label":
-            repository_name = value.workspace_name
-            if not repository_name.startswith("@"):
-                # Support `--noincompatible_unambiguous_label_stringification`
-                repository_name = "@" + repository_name
-            parts = _create_label_parts(
-                repository_name = repository_name,
-                package = value.package,
-                name = value.name,
-            )
+            label = value
         else:
             parts = _parse(value)
 
-        return "{repo_name}//{package}:{name}".format(
-            repo_name = parts.repository_name,
-            package = parts.package,
-            name = parts.name,
-        )
+            is_bazel_6 = hasattr(apple_common, "link_multi_arch_static_library")
+            if is_bazel_6:
+                repo_prefix = "@"
+            else:
+                repo_prefix = ""
+
+            label = Label("{repo_prefix}{repo_name}//{package}:{name}".format(
+                repo_prefix = repo_prefix,
+                repo_name = parts.repository_name,
+                package = parts.package,
+                name = parts.name,
+            ))
+
+        return str(label)
 
     return struct(
         create = _create_label_parts,


### PR DESCRIPTION
Fixes #1598.

Tested:

- Bazel 5.4
- Bazel 6.0 with `--noincompatible_unambiguous_label_stringification`
- Bazel 6.0 with `--noincompatible_unambiguous_label_stringification`
- Bazel 6.0 with `--enable_bzlmod`