### PR TITLE
Remove `top_level_only` from `scheme_autogeneration_mode` docs

### DIFF
--- a/docs/design/custom-xcode-schemes.md
+++ b/docs/design/custom-xcode-schemes.md
@@ -255,9 +255,6 @@ __Values__
 - `none`: No schemes are automatically generated.
 - `all`: A scheme is generated for every buildable target even if custom schemes
   are provided.
-- `top_level_only`: A scheme is generated for every top-level target even if
-  custom schemes are provided. A top-level target in this context is one that is
-  not depended upon by any other target in the Xcode project.
 
 The default value for `scheme_autogeneration_mode` is `auto`.
 


### PR DESCRIPTION
Update docs for `scheme_autogeneration_mode` to match:

https://github.com/buildbuddy-io/rules_xcodeproj/blob/97a4f4254ff5bece0c88f2c77cc80bdc06b65c37/xcodeproj/internal/xcodeproj_rule.bzl#L1588-L1592

And:

https://github.com/buildbuddy-io/rules_xcodeproj/blob/97a4f4254ff5bece0c88f2c77cc80bdc06b65c37/tools/generator/src/DTO/SchemeAutogenerationMode.swift#L1-L5