### PR TITLE
Adjust example to rely on `-I` to find Swift generated header

### DIFF
--- a/examples/integration/iOSApp/Test/ObjCUnitTests/BUILD
+++ b/examples/integration/iOSApp/Test/ObjCUnitTests/BUILD
@@ -20,6 +20,7 @@ objc_library(
         "//iOSApp/Resources/OnlyStructuredResources",
         "@examples_ios_app_external//:ExternalImportedBundle",
     ],
+    includes = ["../TestingUtils"],
     enable_modules = True,
     module_name = "iOSAppObjCUnitTests",
     tags = ["manual"],

--- a/examples/integration/iOSApp/Test/ObjCUnitTests/BUILD
+++ b/examples/integration/iOSApp/Test/ObjCUnitTests/BUILD
@@ -20,8 +20,8 @@ objc_library(
         "//iOSApp/Resources/OnlyStructuredResources",
         "@examples_ios_app_external//:ExternalImportedBundle",
     ],
-    includes = ["../TestingUtils"],
     enable_modules = True,
+    includes = ["../TestingUtils"],
     module_name = "iOSAppObjCUnitTests",
     tags = ["manual"],
     deps = [

--- a/examples/integration/iOSApp/Test/ObjCUnitTests/ObjCUnitTests.m
+++ b/examples/integration/iOSApp/Test/ObjCUnitTests/ObjCUnitTests.m
@@ -1,6 +1,6 @@
 @import XCTest;
 
-#import "iOSApp/Test/TestingUtils/SwiftAPI/TestingUtils-Swift.h"
+#import <SwiftAPI/TestingUtils-Swift.h>
 #import "iOSApp/Source/Utils/Utils.h"
 
 @interface ObjCUnitTests : XCTestCase

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -8542,6 +8542,8 @@
 					external/FXPageControl,
 					"-iquote",
 					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
+					"-IiOSApp/Test/TestingUtils",
+					"-Ibazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils",
 					"-IiOSApp/Source/CoreUtilsObjC",
 					"-Ibazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsObjC",
 					"-DAWESOME",

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -5410,6 +5410,8 @@
                 "external/FXPageControl",
                 "-iquote",
                 "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
+                "-IiOSApp/Test/TestingUtils",
+                "-Ibazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils",
                 "-IiOSApp/Source/CoreUtilsObjC",
                 "-Ibazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsObjC",
                 "-DAWESOME",

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -10121,6 +10121,8 @@
 					external/FXPageControl,
 					"-iquote",
 					"bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
+					"-IiOSApp/Test/TestingUtils",
+					"-Ibazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils",
 					"-IiOSApp/Source/CoreUtilsObjC",
 					"-Ibazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsObjC",
 					"-DAWESOME",

--- a/examples/integration/test/fixtures/bwx_targets_spec.json
+++ b/examples/integration/test/fixtures/bwx_targets_spec.json
@@ -4828,6 +4828,8 @@
                 "external/FXPageControl",
                 "-iquote",
                 "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
+                "-IiOSApp/Test/TestingUtils",
+                "-Ibazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils",
                 "-IiOSApp/Source/CoreUtilsObjC",
                 "-Ibazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsObjC",
                 "-DAWESOME",


### PR DESCRIPTION
This proves that the VFS overlay works with `-I` in addition to `-iquote`.