### PR TITLE
Fix xcode-overlay.yaml handling of `/private/var` paths

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -1025,6 +1025,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
+				REAL_BAZEL_OUT = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				RESOLVED_REPOSITORIES = "\"/external/examples_cc_external\" \"$(SRCROOT)/external\" \"\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";

--- a/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -991,6 +991,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				REAL_BAZEL_OUT = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				RESOLVED_REPOSITORIES = "\"/external/examples_cc_external\" \"$(SRCROOT)/external\" \"\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -9251,6 +9251,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
+				REAL_BAZEL_OUT = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				RESOLVED_REPOSITORIES = "\"/external/examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"/external/examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\" \"\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -10620,6 +10620,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				REAL_BAZEL_OUT = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				RESOLVED_REPOSITORIES = "\"/external/examples_command_line_external/ImportableLibrary\" \"$(SRCROOT)/CommandLine/external/ImportableLibrary\" \"/external/examples_ios_app_external\" \"$(SRCROOT)/iOSApp/external\" \"\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -748,6 +748,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
+				REAL_BAZEL_OUT = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -746,6 +746,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				REAL_BAZEL_OUT = "../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/__main__/bazel-out";
 				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -3061,6 +3061,7 @@
 				);
 				LIBTOOL = "$(BAZEL_INTEGRATION_DIR)/libtool.sh";
 				ONLY_ACTIVE_ARCH = YES;
+				REAL_BAZEL_OUT = "../../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = bazel;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -3252,6 +3252,7 @@
 				LD_RUNPATH_SEARCH_PATHS = (
 				);
 				ONLY_ACTIVE_ARCH = YES;
+				REAL_BAZEL_OUT = "../../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out";
 				RESOLVED_REPOSITORIES = "\"\" \"$(SRCROOT)\"";
 				RULES_XCODEPROJ_BUILD_MODE = xcode;
 				SCHEME_TARGET_IDS_FILE = "$(OBJROOT)/scheme_target_ids";

--- a/tools/generator/src/Generator/CreateProject.swift
+++ b/tools/generator/src/Generator/CreateProject.swift
@@ -87,6 +87,7 @@ $(PROJECT_FILE_PATH)/\(directories.internalDirectoryName)
             // We don't want Xcode to set any search paths, since we set them in
             // `link.params`
             "LD_RUNPATH_SEARCH_PATHS": [],
+            "REAL_BAZEL_OUT": (projectDir + "bazel-out").string,
             "RULES_XCODEPROJ_BUILD_MODE": buildMode.rawValue,
             "SCHEME_TARGET_IDS_FILE": """
 $(OBJROOT)/scheme_target_ids
@@ -132,6 +133,13 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)
             "LastUpgradeCheck": 9999,
         ]
 
+        let projectDirPath: String
+        if projectDir.string.hasPrefix("/private/") {
+            projectDirPath = String(projectDir.string.dropFirst(8))
+        } else {
+            projectDirPath = projectDir.string
+        }
+
         let pbxProject = PBXProject(
             name: project.name,
             buildConfigurationList: buildConfigurationList,
@@ -141,7 +149,7 @@ Xcode \(min(project.minimumXcodeVersion.major, 14)).0
             mainGroup: mainGroup,
             // TODO: Make developmentRegion configurable?
             developmentRegion: "en",
-            projectDirPath: projectDir.string,
+            projectDirPath: projectDirPath,
             attributes: attributes
         )
         pbxProj.add(object: pbxProject)

--- a/tools/generator/test/CreateProjectTests.swift
+++ b/tools/generator/test/CreateProjectTests.swift
@@ -73,6 +73,7 @@ $(INDEXING_DEPLOYMENT_LOCATION__NO)
                 "LD_OBJC_ABI_VERSION": "",
                 "LD_DYLIB_INSTALL_NAME": "",
                 "LD_RUNPATH_SEARCH_PATHS": [],
+                "REAL_BAZEL_OUT": directories.bazelOut.string,
                 "RULES_XCODEPROJ_BUILD_MODE": "xcode",
                 "SCHEME_TARGET_IDS_FILE": """
 $(OBJROOT)/scheme_target_ids
@@ -200,6 +201,7 @@ $(INDEXING_DEPLOYMENT_LOCATION__NO)
                 "LD_OBJC_ABI_VERSION": "",
                 "LD_DYLIB_INSTALL_NAME": "",
                 "LD_RUNPATH_SEARCH_PATHS": [],
+                "REAL_BAZEL_OUT": directories.bazelOut.string,
                 "RULES_XCODEPROJ_BUILD_MODE": "bazel",
                 "SCHEME_TARGET_IDS_FILE": """
 $(OBJROOT)/scheme_target_ids

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -1036,7 +1036,7 @@ def _write_create_xcode_overlay_script(*, ctx, targets):
 
         path = generated_header.path
         build_dir = "$BUILD_DIR/{}".format(path)
-        bazel_out = "$BAZEL_OUT{}".format(path[9:])
+        bazel_out = "$REAL_BAZEL_OUT{}".format(path[9:])
 
         roots.append("""\
 {{"external-contents": "{build_dir}","name": "${{bazel_out_prefix}}{bazel_out}","type": "file"}}\
@@ -1073,7 +1073,6 @@ resolved_workspace_root_element="$(readlink $execroot_workspace_dir/$workspace_r
 workspace_dir="${{resolved_workspace_root_element%/*}}"
 
 bazel_out_full_path="$(perl -MCwd -e 'print Cwd::abs_path shift' "{bazel_out_full}";)"
-bazel_out_full_path="${{bazel_out_full_path#/private}}"
 bazel_out="${{bazel_out_full_path%/{bazel_out_full}}}/bazel-out"
 
 echo "$workspace_dir" > "{out_full}"


### PR DESCRIPTION
For some reason VFS overlays don't resolve symlinks correctly, so they need to have the fully resolved versions in them.