### PR TITLE
Enable bzlmod for development

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,6 +8,7 @@ module(
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "rules_swift", version = "1.5.1", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "rules_apple", version = "2.0.0", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "buildifier_prebuilt", version = "6.0.0.1", dev_dependency = True)
 
 non_module_deps = use_extension("//xcodeproj:extensions.bzl", "non_module_deps")
 use_repo(
@@ -20,4 +21,15 @@ use_repo(
     "com_github_tadija_aexml",
     "com_github_tuist_xcodeproj",
     "rules_xcodeproj_index_import",
+)
+
+dev_non_module_deps = use_extension(
+    "//xcodeproj:extensions.bzl",
+    "dev_non_module_deps",
+    dev_dependency = True,
+)
+use_repo(
+    dev_non_module_deps,
+    "com_github_pointfreeco_swift_custom_dump",
+    "com_github_pointfreeco_xctest_dynamic_overlay",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,10 @@
 workspace(name = "com_github_buildbuddy_io_rules_xcodeproj")
 
-load("//xcodeproj:repositories.bzl", "xcodeproj_rules_dependencies")
+load(
+    "//xcodeproj:repositories.bzl",
+    "xcodeproj_rules_dependencies",
+    "xcodeproj_rules_dev_dependencies",
+)
 
 xcodeproj_rules_dependencies(use_dev_patches = True)
 
@@ -25,48 +29,7 @@ load(
 
 swift_rules_extra_dependencies()
 
-# Setup Swift Custom Dump test dependency
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "com_github_pointfreeco_xctest_dynamic_overlay",
-    build_file_content = """\
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-
-swift_library(
-    name = "XCTestDynamicOverlay",
-    module_name = "XCTestDynamicOverlay",
-    srcs = glob(["Sources/XCTestDynamicOverlay/**/*.swift"]),
-    visibility = ["//visibility:public"],
-)
-""",
-    sha256 = "97169124feb98b409f5b890bd95bb147c2fba0dba3098f9bf24c539270ee9601",
-    strip_prefix = "xctest-dynamic-overlay-0.2.1",
-    url = "https://github.com/pointfreeco/xctest-dynamic-overlay/archive/refs/tags/0.2.1.tar.gz",
-)
-
-http_archive(
-    name = "com_github_pointfreeco_swift_custom_dump",
-    build_file_content = """\
-load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-
-swift_library(
-    name = "CustomDump",
-    module_name = "CustomDump",
-    srcs = glob(["Sources/CustomDump/**/*.swift"]),
-    deps = ["@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay"],
-    visibility = ["//visibility:public"],
-)
-""",
-    patches = [
-        # Custom for our tests
-        "//third_party/com_github_pointfreeco_swift_custom_dump:type_name.patch",
-    ],
-    sha256 = "a45e8f275794960651043623e23abb8365f0455b4ad5976bc56a4fa00c5efb31",
-    strip_prefix = "swift-custom-dump-0.5.0",
-    url = "https://github.com/pointfreeco/swift-custom-dump/archive/refs/tags/0.5.0.tar.gz",
-)
+xcodeproj_rules_dev_dependencies()
 
 # Setup the Skylib dependency, this is required to use the Starlark unittest
 # framework. Since this is only used for rules_xcodeproj's tests, we configure
@@ -79,6 +42,8 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
 # Buildifier
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "buildifier_prebuilt",

--- a/bazel_6.bazelrc
+++ b/bazel_6.bazelrc
@@ -1,1 +1,3 @@
+build --enable_bzlmod
+
 build:cache --experimental_remote_build_event_upload=minimal

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -39,13 +39,13 @@ x_templates:
         - examples/sanitizers/setup-bazel-output-base
 
   commands:
-    - &bazel_5_setup "--output_base=setup-bazel-output-base run --config=workflows @com_github_buildbuddy_io_rules_xcodeproj//tools:set_bazel_5"
-    - &validate_integration "run --config=workflows //test/fixtures:validate"
-    - &build_all "build --config=workflows //..."
-    - &test_all "test --config=workflows //..."
+    - &bazel_5_setup "--output_base=setup-bazel-output-base run --config=workflows --noexperimental_enable_bzlmod @com_github_buildbuddy_io_rules_xcodeproj//tools:set_bazel_5"
+    - &validate_integration "run --config=workflows --noexperimental_enable_bzlmod //test/fixtures:validate"
+    - &build_all "build --config=workflows --noexperimental_enable_bzlmod //..."
+    - &test_all "test --config=workflows --noexperimental_enable_bzlmod //..."
     - &bzlmod_generate_integration "run --config=workflows //test/fixtures:update"
-    - &bzlmod_build_all "build --config=bzlmod_workflows //..."
-    - &bzlmod_test_all "test --config=bzlmod_workflows //test/..."
+    - &bzlmod_build_all "build --config=workflows //..."
+    - &bzlmod_test_all "test --config=workflows //test/..."
 
 actions:
   - name: Buildifier Lint
@@ -60,7 +60,7 @@ actions:
     <<: *light_resources
     <<: *root_workspace
     bazel_commands:
-      - "test --config=workflows //docs:diff_test"
+      - "test --config=workflows --noenable_bzlmod //docs:diff_test"
 
   - name: Test
     <<: *arm64

--- a/docs/update_docs.sh
+++ b/docs/update_docs.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+bazel run --config=cache --noexperimental_enable_bzlmod //docs:update

--- a/examples/integration/.bazelrc
+++ b/examples/integration/.bazelrc
@@ -15,5 +15,8 @@ build:rules_xcodeproj --@build_bazel_rules_swift//swift:universal_tools
 
 build --test_env=INTEGRATION_TEST_ENV_VAR=TRUE
 
+# This example doesn't support bzlmod yet
+build --noexperimental_enable_bzlmod
+
 # Use a user.bazelrc if it exists
 try-import %workspace%/user.bazelrc

--- a/examples/sanitizers/.bazelrc
+++ b/examples/sanitizers/.bazelrc
@@ -1,5 +1,8 @@
 # Import parent workspace settings
 import %workspace%/../../shared.bazelrc
 
+# This example doesn't support bzlmod yet
+build --noexperimental_enable_bzlmod
+
 # Use a user.bazelrc if it exists
 try-import %workspace%/user.bazelrc

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -35,10 +35,6 @@ build:cache --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_common_
 build:cache --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_indexbuild_flags='--bes_backend= --bes_results_url='
 build:cache --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_generator_flags='--bes_backend= --bes_results_url='
 
-build:bzlmod_cache --config=cache
-build:bzlmod_cache --enable_bzlmod
-build:bzlmod_cache --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_common_flags='--config=cache --enable_bzlmod'
-
 # Build with --config=remote to use BuildBuddy RBE
 build:remote --config=cache
 build:remote --remote_executor=grpcs://remote.buildbuddy.io
@@ -52,10 +48,6 @@ build:workflows --color=yes
 build:workflows --terminal_columns=120
 build:workflows --disk_cache=
 build:workflows --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_generator_flags='--config=workflows --bes_backend= --bes_results_url='
-
-build:bzlmod_workflows --config=workflows
-build:bzlmod_workflows --enable_bzlmod
-build:bzlmod_workflows --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_generator_flags='--config=workflows --enable_bzlmod --bes_backend= --bes_results_url='
 
 # Show detailed errors for test failures
 test --test_output=errors --test_summary=detailed

--- a/tools/bazel
+++ b/tools/bazel
@@ -12,4 +12,4 @@ else
   readonly bazel_version_bazelrc="$root_dir/bazel_6.bazelrc"
 fi
 
-exec "$BAZEL_REAL" "--bazelrc=$bazel_version_bazelrc" "$@"
+exec "$BAZEL_REAL" "--noworkspace_rc" "--bazelrc=$bazel_version_bazelrc" "--bazelrc=.bazelrc" "$@"

--- a/xcodeproj/extensions.bzl
+++ b/xcodeproj/extensions.bzl
@@ -1,5 +1,10 @@
 """Module extension for loading dependencies not yet compatible with bzlmod."""
 
-load("//xcodeproj:repositories.bzl", "xcodeproj_rules_dependencies")
+load(
+    "//xcodeproj:repositories.bzl",
+    "xcodeproj_rules_dependencies",
+    "xcodeproj_rules_dev_dependencies",
+)
 
+dev_non_module_deps = module_extension(implementation = lambda _: xcodeproj_rules_dev_dependencies())
 non_module_deps = module_extension(implementation = lambda _: xcodeproj_rules_dependencies(include_bzlmod_ready_dependencies = False))

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -299,3 +299,49 @@ swift_library(
         url = "https://github.com/apple/swift-collections/archive/refs/tags/1.0.2.tar.gz",
         ignore_version_differences = ignore_version_differences,
     )
+
+# buildifier: disable=unnamed-macro
+def xcodeproj_rules_dev_dependencies(ignore_version_differences = False):
+    # Setup Swift Custom Dump test dependency
+    _maybe(
+        http_archive,
+        name = "com_github_pointfreeco_xctest_dynamic_overlay",
+        build_file_content = """\
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+swift_library(
+    name = "XCTestDynamicOverlay",
+    module_name = "XCTestDynamicOverlay",
+    srcs = glob(["Sources/XCTestDynamicOverlay/**/*.swift"]),
+    visibility = ["//visibility:public"],
+)
+""",
+        sha256 = "97169124feb98b409f5b890bd95bb147c2fba0dba3098f9bf24c539270ee9601",
+        strip_prefix = "xctest-dynamic-overlay-0.2.1",
+        url = "https://github.com/pointfreeco/xctest-dynamic-overlay/archive/refs/tags/0.2.1.tar.gz",
+        ignore_version_differences = ignore_version_differences,
+    )
+
+    _maybe(
+        http_archive,
+        name = "com_github_pointfreeco_swift_custom_dump",
+        build_file_content = """\
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+swift_library(
+    name = "CustomDump",
+    module_name = "CustomDump",
+    srcs = glob(["Sources/CustomDump/**/*.swift"]),
+    deps = ["@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay"],
+    visibility = ["//visibility:public"],
+)
+""",
+        patches = [
+            # Custom for our tests
+            "//third_party/com_github_pointfreeco_swift_custom_dump:type_name.patch",
+        ],
+        sha256 = "a45e8f275794960651043623e23abb8365f0455b4ad5976bc56a4fa00c5efb31",
+        strip_prefix = "swift-custom-dump-0.5.0",
+        url = "https://github.com/pointfreeco/swift-custom-dump/archive/refs/tags/0.5.0.tar.gz",
+        ignore_version_differences = ignore_version_differences,
+    )


### PR DESCRIPTION
Since bzlmod is the future, we should default to it where possible. CI for now will have explicit bzlmod based tests until everything is working with bzlmod.