### PR TITLE
Fix missing `import re` in `swift_debug_settings.py`

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -3,6 +3,7 @@
 """An lldb module that registers a stop hook to set swift settings."""
 
 import lldb
+import re
 
 # Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -3,6 +3,7 @@
 """An lldb module that registers a stop hook to set swift settings."""
 
 import lldb
+import re
 
 # Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -3,6 +3,7 @@
 """An lldb module that registers a stop hook to set swift settings."""
 
 import lldb
+import re
 
 # Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -3,6 +3,7 @@
 """An lldb module that registers a stop hook to set swift settings."""
 
 import lldb
+import re
 
 # Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -3,6 +3,7 @@
 """An lldb module that registers a stop hook to set swift settings."""
 
 import lldb
+import re
 
 # Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -3,6 +3,7 @@
 """An lldb module that registers a stop hook to set swift settings."""
 
 import lldb
+import re
 
 # Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -3,6 +3,7 @@
 """An lldb module that registers a stop hook to set swift settings."""
 
 import lldb
+import re
 
 # Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/swift_debug_settings.py
@@ -3,6 +3,7 @@
 """An lldb module that registers a stop hook to set swift settings."""
 
 import lldb
+import re
 
 # Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [

--- a/tools/generator/src/Generator/CreateFilesAndGroups.swift
+++ b/tools/generator/src/Generator/CreateFilesAndGroups.swift
@@ -697,6 +697,7 @@ already was set to `\(existingValue)`.
 """An lldb module that registers a stop hook to set swift settings."""
 
 import lldb
+import re
 
 # Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [

--- a/tools/generator/test/Fixtures.swift
+++ b/tools/generator/test/Fixtures.swift
@@ -1073,6 +1073,7 @@ $(BAZEL_OUT)/z/A.link.params
 """An lldb module that registers a stop hook to set swift settings."""
 
 import lldb
+import re
 
 # Order matters, it needs to be from the most nested to the least
 _BUNDLE_EXTENSIONS = [


### PR DESCRIPTION
```
error: module importing failed: Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Applications/Xcode_14.2.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/importlib/__init__.py", line 169, in reload
    _bootstrap._exec(spec, module)
  File "<frozen importlib._bootstrap>", line 613, in _exec
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Users/matt.robinson/Library/Developer/Xcode/DerivedData/Test-UI-Test-Target-glkvogdjirfkwghjfkgtlxpygokw/Build/Intermediates.noindex/swift_debug_settings.py", line 16, in <module>
    _TRIPLE_MATCH = re.compile(r"([^-]+-[^-]+)(-\D+)[^-]*(-.*)?")
NameError: name 're' is not defined
```