### PR TITLE
Reduce scope of `linker_inputs`

### DIFF
--- a/xcodeproj/internal/linker_input_files.bzl
+++ b/xcodeproj/internal/linker_input_files.bzl
@@ -218,11 +218,11 @@ def _extract_top_level_values(
                 break
 
     return struct(
-        additional_input_files = tuple(additional_input_files),
+        _additional_input_files = tuple(additional_input_files),
+        _static_frameworks = tuple(static_frameworks),
         dynamic_frameworks = tuple(dynamic_frameworks),
         link_args = link_args,
         link_args_inputs = link_args_inputs,
-        static_frameworks = tuple(static_frameworks),
         static_libraries = tuple(static_libraries),
     )
 
@@ -288,9 +288,9 @@ def _to_input_files(linker_inputs):
         return []
 
     return list(
-        top_level_values.additional_input_files +
+        top_level_values._additional_input_files +
         top_level_values.dynamic_frameworks +
-        top_level_values.static_frameworks,
+        top_level_values._static_frameworks,
     ) + [
         file
         for file in top_level_values.static_libraries

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -162,7 +162,6 @@ def _to_xcode_target_linker_inputs(linker_inputs):
         link_args = top_level_values.link_args,
         link_args_inputs = top_level_values.link_args_inputs,
         static_libraries = top_level_values.static_libraries,
-        static_frameworks = top_level_values.static_frameworks,
     )
 
 def _to_xcode_target_outputs(outputs):


### PR DESCRIPTION
This is some refactoring as work towards removing `linker_inputs` in the future.