### PR TITLE
Refactor `get_xcode_library_targets`

### DIFF
--- a/xcodeproj/internal/compilation_providers.bzl
+++ b/xcodeproj/internal/compilation_providers.bzl
@@ -118,7 +118,7 @@ def _to_objc(objc, cc_info):
         ),
     )
 
-def _get_xcode_library_targets(*, compilation_providers):
+def _get_mergable_xcode_library_targets(*, compilation_providers):
     """Returns the Xcode library target dependencies for this target.
 
     Args:
@@ -126,10 +126,16 @@ def _get_xcode_library_targets(*, compilation_providers):
             `compilation_providers.merge`.
 
     Returns:
-        A list of targets `struct`s that are Xcode library targets.
+        A list of `struct`s that contain the following elements:
+
+        * `id`: The target id.
+        * `product_path`: The path to the product.
     """
     return [
-        target
+        struct(
+            id = target.id,
+            product_path = target.product.file_path,
+        )
         for target, providers in (
             compilation_providers._transitive_compilation_providers
         )
@@ -138,6 +144,6 @@ def _get_xcode_library_targets(*, compilation_providers):
 
 compilation_providers = struct(
     collect = _collect_compilation_providers,
-    get_xcode_library_targets = _get_xcode_library_targets,
+    get_mergable_xcode_library_targets = _get_mergable_xcode_library_targets,
     merge = _merge_compilation_providers,
 )

--- a/xcodeproj/internal/top_level_targets.bzl
+++ b/xcodeproj/internal/top_level_targets.bzl
@@ -416,18 +416,15 @@ def process_top_level_target(
     )
 
     if not inputs.srcs:
-        xcode_library_targets = comp_providers.get_xcode_library_targets(
+        mergeable_targets = comp_providers.get_mergable_xcode_library_targets(
             compilation_providers = compilation_providers,
         )
         potential_target_merges = [
             struct(
-                src = struct(
-                    id = mergeable_target.id,
-                    product_path = mergeable_target.product.file_path,
-                ),
+                src = mergeable_target,
                 dest = id,
             )
-            for mergeable_target in xcode_library_targets
+            for mergeable_target in mergeable_targets
         ]
     else:
         potential_target_merges = None


### PR DESCRIPTION
Prevents retaining the actual `xcode_target`s.