### PR TITLE
Make `rules_pkg` a non-dev dependency for now

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,13 +17,12 @@ bazel_dep(
     repo_name = "build_bazel_rules_apple",
 )
 bazel_dep(
-    name = "buildifier_prebuilt",
-    version = "6.0.0.1",
-    dev_dependency = True,
-)
-bazel_dep(
     name = "rules_pkg",
     version = "0.7.0",
+)
+bazel_dep(
+    name = "buildifier_prebuilt",
+    version = "6.0.0.1",
     dev_dependency = True,
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,15 +79,6 @@ stardoc_repositories()
 
 # rules_pkg
 
-http_archive(
-    name = "rules_pkg",
-    sha256 = "451e08a4d78988c06fa3f9306ec813b836b1d076d0f055595444ba4ff22b867f",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.1/rules_pkg-0.7.1.tar.gz",
-        "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.1/rules_pkg-0.7.1.tar.gz",
-    ],
-)
-
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -97,6 +97,17 @@ def xcodeproj_rules_dependencies(
             ignore_version_differences = ignore_version_differences,
         )
 
+        _maybe(
+            http_archive,
+            name = "rules_pkg",
+            sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
+                "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
+            ],
+            ignore_version_differences = ignore_version_differences,
+        )
+
     # `rules_swift` depends on `build_bazel_rules_swift_index_import`, and we
     # also need to use `index-import`, so we could declare the same dependency
     # here in order to reuse it, and in case `rules_swift` stops depending on it


### PR DESCRIPTION
Until I can figure out a way to not have the `load("@rules_pkg//` in build files causing loading errors like this:

> ERROR: Skipping '@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_common_flags': error loading package '@rules_xcodeproj\~override//xcodeproj': Unable to find package for @[unknown repo 'rules_pkg' requested from @rules_xcodeproj\~override]//:mappings.bzl: The repository '@[unknown repo 'rules_pkg' requested from @rules_xcodeproj\~override]' could not be resolved: No repository visible as '@rules_pkg' from repository '@rules_xcodeproj\~override'.