### PR TITLE
Use single letter json keys in `targets_spec.json`

### DIFF
--- a/examples/cc/test/fixtures/bwb_targets_spec.json
+++ b/examples/cc/test/fixtures/bwb_targets_spec.json
@@ -1,7 +1,14 @@
 [
     "//lib2:lib_impl darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib2",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -34,101 +41,90 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 "lib2/lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//lib2:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib2",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "//lib2:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "darwin_x86_64-dbg-STABLE-1/bin/lib2/liblib_impl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//lib:lib_defines darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "//lib:lib_impl darwin_x86_64-dbg-STABLE-1"
         ],
-        "is_swift": false,
-        "label": "//lib:lib_defines",
-        "name": "lib_defines",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "//lib:lib_defines",
+        "n": "lib_defines",
+        "p": {
+            "n": "lib_defines",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_defines",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//lib:lib_headers darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "//lib:lib_defines darwin_x86_64-dbg-STABLE-1"
         ],
-        "is_swift": false,
-        "label": "//lib:lib_headers",
-        "name": "lib_headers",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "//lib:lib_headers",
+        "n": "lib_headers",
+        "p": {
+            "n": "lib_headers",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_headers",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//lib:lib_impl darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -159,38 +155,39 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 "lib/lib.c",
                 "lib/private/private.h"
             ]
         },
-        "is_swift": false,
-        "label": "//lib:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "//lib:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "darwin_x86_64-dbg-STABLE-1/bin/lib/liblib_impl.lo",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//tool:tool darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/tool",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tool.7.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/tool/rules_xcodeproj/tool/tool",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -234,113 +231,99 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "//lib:lib_headers darwin_x86_64-dbg-STABLE-1",
             "//lib2:lib_impl darwin_x86_64-dbg-STABLE-1",
             "@examples_cc_external//:lib_headers darwin_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "tool/main.c"
             ]
         },
-        "is_swift": false,
-        "label": "//tool:tool",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tool.7.link.params",
-            "t": "g"
-        },
-        "name": "tool",
-        "outputs": {
+        "l": "//tool:tool",
+        "n": "tool",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/tool",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": "tool",
-            "is_resource_bundle": false,
-            "name": "tool",
-            "path": {
+        "p": {
+            "e": "tool",
+            "n": "tool",
+            "p": {
                 "_": "darwin_x86_64-dbg-STABLE-1/bin/tool/rules_xcodeproj/tool/tool",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
-        }
+            "t": "com.apple.product-type.tool"
+        },
+        "s": false
     },
     "@examples_cc_external//:lib_defines darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@examples_cc_external//:lib_impl darwin_x86_64-dbg-STABLE-1"
         ],
-        "is_swift": false,
-        "label": "@examples_cc_external//:lib_defines",
-        "name": "lib_defines",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "@examples_cc_external//:lib_defines",
+        "n": "lib_defines",
+        "p": {
+            "n": "lib_defines",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_defines",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "@examples_cc_external//:lib_headers darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@examples_cc_external//:lib_defines darwin_x86_64-dbg-STABLE-1"
         ],
-        "is_swift": false,
-        "label": "@examples_cc_external//:lib_headers",
-        "name": "lib_headers",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "@examples_cc_external//:lib_headers",
+        "n": "lib_headers",
+        "p": {
+            "n": "lib_headers",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_headers",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "@examples_cc_external//:lib_impl darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -371,9 +354,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "examples_cc_external/lib.c",
                     "t": "e"
@@ -384,26 +367,16 @@
                 }
             ]
         },
-        "is_swift": false,
-        "label": "@examples_cc_external//:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "@examples_cc_external//:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external/liblib_impl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     }
 ]

--- a/examples/cc/test/fixtures/bwx_targets_spec.json
+++ b/examples/cc/test/fixtures/bwx_targets_spec.json
@@ -1,7 +1,14 @@
 [
     "//lib2:lib_impl darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib2",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -34,101 +41,90 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 "lib2/lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//lib2:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib2",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "//lib2:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "darwin_x86_64-dbg-STABLE-1/bin/lib2/liblib_impl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//lib:lib_defines darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "//lib:lib_impl darwin_x86_64-dbg-STABLE-1"
         ],
-        "is_swift": false,
-        "label": "//lib:lib_defines",
-        "name": "lib_defines",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "//lib:lib_defines",
+        "n": "lib_defines",
+        "p": {
+            "n": "lib_defines",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_defines",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//lib:lib_headers darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "//lib:lib_defines darwin_x86_64-dbg-STABLE-1"
         ],
-        "is_swift": false,
-        "label": "//lib:lib_headers",
-        "name": "lib_headers",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "//lib:lib_headers",
+        "n": "lib_headers",
+        "p": {
+            "n": "lib_headers",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_headers",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//lib:lib_impl darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -159,38 +155,39 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 "lib/lib.c",
                 "lib/private/private.h"
             ]
         },
-        "is_swift": false,
-        "label": "//lib:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "//lib:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "darwin_x86_64-dbg-STABLE-1/bin/lib/liblib_impl.lo",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//tool:tool darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/tool",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tool.7.link.params",
+            "t": "g"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -233,113 +230,99 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "//lib:lib_headers darwin_x86_64-dbg-STABLE-1",
             "//lib2:lib_impl darwin_x86_64-dbg-STABLE-1",
             "@examples_cc_external//:lib_headers darwin_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "tool/main.c"
             ]
         },
-        "is_swift": false,
-        "label": "//tool:tool",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tool.7.link.params",
-            "t": "g"
-        },
-        "name": "tool",
-        "outputs": {
+        "l": "//tool:tool",
+        "n": "tool",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/tool",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": "tool",
-            "is_resource_bundle": false,
-            "name": "tool",
-            "path": {
+        "p": {
+            "e": "tool",
+            "n": "tool",
+            "p": {
                 "_": "darwin_x86_64-dbg-STABLE-1/bin/tool/rules_xcodeproj/tool/tool",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
-        }
+            "t": "com.apple.product-type.tool"
+        },
+        "s": false
     },
     "@examples_cc_external//:lib_defines darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@examples_cc_external//:lib_impl darwin_x86_64-dbg-STABLE-1"
         ],
-        "is_swift": false,
-        "label": "@examples_cc_external//:lib_defines",
-        "name": "lib_defines",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "@examples_cc_external//:lib_defines",
+        "n": "lib_defines",
+        "p": {
+            "n": "lib_defines",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_defines",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "@examples_cc_external//:lib_headers darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@examples_cc_external//:lib_defines darwin_x86_64-dbg-STABLE-1"
         ],
-        "is_swift": false,
-        "label": "@examples_cc_external//:lib_headers",
-        "name": "lib_headers",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "@examples_cc_external//:lib_headers",
+        "n": "lib_headers",
+        "p": {
+            "n": "lib_headers",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_headers",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "@examples_cc_external//:lib_impl darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -370,9 +353,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "examples_cc_external/lib.c",
                     "t": "e"
@@ -383,26 +366,16 @@
                 }
             ]
         },
-        "is_swift": false,
-        "label": "@examples_cc_external//:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "@examples_cc_external//:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "darwin_x86_64-dbg-STABLE-1/bin/external/examples_cc_external/liblib_impl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     }
 ]

--- a/examples/integration/test/fixtures/bwb_targets_spec.json
+++ b/examples/integration/test/fixtures/bwb_targets_spec.json
@@ -1,7 +1,34 @@
 [
     "//AppClip:AppClip applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "3": {
+            "i": "//AppClip:AppClip.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+            "n": "AppClip.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip/rules_xcodeproj/AppClip/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/AppClip.59.link.params",
+            "t": "g"
+        },
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip/AppClip.app",
             "CODE_SIGN_STYLE": "Automatic",
@@ -22,44 +49,24 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//AppClip:AppClip.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-            "name": "AppClip.library"
-        },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "dependencies": [
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "d": [
             "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip/rules_xcodeproj/AppClip/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "entitlements": {
+        "i": {
+            "e": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip/Entitlements.withbundleid.plist",
                 "t": "g"
             },
-            "srcs": [
+            "s": [
                 "AppClip/AppClip.swift",
                 "AppClip/ContentView.swift"
             ]
         },
-        "label": "//AppClip:AppClip",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/AppClip.59.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "AppClip",
-        "outputs": {
+        "l": "//AppClip:AppClip",
+        "m": true,
+        "n": "AppClip",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -68,33 +75,52 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/AppClip/libAppClip.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "AppClip",
-            "is_resource_bundle": false,
-            "name": "AppClip",
-            "path": {
+            "e": "AppClip",
+            "n": "AppClip",
+            "p": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip/AppClip.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application.on-demand-install-capable"
+            "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
     "//AppClip:AppClip applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//AppClip:AppClip.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "AppClip.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip/rules_xcodeproj/AppClip/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/AppClip.1.link.params",
+            "t": "g"
+        },
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip/AppClip.app",
             "CODE_SIGN_STYLE": "Manual",
@@ -114,44 +140,24 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//AppClip:AppClip.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "AppClip.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip/rules_xcodeproj/AppClip/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "entitlements": {
+        "i": {
+            "e": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip/Entitlements.withbundleid.plist",
                 "t": "g"
             },
-            "srcs": [
+            "s": [
                 "AppClip/AppClip.swift",
                 "AppClip/ContentView.swift"
             ]
         },
-        "label": "//AppClip:AppClip",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/AppClip.1.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "AppClip",
-        "outputs": {
+        "l": "//AppClip:AppClip",
+        "m": true,
+        "n": "AppClip",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -160,33 +166,44 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/AppClip/libAppClip.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "AppClip",
-            "is_resource_bundle": false,
-            "name": "AppClip",
-            "path": {
+            "e": "AppClip",
+            "n": "AppClip",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip/AppClip.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application.on-demand-install-capable"
+            "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
     "//CommandLine/CommandLineTool:CommandLineTool applebin_macos-darwin_x86_64-dbg-STABLE-20",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//CommandLine/CommandLineTool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+            "n": "tool.library"
+        },
+        "4": {
+            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool/rules_xcodeproj/CommandLineTool/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/CommandLineTool.40.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool/rules_xcodeproj/CommandLineTool/CommandLineTool",
             "CLANG_ENABLE_MODULES": true,
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -244,60 +261,55 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//CommandLine/CommandLineTool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-            "name": "tool.library"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-20",
-        "dependencies": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-20",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_headers macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "info_plist": {
-            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool/rules_xcodeproj/CommandLineTool/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineTool/main.m"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineTool:CommandLineTool",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/CommandLineTool.40.link.params",
-            "t": "g"
-        },
-        "name": "CommandLineTool",
-        "outputs": {
+        "l": "//CommandLine/CommandLineTool:CommandLineTool",
+        "n": "CommandLineTool",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineTool/libtool.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "CommandLineTool",
-            "is_resource_bundle": false,
-            "name": "CommandLineTool",
-            "path": {
+            "e": "CommandLineTool",
+            "n": "CommandLineTool",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool/rules_xcodeproj/CommandLineTool/CommandLineTool",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
-        }
+            "t": "com.apple.product-type.tool"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineTool:tool.binary macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineTool",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//CommandLine/CommandLineTool:tool.library macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+            "n": "tool.library"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tool.binary.48.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineTool/rules_xcodeproj/tool.binary/tool.binary",
             "CLANG_ENABLE_MODULES": true,
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -353,56 +365,55 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//CommandLine/CommandLineTool:tool.library macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-            "name": "tool.library"
-        },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "dependencies": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_headers macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineTool/main.m"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineTool:tool.binary",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tool.binary.48.link.params",
-            "t": "g"
-        },
-        "name": "tool.binary",
-        "outputs": {
+        "l": "//CommandLine/CommandLineTool:tool.binary",
+        "n": "tool.binary",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineTool",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineTool/libtool.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tool.binary",
-            "is_resource_bundle": false,
-            "name": "tool.binary",
-            "path": {
+            "e": "tool.binary",
+            "n": "tool.binary",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineTool/rules_xcodeproj/tool.binary/tool.binary",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
-        }
+            "t": "com.apple.product-type.tool"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineTool:tool.binary macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineTool",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//CommandLine/CommandLineTool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+            "n": "tool.library"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tool.binary.56.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineTool/rules_xcodeproj/tool.binary/tool.binary",
             "CLANG_ENABLE_MODULES": true,
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -458,239 +469,206 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//CommandLine/CommandLineTool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-            "name": "tool.library"
-        },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_headers macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineTool/main.m"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineTool:tool.binary",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tool.binary.56.link.params",
-            "t": "g"
-        },
-        "name": "tool.binary",
-        "outputs": {
+        "l": "//CommandLine/CommandLineTool:tool.binary",
+        "n": "tool.binary",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineTool",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineTool/libtool.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tool.binary",
-            "is_resource_bundle": false,
-            "name": "tool.binary",
-            "path": {
+            "e": "tool.binary",
+            "n": "tool.binary",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineTool/rules_xcodeproj/tool.binary/tool.binary",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
-        }
+            "t": "com.apple.product-type.tool"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_defines macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_defines",
-        "name": "lib_defines",
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "l": "//CommandLine/CommandLineToolLib:lib_defines",
+        "n": "lib_defines",
+        "p": {
+            "n": "lib_defines",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_defines",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_defines macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_defines",
-        "name": "lib_defines",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "l": "//CommandLine/CommandLineToolLib:lib_defines",
+        "n": "lib_defines",
+        "p": {
+            "n": "lib_defines",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_defines",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_defines macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_defines",
-        "name": "lib_defines",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "l": "//CommandLine/CommandLineToolLib:lib_defines",
+        "n": "lib_defines",
+        "p": {
+            "n": "lib_defines",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_defines",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_headers macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "dependencies": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18"
         ],
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_headers",
-        "name": "lib_headers",
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "//CommandLine/CommandLineToolLib:lib_headers",
+        "n": "lib_headers",
+        "p": {
+            "n": "lib_headers",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_headers",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_headers macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_headers",
-        "name": "lib_headers",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "//CommandLine/CommandLineToolLib:lib_headers",
+        "n": "lib_headers",
+        "p": {
+            "n": "lib_headers",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_headers",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_headers macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19"
         ],
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_headers",
-        "name": "lib_headers",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "//CommandLine/CommandLineToolLib:lib_headers",
+        "n": "lib_headers",
+        "p": {
+            "n": "lib_headers",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_headers",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_impl macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -732,41 +710,38 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "dependencies": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_defines macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.m",
                 "CommandLine/CommandLineToolLib/private.h"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -808,41 +783,38 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_defines macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.m",
                 "CommandLine/CommandLineToolLib/private.h"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -884,41 +856,38 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_defines macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.m",
                 "CommandLine/CommandLineToolLib/private.h"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_swift macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -930,22 +899,22 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "dependencies": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "d": [
             "//CommandLine/swift_c_module:c_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
             "//CommandLine/CommandLineToolLib:lib_impl macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
             "//CommandLine/CommandLineToolLib:private_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
             "//CommandLine/CommandLineToolLib:private_swift_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18"
         ],
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:lib_swift",
-        "name": "lib_swift",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:lib_swift",
+        "m": true,
+        "n": "lib_swift",
+        "o": {
             "s": {
                 "h": {
                     "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/private/LibSwift-Swift.h",
@@ -957,28 +926,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_swift",
-            "path": {
+        "p": {
+            "n": "lib_swift",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -990,22 +956,22 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "d": [
             "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
             "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
             "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
             "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:lib_swift",
-        "name": "lib_swift",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:lib_swift",
+        "m": true,
+        "n": "lib_swift",
+        "o": {
             "s": {
                 "h": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/private/LibSwift-Swift.h",
@@ -1017,28 +983,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_swift",
-            "path": {
+        "p": {
+            "n": "lib_swift",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1050,22 +1013,22 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "d": [
             "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
             "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
             "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
             "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19"
         ],
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:lib_swift",
-        "name": "lib_swift",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:lib_swift",
+        "m": true,
+        "n": "lib_swift",
+        "o": {
             "s": {
                 "h": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/private/LibSwift-Swift.h",
@@ -1077,28 +1040,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_swift",
-            "path": {
+        "p": {
+            "n": "lib_swift",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/CommandLineToolLib:private_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1128,37 +1088,34 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "inputs": {
-            "srcs": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:private_lib",
-        "name": "private_lib",
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_lib",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:private_lib",
+        "n": "private_lib",
+        "p": {
+            "n": "private_lib",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1188,37 +1145,34 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:private_lib",
-        "name": "private_lib",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_lib",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:private_lib",
+        "n": "private_lib",
+        "p": {
+            "n": "private_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1248,37 +1202,34 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:private_lib",
-        "name": "private_lib",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_lib",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:private_lib",
+        "n": "private_lib",
+        "p": {
+            "n": "private_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:private_swift_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1289,15 +1240,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "inputs": {
-            "srcs": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:private_swift_lib",
-        "name": "private_swift_lib",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:private_swift_lib",
+        "n": "private_swift_lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
@@ -1305,28 +1256,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_swift_lib",
-            "path": {
+        "p": {
+            "n": "private_swift_lib",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1337,15 +1285,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:private_swift_lib",
-        "name": "private_swift_lib",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:private_swift_lib",
+        "n": "private_swift_lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
@@ -1353,28 +1301,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_swift_lib",
-            "path": {
+        "p": {
+            "n": "private_swift_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1385,15 +1330,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:private_swift_lib",
-        "name": "private_swift_lib",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:private_swift_lib",
+        "n": "private_swift_lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
@@ -1401,28 +1346,37 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_swift_lib",
-            "path": {
+        "p": {
+            "n": "private_swift_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-20",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//CommandLine/Tests:CommandLineLibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+            "n": "CommandLineLibSwiftTestsLib"
+        },
+        "4": {
+            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests/rules_xcodeproj/CommandLineToolTests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/CommandLineToolTests.__internal__.__test_bundle.57.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests/CommandLineToolTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -1440,32 +1394,19 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//CommandLine/Tests:CommandLineLibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-            "name": "CommandLineLibSwiftTestsLib"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-20",
-        "dependencies": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-20",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests/rules_xcodeproj/CommandLineToolTests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/Tests/SwiftGreetingsTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/CommandLineToolTests.__internal__.__test_bundle.57.link.params",
-            "t": "g"
-        },
-        "name": "CommandLineToolTests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle",
+        "m": true,
+        "n": "CommandLineToolTests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -1474,33 +1415,33 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/Tests/libCommandLineLibSwiftTestsLib.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "CommandLineToolTests",
-            "is_resource_bundle": false,
-            "name": "CommandLineToolTests",
-            "path": {
+            "e": "CommandLineToolTests",
+            "n": "CommandLineToolTests",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests/CommandLineToolTests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.unit-test"
-        }
+            "t": "com.apple.product-type.bundle.unit-test"
+        },
+        "t": true
     },
     "//CommandLine/swift_c_module:c_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/swift_c_module",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1528,37 +1469,34 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "inputs": {
-            "srcs": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "i": {
+            "s": [
                 "CommandLine/swift_c_module/c_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/swift_c_module:c_lib",
-        "name": "c_lib",
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/swift_c_module",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "c_lib",
-            "path": {
+        "l": "//CommandLine/swift_c_module:c_lib",
+        "n": "c_lib",
+        "p": {
+            "n": "c_lib",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/swift_c_module/libc_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/swift_c_module",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1586,37 +1524,34 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "i": {
+            "s": [
                 "CommandLine/swift_c_module/c_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/swift_c_module:c_lib",
-        "name": "c_lib",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/swift_c_module",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "c_lib",
-            "path": {
+        "l": "//CommandLine/swift_c_module:c_lib",
+        "n": "c_lib",
+        "p": {
+            "n": "c_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/swift_c_module/libc_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/swift_c_module",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1644,37 +1579,50 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "i": {
+            "s": [
                 "CommandLine/swift_c_module/c_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/swift_c_module:c_lib",
-        "name": "c_lib",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/swift_c_module",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "c_lib",
-            "path": {
+        "l": "//CommandLine/swift_c_module:c_lib",
+        "n": "c_lib",
+        "p": {
+            "n": "c_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/swift_c_module/libc_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//Lib/dist/dynamic:iOS applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "4": {
+            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic/rules_xcodeproj/iOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOS.71.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic/Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -1690,59 +1638,58 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "dependencies": [
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "d": [
             "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "info_plist": {
-            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic/rules_xcodeproj/iOS/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:iOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOS.71.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "iOS",
-        "outputs": {
+        "l": "//Lib/dist/dynamic:iOS",
+        "n": "iOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic/frameworks/Lib.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic/Lib.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//Lib/dist/dynamic:iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic/rules_xcodeproj/iOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOS.13.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic/Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -1758,59 +1705,58 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic/rules_xcodeproj/iOS/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:iOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOS.13.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "iOS",
-        "outputs": {
+        "l": "//Lib/dist/dynamic:iOS",
+        "n": "iOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic/frameworks/Lib.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic/Lib.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//Lib/dist/dynamic:tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvos"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOS.73.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -1825,59 +1771,58 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
+        "d": [
             "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6"
         ],
-        "info_plist": {
-            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOS.73.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "tvOS",
-        "outputs": {
+        "l": "//Lib/dist/dynamic:tvOS",
+        "n": "tvOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/frameworks/Lib.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
                 "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/Lib.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//Lib/dist/dynamic:tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOS.15.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -1892,59 +1837,58 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
             "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3"
         ],
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOS.15.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "tvOS",
-        "outputs": {
+        "l": "//Lib/dist/dynamic:tvOS",
+        "n": "tvOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/frameworks/Lib.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/Lib.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//Lib/dist/dynamic:watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "arm64_32",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOS.74.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic/Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -1959,59 +1903,58 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
+        "d": [
             "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOS.74.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "watchOS",
-        "outputs": {
+        "l": "//Lib/dist/dynamic:watchOS",
+        "n": "watchOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic/frameworks/Lib.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
                 "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic/Lib.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//Lib/dist/dynamic:watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOS.16.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic/Lib.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -2026,59 +1969,42 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
             "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOS.16.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "watchOS",
-        "outputs": {
+        "l": "//Lib/dist/dynamic:watchOS",
+        "n": "watchOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic/frameworks/Lib.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic/Lib.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2089,10 +2015,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swift",
@@ -2100,9 +2025,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule",
@@ -2110,28 +2036,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2142,10 +2065,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swift",
@@ -2153,9 +2075,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule",
@@ -2163,28 +2086,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
     {
-        "build_settings": {
+        "1": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvos"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2195,10 +2115,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swift",
@@ -2206,9 +2125,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swiftmodule",
@@ -2216,28 +2136,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
     {
-        "build_settings": {
+        "1": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2248,10 +2165,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swift",
@@ -2259,9 +2175,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule",
@@ -2269,28 +2186,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
     {
-        "build_settings": {
+        "1": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib",
+        "2": {
+            "a": "arm64_32",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2301,10 +2215,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swift",
@@ -2312,9 +2225,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swiftmodule",
@@ -2322,28 +2236,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2354,10 +2265,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swift",
@@ -2365,9 +2275,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule",
@@ -2375,28 +2286,41 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvos"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/LibFramework.tvOS.75.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/LibFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -2411,59 +2335,58 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
+        "d": [
             "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6"
         ],
-        "info_plist": {
-            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//Lib:LibFramework.tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/LibFramework.tvOS.75.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "LibFramework.tvOS",
-        "outputs": {
+        "l": "//Lib:LibFramework.tvOS",
+        "n": "LibFramework.tvOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/frameworks/LibFramework.tvOS.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "LibFramework.tvOS",
-            "is_resource_bundle": false,
-            "name": "LibFramework.tvOS",
-            "path": {
+            "e": "LibFramework.tvOS",
+            "n": "LibFramework.tvOS",
+            "p": {
                 "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/LibFramework.tvOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/LibFramework.tvOS.17.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/LibFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -2478,59 +2401,58 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
             "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3"
         ],
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//Lib:LibFramework.tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/LibFramework.tvOS.17.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "LibFramework.tvOS",
-        "outputs": {
+        "l": "//Lib:LibFramework.tvOS",
+        "n": "LibFramework.tvOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "LibFramework.tvOS",
-            "is_resource_bundle": false,
-            "name": "LibFramework.tvOS",
-            "path": {
+            "e": "LibFramework.tvOS",
+            "n": "LibFramework.tvOS",
+            "p": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/LibFramework.tvOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib",
+        "2": {
+            "a": "arm64_32",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/LibFramework.watchOS.66.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/LibFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -2545,59 +2467,58 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
+        "d": [
             "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//Lib:LibFramework.watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/LibFramework.watchOS.66.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "LibFramework.watchOS",
-        "outputs": {
+        "l": "//Lib:LibFramework.watchOS",
+        "n": "LibFramework.watchOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/frameworks/LibFramework.watchOS.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "LibFramework.watchOS",
-            "is_resource_bundle": false,
-            "name": "LibFramework.watchOS",
-            "path": {
+            "e": "LibFramework.watchOS",
+            "n": "LibFramework.watchOS",
+            "p": {
                 "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/LibFramework.watchOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/LibFramework.watchOS.8.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/LibFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -2612,59 +2533,66 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
             "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//Lib:LibFramework.watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/LibFramework.watchOS.8.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "LibFramework.watchOS",
-        "outputs": {
+        "l": "//Lib:LibFramework.watchOS",
+        "n": "LibFramework.watchOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "LibFramework.watchOS",
-            "is_resource_bundle": false,
-            "name": "LibFramework.watchOS",
-            "path": {
+            "e": "LibFramework.watchOS",
+            "n": "LibFramework.watchOS",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/LibFramework.watchOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//UI:UIFramework.iOS applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "3": {
+            "i": "//UI:UI ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/frameworks/LibFramework.iOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.iOS.64.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/UIFramework.iOS.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -2688,46 +2616,22 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//UI:UI ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-            "name": "UI"
-        },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "dependencies": [
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "d": [
             "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "hdrs": [
+        "i": {
+            "h": [
                 "UI/UI.h"
             ],
-            "srcs": [
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.iOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.iOS.64.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/frameworks/LibFramework.iOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.iOS",
-        "outputs": {
+        "l": "//UI:UIFramework.iOS",
+        "m": true,
+        "n": "UIFramework.iOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -2736,15 +2640,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/frameworks/UIFramework.iOS.framework",
                     "t": "g"
@@ -2754,19 +2651,49 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.iOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.iOS",
-            "path": {
+            "e": "UIFramework.iOS",
+            "n": "UIFramework.iOS",
+            "p": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/UIFramework.iOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//UI:UI ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/frameworks/LibFramework.iOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.iOS.6.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/UIFramework.iOS.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -2790,46 +2717,22 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//UI:UI ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "UI"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "hdrs": [
+        "i": {
+            "h": [
                 "UI/UI.h"
             ],
-            "srcs": [
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.iOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.iOS.6.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/frameworks/LibFramework.iOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.iOS",
-        "outputs": {
+        "l": "//UI:UIFramework.iOS",
+        "m": true,
+        "n": "UIFramework.iOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -2838,15 +2741,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/frameworks/UIFramework.iOS.framework",
                     "t": "g"
@@ -2856,22 +2752,52 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.iOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.iOS",
-            "path": {
+            "e": "UIFramework.iOS",
+            "n": "UIFramework.iOS",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/UIFramework.iOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//UI:UIFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvos"
+        },
+        "3": {
+            "i": "//UI:UI tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.tvOS.76.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14"
         ],
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/UIFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -2894,44 +2820,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//UI:UI tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
-            "name": "UI"
-        },
-        "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
+        "d": [
             "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
             "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.tvOS.76.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.tvOS",
-        "outputs": {
+        "l": "//UI:UIFramework.tvOS",
+        "m": true,
+        "n": "UIFramework.tvOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -2940,15 +2842,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/frameworks/UIFramework.tvOS.framework",
                     "t": "g"
@@ -2958,22 +2853,52 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.tvOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.tvOS",
-            "path": {
+            "e": "UIFramework.tvOS",
+            "n": "UIFramework.tvOS",
+            "p": {
                 "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/UIFramework.tvOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "3": {
+            "i": "//UI:UI tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.tvOS.18.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13"
         ],
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/UIFramework.tvOS.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -2996,44 +2921,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//UI:UI tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
-            "name": "UI"
-        },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
             "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
             "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.tvOS.18.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.tvOS",
-        "outputs": {
+        "l": "//UI:UIFramework.tvOS",
+        "m": true,
+        "n": "UIFramework.tvOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3042,15 +2943,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/frameworks/UIFramework.tvOS.framework",
                     "t": "g"
@@ -3060,22 +2954,52 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.tvOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.tvOS",
-            "path": {
+            "e": "UIFramework.tvOS",
+            "n": "UIFramework.tvOS",
+            "p": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/UIFramework.tvOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI",
+        "2": {
+            "a": "arm64_32",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "3": {
+            "i": "//UI:UI watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/frameworks/LibFramework.watchOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.watchOS.67.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10"
         ],
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/UIFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -3098,44 +3022,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//UI:UI watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
-            "name": "UI"
-        },
-        "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
+        "d": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
             "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.watchOS.67.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/frameworks/LibFramework.watchOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.watchOS",
-        "outputs": {
+        "l": "//UI:UIFramework.watchOS",
+        "m": true,
+        "n": "UIFramework.watchOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3144,15 +3044,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/frameworks/UIFramework.watchOS.framework",
                     "t": "g"
@@ -3162,22 +3055,52 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.watchOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.watchOS",
-            "path": {
+            "e": "UIFramework.watchOS",
+            "n": "UIFramework.watchOS",
+            "p": {
                 "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/UIFramework.watchOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "3": {
+            "i": "//UI:UI watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.watchOS.9.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/UIFramework.watchOS.framework",
             "CODE_SIGN_STYLE": "Manual",
@@ -3200,44 +3123,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//UI:UI watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
-            "name": "UI"
-        },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
             "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UIFramework.watchOS.9.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.watchOS",
-        "outputs": {
+        "l": "//UI:UIFramework.watchOS",
+        "m": true,
+        "n": "UIFramework.watchOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3246,15 +3145,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/frameworks/UIFramework.watchOS.framework",
                     "t": "g"
@@ -3264,19 +3156,45 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.watchOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.watchOS",
-            "path": {
+            "e": "UIFramework.watchOS",
+            "n": "UIFramework.watchOS",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/UIFramework.watchOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "3": {
+            "i": "//WidgetExtension:WidgetExtension.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+            "n": "WidgetExtension.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/WidgetExtension.62.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension/WidgetExtension.appex",
             "CODE_SIGN_STYLE": "Automatic",
@@ -3297,21 +3215,12 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//WidgetExtension:WidgetExtension.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-            "name": "WidgetExtension.library"
-        },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "dependencies": [
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "d": [
             "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "WidgetExtension/WidgetExtension.swift",
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/WidgetExtension/Intents.swift",
@@ -3319,21 +3228,10 @@
                 }
             ]
         },
-        "label": "//WidgetExtension:WidgetExtension",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/WidgetExtension.62.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "WidgetExtension",
-        "outputs": {
+        "l": "//WidgetExtension:WidgetExtension",
+        "m": true,
+        "n": "WidgetExtension",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3342,33 +3240,52 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/WidgetExtension/libWidgetExtension.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "WidgetExtension",
-            "is_resource_bundle": false,
-            "name": "WidgetExtension",
-            "path": {
+            "e": "WidgetExtension",
+            "n": "WidgetExtension",
+            "p": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension/WidgetExtension.appex",
                 "t": "g"
             },
-            "type": "com.apple.product-type.app-extension"
+            "t": "com.apple.product-type.app-extension"
         }
     },
     "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//WidgetExtension:WidgetExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "WidgetExtension.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/WidgetExtension.4.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension/WidgetExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
@@ -3388,21 +3305,12 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//WidgetExtension:WidgetExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "WidgetExtension.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "WidgetExtension/WidgetExtension.swift",
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/WidgetExtension/Intents.swift",
@@ -3410,21 +3318,10 @@
                 }
             ]
         },
-        "label": "//WidgetExtension:WidgetExtension",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/WidgetExtension.4.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "WidgetExtension",
-        "outputs": {
+        "l": "//WidgetExtension:WidgetExtension",
+        "m": true,
+        "n": "WidgetExtension",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3433,33 +3330,36 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/WidgetExtension/libWidgetExtension.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "WidgetExtension",
-            "is_resource_bundle": false,
-            "name": "WidgetExtension",
-            "path": {
+            "e": "WidgetExtension",
+            "n": "WidgetExtension",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension/WidgetExtension.appex",
                 "t": "g"
             },
-            "type": "com.apple.product-type.app-extension"
+            "t": "com.apple.product-type.app-extension"
         }
     },
     "//iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/rules_xcodeproj/iMessageApp/Info.plist",
+            "t": "g"
+        },
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/iMessageApp.app",
             "CODE_SIGN_STYLE": "Manual",
@@ -3472,45 +3372,59 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "extensions": [
+        "e": [
             "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/rules_xcodeproj/iMessageApp/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//iMessageApp:iMessageApp",
-        "name": "iMessageApp",
-        "outputs": {
+        "l": "//iMessageApp:iMessageApp",
+        "n": "iMessageApp",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": "iMessageApp",
-            "is_resource_bundle": false,
-            "name": "iMessageApp",
-            "path": {
+        "p": {
+            "e": "iMessageApp",
+            "n": "iMessageApp",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/iMessageApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application.messages"
-        }
+            "t": "com.apple.product-type.application.messages"
+        },
+        "s": false
     },
     "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//iMessageApp:iMessageAppExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "iMessageAppExtension.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/rules_xcodeproj/iMessageAppExtension/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iMessageAppExtension.24.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/iMessageAppExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
@@ -3530,39 +3444,19 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//iMessageApp:iMessageAppExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "iMessageAppExtension.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/rules_xcodeproj/iMessageAppExtension/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "iMessageApp/MessagesViewController.swift"
             ]
         },
-        "label": "//iMessageApp:iMessageAppExtension",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iMessageAppExtension.24.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "iMessageAppExtension",
-        "outputs": {
+        "l": "//iMessageApp:iMessageAppExtension",
+        "m": true,
+        "n": "iMessageAppExtension",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3571,33 +3465,32 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iMessageApp/libiMessageAppExtension.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "iMessageAppExtension",
-            "is_resource_bundle": false,
-            "name": "iMessageAppExtension",
-            "path": {
+            "e": "iMessageAppExtension",
+            "n": "iMessageAppExtension",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/iMessageAppExtension.appex",
                 "t": "g"
             },
-            "type": "com.apple.product-type.app-extension.messages"
+            "t": "com.apple.product-type.app-extension.messages"
         }
     },
     "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -3637,40 +3530,37 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-        "dependencies": [
+        "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+        "d": [
             "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m"
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer",
-        "name": "MixedAnswer",
-        "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "MixedAnswer",
-            "path": {
+        "l": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer",
+        "n": "MixedAnswer",
+        "p": {
+            "n": "MixedAnswer",
+            "p": {
                 "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -3714,40 +3604,37 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "d": [
             "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m"
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer",
-        "name": "MixedAnswer",
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "MixedAnswer",
-            "path": {
+        "l": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer",
+        "n": "MixedAnswer",
+        "p": {
+            "n": "MixedAnswer",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -3758,15 +3645,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-        "inputs": {
-            "srcs": [
+        "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+        "i": {
+            "s": [
                 "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swift"
             ]
         },
-        "label": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift",
-        "name": "MixedAnswerLib_Swift",
-        "outputs": {
+        "l": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift",
+        "n": "MixedAnswerLib_Swift",
+        "o": {
             "s": {
                 "h": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
@@ -3778,28 +3665,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "MixedAnswerLib_Swift",
-            "path": {
+        "p": {
+            "n": "MixedAnswerLib_Swift",
+            "p": {
                 "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -3810,15 +3694,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swift"
             ]
         },
-        "label": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift",
-        "name": "MixedAnswerLib_Swift",
-        "outputs": {
+        "l": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift",
+        "n": "MixedAnswerLib_Swift",
+        "o": {
             "s": {
                 "h": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
@@ -3830,28 +3714,37 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "MixedAnswerLib_Swift",
-            "path": {
+        "p": {
+            "n": "MixedAnswerLib_Swift",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "3": {
+            "i": "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+            "n": "CoreUtilsObjC"
+        },
+        "4": {
+            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/FrameworkCoreUtilsObjC.63.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -3900,45 +3793,25 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-            "name": "CoreUtilsObjC"
-        },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "info_plist": {
-            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "hdrs": [
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "i": {
+            "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "pch": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
-            "srcs": [
+            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
+            "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/RealAnswer.h"
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/FrameworkCoreUtilsObjC.63.link.params",
-            "t": "g"
-        },
-        "name": "FrameworkCoreUtilsObjC",
-        "outputs": {
+        "l": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
+        "n": "FrameworkCoreUtilsObjC",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
                     "t": "g"
@@ -3948,19 +3821,38 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "CoreUtilsObjC",
-            "is_resource_bundle": false,
-            "name": "CoreUtilsObjC",
-            "path": {
+            "e": "CoreUtilsObjC",
+            "n": "CoreUtilsObjC",
+            "p": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "CoreUtilsObjC"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/FrameworkCoreUtilsObjC.5.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -4013,45 +3905,25 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "CoreUtilsObjC"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "hdrs": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "i": {
+            "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "pch": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
-            "srcs": [
+            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
+            "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/RealAnswer.h"
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/FrameworkCoreUtilsObjC.5.link.params",
-            "t": "g"
-        },
-        "name": "FrameworkCoreUtilsObjC",
-        "outputs": {
+        "l": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
+        "n": "FrameworkCoreUtilsObjC",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
                     "t": "g"
@@ -4061,19 +3933,26 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "CoreUtilsObjC",
-            "is_resource_bundle": false,
-            "name": "CoreUtilsObjC",
-            "path": {
+            "e": "CoreUtilsObjC",
+            "n": "CoreUtilsObjC",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/Utils",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -4123,49 +4002,78 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "d": [
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-7",
             "@FXPageControl//:FXPageControl ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "iOSApp/Source/Utils/Foo.m"
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Source/Utils:Utils",
-        "name": "Utils",
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/Utils",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Utils",
-            "path": {
+        "l": "//iOSApp/Source/Utils:Utils",
+        "n": "Utils",
+        "p": {
+            "n": "Utils",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/Utils/libUtils.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//iOSApp/Source:iOSApp applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "3": {
+            "i": "//iOSApp/Source:iOSApp.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+            "n": "iOSApp.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/frameworks/UIFramework.iOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/frameworks/LibFramework.iOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOSApp.70.link.params",
+            "t": "g"
+        },
+        "7": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-8",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-dbg-STABLE-8",
             "//UI:UIFramework.iOS applebin_ios-ios_arm64-dbg-STABLE-8"
         ],
-        "app_clips": [
+        "a": [
             "//AppClip:AppClip applebin_ios-ios_arm64-dbg-STABLE-8"
         ],
-        "build_settings": {
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/iOSApp.app",
             "CODE_SIGN_STYLE": "Automatic",
@@ -4186,12 +4094,8 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//iOSApp/Source:iOSApp.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-            "name": "iOSApp.library"
-        },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "dependencies": [
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "d": [
             "//AppClip:AppClip applebin_ios-ios_arm64-dbg-STABLE-8",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-8",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-dbg-STABLE-8",
@@ -4201,47 +4105,19 @@
             "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-dbg-STABLE-8"
         ],
-        "extensions": [
+        "e": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-8"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "entitlements": "iOSApp/Source/ios app.entitlements",
-            "srcs": [
+        "i": {
+            "e": "iOSApp/Source/ios app.entitlements",
+            "s": [
                 "iOSApp/Source/iOSApp.swift"
             ]
         },
-        "label": "//iOSApp/Source:iOSApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOSApp.70.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/frameworks/UIFramework.iOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/frameworks/LibFramework.iOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "iOSApp",
-        "outputs": {
+        "l": "//iOSApp/Source:iOSApp",
+        "m": true,
+        "n": "iOSApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -4250,42 +4126,73 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/libiOSApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "iOSApp_ExecutableName",
-            "is_resource_bundle": false,
-            "name": "iOSApp",
-            "path": {
+            "e": "iOSApp_ExecutableName",
+            "n": "iOSApp",
+            "p": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/iOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         },
-        "watch_application": "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-STABLE-12"
+        "w": "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-STABLE-12"
     },
     "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "iOSApp.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/frameworks/UIFramework.iOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/frameworks/LibFramework.iOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOSApp.12.link.params",
+            "t": "g"
+        },
+        "7": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "app_clips": [
+        "a": [
             "//AppClip:AppClip applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "build_settings": {
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/iOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
@@ -4305,12 +4212,8 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "iOSApp.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//AppClip:AppClip applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-7",
@@ -4320,27 +4223,63 @@
             "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "extensions": [
+        "e": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "entitlements": "iOSApp/Source/ios app.entitlements",
-            "srcs": [
+        "i": {
+            "e": "iOSApp/Source/ios app.entitlements",
+            "s": [
                 "iOSApp/Source/iOSApp.swift"
             ]
         },
-        "label": "//iOSApp/Source:iOSApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOSApp.12.link.params",
+        "l": "//iOSApp/Source:iOSApp",
+        "m": true,
+        "n": "iOSApp",
+        "o": {
+            "p": true,
+            "s": {
+                "m": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/iOSApp.swiftmodule",
+                    "t": "g"
+                }
+            }
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/libiOSApp.library.a",
+                    "t": "g"
+                }
+            ],
+            "e": "iOSApp_ExecutableName",
+            "n": "iOSApp",
+            "p": {
+                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/iOSApp.app",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.application"
+        },
+        "w": "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11"
+    },
+    "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
+    {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "iOSAppObjCUnitTests.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/rules_xcodeproj/iOSAppObjCUnitTests.__internal__.__test_bundle/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
                     "t": "e"
@@ -4359,50 +4298,17 @@
                 }
             ]
         },
-        "name": "iOSApp",
-        "outputs": {
-            "p": true,
-            "s": {
-                "m": {
-                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/iOSApp.swiftmodule",
-                    "t": "g"
-                }
-            }
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOSAppObjCUnitTests.__internal__.__test_bundle.23.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/libiOSApp.library.a",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "iOSApp_ExecutableName",
-            "is_resource_bundle": false,
-            "name": "iOSApp",
-            "path": {
-                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/iOSApp.app",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.application"
-        },
-        "watch_application": "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11"
-    },
-    "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
-    {
-        "additional_scheme_targets": [
+        "7": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "build_settings": {
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
             "CLANG_ENABLE_MODULES": true,
             "CODE_SIGN_STYLE": "Manual",
@@ -4471,35 +4377,61 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
-        "compile_target": {
-            "id": "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "iOSAppObjCUnitTests.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/rules_xcodeproj/iOSAppObjCUnitTests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "i": {
+            "s": [
                 "iOSApp/Test/ObjCUnitTests/ObjCUnitTests.m"
             ]
         },
-        "is_swift": false,
-        "is_testonly": true,
-        "label": "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOSAppObjCUnitTests.__internal__.__test_bundle.23.link.params",
+        "l": "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.__internal__.__test_bundle",
+        "n": "iOSAppObjCUnitTests.__internal__.__test_bundle",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/ObjCUnitTests/libiOSAppObjCUnitTests.library.a",
+                    "t": "g"
+                }
+            ],
+            "e": "iOSAppObjCUnitTests",
+            "n": "iOSAppObjCUnitTests",
+            "p": {
+                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.bundle.unit-test"
+        },
+        "s": false,
+        "t": true
+    },
+    "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
+    {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "iOSAppSwiftUnitTests.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/rules_xcodeproj/iOSAppSwiftUnitTests.__internal__.__test_bundle/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
                     "t": "e"
@@ -4518,44 +4450,17 @@
                 }
             ]
         },
-        "name": "iOSAppObjCUnitTests.__internal__.__test_bundle",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOSAppSwiftUnitTests.__internal__.__test_bundle.26.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/ObjCUnitTests/libiOSAppObjCUnitTests.library.a",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "iOSAppObjCUnitTests",
-            "is_resource_bundle": false,
-            "name": "iOSAppObjCUnitTests",
-            "path": {
-                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.bundle.unit-test"
-        },
-        "test_host": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7"
-    },
-    "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
-    {
-        "additional_scheme_targets": [
+        "7": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "build_settings": {
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -4574,55 +4479,23 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
-        "compile_target": {
-            "id": "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "iOSAppSwiftUnitTests.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/rules_xcodeproj/iOSAppSwiftUnitTests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "i": {
+            "s": [
                 "iOSApp/Test/SwiftUnitTests/SwiftUnitTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/iOSAppSwiftUnitTests.__internal__.__test_bundle.26.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/frameworks/UIFramework.iOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/frameworks/LibFramework.iOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "iOSAppSwiftUnitTests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle",
+        "m": true,
+        "n": "iOSAppSwiftUnitTests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -4631,34 +4504,33 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/SwiftUnitTests/libiOSAppSwiftUnitTests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "iOSAppSwiftUnitTests",
-            "is_resource_bundle": false,
-            "name": "iOSAppSwiftUnitTests",
-            "path": {
+            "e": "iOSAppSwiftUnitTests",
+            "n": "iOSAppSwiftUnitTests",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.unit-test"
+            "t": "com.apple.product-type.bundle.unit-test"
         },
-        "test_host": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7"
+        "t": true
     },
     "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -4669,19 +4541,18 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/TestingUtils.swift",
                     "t": "g"
                 }
             ]
         },
-        "is_testonly": true,
-        "label": "//iOSApp/Test/TestingUtils:TestingUtils",
-        "name": "TestingUtils",
-        "outputs": {
+        "l": "//iOSApp/Test/TestingUtils:TestingUtils",
+        "n": "TestingUtils",
+        "o": {
             "s": {
                 "h": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/SwiftAPI/TestingUtils-Swift.h",
@@ -4693,28 +4564,43 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "TestingUtils",
-            "path": {
+        "p": {
+            "n": "TestingUtils",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/libTestingUtils.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "t": true
     },
     "//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-dbg-STABLE-16",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//macOSApp/Source:macOSApp.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15",
+            "n": "macOSApp.library"
+        },
+        "4": {
+            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source/rules_xcodeproj/macOSApp/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                "macOSApp/third_party/ExampleFramework.framework"
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/macOSApp.27.link.params",
+            "t": "g"
+        },
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source/macOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
@@ -4733,34 +4619,17 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//macOSApp/Source:macOSApp.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15",
-            "name": "macOSApp.library"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-16",
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source/rules_xcodeproj/macOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-16",
+        "i": {
+            "s": [
                 "macOSApp/Source/ContentView.swift",
                 "macOSApp/Source/macOSApp.swift"
             ]
         },
-        "label": "//macOSApp/Source:macOSApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/macOSApp.27.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                "macOSApp/third_party/ExampleFramework.framework"
-            ]
-        },
-        "name": "macOSApp",
-        "outputs": {
+        "l": "//macOSApp/Source:macOSApp",
+        "m": true,
+        "n": "macOSApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -4769,36 +4638,47 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15/bin/macOSApp/Source/libmacOSApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "macOSApp",
-            "is_resource_bundle": false,
-            "name": "macOSApp",
-            "path": {
+            "e": "macOSApp",
+            "n": "macOSApp",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source/macOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         }
     },
     "//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-16",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//macOSApp/Test/UITests:macOSAppUITests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15",
+            "n": "macOSAppUITests.library"
+        },
+        "4": {
+            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests/rules_xcodeproj/macOSAppUITests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/macOSAppUITests.__internal__.__test_bundle.28.link.params",
+            "t": "g"
+        },
+        "7": [
             "//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-dbg-STABLE-16"
         ],
-        "build_settings": {
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -4816,32 +4696,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//macOSApp/Test/UITests:macOSAppUITests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15",
-            "name": "macOSAppUITests.library"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-16",
-        "dependencies": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-16",
+        "d": [
             "//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-dbg-STABLE-16"
         ],
-        "info_plist": {
-            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests/rules_xcodeproj/macOSAppUITests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "h": "//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-dbg-STABLE-16",
+        "i": {
+            "s": [
                 "macOSApp/Test/UITests/UITests.swift",
                 "macOSApp/Test/UITests/UITestsLaunchTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/macOSAppUITests.__internal__.__test_bundle.28.link.params",
-            "t": "g"
-        },
-        "name": "macOSAppUITests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle",
+        "n": "macOSAppUITests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -4850,38 +4718,65 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15/bin/macOSApp/Test/UITests/libmacOSAppUITests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "macOSAppUITests",
-            "is_resource_bundle": false,
-            "name": "macOSAppUITests",
-            "path": {
+            "e": "macOSAppUITests",
+            "n": "macOSAppUITests",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.ui-testing"
+            "t": "com.apple.product-type.bundle.ui-testing"
         },
-        "test_host": "//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-dbg-STABLE-16"
+        "t": true
     },
     "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_arm64-dbg-STABLE-14",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvos"
+        },
+        "3": {
+            "i": "//tvOSApp/Source:tvOSApp.library tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
+            "n": "tvOSApp.library"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/frameworks/UIFramework.tvOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOSApp.77.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
             "//UI:UIFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14"
         ],
-        "build_settings": {
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source/tvOSApp.app",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -4900,48 +4795,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tvOSApp/Source:tvOSApp.library tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
-            "name": "tvOSApp.library"
-        },
-        "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
+        "d": [
             "//UI:UIFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
             "//UI:UIFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "tvOSApp/Source/tvOSApp.swift"
             ]
         },
-        "label": "//tvOSApp/Source:tvOSApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOSApp.77.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/frameworks/UIFramework.tvOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "tvOSApp",
-        "outputs": {
+        "l": "//tvOSApp/Source:tvOSApp",
+        "m": true,
+        "n": "tvOSApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -4950,37 +4817,64 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/tvOSApp/Source/libtvOSApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tvOSApp",
-            "is_resource_bundle": false,
-            "name": "tvOSApp",
-            "path": {
+            "e": "tvOSApp",
+            "n": "tvOSApp",
+            "p": {
                 "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source/tvOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         }
     },
     "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "3": {
+            "i": "//tvOSApp/Source:tvOSApp.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
+            "n": "tvOSApp.library"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/frameworks/UIFramework.tvOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOSApp.19.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
             "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13"
         ],
-        "build_settings": {
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source/tvOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -4998,48 +4892,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tvOSApp/Source:tvOSApp.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
-            "name": "tvOSApp.library"
-        },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
             "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
             "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "tvOSApp/Source/tvOSApp.swift"
             ]
         },
-        "label": "//tvOSApp/Source:tvOSApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOSApp.19.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/frameworks/UIFramework.tvOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "tvOSApp",
-        "outputs": {
+        "l": "//tvOSApp/Source:tvOSApp",
+        "m": true,
+        "n": "tvOSApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5048,38 +4914,49 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/tvOSApp/Source/libtvOSApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tvOSApp",
-            "is_resource_bundle": false,
-            "name": "tvOSApp",
-            "path": {
+            "e": "tvOSApp",
+            "n": "tvOSApp",
+            "p": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source/tvOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         }
     },
     "//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-STABLE-13",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "3": {
+            "i": "//tvOSApp/Test/UITests:tvOSAppUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
+            "n": "tvOSAppUITests.library"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests/rules_xcodeproj/tvOSAppUITests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOSAppUITests.__internal__.__test_bundle.29.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
             "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
             "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13"
         ],
-        "build_settings": {
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -5097,32 +4974,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tvOSApp/Test/UITests:tvOSAppUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
-            "name": "tvOSAppUITests.library"
-        },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
             "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13"
         ],
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests/rules_xcodeproj/tvOSAppUITests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "h": "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "i": {
+            "s": [
                 "tvOSApp/Test/UITests/UITests.swift",
                 "tvOSApp/Test/UITests/UITestsLaunchTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOSAppUITests.__internal__.__test_bundle.29.link.params",
-            "t": "g"
-        },
-        "name": "tvOSAppUITests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle",
+        "n": "tvOSAppUITests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5131,39 +4996,66 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/tvOSApp/Test/UITests/libtvOSAppUITests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tvOSAppUITests",
-            "is_resource_bundle": false,
-            "name": "tvOSAppUITests",
-            "path": {
+            "e": "tvOSAppUITests",
+            "n": "tvOSAppUITests",
+            "p": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.ui-testing"
+            "t": "com.apple.product-type.bundle.ui-testing"
         },
-        "test_host": "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13"
+        "t": true
     },
     "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-STABLE-13",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "3": {
+            "i": "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
+            "n": "tvOSAppUnitTests.library"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests/rules_xcodeproj/tvOSAppUnitTests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/frameworks/UIFramework.tvOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOSAppUnitTests.__internal__.__test_bundle.30.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
             "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
             "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13"
         ],
-        "build_settings": {
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -5181,49 +5073,21 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
-            "name": "tvOSAppUnitTests.library"
-        },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
             "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13",
             "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests/rules_xcodeproj/tvOSAppUnitTests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "h": "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "i": {
+            "s": [
                 "tvOSApp/Test/UnitTests/UnitTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/tvOSAppUnitTests.__internal__.__test_bundle.30.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/frameworks/UIFramework.tvOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "tvOSAppUnitTests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle",
+        "m": true,
+        "n": "tvOSAppUnitTests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5232,38 +5096,49 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/tvOSApp/Test/UnitTests/libtvOSAppUnitTests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tvOSAppUnitTests",
-            "is_resource_bundle": false,
-            "name": "tvOSAppUnitTests",
-            "path": {
+            "e": "tvOSAppUnitTests",
+            "n": "tvOSAppUnitTests",
+            "p": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.unit-test"
+            "t": "com.apple.product-type.bundle.unit-test"
         },
-        "test_host": "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13"
+        "t": true
     },
     "//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-9",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "3": {
+            "i": "//watchOSApp/Test/UITests:watchOSAppUITests.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
+            "n": "watchOSAppUITests.library"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests/rules_xcodeproj/watchOSAppUITests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOSAppUITests.__internal__.__test_bundle.31.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "build_settings": {
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -5281,32 +5156,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//watchOSApp/Test/UITests:watchOSAppUITests.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
-            "name": "watchOSAppUITests.library"
-        },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
             "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests/rules_xcodeproj/watchOSAppUITests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "h": "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11",
+        "i": {
+            "s": [
                 "watchOSApp/Test/UITests/WatchOSAppUITests.swift",
                 "watchOSApp/Test/UITests/WatchOSAppUITestsLaunchTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOSAppUITests.__internal__.__test_bundle.31.link.params",
-            "t": "g"
-        },
-        "name": "watchOSAppUITests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle",
+        "n": "watchOSAppUITests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5315,38 +5178,41 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/watchOSApp/Test/UITests/libwatchOSAppUITests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "watchOSAppUITests",
-            "is_resource_bundle": false,
-            "name": "watchOSAppUITests",
-            "path": {
+            "e": "watchOSAppUITests",
+            "n": "watchOSAppUITests",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.ui-testing"
+            "t": "com.apple.product-type.bundle.ui-testing"
         },
-        "test_host": "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11"
+        "t": true
     },
     "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-STABLE-12",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp",
+        "2": {
+            "a": "arm64_32",
+            "m": "8.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10"
         ],
-        "build_settings": {
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp/watchOSApp.app",
             "CODE_SIGN_STYLE": "Automatic",
@@ -5359,49 +5225,47 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12",
+        "d": [
             "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-STABLE-10"
         ],
-        "extensions": [
+        "e": [
             "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-STABLE-10"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//watchOSApp:watchOSApp",
-        "name": "watchOSApp",
-        "outputs": {
+        "l": "//watchOSApp:watchOSApp",
+        "n": "watchOSApp",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "8.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": "watchOSApp",
-            "is_resource_bundle": false,
-            "name": "watchOSApp",
-            "path": {
+        "p": {
+            "e": "watchOSApp",
+            "n": "watchOSApp",
+            "p": {
                 "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp/watchOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application.watchapp2"
-        }
+            "t": "com.apple.product-type.application.watchapp2"
+        },
+        "s": false
     },
     "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin/watchOSApp",
+        "2": {
+            "a": "x86_64",
+            "m": "8.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "build_settings": {
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin/watchOSApp/watchOSApp.app",
             "CODE_SIGN_STYLE": "Manual",
@@ -5413,49 +5277,71 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-11",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-11",
+        "d": [
             "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "extensions": [
+        "e": [
             "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist",
-            "t": "g"
-        },
-        "is_swift": false,
-        "label": "//watchOSApp:watchOSApp",
-        "name": "watchOSApp",
-        "outputs": {
+        "l": "//watchOSApp:watchOSApp",
+        "n": "watchOSApp",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin/watchOSApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "8.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": "watchOSApp",
-            "is_resource_bundle": false,
-            "name": "watchOSApp",
-            "path": {
+        "p": {
+            "e": "watchOSApp",
+            "n": "watchOSApp",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin/watchOSApp/watchOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application.watchapp2"
-        }
+            "t": "com.apple.product-type.application.watchapp2"
+        },
+        "s": false
     },
     "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-9",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "3": {
+            "i": "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
+            "n": "watchOSAppExtensionUnitTests.library"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests/rules_xcodeproj/watchOSAppExtensionUnitTests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/frameworks/UIFramework.watchOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOSAppExtensionUnitTests.__internal__.__test_bundle.32.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "build_settings": {
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -5473,49 +5359,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
-            "name": "watchOSAppExtensionUnitTests.library"
-        },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests/rules_xcodeproj/watchOSAppExtensionUnitTests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "watchOSAppExtension/Test/UnitTests/WatchOSAppExtensionTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOSAppExtensionUnitTests.__internal__.__test_bundle.32.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/frameworks/UIFramework.watchOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "watchOSAppExtensionUnitTests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle",
+        "m": true,
+        "n": "watchOSAppExtensionUnitTests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5524,37 +5381,65 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/watchOSAppExtension/Test/UnitTests/libwatchOSAppExtensionUnitTests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "watchOSAppExtensionUnitTests",
-            "is_resource_bundle": false,
-            "name": "watchOSAppExtensionUnitTests",
-            "path": {
+            "e": "watchOSAppExtensionUnitTests",
+            "n": "watchOSAppExtensionUnitTests",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.unit-test"
-        }
+            "t": "com.apple.product-type.bundle.unit-test"
+        },
+        "t": true
     },
     "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension",
+        "2": {
+            "a": "arm64_32",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "3": {
+            "i": "//watchOSAppExtension:watchOSAppExtension.library watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
+            "n": "watchOSAppExtension.library"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension/rules_xcodeproj/watchOSAppExtension/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/frameworks/UIFramework.watchOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/frameworks/LibFramework.watchOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOSAppExtension.68.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10"
         ],
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "CODE_SIGN_STYLE": "Automatic",
@@ -5574,48 +5459,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//watchOSAppExtension:watchOSAppExtension.library watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
-            "name": "watchOSAppExtension.library"
-        },
-        "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
+        "d": [
             "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension/rules_xcodeproj/watchOSAppExtension/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "watchOSAppExtension/watchOSApp.swift"
             ]
         },
-        "label": "//watchOSAppExtension:watchOSAppExtension",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOSAppExtension.68.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/frameworks/UIFramework.watchOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/frameworks/LibFramework.watchOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "watchOSAppExtension",
-        "outputs": {
+        "l": "//watchOSAppExtension:watchOSAppExtension",
+        "m": true,
+        "n": "watchOSAppExtension",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5624,37 +5481,64 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/watchOSAppExtension/libwatchOSAppExtension.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "watchOSAppExtension",
-            "is_resource_bundle": false,
-            "name": "watchOSAppExtension",
-            "path": {
+            "e": "watchOSAppExtension",
+            "n": "watchOSAppExtension",
+            "p": {
                 "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension/watchOSAppExtension.appex",
                 "t": "g"
             },
-            "type": "com.apple.product-type.watchkit2-extension"
+            "t": "com.apple.product-type.watchkit2-extension"
         }
     },
     "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_x86_64-dbg-STABLE-9",
     {
-        "additional_scheme_targets": [
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "3": {
+            "i": "//watchOSAppExtension:watchOSAppExtension.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
+            "n": "watchOSAppExtension.library"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/rules_xcodeproj/watchOSAppExtension/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/frameworks/UIFramework.watchOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOSAppExtension.10.link.params",
+            "t": "g"
+        },
+        "7": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/watchOSAppExtension.appex",
             "CODE_SIGN_STYLE": "Manual",
@@ -5673,48 +5557,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//watchOSAppExtension:watchOSAppExtension.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
-            "name": "watchOSAppExtension.library"
-        },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/rules_xcodeproj/watchOSAppExtension/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "watchOSAppExtension/watchOSApp.swift"
             ]
         },
-        "label": "//watchOSAppExtension:watchOSAppExtension",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/watchOSAppExtension.10.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/frameworks/UIFramework.watchOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "watchOSAppExtension",
-        "outputs": {
+        "l": "//watchOSAppExtension:watchOSAppExtension",
+        "m": true,
+        "n": "watchOSAppExtension",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5723,33 +5579,32 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/watchOSAppExtension/libwatchOSAppExtension.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "watchOSAppExtension",
-            "is_resource_bundle": false,
-            "name": "watchOSAppExtension",
-            "path": {
+            "e": "watchOSAppExtension",
+            "n": "watchOSAppExtension",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/watchOSAppExtension.appex",
                 "t": "g"
             },
-            "type": "com.apple.product-type.watchkit2-extension"
+            "t": "com.apple.product-type.watchkit2-extension"
         }
     },
     "@FXPageControl//:FXPageControl ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -5793,35 +5648,25 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "FXPageControl/FXPageControl/FXPageControl.m",
                     "t": "e"
                 }
             ]
         },
-        "is_swift": false,
-        "label": "@FXPageControl//:FXPageControl",
-        "name": "FXPageControl",
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "FXPageControl",
-            "path": {
+        "l": "@FXPageControl//:FXPageControl",
+        "n": "FXPageControl",
+        "p": {
+            "n": "FXPageControl",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl/libFXPageControl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     }
 ]

--- a/examples/integration/test/fixtures/bwx_targets_spec.json
+++ b/examples/integration/test/fixtures/bwx_targets_spec.json
@@ -1,7 +1,34 @@
 [
     "//AppClip:AppClip applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "3": {
+            "i": "//AppClip:AppClip.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+            "n": "AppClip.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip/rules_xcodeproj/AppClip/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/AppClip.60.link.params",
+            "t": "g"
+        },
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -21,49 +48,29 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//AppClip:AppClip.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-            "name": "AppClip.library"
-        },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "dependencies": [
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "d": [
             "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip/rules_xcodeproj/AppClip/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "entitlements": {
+        "i": {
+            "e": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip/Entitlements.withbundleid.plist",
                 "t": "g"
             },
-            "resources": [
+            "r": [
                 "AppClip/PreviewContent/Preview Assets.xcassets",
                 "Lib/Resources/Assets.xcassets",
                 "AppClip/Assets.xcassets"
             ],
-            "srcs": [
+            "s": [
                 "AppClip/AppClip.swift",
                 "AppClip/ContentView.swift"
             ]
         },
-        "label": "//AppClip:AppClip",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/AppClip.60.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "AppClip",
-        "outputs": {
+        "l": "//AppClip:AppClip",
+        "m": true,
+        "n": "AppClip",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -72,33 +79,52 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/AppClip/libAppClip.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "AppClip",
-            "is_resource_bundle": false,
-            "name": "AppClip",
-            "path": {
+            "e": "AppClip",
+            "n": "AppClip",
+            "p": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/AppClip/AppClip.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application.on-demand-install-capable"
+            "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
     "//AppClip:AppClip applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//AppClip:AppClip.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "AppClip.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip/rules_xcodeproj/AppClip/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/AppClip.1.link.params",
+            "t": "g"
+        },
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -117,49 +143,29 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//AppClip:AppClip.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "AppClip.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip/rules_xcodeproj/AppClip/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "entitlements": {
+        "i": {
+            "e": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip/Entitlements.withbundleid.plist",
                 "t": "g"
             },
-            "resources": [
+            "r": [
                 "AppClip/PreviewContent/Preview Assets.xcassets",
                 "Lib/Resources/Assets.xcassets",
                 "AppClip/Assets.xcassets"
             ],
-            "srcs": [
+            "s": [
                 "AppClip/AppClip.swift",
                 "AppClip/ContentView.swift"
             ]
         },
-        "label": "//AppClip:AppClip",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/AppClip.1.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "AppClip",
-        "outputs": {
+        "l": "//AppClip:AppClip",
+        "m": true,
+        "n": "AppClip",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -168,33 +174,44 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/AppClip/libAppClip.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "AppClip",
-            "is_resource_bundle": false,
-            "name": "AppClip",
-            "path": {
+            "e": "AppClip",
+            "n": "AppClip",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/AppClip/AppClip.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application.on-demand-install-capable"
+            "t": "com.apple.product-type.application.on-demand-install-capable"
         }
     },
     "//CommandLine/CommandLineTool:CommandLineTool applebin_macos-darwin_x86_64-dbg-STABLE-20",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//CommandLine/CommandLineTool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+            "n": "tool.library"
+        },
+        "4": {
+            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool/rules_xcodeproj/CommandLineTool/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/CommandLineTool.41.link.params",
+            "t": "g"
+        },
+        "b": {
             "CLANG_ENABLE_MODULES": true,
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -251,60 +268,55 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//CommandLine/CommandLineTool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-            "name": "tool.library"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-20",
-        "dependencies": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-20",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_headers macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "info_plist": {
-            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool/rules_xcodeproj/CommandLineTool/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineTool/main.m"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineTool:CommandLineTool",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/CommandLineTool.41.link.params",
-            "t": "g"
-        },
-        "name": "CommandLineTool",
-        "outputs": {
+        "l": "//CommandLine/CommandLineTool:CommandLineTool",
+        "n": "CommandLineTool",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineTool/libtool.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "CommandLineTool",
-            "is_resource_bundle": false,
-            "name": "CommandLineTool",
-            "path": {
+            "e": "CommandLineTool",
+            "n": "CommandLineTool",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool/rules_xcodeproj/CommandLineTool/CommandLineTool",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
-        }
+            "t": "com.apple.product-type.tool"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineTool:tool.binary macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineTool",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//CommandLine/CommandLineTool:tool.library macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+            "n": "tool.library"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tool.binary.49.link.params",
+            "t": "g"
+        },
+        "b": {
             "CLANG_ENABLE_MODULES": true,
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -359,56 +371,55 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//CommandLine/CommandLineTool:tool.library macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-            "name": "tool.library"
-        },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "dependencies": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_headers macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineTool/main.m"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineTool:tool.binary",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tool.binary.49.link.params",
-            "t": "g"
-        },
-        "name": "tool.binary",
-        "outputs": {
+        "l": "//CommandLine/CommandLineTool:tool.binary",
+        "n": "tool.binary",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineTool",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineTool/libtool.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tool.binary",
-            "is_resource_bundle": false,
-            "name": "tool.binary",
-            "path": {
+            "e": "tool.binary",
+            "n": "tool.binary",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineTool/rules_xcodeproj/tool.binary/tool.binary",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
-        }
+            "t": "com.apple.product-type.tool"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineTool:tool.binary macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineTool",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//CommandLine/CommandLineTool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+            "n": "tool.library"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tool.binary.57.link.params",
+            "t": "g"
+        },
+        "b": {
             "CLANG_ENABLE_MODULES": true,
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -463,239 +474,206 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//CommandLine/CommandLineTool:tool.library macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-            "name": "tool.library"
-        },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_headers macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineTool/main.m"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineTool:tool.binary",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tool.binary.57.link.params",
-            "t": "g"
-        },
-        "name": "tool.binary",
-        "outputs": {
+        "l": "//CommandLine/CommandLineTool:tool.binary",
+        "n": "tool.binary",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineTool",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineTool/libtool.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tool.binary",
-            "is_resource_bundle": false,
-            "name": "tool.binary",
-            "path": {
+            "e": "tool.binary",
+            "n": "tool.binary",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineTool/rules_xcodeproj/tool.binary/tool.binary",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
-        }
+            "t": "com.apple.product-type.tool"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_defines macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_defines",
-        "name": "lib_defines",
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "l": "//CommandLine/CommandLineToolLib:lib_defines",
+        "n": "lib_defines",
+        "p": {
+            "n": "lib_defines",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_defines",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_defines macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_defines",
-        "name": "lib_defines",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "l": "//CommandLine/CommandLineToolLib:lib_defines",
+        "n": "lib_defines",
+        "p": {
+            "n": "lib_defines",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_defines",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_defines macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_defines",
-        "name": "lib_defines",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "l": "//CommandLine/CommandLineToolLib:lib_defines",
+        "n": "lib_defines",
+        "p": {
+            "n": "lib_defines",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_defines",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_headers macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "dependencies": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18"
         ],
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_headers",
-        "name": "lib_headers",
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "//CommandLine/CommandLineToolLib:lib_headers",
+        "n": "lib_headers",
+        "p": {
+            "n": "lib_headers",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_headers",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_headers macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_headers",
-        "name": "lib_headers",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "//CommandLine/CommandLineToolLib:lib_headers",
+        "n": "lib_headers",
+        "p": {
+            "n": "lib_headers",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_headers",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_headers macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19"
         ],
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_headers",
-        "name": "lib_headers",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
+        "l": "//CommandLine/CommandLineToolLib:lib_headers",
+        "n": "lib_headers",
+        "p": {
+            "n": "lib_headers",
+            "t": "com.apple.product-type.library.static"
         },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_headers",
-            "path": null,
-            "type": "com.apple.product-type.library.static"
-        }
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_impl macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -737,41 +715,38 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "dependencies": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_defines macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.m",
                 "CommandLine/CommandLineToolLib/private.h"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -813,41 +788,38 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_defines macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.m",
                 "CommandLine/CommandLineToolLib/private.h"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -889,41 +861,38 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_defines macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.m",
                 "CommandLine/CommandLineToolLib/private.h"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:lib_impl",
-        "name": "lib_impl",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_impl",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:lib_impl",
+        "n": "lib_impl",
+        "p": {
+            "n": "lib_impl",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/liblib_impl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:lib_swift macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -935,22 +904,22 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "dependencies": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "d": [
             "//CommandLine/swift_c_module:c_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
             "//CommandLine/CommandLineToolLib:lib_impl macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
             "//CommandLine/CommandLineToolLib:private_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
             "//CommandLine/CommandLineToolLib:private_swift_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18"
         ],
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:lib_swift",
-        "name": "lib_swift",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:lib_swift",
+        "m": true,
+        "n": "lib_swift",
+        "o": {
             "s": {
                 "h": {
                     "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/private/LibSwift-Swift.h",
@@ -962,28 +931,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_swift",
-            "path": {
+        "p": {
+            "n": "lib_swift",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -995,22 +961,22 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "d": [
             "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
             "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
             "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
             "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:lib_swift",
-        "name": "lib_swift",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:lib_swift",
+        "m": true,
+        "n": "lib_swift",
+        "o": {
             "s": {
                 "h": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/private/LibSwift-Swift.h",
@@ -1022,28 +988,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_swift",
-            "path": {
+        "p": {
+            "n": "lib_swift",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1055,22 +1018,22 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "dependencies": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "d": [
             "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
             "//CommandLine/CommandLineToolLib:lib_impl macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
             "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
             "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19"
         ],
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:lib_swift",
-        "name": "lib_swift",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:lib_swift",
+        "m": true,
+        "n": "lib_swift",
+        "o": {
             "s": {
                 "h": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/private/LibSwift-Swift.h",
@@ -1082,28 +1045,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "lib_swift",
-            "path": {
+        "p": {
+            "n": "lib_swift",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/liblib_swift.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/CommandLineToolLib:private_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1133,37 +1093,34 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "inputs": {
-            "srcs": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:private_lib",
-        "name": "private_lib",
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_lib",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:private_lib",
+        "n": "private_lib",
+        "p": {
+            "n": "private_lib",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1193,37 +1150,34 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:private_lib",
-        "name": "private_lib",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_lib",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:private_lib",
+        "n": "private_lib",
+        "p": {
+            "n": "private_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:private_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1253,37 +1207,34 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/CommandLineToolLib:private_lib",
-        "name": "private_lib",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_lib",
-            "path": {
+        "l": "//CommandLine/CommandLineToolLib:private_lib",
+        "n": "private_lib",
+        "p": {
+            "n": "private_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/libprivate_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/CommandLineToolLib:private_swift_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1294,15 +1245,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "inputs": {
-            "srcs": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:private_swift_lib",
-        "name": "private_swift_lib",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:private_swift_lib",
+        "n": "private_swift_lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
@@ -1310,28 +1261,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_swift_lib",
-            "path": {
+        "p": {
+            "n": "private_swift_lib",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1342,15 +1290,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:private_swift_lib",
-        "name": "private_swift_lib",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:private_swift_lib",
+        "n": "private_swift_lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
@@ -1358,28 +1306,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_swift_lib",
-            "path": {
+        "p": {
+            "n": "private_swift_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/CommandLineToolLib:private_swift_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1390,15 +1335,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "i": {
+            "s": [
                 "CommandLine/CommandLineToolLib/private_lib.swift"
             ]
         },
-        "label": "//CommandLine/CommandLineToolLib:private_swift_lib",
-        "name": "private_swift_lib",
-        "outputs": {
+        "l": "//CommandLine/CommandLineToolLib:private_swift_lib",
+        "n": "private_swift_lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/_SwiftLib.swiftmodule",
@@ -1406,28 +1351,37 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "private_swift_lib",
-            "path": {
+        "p": {
+            "n": "private_swift_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/CommandLineToolLib/libprivate_swift_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-20",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//CommandLine/Tests:CommandLineLibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+            "n": "CommandLineLibSwiftTestsLib"
+        },
+        "4": {
+            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests/rules_xcodeproj/CommandLineToolTests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/CommandLineToolTests.__internal__.__test_bundle.58.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -1444,32 +1398,19 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//CommandLine/Tests:CommandLineLibSwiftTestsLib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-            "name": "CommandLineLibSwiftTestsLib"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-20",
-        "dependencies": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-20",
+        "d": [
             "//CommandLine/CommandLineToolLib:lib_swift macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests/rules_xcodeproj/CommandLineToolTests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "CommandLine/Tests/SwiftGreetingsTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/CommandLineToolTests.__internal__.__test_bundle.58.link.params",
-            "t": "g"
-        },
-        "name": "CommandLineToolTests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle",
+        "m": true,
+        "n": "CommandLineToolTests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -1478,33 +1419,33 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/Tests/libCommandLineLibSwiftTestsLib.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "CommandLineToolTests",
-            "is_resource_bundle": false,
-            "name": "CommandLineToolTests",
-            "path": {
+            "e": "CommandLineToolTests",
+            "n": "CommandLineToolTests",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests/CommandLineToolTests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.unit-test"
-        }
+            "t": "com.apple.product-type.bundle.unit-test"
+        },
+        "t": true
     },
     "//CommandLine/swift_c_module:c_lib macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/swift_c_module",
+        "2": {
+            "a": "arm64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1532,37 +1473,34 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
-        "inputs": {
-            "srcs": [
+        "c": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
+        "i": {
+            "s": [
                 "CommandLine/swift_c_module/c_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/swift_c_module:c_lib",
-        "name": "c_lib",
-        "package_bin_dir": "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/swift_c_module",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "c_lib",
-            "path": {
+        "l": "//CommandLine/swift_c_module:c_lib",
+        "n": "c_lib",
+        "p": {
+            "n": "c_lib",
+            "p": {
                 "_": "macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/swift_c_module/libc_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/swift_c_module",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1590,37 +1528,34 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17",
+        "i": {
+            "s": [
                 "CommandLine/swift_c_module/c_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/swift_c_module:c_lib",
-        "name": "c_lib",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/swift_c_module",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "c_lib",
-            "path": {
+        "l": "//CommandLine/swift_c_module:c_lib",
+        "n": "c_lib",
+        "p": {
+            "n": "c_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-17/bin/CommandLine/swift_c_module/libc_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//CommandLine/swift_c_module:c_lib macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/swift_c_module",
+        "2": {
+            "a": "x86_64",
+            "m": "11.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1648,106 +1583,50 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19",
+        "i": {
+            "s": [
                 "CommandLine/swift_c_module/c_lib.c"
             ]
         },
-        "is_swift": false,
-        "label": "//CommandLine/swift_c_module:c_lib",
-        "name": "c_lib",
-        "package_bin_dir": "bazel-out/macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/swift_c_module",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "11.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "c_lib",
-            "path": {
+        "l": "//CommandLine/swift_c_module:c_lib",
+        "n": "c_lib",
+        "p": {
+            "n": "c_lib",
+            "p": {
                 "_": "macos-x86_64-min11.0-applebin_macos-darwin_x86_64-dbg-STABLE-19/bin/CommandLine/swift_c_module/libc_lib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//Lib/dist/dynamic:iOS applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "build_settings": {
-            "APPLICATION_EXTENSION_API_ONLY": true,
-            "CODE_SIGN_STYLE": "Manual",
-            "DEBUG_INFORMATION_FORMAT": "dwarf",
-            "ENABLE_BITCODE": false,
-            "ENABLE_STRICT_OBJC_MSGSEND": true,
-            "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
-            "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
-            "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "TARGETED_DEVICE_FAMILY": "1"
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
         },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "dependencies": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
-        ],
-        "info_plist": {
+        "4": {
             "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic/rules_xcodeproj/iOS/Info.plist",
             "t": "g"
         },
-        "inputs": {
-            "resources": [
-                "Lib/Resources/Assets.xcassets"
-            ]
-        },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:iOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOS.73.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "iOS",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOS.73.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic/frameworks/Lib.framework",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
-                "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic/Lib.framework",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.framework"
-        }
-    },
-    "//Lib/dist/dynamic:iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
-    {
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -1759,64 +1638,63 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "d": [
+            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic/rules_xcodeproj/iOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:iOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOS.14.link.params",
+        "l": "//Lib/dist/dynamic:iOS",
+        "n": "iOS",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic/frameworks/Lib.framework",
+                    "t": "g"
+                }
+            ],
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
+                "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/dist/dynamic/Lib.framework",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
+    },
+    "//Lib/dist/dynamic:iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
+    {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic/rules_xcodeproj/iOS/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "iOS",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOS.14.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic/frameworks/Lib.framework",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
-                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic/Lib.framework",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.framework"
-        }
-    },
-    "//Lib/dist/dynamic:tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
-    {
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -1825,66 +1703,66 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0"
+            "SWIFT_VERSION": "5.0",
+            "TARGETED_DEVICE_FAMILY": "1"
         },
-        "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
-        "dependencies": [
-            "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6"
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
+            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "info_plist": {
-            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOS.75.link.params",
+        "l": "//Lib/dist/dynamic:iOS",
+        "n": "iOS",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic/frameworks/Lib.framework",
+                    "t": "g"
+                }
+            ],
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
+                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/dist/dynamic/Lib.framework",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
+    },
+    "//Lib/dist/dynamic:tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
+    {
+        "1": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvos"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "tvOS",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOS.75.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvos"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/frameworks/Lib.framework",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
-                "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/Lib.framework",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.framework"
-        }
-    },
-    "//Lib/dist/dynamic:tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-    {
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -1895,64 +1773,63 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
-            "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3"
+        "c": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
+        "d": [
+            "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6"
         ],
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOS.16.link.params",
+        "l": "//Lib/dist/dynamic:tvOS",
+        "n": "tvOS",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/frameworks/Lib.framework",
+                    "t": "g"
+                }
+            ],
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
+                "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/Lib.framework",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
+    },
+    "//Lib/dist/dynamic:tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+    {
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "tvOS",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOS.16.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/frameworks/Lib.framework",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
-                "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/Lib.framework",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.framework"
-        }
-    },
-    "//Lib/dist/dynamic:watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
-    {
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -1963,64 +1840,63 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
-        "dependencies": [
-            "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5"
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
+            "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOS.76.link.params",
+        "l": "//Lib/dist/dynamic:tvOS",
+        "n": "tvOS",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/frameworks/Lib.framework",
+                    "t": "g"
+                }
+            ],
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
+                "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/Lib.framework",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
+    },
+    "//Lib/dist/dynamic:watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
+    {
+        "1": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "arm64_32",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "watchOS",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOS.76.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic/frameworks/Lib.framework",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
-                "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic/Lib.framework",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.framework"
-        }
-    },
-    "//Lib/dist/dynamic:watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-    {
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -2031,64 +1907,114 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
-            "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2"
+        "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
+        "d": [
+            "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//Lib/dist/dynamic:watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOS.17.link.params",
+        "l": "//Lib/dist/dynamic:watchOS",
+        "n": "watchOS",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic/frameworks/Lib.framework",
+                    "t": "g"
+                }
+            ],
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
+                "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/dist/dynamic/Lib.framework",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
+    },
+    "//Lib/dist/dynamic:watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+    {
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic/rules_xcodeproj/watchOS/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "watchOS",
-        "outputs": {
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOS.17.link.params",
+            "t": "g"
+        },
+        "b": {
+            "APPLICATION_EXTENSION_API_ONLY": true,
+            "CODE_SIGN_STYLE": "Manual",
+            "DEBUG_INFORMATION_FORMAT": "dwarf",
+            "ENABLE_BITCODE": false,
+            "ENABLE_STRICT_OBJC_MSGSEND": true,
+            "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
+            "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+            "SWIFT_VERSION": "5.0"
+        },
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
+            "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2"
+        ],
+        "i": {
+            "r": [
+                "Lib/Resources/Assets.xcassets"
+            ]
+        },
+        "l": "//Lib/dist/dynamic:watchOS",
+        "n": "watchOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic/frameworks/Lib.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "Lib",
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+            "e": "Lib",
+            "n": "Lib",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/dist/dynamic/Lib.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2099,10 +2025,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swift",
@@ -2110,9 +2035,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/Lib.swiftmodule",
@@ -2120,28 +2046,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2152,10 +2075,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swift",
@@ -2163,9 +2085,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/Lib.swiftmodule",
@@ -2173,28 +2096,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
     {
-        "build_settings": {
+        "1": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvos"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2205,10 +2125,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swift",
@@ -2216,9 +2135,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/Lib.swiftmodule",
@@ -2226,28 +2146,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
     {
-        "build_settings": {
+        "1": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2258,10 +2175,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swift",
@@ -2269,9 +2185,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/Lib.swiftmodule",
@@ -2279,28 +2196,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
     {
-        "build_settings": {
+        "1": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib",
+        "2": {
+            "a": "arm64_32",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2311,10 +2225,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swift",
@@ -2322,9 +2235,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/Lib.swiftmodule",
@@ -2332,28 +2246,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -2364,10 +2275,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "c": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
+        "i": {
+            "s": [
                 "Lib/Resources.swift",
                 {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swift",
@@ -2375,9 +2285,10 @@
                 }
             ]
         },
-        "label": "//Lib:Lib",
-        "name": "Lib",
-        "outputs": {
+        "l": "//Lib:Lib",
+        "m": true,
+        "n": "Lib",
+        "o": {
             "s": {
                 "m": {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/Lib.swiftmodule",
@@ -2385,97 +2296,41 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Lib",
-            "path": {
+        "p": {
+            "n": "Lib",
+            "p": {
                 "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/Lib/libLib.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//Lib:LibFramework.iOS applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "build_settings": {
-            "APPLICATION_EXTENSION_API_ONLY": true,
-            "CODE_SIGN_STYLE": "Manual",
-            "DEBUG_INFORMATION_FORMAT": "dwarf",
-            "ENABLE_BITCODE": false,
-            "ENABLE_STRICT_OBJC_MSGSEND": true,
-            "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
-            "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
-            "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0",
-            "TARGETED_DEVICE_FAMILY": "1"
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
         },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "dependencies": [
-            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
-        ],
-        "info_plist": {
+        "4": {
             "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/rules_xcodeproj/LibFramework.iOS/Info.plist",
             "t": "g"
         },
-        "inputs": {
-            "resources": [
-                "Lib/Resources/Assets.xcassets"
-            ]
-        },
-        "is_swift": false,
-        "label": "//Lib:LibFramework.iOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.iOS.65.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "LibFramework.iOS",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.iOS.65.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/frameworks/LibFramework.iOS.framework",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "LibFramework.iOS",
-            "is_resource_bundle": false,
-            "name": "LibFramework.iOS",
-            "path": {
-                "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/LibFramework.iOS.framework",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.framework"
-        }
-    },
-    "//Lib:LibFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
-    {
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -2487,64 +2342,63 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
-            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "d": [
+            "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/rules_xcodeproj/LibFramework.iOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//Lib:LibFramework.iOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.iOS.6.link.params",
+        "l": "//Lib:LibFramework.iOS",
+        "n": "LibFramework.iOS",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/frameworks/LibFramework.iOS.framework",
+                    "t": "g"
+                }
+            ],
+            "e": "LibFramework.iOS",
+            "n": "LibFramework.iOS",
+            "p": {
+                "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/LibFramework.iOS.framework",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
+    },
+    "//Lib:LibFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
+    {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/rules_xcodeproj/LibFramework.iOS/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "LibFramework.iOS",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.iOS.6.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/frameworks/LibFramework.iOS.framework",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "LibFramework.iOS",
-            "is_resource_bundle": false,
-            "name": "LibFramework.iOS",
-            "path": {
-                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/LibFramework.iOS.framework",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.framework"
-        }
-    },
-    "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
-    {
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -2553,66 +2407,66 @@
             "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
             "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
-            "SWIFT_VERSION": "5.0"
+            "SWIFT_VERSION": "5.0",
+            "TARGETED_DEVICE_FAMILY": "1"
         },
-        "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
-        "dependencies": [
-            "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6"
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
+            "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "info_plist": {
-            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//Lib:LibFramework.tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.tvOS.77.link.params",
+        "l": "//Lib:LibFramework.iOS",
+        "n": "LibFramework.iOS",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/frameworks/LibFramework.iOS.framework",
+                    "t": "g"
+                }
+            ],
+            "e": "LibFramework.iOS",
+            "n": "LibFramework.iOS",
+            "p": {
+                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/LibFramework.iOS.framework",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
+    },
+    "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
+    {
+        "1": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvos"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "LibFramework.tvOS",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.tvOS.77.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvos"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "LibFramework.tvOS",
-            "is_resource_bundle": false,
-            "name": "LibFramework.tvOS",
-            "path": {
-                "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/LibFramework.tvOS.framework",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.framework"
-        }
-    },
-    "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-    {
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -2623,64 +2477,63 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
-            "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3"
+        "c": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
+        "d": [
+            "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6"
         ],
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//Lib:LibFramework.tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.tvOS.18.link.params",
+        "l": "//Lib:LibFramework.tvOS",
+        "n": "LibFramework.tvOS",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ],
+            "e": "LibFramework.tvOS",
+            "n": "LibFramework.tvOS",
+            "p": {
+                "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/LibFramework.tvOS.framework",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
+    },
+    "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+    {
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "LibFramework.tvOS",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.tvOS.18.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "LibFramework.tvOS",
-            "is_resource_bundle": false,
-            "name": "LibFramework.tvOS",
-            "path": {
-                "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/LibFramework.tvOS.framework",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.framework"
-        }
-    },
-    "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
-    {
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -2691,64 +2544,63 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
-        "dependencies": [
-            "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5"
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
+            "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//Lib:LibFramework.watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.watchOS.68.link.params",
+        "l": "//Lib:LibFramework.tvOS",
+        "n": "LibFramework.tvOS",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ],
+            "e": "LibFramework.tvOS",
+            "n": "LibFramework.tvOS",
+            "p": {
+                "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/LibFramework.tvOS.framework",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
+    },
+    "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
+    {
+        "1": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib",
+        "2": {
+            "a": "arm64_32",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "LibFramework.watchOS",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.watchOS.68.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/frameworks/LibFramework.watchOS.framework",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "LibFramework.watchOS",
-            "is_resource_bundle": false,
-            "name": "LibFramework.watchOS",
-            "path": {
-                "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/LibFramework.watchOS.framework",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.framework"
-        }
-    },
-    "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-    {
-        "build_settings": {
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -2759,64 +2611,138 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
-            "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2"
+        "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
+        "d": [
+            "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//Lib:LibFramework.watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.watchOS.9.link.params",
+        "l": "//Lib:LibFramework.watchOS",
+        "n": "LibFramework.watchOS",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/frameworks/LibFramework.watchOS.framework",
+                    "t": "g"
+                }
+            ],
+            "e": "LibFramework.watchOS",
+            "n": "LibFramework.watchOS",
+            "p": {
+                "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/LibFramework.watchOS.framework",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
+    },
+    "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+    {
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/rules_xcodeproj/LibFramework.watchOS/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
                     "t": "e"
                 }
             ]
         },
-        "name": "LibFramework.watchOS",
-        "outputs": {
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/LibFramework.watchOS.9.link.params",
+            "t": "g"
+        },
+        "b": {
+            "APPLICATION_EXTENSION_API_ONLY": true,
+            "CODE_SIGN_STYLE": "Manual",
+            "DEBUG_INFORMATION_FORMAT": "dwarf",
+            "ENABLE_BITCODE": false,
+            "ENABLE_STRICT_OBJC_MSGSEND": true,
+            "PRODUCT_BUNDLE_IDENTIFIER": "io.budilebuddy.LibFramework",
+            "SWIFT_OBJC_INTERFACE_HEADER_NAME": "",
+            "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
+            "SWIFT_VERSION": "5.0"
+        },
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
+            "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2"
+        ],
+        "i": {
+            "r": [
+                "Lib/Resources/Assets.xcassets"
+            ]
+        },
+        "l": "//Lib:LibFramework.watchOS",
+        "n": "LibFramework.watchOS",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
                     "t": "g"
                 }
             ],
-            "executable_name": "LibFramework.watchOS",
-            "is_resource_bundle": false,
-            "name": "LibFramework.watchOS",
-            "path": {
+            "e": "LibFramework.watchOS",
+            "n": "LibFramework.watchOS",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/LibFramework.watchOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//UI:UIFramework.iOS applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "3": {
+            "i": "//UI:UI ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/frameworks/LibFramework.iOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.iOS.66.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -2835,47 +2761,23 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//UI:UI ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-            "name": "UI"
-        },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "dependencies": [
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "d": [
             "//Lib:LibFramework.iOS applebin_ios-ios_arm64-dbg-STABLE-8",
             "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "hdrs": [
+        "i": {
+            "h": [
                 "UI/UI.h"
             ],
-            "srcs": [
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.iOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.iOS.66.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/frameworks/LibFramework.iOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.iOS",
-        "outputs": {
+        "l": "//UI:UIFramework.iOS",
+        "m": true,
+        "n": "UIFramework.iOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -2884,15 +2786,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/frameworks/UIFramework.iOS.framework",
                     "t": "g"
@@ -2902,19 +2797,49 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.iOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.iOS",
-            "path": {
+            "e": "UIFramework.iOS",
+            "n": "UIFramework.iOS",
+            "p": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/UIFramework.iOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//UI:UIFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//UI:UI ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/frameworks/LibFramework.iOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.iOS.7.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -2933,47 +2858,23 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//UI:UI ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "UI"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//Lib:LibFramework.iOS applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/rules_xcodeproj/UIFramework.iOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "hdrs": [
+        "i": {
+            "h": [
                 "UI/UI.h"
             ],
-            "srcs": [
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.iOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.iOS.7.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/frameworks/LibFramework.iOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.iOS",
-        "outputs": {
+        "l": "//UI:UIFramework.iOS",
+        "m": true,
+        "n": "UIFramework.iOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -2982,15 +2883,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/frameworks/UIFramework.iOS.framework",
                     "t": "g"
@@ -3000,19 +2894,49 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.iOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.iOS",
-            "path": {
+            "e": "UIFramework.iOS",
+            "n": "UIFramework.iOS",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/UIFramework.iOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//UI:UIFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvos"
+        },
+        "3": {
+            "i": "//UI:UI tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.tvOS.78.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -3030,44 +2954,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//UI:UI tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
-            "name": "UI"
-        },
-        "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
+        "d": [
             "//Lib:LibFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
             "//Lib:Lib tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.tvOS.78.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.tvOS",
-        "outputs": {
+        "l": "//UI:UIFramework.tvOS",
+        "m": true,
+        "n": "UIFramework.tvOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3076,15 +2976,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/frameworks/UIFramework.tvOS.framework",
                     "t": "g"
@@ -3094,19 +2987,49 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.tvOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.tvOS",
-            "path": {
+            "e": "UIFramework.tvOS",
+            "n": "UIFramework.tvOS",
+            "p": {
                 "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/UIFramework.tvOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "3": {
+            "i": "//UI:UI tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.tvOS.19.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -3124,44 +3047,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//UI:UI tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
-            "name": "UI"
-        },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
             "//Lib:LibFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
             "//Lib:Lib tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.tvOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.tvOS.19.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.tvOS",
-        "outputs": {
+        "l": "//UI:UIFramework.tvOS",
+        "m": true,
+        "n": "UIFramework.tvOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3170,15 +3069,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/frameworks/UIFramework.tvOS.framework",
                     "t": "g"
@@ -3188,19 +3080,49 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.tvOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.tvOS",
-            "path": {
+            "e": "UIFramework.tvOS",
+            "n": "UIFramework.tvOS",
+            "p": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/UIFramework.tvOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI",
+        "2": {
+            "a": "arm64_32",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "3": {
+            "i": "//UI:UI watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/frameworks/LibFramework.watchOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.watchOS.69.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -3218,44 +3140,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//UI:UI watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
-            "name": "UI"
-        },
-        "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
+        "d": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
             "//Lib:Lib watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.watchOS.69.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/frameworks/LibFramework.watchOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.watchOS",
-        "outputs": {
+        "l": "//UI:UIFramework.watchOS",
+        "m": true,
+        "n": "UIFramework.watchOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3264,15 +3162,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/frameworks/UIFramework.watchOS.framework",
                     "t": "g"
@@ -3282,19 +3173,49 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.watchOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.watchOS",
-            "path": {
+            "e": "UIFramework.watchOS",
+            "n": "UIFramework.watchOS",
+            "p": {
                 "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/UIFramework.watchOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "3": {
+            "i": "//UI:UI watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
+            "n": "UI"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.watchOS.10.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -3312,44 +3233,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//UI:UI watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
-            "name": "UI"
-        },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
             "//Lib:LibFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
             "//Lib:Lib watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/rules_xcodeproj/UIFramework.watchOS/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "UI/ContentView.swift"
             ]
         },
-        "label": "//UI:UIFramework.watchOS",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UIFramework.watchOS.10.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "UIFramework.watchOS",
-        "outputs": {
+        "l": "//UI:UIFramework.watchOS",
+        "m": true,
+        "n": "UIFramework.watchOS",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3358,15 +3255,8 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/frameworks/UIFramework.watchOS.framework",
                     "t": "g"
@@ -3376,19 +3266,45 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "UIFramework.watchOS",
-            "is_resource_bundle": false,
-            "name": "UIFramework.watchOS",
-            "path": {
+            "e": "UIFramework.watchOS",
+            "n": "UIFramework.watchOS",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/UIFramework.watchOS.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
+            "t": "com.apple.product-type.framework"
         }
     },
     "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "3": {
+            "i": "//WidgetExtension:WidgetExtension.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+            "n": "WidgetExtension.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/WidgetExtension.63.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -3408,25 +3324,16 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//WidgetExtension:WidgetExtension.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-            "name": "WidgetExtension.library"
-        },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "dependencies": [
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "d": [
             "//Lib:Lib ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets",
                 "WidgetExtension/Assets.xcassets"
             ],
-            "srcs": [
+            "s": [
                 "WidgetExtension/WidgetExtension.swift",
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/WidgetExtension/Intents.swift",
@@ -3434,21 +3341,10 @@
                 }
             ]
         },
-        "label": "//WidgetExtension:WidgetExtension",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/WidgetExtension.63.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "WidgetExtension",
-        "outputs": {
+        "l": "//WidgetExtension:WidgetExtension",
+        "m": true,
+        "n": "WidgetExtension",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3457,33 +3353,52 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/WidgetExtension/libWidgetExtension.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "WidgetExtension",
-            "is_resource_bundle": false,
-            "name": "WidgetExtension",
-            "path": {
+            "e": "WidgetExtension",
+            "n": "WidgetExtension",
+            "p": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/WidgetExtension/WidgetExtension.appex",
                 "t": "g"
             },
-            "type": "com.apple.product-type.app-extension"
+            "t": "com.apple.product-type.app-extension"
         }
     },
     "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//WidgetExtension:WidgetExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "WidgetExtension.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/WidgetExtension.4.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -3502,25 +3417,16 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//WidgetExtension:WidgetExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "WidgetExtension.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension/rules_xcodeproj/WidgetExtension/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "Lib/Resources/Assets.xcassets",
                 "WidgetExtension/Assets.xcassets"
             ],
-            "srcs": [
+            "s": [
                 "WidgetExtension/WidgetExtension.swift",
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/WidgetExtension/Intents.swift",
@@ -3528,21 +3434,10 @@
                 }
             ]
         },
-        "label": "//WidgetExtension:WidgetExtension",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/WidgetExtension.4.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "WidgetExtension",
-        "outputs": {
+        "l": "//WidgetExtension:WidgetExtension",
+        "m": true,
+        "n": "WidgetExtension",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3551,33 +3446,36 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/WidgetExtension/libWidgetExtension.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "WidgetExtension",
-            "is_resource_bundle": false,
-            "name": "WidgetExtension",
-            "path": {
+            "e": "WidgetExtension",
+            "n": "WidgetExtension",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/WidgetExtension/WidgetExtension.appex",
                 "t": "g"
             },
-            "type": "com.apple.product-type.app-extension"
+            "t": "com.apple.product-type.app-extension"
         }
     },
     "//iMessageApp:iMessageApp applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/rules_xcodeproj/iMessageApp/Info.plist",
+            "t": "g"
+        },
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -3589,50 +3487,64 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "extensions": [
+        "e": [
             "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/rules_xcodeproj/iMessageApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "iMessageApp/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//iMessageApp:iMessageApp",
-        "name": "iMessageApp",
-        "outputs": {
+        "l": "//iMessageApp:iMessageApp",
+        "n": "iMessageApp",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": "iMessageApp",
-            "is_resource_bundle": false,
-            "name": "iMessageApp",
-            "path": {
+        "p": {
+            "e": "iMessageApp",
+            "n": "iMessageApp",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/iMessageApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application.messages"
-        }
+            "t": "com.apple.product-type.application.messages"
+        },
+        "s": false
     },
     "//iMessageApp:iMessageAppExtension applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//iMessageApp:iMessageAppExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "iMessageAppExtension.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/rules_xcodeproj/iMessageAppExtension/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iMessageAppExtension.25.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -3651,44 +3563,24 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//iMessageApp:iMessageAppExtension.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "iMessageAppExtension.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//Lib:Lib ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/rules_xcodeproj/iMessageAppExtension/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "iMessageApp/ExtensionAssets.xcassets",
                 "Lib/Resources/Assets.xcassets",
                 "iMessageApp/Base.lproj/MainInterface.storyboard"
             ],
-            "srcs": [
+            "s": [
                 "iMessageApp/MessagesViewController.swift"
             ]
         },
-        "label": "//iMessageApp:iMessageAppExtension",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iMessageAppExtension.25.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                }
-            ]
-        },
-        "name": "iMessageAppExtension",
-        "outputs": {
+        "l": "//iMessageApp:iMessageAppExtension",
+        "m": true,
+        "n": "iMessageAppExtension",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -3697,38 +3589,37 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iMessageApp/libiMessageAppExtension.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "iMessageAppExtension",
-            "is_resource_bundle": false,
-            "name": "iMessageAppExtension",
-            "path": {
+            "e": "iMessageAppExtension",
+            "n": "iMessageAppExtension",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iMessageApp/iMessageAppExtension.appex",
                 "t": "g"
             },
-            "type": "com.apple.product-type.app-extension.messages"
+            "t": "com.apple.product-type.app-extension.messages"
         }
     },
     "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleNestedResources",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "b": {
             "PRODUCT_BUNDLE_IDENTIFIER": "com.example.resources.nested"
         },
-        "configuration": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-        "inputs": {
-            "resources": [
+        "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+        "i": {
+            "r": [
                 "iOSApp/Resources/ExampleNestedResources/Assets.xcassets",
                 "iOSApp/Resources/ExampleNestedResources/en.lproj/Localizable.strings",
                 "iOSApp/Resources/ExampleNestedResources/es.lproj/Localizable.strings",
@@ -3745,36 +3636,34 @@
                 }
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources",
-        "name": "ExampleNestedResources",
-        "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleNestedResources",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": true,
-            "name": "ExampleNestedResources",
-            "path": {
+        "l": "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources",
+        "n": "ExampleNestedResources",
+        "p": {
+            "n": "ExampleNestedResources",
+            "p": {
                 "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleNestedResources/ExampleNestedResources.bundle",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle"
-        }
+            "r": true,
+            "t": "com.apple.product-type.bundle"
+        },
+        "s": false
     },
     "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleNestedResources",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "PRODUCT_BUNDLE_IDENTIFIER": "com.example.resources.nested"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "resources": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "i": {
+            "r": [
                 "iOSApp/Resources/ExampleNestedResources/Assets.xcassets",
                 "iOSApp/Resources/ExampleNestedResources/en.lproj/Localizable.strings",
                 "iOSApp/Resources/ExampleNestedResources/es.lproj/Localizable.strings",
@@ -3791,39 +3680,37 @@
                 }
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources",
-        "name": "ExampleNestedResources",
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleNestedResources",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": true,
-            "name": "ExampleNestedResources",
-            "path": {
+        "l": "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources",
+        "n": "ExampleNestedResources",
+        "p": {
+            "n": "ExampleNestedResources",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleNestedResources/ExampleNestedResources.bundle",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle"
-        }
+            "r": true,
+            "t": "com.apple.product-type.bundle"
+        },
+        "s": false
     },
     "//iOSApp/Resources/ExampleResources:ExampleResources ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleResources",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "b": {
             "PRODUCT_BUNDLE_IDENTIFIER": "com.example.resources"
         },
-        "configuration": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-        "dependencies": [
+        "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+        "d": [
             "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "iOSApp/Resources/ExampleResources/Assets.xcassets",
                 {
                     "_": "iOSApp/Resources/ExampleResources/nested",
@@ -3838,42 +3725,40 @@
                 }
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Resources/ExampleResources:ExampleResources",
-        "name": "ExampleResources",
-        "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleResources",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": true,
-            "name": "ExampleResources",
-            "path": {
+        "l": "//iOSApp/Resources/ExampleResources:ExampleResources",
+        "n": "ExampleResources",
+        "p": {
+            "n": "ExampleResources",
+            "p": {
                 "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Resources/ExampleResources/ExampleResources.bundle",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle"
+            "r": true,
+            "t": "com.apple.product-type.bundle"
         },
-        "resource_bundle_dependencies": [
+        "r": [
             "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
-        ]
+        ],
+        "s": false
     },
     "//iOSApp/Resources/ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleResources",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "PRODUCT_BUNDLE_IDENTIFIER": "com.example.resources"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "d": [
             "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "iOSApp/Resources/ExampleResources/Assets.xcassets",
                 {
                     "_": "iOSApp/Resources/ExampleResources/nested",
@@ -3888,39 +3773,37 @@
                 }
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Resources/ExampleResources:ExampleResources",
-        "name": "ExampleResources",
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleResources",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": true,
-            "name": "ExampleResources",
-            "path": {
+        "l": "//iOSApp/Resources/ExampleResources:ExampleResources",
+        "n": "ExampleResources",
+        "p": {
+            "n": "ExampleResources",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/ExampleResources/ExampleResources.bundle",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle"
+            "r": true,
+            "t": "com.apple.product-type.bundle"
         },
-        "resource_bundle_dependencies": [
+        "r": [
             "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ]
+        ],
+        "s": false
     },
     "//iOSApp/Resources/OnlyStructuredResources:OnlyStructuredResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/OnlyStructuredResources",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "PRODUCT_BUNDLE_IDENTIFIER": "com.example.only_structured_resources"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "resources": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "i": {
+            "r": [
                 {
                     "_": "iOSApp/Resources/OnlyStructuredResources/Nested",
                     "f": true,
@@ -3928,31 +3811,29 @@
                 }
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Resources/OnlyStructuredResources:OnlyStructuredResources",
-        "name": "OnlyStructuredResources",
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/OnlyStructuredResources",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": true,
-            "name": "OnlyStructuredResources",
-            "path": {
+        "l": "//iOSApp/Resources/OnlyStructuredResources:OnlyStructuredResources",
+        "n": "OnlyStructuredResources",
+        "p": {
+            "n": "OnlyStructuredResources",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Resources/OnlyStructuredResources/OnlyStructuredResources.bundle",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle"
-        }
+            "r": true,
+            "t": "com.apple.product-type.bundle"
+        },
+        "s": false
     },
     "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -3992,40 +3873,37 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-        "dependencies": [
+        "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+        "d": [
             "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m"
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer",
-        "name": "MixedAnswer",
-        "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "MixedAnswer",
-            "path": {
+        "l": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer",
+        "n": "MixedAnswer",
+        "p": {
+            "n": "MixedAnswer",
+            "p": {
                 "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -4069,40 +3947,37 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "d": [
             "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.m"
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer",
-        "name": "MixedAnswer",
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "MixedAnswer",
-            "path": {
+        "l": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer",
+        "n": "MixedAnswer",
+        "p": {
+            "n": "MixedAnswer",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswer.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -4113,15 +3988,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-        "inputs": {
-            "srcs": [
+        "c": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+        "i": {
+            "s": [
                 "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swift"
             ]
         },
-        "label": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift",
-        "name": "MixedAnswerLib_Swift",
-        "outputs": {
+        "l": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift",
+        "n": "MixedAnswerLib_Swift",
+        "o": {
             "s": {
                 "h": {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
@@ -4133,28 +4008,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "MixedAnswerLib_Swift",
-            "path": {
+        "p": {
+            "n": "MixedAnswerLib_Swift",
+            "p": {
                 "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -4165,15 +4037,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 "iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer.swift"
             ]
         },
-        "label": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift",
-        "name": "MixedAnswerLib_Swift",
-        "outputs": {
+        "l": "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswerLib_Swift",
+        "n": "MixedAnswerLib_Swift",
+        "o": {
             "s": {
                 "h": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/MixedAnswer-Swift.h",
@@ -4185,28 +4057,37 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "MixedAnswerLib_Swift",
-            "path": {
+        "p": {
+            "n": "MixedAnswerLib_Swift",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/CoreUtilsMixed/MixedAnswer/libMixedAnswerLib_Swift.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "3": {
+            "i": "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+            "n": "CoreUtilsObjC"
+        },
+        "4": {
+            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/FrameworkCoreUtilsObjC.64.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -4253,45 +4134,25 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-            "name": "CoreUtilsObjC"
-        },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "info_plist": {
-            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "hdrs": [
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "i": {
+            "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "pch": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
-            "srcs": [
+            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
+            "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/RealAnswer.h"
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/FrameworkCoreUtilsObjC.64.link.params",
-            "t": "g"
-        },
-        "name": "FrameworkCoreUtilsObjC",
-        "outputs": {
+        "l": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
+        "n": "FrameworkCoreUtilsObjC",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
                     "t": "g"
@@ -4301,19 +4162,38 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "CoreUtilsObjC",
-            "is_resource_bundle": false,
-            "name": "CoreUtilsObjC",
-            "path": {
+            "e": "CoreUtilsObjC",
+            "n": "CoreUtilsObjC",
+            "p": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "CoreUtilsObjC"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/FrameworkCoreUtilsObjC.5.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -4364,45 +4244,25 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//iOSApp/Source/CoreUtilsObjC:CoreUtilsObjC ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "CoreUtilsObjC"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/rules_xcodeproj/FrameworkCoreUtilsObjC/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "hdrs": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "i": {
+            "h": [
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h"
             ],
-            "pch": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
-            "srcs": [
+            "p": "iOSApp/Source/CoreUtilsObjC/CoreUtils/CoreUtils.pch",
+            "s": [
                 "iOSApp/Source/CoreUtilsObjC/Answers.mm",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/Answers.h",
                 "iOSApp/Source/CoreUtilsObjC/CoreUtils/RealAnswer.h"
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/FrameworkCoreUtilsObjC.5.link.params",
-            "t": "g"
-        },
-        "name": "FrameworkCoreUtilsObjC",
-        "outputs": {
+        "l": "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC",
+        "n": "FrameworkCoreUtilsObjC",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
                     "t": "g"
@@ -4412,19 +4272,26 @@
                     "t": "g"
                 }
             ],
-            "executable_name": "CoreUtilsObjC",
-            "is_resource_bundle": false,
-            "name": "CoreUtilsObjC",
-            "path": {
+            "e": "CoreUtilsObjC",
+            "n": "CoreUtilsObjC",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/CoreUtilsObjC.framework",
                 "t": "g"
             },
-            "type": "com.apple.product-type.framework"
-        }
+            "t": "com.apple.product-type.framework"
+        },
+        "s": false
     },
     "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/Utils",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -4474,44 +4341,73 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "d": [
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-7",
             "@FXPageControl//:FXPageControl ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "iOSApp/Source/Utils/Foo.m"
             ]
         },
-        "is_swift": false,
-        "label": "//iOSApp/Source/Utils:Utils",
-        "name": "Utils",
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/Utils",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "Utils",
-            "path": {
+        "l": "//iOSApp/Source/Utils:Utils",
+        "n": "Utils",
+        "p": {
+            "n": "Utils",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/Utils/libUtils.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "//iOSApp/Source:iOSApp applebin_ios-ios_arm64-dbg-STABLE-8",
     {
-        "app_clips": [
+        "1": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphoneos"
+        },
+        "3": {
+            "i": "//iOSApp/Source:iOSApp.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
+            "n": "iOSApp.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/frameworks/UIFramework.iOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/frameworks/LibFramework.iOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOSApp.72.link.params",
+            "t": "g"
+        },
+        "a": [
             "//AppClip:AppClip applebin_ios-ios_arm64-dbg-STABLE-8"
         ],
-        "build_settings": {
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -4531,12 +4427,8 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//iOSApp/Source:iOSApp.library ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
-            "name": "iOSApp.library"
-        },
-        "configuration": "applebin_ios-ios_arm64-dbg-STABLE-8",
-        "dependencies": [
+        "c": "applebin_ios-ios_arm64-dbg-STABLE-8",
+        "d": [
             "//AppClip:AppClip applebin_ios-ios_arm64-dbg-STABLE-8",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-8",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-dbg-STABLE-8",
@@ -4546,17 +4438,12 @@
             "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_arm64-dbg-STABLE-8"
         ],
-        "extensions": [
+        "e": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_arm64-dbg-STABLE-8"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "entitlements": "iOSApp/Source/ios app.entitlements",
-            "resources": [
+        "i": {
+            "e": "iOSApp/Source/ios app.entitlements",
+            "r": [
                 "iOSApp/Source/PreviewContent/Preview Assets.xcassets",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@2x.png",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@3x.png",
@@ -4580,37 +4467,14 @@
                 "iOSApp/Source/en.lproj/unprocessed.json",
                 "iOSApp/Source/es.lproj/unprocessed.json"
             ],
-            "srcs": [
+            "s": [
                 "iOSApp/Source/iOSApp.swift"
             ]
         },
-        "label": "//iOSApp/Source:iOSApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOSApp.72.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_armv7/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/UI/frameworks/UIFramework.iOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/Lib/frameworks/LibFramework.iOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "iOSApp",
-        "outputs": {
+        "l": "//iOSApp/Source:iOSApp",
+        "m": true,
+        "n": "iOSApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -4619,41 +4483,72 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphoneos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4/bin/iOSApp/Source/libiOSApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "iOSApp_ExecutableName",
-            "is_resource_bundle": false,
-            "name": "iOSApp",
-            "path": {
+            "e": "iOSApp_ExecutableName",
+            "n": "iOSApp",
+            "p": {
                 "_": "applebin_ios-ios_arm64-dbg-STABLE-8/bin/iOSApp/Source/iOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         },
-        "resource_bundle_dependencies": [
+        "r": [
             "//iOSApp/Resources/ExampleResources:ExampleResources ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4",
             "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-arm64-min15.0-applebin_ios-ios_arm64-dbg-STABLE-4"
         ],
-        "watch_application": "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-STABLE-12"
+        "w": "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-STABLE-12"
     },
     "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
     {
-        "app_clips": [
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "iOSApp.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/frameworks/UIFramework.iOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/frameworks/LibFramework.iOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOSApp.13.link.params",
+            "t": "g"
+        },
+        "a": [
             "//AppClip:AppClip applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "build_settings": {
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -4672,12 +4567,8 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//iOSApp/Source:iOSApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "iOSApp.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//AppClip:AppClip applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-7",
@@ -4687,17 +4578,12 @@
             "//iOSApp/Source/CoreUtilsMixed/MixedAnswer:MixedAnswer ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Source/CoreUtilsObjC:FrameworkCoreUtilsObjC applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "extensions": [
+        "e": [
             "//WidgetExtension:WidgetExtension applebin_ios-ios_x86_64-dbg-STABLE-7"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/rules_xcodeproj/iOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "entitlements": "iOSApp/Source/ios app.entitlements",
-            "resources": [
+        "i": {
+            "e": "iOSApp/Source/ios app.entitlements",
+            "r": [
                 "iOSApp/Source/PreviewContent/Preview Assets.xcassets",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@2x.png",
                 "iOSApp/Source/AltIcons/AltIcon-60.alticon/AltIcon-60@3x.png",
@@ -4721,17 +4607,62 @@
                 "iOSApp/Source/en.lproj/unprocessed.json",
                 "iOSApp/Source/es.lproj/unprocessed.json"
             ],
-            "srcs": [
+            "s": [
                 "iOSApp/Source/iOSApp.swift"
             ]
         },
-        "label": "//iOSApp/Source:iOSApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOSApp.13.link.params",
+        "l": "//iOSApp/Source:iOSApp",
+        "m": true,
+        "n": "iOSApp",
+        "o": {
+            "p": true,
+            "s": {
+                "m": {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/iOSApp.swiftmodule",
+                    "t": "g"
+                }
+            }
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/libiOSApp.library.a",
+                    "t": "g"
+                }
+            ],
+            "e": "iOSApp_ExecutableName",
+            "n": "iOSApp",
+            "p": {
+                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/iOSApp.app",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.application"
+        },
+        "r": [
+            "//iOSApp/Resources/ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
+        ],
+        "w": "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11"
+    },
+    "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
+    {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "iOSAppObjCUnitTests.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/rules_xcodeproj/iOSAppObjCUnitTests.__internal__.__test_bundle/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
                     "t": "e"
@@ -4750,48 +4681,11 @@
                 }
             ]
         },
-        "name": "iOSApp",
-        "outputs": {
-            "p": true,
-            "s": {
-                "m": {
-                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/iOSApp.swiftmodule",
-                    "t": "g"
-                }
-            }
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOSAppObjCUnitTests.__internal__.__test_bundle.24.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Source/libiOSApp.library.a",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "iOSApp_ExecutableName",
-            "is_resource_bundle": false,
-            "name": "iOSApp",
-            "path": {
-                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/iOSApp.app",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.application"
-        },
-        "resource_bundle_dependencies": [
-            "//iOSApp/Resources/ExampleResources:ExampleResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "//iOSApp/Resources/ExampleNestedResources:ExampleNestedResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
-        "watch_application": "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11"
-    },
-    "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
-    {
-        "build_settings": {
+        "b": {
             "CLANG_ENABLE_MODULES": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -4859,23 +4753,16 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
-        "compile_target": {
-            "id": "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "iOSAppObjCUnitTests.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/rules_xcodeproj/iOSAppObjCUnitTests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "i": {
+            "r": [
                 {
                     "_": "examples_ios_app_external/bundles/Utils.bundle",
                     "f": true,
@@ -4883,19 +4770,55 @@
                     "t": "e"
                 }
             ],
-            "srcs": [
+            "s": [
                 "iOSApp/Test/ObjCUnitTests/ObjCUnitTests.m"
             ]
         },
-        "is_swift": false,
-        "is_testonly": true,
-        "label": "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOSAppObjCUnitTests.__internal__.__test_bundle.24.link.params",
+        "l": "//iOSApp/Test/ObjCUnitTests:iOSAppObjCUnitTests.__internal__.__test_bundle",
+        "n": "iOSAppObjCUnitTests.__internal__.__test_bundle",
+        "o": {
+            "p": true
+        },
+        "p": {
+            "a": [
+                {
+                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/ObjCUnitTests/libiOSAppObjCUnitTests.library.a",
+                    "t": "g"
+                }
+            ],
+            "e": "iOSAppObjCUnitTests",
+            "n": "iOSAppObjCUnitTests",
+            "p": {
+                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
+                "t": "g"
+            },
+            "t": "com.apple.product-type.bundle.unit-test"
+        },
+        "r": [
+            "//iOSApp/Resources/OnlyStructuredResources:OnlyStructuredResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
+        ],
+        "s": false,
+        "t": true
+    },
+    "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
+    {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "iOSAppSwiftUnitTests.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/rules_xcodeproj/iOSAppSwiftUnitTests.__internal__.__test_bundle/Info.plist",
             "t": "g"
         },
-        "linker_inputs": {
-            "dynamic_frameworks": [
+        "5": {
+            "d": [
                 {
                     "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
                     "t": "e"
@@ -4914,41 +4837,11 @@
                 }
             ]
         },
-        "name": "iOSAppObjCUnitTests.__internal__.__test_bundle",
-        "outputs": {
-            "p": true
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOSAppSwiftUnitTests.__internal__.__test_bundle.27.link.params",
+            "t": "g"
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
-                {
-                    "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/ObjCUnitTests/libiOSAppObjCUnitTests.library.a",
-                    "t": "g"
-                }
-            ],
-            "executable_name": "iOSAppObjCUnitTests",
-            "is_resource_bundle": false,
-            "name": "iOSAppObjCUnitTests",
-            "path": {
-                "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/ObjCUnitTests/iOSAppObjCUnitTests.xctest",
-                "t": "g"
-            },
-            "type": "com.apple.product-type.bundle.unit-test"
-        },
-        "resource_bundle_dependencies": [
-            "//iOSApp/Resources/OnlyStructuredResources:OnlyStructuredResources ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
-        ],
-        "test_host": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7"
-    },
-    "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
-    {
-        "build_settings": {
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -4966,24 +4859,16 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1,2"
         },
-        "compile_target": {
-            "id": "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "iOSAppSwiftUnitTests.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-7",
-        "dependencies": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "d": [
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
             "//iOSApp/Source/Utils:Utils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
             "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/rules_xcodeproj/iOSAppSwiftUnitTests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "h": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7",
+        "i": {
+            "r": [
                 "iOSApp/Resources/ExampleResources/Assets.xcassets",
                 {
                     "_": "examples_ios_app_external/bundles/Utils.bundle",
@@ -4992,38 +4877,14 @@
                     "t": "e"
                 }
             ],
-            "srcs": [
+            "s": [
                 "iOSApp/Test/SwiftUnitTests/SwiftUnitTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/iOSAppSwiftUnitTests.__internal__.__test_bundle.27.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/ios-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Source/CoreUtilsObjC/frameworks/CoreUtilsObjC.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/UI/frameworks/UIFramework.iOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/Lib/frameworks/LibFramework.iOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "iOSAppSwiftUnitTests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle",
+        "m": true,
+        "n": "iOSAppSwiftUnitTests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5032,34 +4893,33 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/SwiftUnitTests/libiOSAppSwiftUnitTests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "iOSAppSwiftUnitTests",
-            "is_resource_bundle": false,
-            "name": "iOSAppSwiftUnitTests",
-            "path": {
+            "e": "iOSAppSwiftUnitTests",
+            "n": "iOSAppSwiftUnitTests",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-7/bin/iOSApp/Test/SwiftUnitTests/iOSAppSwiftUnitTests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.unit-test"
+            "t": "com.apple.product-type.bundle.unit-test"
         },
-        "test_host": "//iOSApp/Source:iOSApp applebin_ios-ios_x86_64-dbg-STABLE-7"
+        "t": true
     },
     "//iOSApp/Test/TestingUtils:TestingUtils ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -5070,19 +4930,18 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/TestingUtils.swift",
                     "t": "g"
                 }
             ]
         },
-        "is_testonly": true,
-        "label": "//iOSApp/Test/TestingUtils:TestingUtils",
-        "name": "TestingUtils",
-        "outputs": {
+        "l": "//iOSApp/Test/TestingUtils:TestingUtils",
+        "n": "TestingUtils",
+        "o": {
             "s": {
                 "h": {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/SwiftAPI/TestingUtils-Swift.h",
@@ -5094,28 +4953,43 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "TestingUtils",
-            "path": {
+        "p": {
+            "n": "TestingUtils",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/iOSApp/Test/TestingUtils/libTestingUtils.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "t": true
     },
     "//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-dbg-STABLE-16",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//macOSApp/Source:macOSApp.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15",
+            "n": "macOSApp.library"
+        },
+        "4": {
+            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source/rules_xcodeproj/macOSApp/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                "macOSApp/third_party/ExampleFramework.framework"
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/macOSApp.28.link.params",
+            "t": "g"
+        },
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -5133,38 +5007,21 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//macOSApp/Source:macOSApp.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15",
-            "name": "macOSApp.library"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-16",
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source/rules_xcodeproj/macOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-16",
+        "i": {
+            "r": [
                 "macOSApp/Source/PreviewContent/Preview Assets.xcassets",
                 "macOSApp/Source/Assets.xcassets"
             ],
-            "srcs": [
+            "s": [
                 "macOSApp/Source/ContentView.swift",
                 "macOSApp/Source/macOSApp.swift"
             ]
         },
-        "label": "//macOSApp/Source:macOSApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/macOSApp.28.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                "macOSApp/third_party/ExampleFramework.framework"
-            ]
-        },
-        "name": "macOSApp",
-        "outputs": {
+        "l": "//macOSApp/Source:macOSApp",
+        "m": true,
+        "n": "macOSApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5173,33 +5030,44 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15/bin/macOSApp/Source/libmacOSApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "macOSApp",
-            "is_resource_bundle": false,
-            "name": "macOSApp",
-            "path": {
+            "e": "macOSApp",
+            "n": "macOSApp",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Source/macOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         }
     },
     "//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-16",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//macOSApp/Test/UITests:macOSAppUITests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15",
+            "n": "macOSAppUITests.library"
+        },
+        "4": {
+            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests/rules_xcodeproj/macOSAppUITests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/macOSAppUITests.__internal__.__test_bundle.29.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -5216,32 +5084,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//macOSApp/Test/UITests:macOSAppUITests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15",
-            "name": "macOSAppUITests.library"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-16",
-        "dependencies": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-16",
+        "d": [
             "//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-dbg-STABLE-16"
         ],
-        "info_plist": {
-            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests/rules_xcodeproj/macOSAppUITests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "h": "//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-dbg-STABLE-16",
+        "i": {
+            "s": [
                 "macOSApp/Test/UITests/UITests.swift",
                 "macOSApp/Test/UITests/UITestsLaunchTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/macOSAppUITests.__internal__.__test_bundle.29.link.params",
-            "t": "g"
-        },
-        "name": "macOSAppUITests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//macOSApp/Test/UITests:macOSAppUITests.__internal__.__test_bundle",
+        "n": "macOSAppUITests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5250,34 +5106,61 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-15/bin/macOSApp/Test/UITests/libmacOSAppUITests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "macOSAppUITests",
-            "is_resource_bundle": false,
-            "name": "macOSAppUITests",
-            "path": {
+            "e": "macOSAppUITests",
+            "n": "macOSAppUITests",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITests/macOSAppUITests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.ui-testing"
+            "t": "com.apple.product-type.bundle.ui-testing"
         },
-        "test_host": "//macOSApp/Source:macOSApp applebin_macos-darwin_x86_64-dbg-STABLE-16"
+        "t": true
     },
     "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_arm64-dbg-STABLE-14",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source",
+        "2": {
+            "a": "arm64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvos"
+        },
+        "3": {
+            "i": "//tvOSApp/Source:tvOSApp.library tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
+            "n": "tvOSApp.library"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/frameworks/UIFramework.tvOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOSApp.79.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "DEVELOPMENT_TEAM": "V82V4GQZXM",
@@ -5295,52 +5178,24 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tvOSApp/Source:tvOSApp.library tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6",
-            "name": "tvOSApp.library"
-        },
-        "configuration": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_arm64-dbg-STABLE-14",
+        "d": [
             "//UI:UIFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14",
             "//UI:UIFramework.tvOS applebin_tvos-tvos_arm64-dbg-STABLE-14"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "tvOSApp/Resources/PreviewContent/Preview Assets.xcassets",
                 "tvOSApp/Resources/Assets.xcassets"
             ],
-            "srcs": [
+            "s": [
                 "tvOSApp/Source/tvOSApp.swift"
             ]
         },
-        "label": "//tvOSApp/Source:tvOSApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOSApp.79.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/frameworks/UIFramework.tvOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "tvOSApp",
-        "outputs": {
+        "l": "//tvOSApp/Source:tvOSApp",
+        "m": true,
+        "n": "tvOSApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5349,33 +5204,60 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source",
-        "platform": {
-            "arch": "arm64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "tvos-arm64-min15.0-applebin_tvos-tvos_arm64-dbg-STABLE-6/bin/tvOSApp/Source/libtvOSApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tvOSApp",
-            "is_resource_bundle": false,
-            "name": "tvOSApp",
-            "path": {
+            "e": "tvOSApp",
+            "n": "tvOSApp",
+            "p": {
                 "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source/tvOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         }
     },
     "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "3": {
+            "i": "//tvOSApp/Source:tvOSApp.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
+            "n": "tvOSApp.library"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/frameworks/UIFramework.tvOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOSApp.20.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -5392,52 +5274,24 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tvOSApp/Source:tvOSApp.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
-            "name": "tvOSApp.library"
-        },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
             "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13",
             "//UI:UIFramework.tvOS applebin_tvos-tvos_x86_64-dbg-STABLE-13"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "tvOSApp/Resources/PreviewContent/Preview Assets.xcassets",
                 "tvOSApp/Resources/Assets.xcassets"
             ],
-            "srcs": [
+            "s": [
                 "tvOSApp/Source/tvOSApp.swift"
             ]
         },
-        "label": "//tvOSApp/Source:tvOSApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOSApp.20.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/frameworks/UIFramework.tvOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "tvOSApp",
-        "outputs": {
+        "l": "//tvOSApp/Source:tvOSApp",
+        "m": true,
+        "n": "tvOSApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5446,33 +5300,44 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/tvOSApp/Source/libtvOSApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tvOSApp",
-            "is_resource_bundle": false,
-            "name": "tvOSApp",
-            "path": {
+            "e": "tvOSApp",
+            "n": "tvOSApp",
+            "p": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source/tvOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         }
     },
     "//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-STABLE-13",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "3": {
+            "i": "//tvOSApp/Test/UITests:tvOSAppUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
+            "n": "tvOSAppUITests.library"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests/rules_xcodeproj/tvOSAppUITests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOSAppUITests.__internal__.__test_bundle.30.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -5489,32 +5354,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tvOSApp/Test/UITests:tvOSAppUITests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
-            "name": "tvOSAppUITests.library"
-        },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
             "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13"
         ],
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests/rules_xcodeproj/tvOSAppUITests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "h": "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "i": {
+            "s": [
                 "tvOSApp/Test/UITests/UITests.swift",
                 "tvOSApp/Test/UITests/UITestsLaunchTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOSAppUITests.__internal__.__test_bundle.30.link.params",
-            "t": "g"
-        },
-        "name": "tvOSAppUITests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//tvOSApp/Test/UITests:tvOSAppUITests.__internal__.__test_bundle",
+        "n": "tvOSAppUITests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5523,34 +5376,61 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/tvOSApp/Test/UITests/libtvOSAppUITests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tvOSAppUITests",
-            "is_resource_bundle": false,
-            "name": "tvOSAppUITests",
-            "path": {
+            "e": "tvOSAppUITests",
+            "n": "tvOSAppUITests",
+            "p": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UITests/tvOSAppUITests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.ui-testing"
+            "t": "com.apple.product-type.bundle.ui-testing"
         },
-        "test_host": "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13"
+        "t": true
     },
     "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle applebin_tvos-tvos_x86_64-dbg-STABLE-13",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "tvos",
+            "v": "appletvsimulator"
+        },
+        "3": {
+            "i": "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
+            "n": "tvOSAppUnitTests.library"
+        },
+        "4": {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests/rules_xcodeproj/tvOSAppUnitTests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/frameworks/UIFramework.tvOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOSAppUnitTests.__internal__.__test_bundle.31.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -5567,49 +5447,21 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.library tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3",
-            "name": "tvOSAppUnitTests.library"
-        },
-        "configuration": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
-        "dependencies": [
+        "c": "applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "d": [
             "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13",
             "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests/rules_xcodeproj/tvOSAppUnitTests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "h": "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13",
+        "i": {
+            "s": [
                 "tvOSApp/Test/UnitTests/UnitTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/tvOSAppUnitTests.__internal__.__test_bundle.31.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/tvos-arm64_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/frameworks/UIFramework.tvOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/frameworks/LibFramework.tvOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "tvOSAppUnitTests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//tvOSApp/Test/UnitTests:tvOSAppUnitTests.__internal__.__test_bundle",
+        "m": true,
+        "n": "tvOSAppUnitTests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5618,34 +5470,45 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "tvos",
-            "variant": "appletvsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "tvos-x86_64-min15.0-applebin_tvos-tvos_x86_64-dbg-STABLE-3/bin/tvOSApp/Test/UnitTests/libtvOSAppUnitTests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tvOSAppUnitTests",
-            "is_resource_bundle": false,
-            "name": "tvOSAppUnitTests",
-            "path": {
+            "e": "tvOSAppUnitTests",
+            "n": "tvOSAppUnitTests",
+            "p": {
                 "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Test/UnitTests/tvOSAppUnitTests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.unit-test"
+            "t": "com.apple.product-type.bundle.unit-test"
         },
-        "test_host": "//tvOSApp/Source:tvOSApp applebin_tvos-tvos_x86_64-dbg-STABLE-13"
+        "t": true
     },
     "//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-9",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "3": {
+            "i": "//watchOSApp/Test/UITests:watchOSAppUITests.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
+            "n": "watchOSAppUITests.library"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests/rules_xcodeproj/watchOSAppUITests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOSAppUITests.__internal__.__test_bundle.32.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -5662,32 +5525,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//watchOSApp/Test/UITests:watchOSAppUITests.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
-            "name": "watchOSAppUITests.library"
-        },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
             "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests/rules_xcodeproj/watchOSAppUITests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "h": "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11",
+        "i": {
+            "s": [
                 "watchOSApp/Test/UITests/WatchOSAppUITests.swift",
                 "watchOSApp/Test/UITests/WatchOSAppUITestsLaunchTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOSAppUITests.__internal__.__test_bundle.32.link.params",
-            "t": "g"
-        },
-        "name": "watchOSAppUITests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//watchOSApp/Test/UITests:watchOSAppUITests.__internal__.__test_bundle",
+        "n": "watchOSAppUITests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5696,34 +5547,37 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/watchOSApp/Test/UITests/libwatchOSAppUITests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "watchOSAppUITests",
-            "is_resource_bundle": false,
-            "name": "watchOSAppUITests",
-            "path": {
+            "e": "watchOSAppUITests",
+            "n": "watchOSAppUITests",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSApp/Test/UITests/watchOSAppUITests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.ui-testing"
+            "t": "com.apple.product-type.bundle.ui-testing"
         },
-        "test_host": "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11"
+        "t": true
     },
     "//watchOSApp:watchOSApp applebin_watchos-watchos_arm64_32-dbg-STABLE-12",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp",
+        "2": {
+            "a": "arm64_32",
+            "m": "8.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist",
+            "t": "g"
+        },
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -5735,50 +5589,48 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12",
+        "d": [
             "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-STABLE-10"
         ],
-        "extensions": [
+        "e": [
             "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-STABLE-10"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "watchOSApp/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//watchOSApp:watchOSApp",
-        "name": "watchOSApp",
-        "outputs": {
+        "l": "//watchOSApp:watchOSApp",
+        "n": "watchOSApp",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "8.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": "watchOSApp",
-            "is_resource_bundle": false,
-            "name": "watchOSApp",
-            "path": {
+        "p": {
+            "e": "watchOSApp",
+            "n": "watchOSApp",
+            "p": {
                 "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-12/bin/watchOSApp/watchOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application.watchapp2"
-        }
+            "t": "com.apple.product-type.application.watchapp2"
+        },
+        "s": false
     },
     "//watchOSApp:watchOSApp applebin_watchos-watchos_x86_64-dbg-STABLE-11",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin/watchOSApp",
+        "2": {
+            "a": "x86_64",
+            "m": "8.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist",
+            "t": "g"
+        },
+        "b": {
             "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -5789,50 +5641,72 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-11",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-11",
+        "d": [
             "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "extensions": [
+        "e": [
             "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin/watchOSApp/rules_xcodeproj/watchOSApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "watchOSApp/Assets.xcassets"
             ]
         },
-        "is_swift": false,
-        "label": "//watchOSApp:watchOSApp",
-        "name": "watchOSApp",
-        "outputs": {
+        "l": "//watchOSApp:watchOSApp",
+        "n": "watchOSApp",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin/watchOSApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "8.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": "watchOSApp",
-            "is_resource_bundle": false,
-            "name": "watchOSApp",
-            "path": {
+        "p": {
+            "e": "watchOSApp",
+            "n": "watchOSApp",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-11/bin/watchOSApp/watchOSApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application.watchapp2"
-        }
+            "t": "com.apple.product-type.application.watchapp2"
+        },
+        "s": false
     },
     "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle applebin_watchos-watchos_x86_64-dbg-STABLE-9",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "3": {
+            "i": "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
+            "n": "watchOSAppExtensionUnitTests.library"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests/rules_xcodeproj/watchOSAppExtensionUnitTests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/frameworks/UIFramework.watchOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOSAppExtensionUnitTests.__internal__.__test_bundle.33.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -5849,49 +5723,20 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
-            "name": "watchOSAppExtensionUnitTests.library"
-        },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests/rules_xcodeproj/watchOSAppExtensionUnitTests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "watchOSAppExtension/Test/UnitTests/WatchOSAppExtensionTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOSAppExtensionUnitTests.__internal__.__test_bundle.33.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/frameworks/UIFramework.watchOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "watchOSAppExtensionUnitTests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//watchOSAppExtension/Test/UnitTests:watchOSAppExtensionUnitTests.__internal__.__test_bundle",
+        "m": true,
+        "n": "watchOSAppExtensionUnitTests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5900,33 +5745,61 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/watchOSAppExtension/Test/UnitTests/libwatchOSAppExtensionUnitTests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "watchOSAppExtensionUnitTests",
-            "is_resource_bundle": false,
-            "name": "watchOSAppExtensionUnitTests",
-            "path": {
+            "e": "watchOSAppExtensionUnitTests",
+            "n": "watchOSAppExtensionUnitTests",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/Test/UnitTests/watchOSAppExtensionUnitTests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.unit-test"
-        }
+            "t": "com.apple.product-type.bundle.unit-test"
+        },
+        "t": true
     },
     "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension",
+        "2": {
+            "a": "arm64_32",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchos"
+        },
+        "3": {
+            "i": "//watchOSAppExtension:watchOSAppExtension.library watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
+            "n": "watchOSAppExtension.library"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension/rules_xcodeproj/watchOSAppExtension/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/frameworks/UIFramework.watchOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/frameworks/LibFramework.watchOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOSAppExtension.70.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Automatic",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -5945,51 +5818,23 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//watchOSAppExtension:watchOSAppExtension.library watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5",
-            "name": "watchOSAppExtension.library"
-        },
-        "configuration": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
+        "d": [
             "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_arm64_32-dbg-STABLE-10"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension/rules_xcodeproj/watchOSAppExtension/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "watchOSAppExtension/Assets.xcassets"
             ],
-            "srcs": [
+            "s": [
                 "watchOSAppExtension/watchOSApp.swift"
             ]
         },
-        "label": "//watchOSAppExtension:watchOSAppExtension",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOSAppExtension.70.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_32_armv7k/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/UI/frameworks/UIFramework.watchOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/Lib/frameworks/LibFramework.watchOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "watchOSAppExtension",
-        "outputs": {
+        "l": "//watchOSAppExtension:watchOSAppExtension",
+        "m": true,
+        "n": "watchOSAppExtension",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -5998,33 +5843,60 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension",
-        "platform": {
-            "arch": "arm64_32",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchos"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "watchos-arm64_32-min7.0-applebin_watchos-watchos_arm64_32-dbg-STABLE-5/bin/watchOSAppExtension/libwatchOSAppExtension.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "watchOSAppExtension",
-            "is_resource_bundle": false,
-            "name": "watchOSAppExtension",
-            "path": {
+            "e": "watchOSAppExtension",
+            "n": "watchOSAppExtension",
+            "p": {
                 "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension/watchOSAppExtension.appex",
                 "t": "g"
             },
-            "type": "com.apple.product-type.watchkit2-extension"
+            "t": "com.apple.product-type.watchkit2-extension"
         }
     },
     "//watchOSAppExtension:watchOSAppExtension applebin_watchos-watchos_x86_64-dbg-STABLE-9",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension",
+        "2": {
+            "a": "x86_64",
+            "m": "7.0",
+            "o": "watchos",
+            "v": "watchsimulator"
+        },
+        "3": {
+            "i": "//watchOSAppExtension:watchOSAppExtension.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
+            "n": "watchOSAppExtension.library"
+        },
+        "4": {
+            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/rules_xcodeproj/watchOSAppExtension/Info.plist",
+            "t": "g"
+        },
+        "5": {
+            "d": [
+                {
+                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
+                    "t": "e"
+                },
+                {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/frameworks/UIFramework.watchOS.framework",
+                    "t": "g"
+                },
+                {
+                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
+                    "t": "g"
+                }
+            ]
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOSAppExtension.11.link.params",
+            "t": "g"
+        },
+        "b": {
             "APPLICATION_EXTENSION_API_ONLY": true,
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -6042,51 +5914,23 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//watchOSAppExtension:watchOSAppExtension.library watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2",
-            "name": "watchOSAppExtension.library"
-        },
-        "configuration": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
-        "dependencies": [
+        "c": "applebin_watchos-watchos_x86_64-dbg-STABLE-9",
+        "d": [
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9",
             "//UI:UIFramework.watchOS applebin_watchos-watchos_x86_64-dbg-STABLE-9"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/rules_xcodeproj/watchOSAppExtension/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "resources": [
+        "i": {
+            "r": [
                 "watchOSAppExtension/Assets.xcassets"
             ],
-            "srcs": [
+            "s": [
                 "watchOSAppExtension/watchOSApp.swift"
             ]
         },
-        "label": "//watchOSAppExtension:watchOSAppExtension",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/watchOSAppExtension.11.link.params",
-            "t": "g"
-        },
-        "linker_inputs": {
-            "dynamic_frameworks": [
-                {
-                    "_": "com_github_krzyzanowskim_cryptoswift/CryptoSwift.xcframework/watchos-arm64_i386_x86_64-simulator/CryptoSwift.framework",
-                    "t": "e"
-                },
-                {
-                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/UI/frameworks/UIFramework.watchOS.framework",
-                    "t": "g"
-                },
-                {
-                    "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/Lib/frameworks/LibFramework.watchOS.framework",
-                    "t": "g"
-                }
-            ]
-        },
-        "name": "watchOSAppExtension",
-        "outputs": {
+        "l": "//watchOSAppExtension:watchOSAppExtension",
+        "m": true,
+        "n": "watchOSAppExtension",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -6095,33 +5939,32 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "7.0",
-            "os": "watchos",
-            "variant": "watchsimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "watchos-x86_64-min7.0-applebin_watchos-watchos_x86_64-dbg-STABLE-2/bin/watchOSAppExtension/libwatchOSAppExtension.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "watchOSAppExtension",
-            "is_resource_bundle": false,
-            "name": "watchOSAppExtension",
-            "path": {
+            "e": "watchOSAppExtension",
+            "n": "watchOSAppExtension",
+            "p": {
                 "_": "applebin_watchos-watchos_x86_64-dbg-STABLE-9/bin/watchOSAppExtension/watchOSAppExtension.appex",
                 "t": "g"
             },
-            "type": "com.apple.product-type.watchkit2-extension"
+            "t": "com.apple.product-type.watchkit2-extension"
         }
     },
     "@FXPageControl//:FXPageControl ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -6165,35 +6008,25 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "FXPageControl/FXPageControl/FXPageControl.m",
                     "t": "e"
                 }
             ]
         },
-        "is_swift": false,
-        "label": "@FXPageControl//:FXPageControl",
-        "name": "FXPageControl",
-        "package_bin_dir": "bazel-out/ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "FXPageControl",
-            "path": {
+        "l": "@FXPageControl//:FXPageControl",
+        "n": "FXPageControl",
+        "p": {
+            "n": "FXPageControl",
+            "p": {
                 "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/external/FXPageControl/libFXPageControl.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     }
 ]

--- a/examples/sanitizers/test/fixtures/bwb_targets_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_targets_spec.json
@@ -1,7 +1,26 @@
 [
     "//AddressSanitizerApp:AddressSanitizerApp applebin_ios-ios_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "AddressSanitizerApp.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/AddressSanitizerApp.0.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp/AddressSanitizerApp.ipa",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -20,29 +39,17 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "AddressSanitizerApp.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-2",
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-2",
+        "i": {
+            "s": [
                 "AddressSanitizerApp/AddressSanitizerApp.swift",
                 "AddressSanitizerApp/AddressSanitizerExamples.swift",
                 "AddressSanitizerApp/ContentView.swift"
             ]
         },
-        "label": "//AddressSanitizerApp:AddressSanitizerApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/AddressSanitizerApp.0.link.params",
-            "t": "g"
-        },
-        "name": "AddressSanitizerApp",
-        "outputs": {
+        "l": "//AddressSanitizerApp:AddressSanitizerApp",
+        "n": "AddressSanitizerApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -51,33 +58,44 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/AddressSanitizerApp/libAddressSanitizerApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "AddressSanitizerApp",
-            "is_resource_bundle": false,
-            "name": "AddressSanitizerApp",
-            "path": {
+            "e": "AddressSanitizerApp",
+            "n": "AddressSanitizerApp",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp/AddressSanitizerApp_archive-root/Payload/AddressSanitizerApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         }
     },
     "//ThreadSanitizerApp:ThreadSanitizerApp applebin_ios-ios_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//ThreadSanitizerApp:ThreadSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "ThreadSanitizerApp.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp/rules_xcodeproj/ThreadSanitizerApp/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/ThreadSanitizerApp.1.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp/ThreadSanitizerApp.ipa",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -96,29 +114,17 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//ThreadSanitizerApp:ThreadSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "ThreadSanitizerApp.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-2",
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp/rules_xcodeproj/ThreadSanitizerApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-2",
+        "i": {
+            "s": [
                 "ThreadSanitizerApp/ContentView.swift",
                 "ThreadSanitizerApp/ThreadSanitizerApp.swift",
                 "ThreadSanitizerApp/ThreadSanitizerExamples.swift"
             ]
         },
-        "label": "//ThreadSanitizerApp:ThreadSanitizerApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/ThreadSanitizerApp.1.link.params",
-            "t": "g"
-        },
-        "name": "ThreadSanitizerApp",
-        "outputs": {
+        "l": "//ThreadSanitizerApp:ThreadSanitizerApp",
+        "n": "ThreadSanitizerApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -127,33 +133,44 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/ThreadSanitizerApp/libThreadSanitizerApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "ThreadSanitizerApp",
-            "is_resource_bundle": false,
-            "name": "ThreadSanitizerApp",
-            "path": {
+            "e": "ThreadSanitizerApp",
+            "n": "ThreadSanitizerApp",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp/ThreadSanitizerApp_archive-root/Payload/ThreadSanitizerApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         }
     },
     "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp applebin_ios-ios_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/UndefinedBehaviorSanitizerApp",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "UndefinedBehaviorSanitizerApp.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/UndefinedBehaviorSanitizerApp/rules_xcodeproj/UndefinedBehaviorSanitizerApp/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UndefinedBehaviorSanitizerApp.2.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/UndefinedBehaviorSanitizerApp/UndefinedBehaviorSanitizerApp.ipa",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -200,54 +217,34 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "UndefinedBehaviorSanitizerApp.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-2",
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/UndefinedBehaviorSanitizerApp/rules_xcodeproj/UndefinedBehaviorSanitizerApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-2",
+        "i": {
+            "s": [
                 "UndefinedBehaviorSanitizerApp/Sources/AppDelegate.h",
                 "UndefinedBehaviorSanitizerApp/Sources/AppDelegate.m",
                 "UndefinedBehaviorSanitizerApp/Sources/main.m"
             ]
         },
-        "is_swift": false,
-        "label": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwb.generator-params/UndefinedBehaviorSanitizerApp.2.link.params",
-            "t": "g"
-        },
-        "name": "UndefinedBehaviorSanitizerApp",
-        "outputs": {
+        "l": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
+        "n": "UndefinedBehaviorSanitizerApp",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/UndefinedBehaviorSanitizerApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/UndefinedBehaviorSanitizerApp/libUndefinedBehaviorSanitizerApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "UndefinedBehaviorSanitizerApp",
-            "is_resource_bundle": false,
-            "name": "UndefinedBehaviorSanitizerApp",
-            "path": {
+            "e": "UndefinedBehaviorSanitizerApp",
+            "n": "UndefinedBehaviorSanitizerApp",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/UndefinedBehaviorSanitizerApp/UndefinedBehaviorSanitizerApp_archive-root/Payload/UndefinedBehaviorSanitizerApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
-        }
+            "t": "com.apple.product-type.application"
+        },
+        "s": false
     }
 ]

--- a/examples/sanitizers/test/fixtures/bwx_targets_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_targets_spec.json
@@ -1,7 +1,26 @@
 [
     "//AddressSanitizerApp:AddressSanitizerApp applebin_ios-ios_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "AddressSanitizerApp.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/AddressSanitizerApp.0.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -19,29 +38,17 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//AddressSanitizerApp:AddressSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "AddressSanitizerApp.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-2",
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp/rules_xcodeproj/AddressSanitizerApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-2",
+        "i": {
+            "s": [
                 "AddressSanitizerApp/AddressSanitizerApp.swift",
                 "AddressSanitizerApp/AddressSanitizerExamples.swift",
                 "AddressSanitizerApp/ContentView.swift"
             ]
         },
-        "label": "//AddressSanitizerApp:AddressSanitizerApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/AddressSanitizerApp.0.link.params",
-            "t": "g"
-        },
-        "name": "AddressSanitizerApp",
-        "outputs": {
+        "l": "//AddressSanitizerApp:AddressSanitizerApp",
+        "n": "AddressSanitizerApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -50,33 +57,44 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/AddressSanitizerApp/libAddressSanitizerApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "AddressSanitizerApp",
-            "is_resource_bundle": false,
-            "name": "AddressSanitizerApp",
-            "path": {
+            "e": "AddressSanitizerApp",
+            "n": "AddressSanitizerApp",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/AddressSanitizerApp/AddressSanitizerApp_archive-root/Payload/AddressSanitizerApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         }
     },
     "//ThreadSanitizerApp:ThreadSanitizerApp applebin_ios-ios_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//ThreadSanitizerApp:ThreadSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "ThreadSanitizerApp.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp/rules_xcodeproj/ThreadSanitizerApp/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/ThreadSanitizerApp.1.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -94,29 +112,17 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//ThreadSanitizerApp:ThreadSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "ThreadSanitizerApp.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-2",
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp/rules_xcodeproj/ThreadSanitizerApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-2",
+        "i": {
+            "s": [
                 "ThreadSanitizerApp/ContentView.swift",
                 "ThreadSanitizerApp/ThreadSanitizerApp.swift",
                 "ThreadSanitizerApp/ThreadSanitizerExamples.swift"
             ]
         },
-        "label": "//ThreadSanitizerApp:ThreadSanitizerApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/ThreadSanitizerApp.1.link.params",
-            "t": "g"
-        },
-        "name": "ThreadSanitizerApp",
-        "outputs": {
+        "l": "//ThreadSanitizerApp:ThreadSanitizerApp",
+        "n": "ThreadSanitizerApp",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -125,33 +131,44 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/ThreadSanitizerApp/libThreadSanitizerApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "ThreadSanitizerApp",
-            "is_resource_bundle": false,
-            "name": "ThreadSanitizerApp",
-            "path": {
+            "e": "ThreadSanitizerApp",
+            "n": "ThreadSanitizerApp",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/ThreadSanitizerApp/ThreadSanitizerApp_archive-root/Payload/ThreadSanitizerApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
+            "t": "com.apple.product-type.application"
         }
     },
     "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp applebin_ios-ios_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/UndefinedBehaviorSanitizerApp",
+        "2": {
+            "a": "x86_64",
+            "m": "15.0",
+            "o": "ios",
+            "v": "iphonesimulator"
+        },
+        "3": {
+            "i": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
+            "n": "UndefinedBehaviorSanitizerApp.library"
+        },
+        "4": {
+            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/UndefinedBehaviorSanitizerApp/rules_xcodeproj/UndefinedBehaviorSanitizerApp/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UndefinedBehaviorSanitizerApp.2.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -197,54 +214,34 @@
             "SWIFT_VERSION": "5.0",
             "TARGETED_DEVICE_FAMILY": "1"
         },
-        "compile_target": {
-            "id": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp.library ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1",
-            "name": "UndefinedBehaviorSanitizerApp.library"
-        },
-        "configuration": "applebin_ios-ios_x86_64-dbg-STABLE-2",
-        "info_plist": {
-            "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/UndefinedBehaviorSanitizerApp/rules_xcodeproj/UndefinedBehaviorSanitizerApp/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "c": "applebin_ios-ios_x86_64-dbg-STABLE-2",
+        "i": {
+            "s": [
                 "UndefinedBehaviorSanitizerApp/Sources/AppDelegate.h",
                 "UndefinedBehaviorSanitizerApp/Sources/AppDelegate.m",
                 "UndefinedBehaviorSanitizerApp/Sources/main.m"
             ]
         },
-        "is_swift": false,
-        "label": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/xcodeproj_bwx.generator-params/UndefinedBehaviorSanitizerApp.2.link.params",
-            "t": "g"
-        },
-        "name": "UndefinedBehaviorSanitizerApp",
-        "outputs": {
+        "l": "//UndefinedBehaviorSanitizerApp:UndefinedBehaviorSanitizerApp",
+        "n": "UndefinedBehaviorSanitizerApp",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_ios-ios_x86_64-dbg-STABLE-2/bin/UndefinedBehaviorSanitizerApp",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "15.0",
-            "os": "ios",
-            "variant": "iphonesimulator"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "ios-x86_64-min15.0-applebin_ios-ios_x86_64-dbg-STABLE-1/bin/UndefinedBehaviorSanitizerApp/libUndefinedBehaviorSanitizerApp.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "UndefinedBehaviorSanitizerApp",
-            "is_resource_bundle": false,
-            "name": "UndefinedBehaviorSanitizerApp",
-            "path": {
+            "e": "UndefinedBehaviorSanitizerApp",
+            "n": "UndefinedBehaviorSanitizerApp",
+            "p": {
                 "_": "applebin_ios-ios_x86_64-dbg-STABLE-2/bin/UndefinedBehaviorSanitizerApp/UndefinedBehaviorSanitizerApp_archive-root/Payload/UndefinedBehaviorSanitizerApp.app",
                 "t": "g"
             },
-            "type": "com.apple.product-type.application"
-        }
+            "t": "com.apple.product-type.application"
+        },
+        "s": false
     }
 ]

--- a/test/fixtures/generator/bwb_targets_spec.json
+++ b/test/fixtures/generator/bwb_targets_spec.json
@@ -1,7 +1,26 @@
 [
     "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//tools/generator/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+            "n": "tests.library"
+        },
+        "4": {
+            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwb.generator-params/tests.__internal__.__test_bundle.10.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test/tests.__internal__.__test_bundle.zip",
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
@@ -19,22 +38,13 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tools/generator/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-            "name": "tests.library"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
-        "dependencies": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
+        "d": [
             "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
             "@com_github_pointfreeco_swift_custom_dump//:CustomDump macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "tools/generator/test/AddTargetsTests.swift",
                 "tools/generator/test/Array+ExtensionsTests.swift",
                 "tools/generator/test/BazelLabel+TestExtensions.swift",
@@ -86,14 +96,10 @@
                 "tools/generator/test/XcodeSchemeTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//tools/generator/test:tests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwb.generator-params/tests.__internal__.__test_bundle.10.link.params",
-            "t": "g"
-        },
-        "name": "tests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//tools/generator/test:tests.__internal__.__test_bundle",
+        "m": true,
+        "n": "tests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -102,33 +108,37 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/test/libtests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tests",
-            "is_resource_bundle": false,
-            "name": "tests",
-            "path": {
+            "e": "tests",
+            "n": "tests",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.unit-test"
-        }
+            "t": "com.apple.product-type.bundle.unit-test"
+        },
+        "t": true
     },
     "//tools/generator:generator applebin_macos-darwin_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwb.generator-params/generator.7.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/rules_xcodeproj/generator/generator",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -137,42 +147,36 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
-        "dependencies": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
+        "d": [
             "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "is_swift": false,
-        "label": "//tools/generator:generator",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwb.generator-params/generator.7.link.params",
-            "t": "g"
-        },
-        "name": "generator",
-        "outputs": {
+        "l": "//tools/generator:generator",
+        "n": "generator",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": "generator",
-            "is_resource_bundle": false,
-            "name": "generator",
-            "path": {
+        "p": {
+            "e": "generator",
+            "n": "generator",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/rules_xcodeproj/generator/generator",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
-        }
+            "t": "com.apple.product-type.tool"
+        },
+        "s": false
     },
     "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -184,16 +188,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@com_github_apple_swift_collections//:OrderedCollections macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
             "@com_github_kylef_pathkit//:PathKit macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
             "@com_github_michaeleisel_zippyjson//:ZippyJSON macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
             "@com_github_tuist_xcodeproj//:XcodeProj macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "tools/generator/src/BuildSettingConditional.swift",
                 "tools/generator/src/DTO/BazelLabel.swift",
                 "tools/generator/src/DTO/BuildMode.swift",
@@ -266,9 +269,10 @@
                 "tools/generator/src/Logger.swift"
             ]
         },
-        "label": "//tools/generator:generator.library",
-        "name": "generator.library",
-        "outputs": {
+        "l": "//tools/generator:generator.library",
+        "m": true,
+        "n": "generator.library",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/generator.swiftmodule",
@@ -276,28 +280,33 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "generator.library",
-            "path": {
+        "p": {
+            "n": "generator.library",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/libgenerator.library.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/swiftc_stub",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//tools/swiftc_stub:swiftc_stub.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+            "n": "swiftc_stub.library"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwb.generator-params/swiftc.11.link.params",
+            "t": "g"
+        },
+        "b": {
             "BAZEL_OUTPUTS_PRODUCT": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/swiftc_stub/rules_xcodeproj/swiftc/swiftc",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -309,23 +318,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tools/swiftc_stub:swiftc_stub.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-            "name": "swiftc_stub.library"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
-        "inputs": {
-            "srcs": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
+        "i": {
+            "s": [
                 "tools/swiftc_stub/main.swift"
             ]
         },
-        "label": "//tools/swiftc_stub:swiftc",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwb.generator-params/swiftc.11.link.params",
-            "t": "g"
-        },
-        "name": "swiftc",
-        "outputs": {
+        "l": "//tools/swiftc_stub:swiftc",
+        "n": "swiftc",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -334,33 +335,32 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/swiftc_stub",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub/libswiftc_stub.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "swiftc",
-            "is_resource_bundle": false,
-            "name": "swiftc",
-            "path": {
+            "e": "swiftc",
+            "n": "swiftc",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/swiftc_stub/rules_xcodeproj/swiftc/swiftc",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
+            "t": "com.apple.product-type.tool"
         }
     },
     "@com_github_apple_swift_collections//:OrderedCollections macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -371,9 +371,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "com_github_apple_swift_collections/Sources/OrderedCollections/HashTable/_HashTable+Bucket.swift",
                     "t": "e"
@@ -576,9 +576,9 @@
                 }
             ]
         },
-        "label": "@com_github_apple_swift_collections//:OrderedCollections",
-        "name": "OrderedCollections",
-        "outputs": {
+        "l": "@com_github_apple_swift_collections//:OrderedCollections",
+        "n": "OrderedCollections",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule",
@@ -586,28 +586,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "OrderedCollections",
-            "path": {
+        "p": {
+            "n": "OrderedCollections",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "@com_github_kylef_pathkit//:PathKit macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -618,18 +615,18 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "com_github_kylef_pathkit/Sources/PathKit.swift",
                     "t": "e"
                 }
             ]
         },
-        "label": "@com_github_kylef_pathkit//:PathKit",
-        "name": "PathKit",
-        "outputs": {
+        "l": "@com_github_kylef_pathkit//:PathKit",
+        "n": "PathKit",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
@@ -637,28 +634,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "PathKit",
-            "path": {
+        "p": {
+            "n": "PathKit",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/libPathKit.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -705,9 +699,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/JJLISO8601DateFormatter.m",
                     "t": "e"
@@ -738,31 +732,28 @@
                 }
             ]
         },
-        "is_swift": false,
-        "label": "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter",
-        "name": "JJLISO8601DateFormatter",
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "JJLISO8601DateFormatter",
-            "path": {
+        "l": "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter",
+        "n": "JJLISO8601DateFormatter",
+        "p": {
+            "n": "JJLISO8601DateFormatter",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "@com_github_michaeleisel_zippyjson//:ZippyJSON macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -773,23 +764,23 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
             "@com_github_michaeleisel_zippyjsoncfamily//:ZippyJSONCFamily macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 {
                     "_": "com_github_michaeleisel_zippyjson/Sources/ZippyJSON/ZippyJSONDecoder.swift",
                     "t": "e"
                 }
             ]
         },
-        "label": "@com_github_michaeleisel_zippyjson//:ZippyJSON",
-        "name": "ZippyJSON",
-        "outputs": {
+        "l": "@com_github_michaeleisel_zippyjson//:ZippyJSON",
+        "m": true,
+        "n": "ZippyJSON",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftmodule",
@@ -797,28 +788,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "ZippyJSON",
-            "path": {
+        "p": {
+            "n": "ZippyJSON",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "@com_github_michaeleisel_zippyjsoncfamily//:ZippyJSONCFamily macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -867,9 +855,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/JSONSerialization.mm",
                     "t": "e"
@@ -888,31 +876,28 @@
                 }
             ]
         },
-        "is_swift": false,
-        "label": "@com_github_michaeleisel_zippyjsoncfamily//:ZippyJSONCFamily",
-        "name": "ZippyJSONCFamily",
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "ZippyJSONCFamily",
-            "path": {
+        "l": "@com_github_michaeleisel_zippyjsoncfamily//:ZippyJSONCFamily",
+        "n": "ZippyJSONCFamily",
+        "p": {
+            "n": "ZippyJSONCFamily",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "@com_github_pointfreeco_swift_custom_dump//:CustomDump macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -924,12 +909,12 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 {
                     "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreImage.swift",
                     "t": "e"
@@ -1032,9 +1017,9 @@
                 }
             ]
         },
-        "label": "@com_github_pointfreeco_swift_custom_dump//:CustomDump",
-        "name": "CustomDump",
-        "outputs": {
+        "l": "@com_github_pointfreeco_swift_custom_dump//:CustomDump",
+        "n": "CustomDump",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule",
@@ -1042,28 +1027,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "CustomDump",
-            "path": {
+        "p": {
+            "n": "CustomDump",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1074,18 +1056,18 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "com_github_pointfreeco_xctest_dynamic_overlay/Sources/XCTestDynamicOverlay/XCTFail.swift",
                     "t": "e"
                 }
             ]
         },
-        "label": "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay",
-        "name": "XCTestDynamicOverlay",
-        "outputs": {
+        "l": "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay",
+        "n": "XCTestDynamicOverlay",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
@@ -1093,28 +1075,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "XCTestDynamicOverlay",
-            "path": {
+        "p": {
+            "n": "XCTestDynamicOverlay",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "@com_github_tuist_xcodeproj//:XcodeProj macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1126,12 +1105,12 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@com_github_kylef_pathkit//:PathKit macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 {
                     "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Errors/Errors.swift",
                     "t": "e"
@@ -1514,9 +1493,9 @@
                 }
             ]
         },
-        "label": "@com_github_tuist_xcodeproj//:XcodeProj",
-        "name": "XcodeProj",
-        "outputs": {
+        "l": "@com_github_tuist_xcodeproj//:XcodeProj",
+        "n": "XcodeProj",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
@@ -1524,23 +1503,13 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "XcodeProj",
-            "path": {
+        "p": {
+            "n": "XcodeProj",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     }
 ]

--- a/test/fixtures/generator/bwx_targets_spec.json
+++ b/test/fixtures/generator/bwx_targets_spec.json
@@ -1,7 +1,26 @@
 [
     "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//tools/generator/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+            "n": "tests.library"
+        },
+        "4": {
+            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
+            "t": "g"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwx.generator-params/tests.__internal__.__test_bundle.10.link.params",
+            "t": "g"
+        },
+        "b": {
             "CODE_SIGN_STYLE": "Manual",
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
@@ -18,22 +37,13 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tools/generator/test:tests.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-            "name": "tests.library"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
-        "dependencies": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
+        "d": [
             "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
             "@com_github_pointfreeco_swift_custom_dump//:CustomDump macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "info_plist": {
-            "_": "applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test/rules_xcodeproj/tests.__internal__.__test_bundle/Info.plist",
-            "t": "g"
-        },
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "tools/generator/test/AddTargetsTests.swift",
                 "tools/generator/test/Array+ExtensionsTests.swift",
                 "tools/generator/test/BazelLabel+TestExtensions.swift",
@@ -85,14 +95,10 @@
                 "tools/generator/test/XcodeSchemeTests.swift"
             ]
         },
-        "is_testonly": true,
-        "label": "//tools/generator/test:tests.__internal__.__test_bundle",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwx.generator-params/tests.__internal__.__test_bundle.10.link.params",
-            "t": "g"
-        },
-        "name": "tests.__internal__.__test_bundle",
-        "outputs": {
+        "l": "//tools/generator/test:tests.__internal__.__test_bundle",
+        "m": true,
+        "n": "tests.__internal__.__test_bundle",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -101,33 +107,37 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/test/libtests.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "tests",
-            "is_resource_bundle": false,
-            "name": "tests",
-            "path": {
+            "e": "tests",
+            "n": "tests",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/test/tests.__internal__.__test_bundle_archive-root/tests.xctest",
                 "t": "g"
             },
-            "type": "com.apple.product-type.bundle.unit-test"
-        }
+            "t": "com.apple.product-type.bundle.unit-test"
+        },
+        "t": true
     },
     "//tools/generator:generator applebin_macos-darwin_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwx.generator-params/generator.7.link.params",
+            "t": "g"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -135,42 +145,36 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
-        "dependencies": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
+        "d": [
             "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "is_swift": false,
-        "label": "//tools/generator:generator",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwx.generator-params/generator.7.link.params",
-            "t": "g"
-        },
-        "name": "generator",
-        "outputs": {
+        "l": "//tools/generator:generator",
+        "n": "generator",
+        "o": {
             "p": true
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": "generator",
-            "is_resource_bundle": false,
-            "name": "generator",
-            "path": {
+        "p": {
+            "e": "generator",
+            "n": "generator",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/generator/rules_xcodeproj/generator/generator",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
-        }
+            "t": "com.apple.product-type.tool"
+        },
+        "s": false
     },
     "//tools/generator:generator.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -182,16 +186,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@com_github_apple_swift_collections//:OrderedCollections macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
             "@com_github_kylef_pathkit//:PathKit macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
             "@com_github_michaeleisel_zippyjson//:ZippyJSON macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
             "@com_github_tuist_xcodeproj//:XcodeProj macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 "tools/generator/src/BuildSettingConditional.swift",
                 "tools/generator/src/DTO/BazelLabel.swift",
                 "tools/generator/src/DTO/BuildMode.swift",
@@ -264,9 +267,10 @@
                 "tools/generator/src/Logger.swift"
             ]
         },
-        "label": "//tools/generator:generator.library",
-        "name": "generator.library",
-        "outputs": {
+        "l": "//tools/generator:generator.library",
+        "m": true,
+        "n": "generator.library",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/generator.swiftmodule",
@@ -274,28 +278,33 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "generator.library",
-            "path": {
+        "p": {
+            "n": "generator.library",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/generator/libgenerator.library.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "//tools/swiftc_stub:swiftc applebin_macos-darwin_x86_64-dbg-STABLE-2",
     {
-        "build_settings": {
+        "1": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/swiftc_stub",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "3": {
+            "i": "//tools/swiftc_stub:swiftc_stub.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+            "n": "swiftc_stub.library"
+        },
+        "6": {
+            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwx.generator-params/swiftc.11.link.params",
+            "t": "g"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -306,23 +315,15 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "compile_target": {
-            "id": "//tools/swiftc_stub:swiftc_stub.library macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-            "name": "swiftc_stub.library"
-        },
-        "configuration": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
-        "inputs": {
-            "srcs": [
+        "c": "applebin_macos-darwin_x86_64-dbg-STABLE-2",
+        "i": {
+            "s": [
                 "tools/swiftc_stub/main.swift"
             ]
         },
-        "label": "//tools/swiftc_stub:swiftc",
-        "link_params": {
-            "_": "darwin_x86_64-dbg-STABLE-0/bin/test/fixtures/generator/xcodeproj_bwx.generator-params/swiftc.11.link.params",
-            "t": "g"
-        },
-        "name": "swiftc",
-        "outputs": {
+        "l": "//tools/swiftc_stub:swiftc",
+        "n": "swiftc",
+        "o": {
             "p": true,
             "s": {
                 "m": {
@@ -331,33 +332,32 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/swiftc_stub",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [
+        "p": {
+            "a": [
                 {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/tools/swiftc_stub/libswiftc_stub.library.a",
                     "t": "g"
                 }
             ],
-            "executable_name": "swiftc",
-            "is_resource_bundle": false,
-            "name": "swiftc",
-            "path": {
+            "e": "swiftc",
+            "n": "swiftc",
+            "p": {
                 "_": "applebin_macos-darwin_x86_64-dbg-STABLE-2/bin/tools/swiftc_stub/rules_xcodeproj/swiftc/swiftc",
                 "t": "g"
             },
-            "type": "com.apple.product-type.tool"
+            "t": "com.apple.product-type.tool"
         }
     },
     "@com_github_apple_swift_collections//:OrderedCollections macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -368,9 +368,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "com_github_apple_swift_collections/Sources/OrderedCollections/HashTable/_HashTable+Bucket.swift",
                     "t": "e"
@@ -573,9 +573,9 @@
                 }
             ]
         },
-        "label": "@com_github_apple_swift_collections//:OrderedCollections",
-        "name": "OrderedCollections",
-        "outputs": {
+        "l": "@com_github_apple_swift_collections//:OrderedCollections",
+        "n": "OrderedCollections",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/OrderedCollections.swiftmodule",
@@ -583,28 +583,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "OrderedCollections",
-            "path": {
+        "p": {
+            "n": "OrderedCollections",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_apple_swift_collections/libOrderedCollections.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "@com_github_kylef_pathkit//:PathKit macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -615,18 +612,18 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "com_github_kylef_pathkit/Sources/PathKit.swift",
                     "t": "e"
                 }
             ]
         },
-        "label": "@com_github_kylef_pathkit//:PathKit",
-        "name": "PathKit",
-        "outputs": {
+        "l": "@com_github_kylef_pathkit//:PathKit",
+        "n": "PathKit",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/PathKit.swiftmodule",
@@ -634,28 +631,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "PathKit",
-            "path": {
+        "p": {
+            "n": "PathKit",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_kylef_pathkit/libPathKit.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -702,9 +696,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "com_github_michaeleisel_jjliso8601dateformatter/Sources/JJLISO8601DateFormatter/JJLISO8601DateFormatter.m",
                     "t": "e"
@@ -735,31 +729,28 @@
                 }
             ]
         },
-        "is_swift": false,
-        "label": "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter",
-        "name": "JJLISO8601DateFormatter",
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "JJLISO8601DateFormatter",
-            "path": {
+        "l": "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter",
+        "n": "JJLISO8601DateFormatter",
+        "p": {
+            "n": "JJLISO8601DateFormatter",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_jjliso8601dateformatter/libJJLISO8601DateFormatter.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "@com_github_michaeleisel_zippyjson//:ZippyJSON macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -770,23 +761,23 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@com_github_michaeleisel_jjliso8601dateformatter//:JJLISO8601DateFormatter macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
             "@com_github_michaeleisel_zippyjsoncfamily//:ZippyJSONCFamily macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "has_modulemaps": true,
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 {
                     "_": "com_github_michaeleisel_zippyjson/Sources/ZippyJSON/ZippyJSONDecoder.swift",
                     "t": "e"
                 }
             ]
         },
-        "label": "@com_github_michaeleisel_zippyjson//:ZippyJSON",
-        "name": "ZippyJSON",
-        "outputs": {
+        "l": "@com_github_michaeleisel_zippyjson//:ZippyJSON",
+        "m": true,
+        "n": "ZippyJSON",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/ZippyJSON.swiftmodule",
@@ -794,28 +785,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "ZippyJSON",
-            "path": {
+        "p": {
+            "n": "ZippyJSON",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjson/libZippyJSON.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "@com_github_michaeleisel_zippyjsoncfamily//:ZippyJSONCFamily macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -864,9 +852,9 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "com_github_michaeleisel_zippyjsoncfamily/Sources/ZippyJSONCFamily/JSONSerialization.mm",
                     "t": "e"
@@ -885,31 +873,28 @@
                 }
             ]
         },
-        "is_swift": false,
-        "label": "@com_github_michaeleisel_zippyjsoncfamily//:ZippyJSONCFamily",
-        "name": "ZippyJSONCFamily",
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "ZippyJSONCFamily",
-            "path": {
+        "l": "@com_github_michaeleisel_zippyjsoncfamily//:ZippyJSONCFamily",
+        "n": "ZippyJSONCFamily",
+        "p": {
+            "n": "ZippyJSONCFamily",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_michaeleisel_zippyjsoncfamily/libZippyJSONCFamily.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
-        }
+            "t": "com.apple.product-type.library.static"
+        },
+        "s": false
     },
     "@com_github_pointfreeco_swift_custom_dump//:CustomDump macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -921,12 +906,12 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 {
                     "_": "com_github_pointfreeco_swift_custom_dump/Sources/CustomDump/Conformances/CoreImage.swift",
                     "t": "e"
@@ -1029,9 +1014,9 @@
                 }
             ]
         },
-        "label": "@com_github_pointfreeco_swift_custom_dump//:CustomDump",
-        "name": "CustomDump",
-        "outputs": {
+        "l": "@com_github_pointfreeco_swift_custom_dump//:CustomDump",
+        "n": "CustomDump",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump/CustomDump.swiftmodule",
@@ -1039,28 +1024,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "CustomDump",
-            "path": {
+        "p": {
+            "n": "CustomDump",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_swift_custom_dump/libCustomDump.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1071,18 +1053,18 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "inputs": {
-            "srcs": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "i": {
+            "s": [
                 {
                     "_": "com_github_pointfreeco_xctest_dynamic_overlay/Sources/XCTestDynamicOverlay/XCTFail.swift",
                     "t": "e"
                 }
             ]
         },
-        "label": "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay",
-        "name": "XCTestDynamicOverlay",
-        "outputs": {
+        "l": "@com_github_pointfreeco_xctest_dynamic_overlay//:XCTestDynamicOverlay",
+        "n": "XCTestDynamicOverlay",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/XCTestDynamicOverlay.swiftmodule",
@@ -1090,28 +1072,25 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "XCTestDynamicOverlay",
-            "path": {
+        "p": {
+            "n": "XCTestDynamicOverlay",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_pointfreeco_xctest_dynamic_overlay/libXCTestDynamicOverlay.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     },
     "@com_github_tuist_xcodeproj//:XcodeProj macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
     {
-        "build_settings": {
+        "1": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj",
+        "2": {
+            "a": "x86_64",
+            "m": "12.0",
+            "o": "macos",
+            "v": "macosx"
+        },
+        "b": {
             "DEBUG_INFORMATION_FORMAT": "dwarf",
             "ENABLE_BITCODE": false,
             "ENABLE_STRICT_OBJC_MSGSEND": true,
@@ -1123,12 +1102,12 @@
             "SWIFT_OPTIMIZATION_LEVEL": "-Onone",
             "SWIFT_VERSION": "5.0"
         },
-        "configuration": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
-        "dependencies": [
+        "c": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1",
+        "d": [
             "@com_github_kylef_pathkit//:PathKit macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1"
         ],
-        "inputs": {
-            "srcs": [
+        "i": {
+            "s": [
                 {
                     "_": "com_github_tuist_xcodeproj/Sources/XcodeProj/Errors/Errors.swift",
                     "t": "e"
@@ -1511,9 +1490,9 @@
                 }
             ]
         },
-        "label": "@com_github_tuist_xcodeproj//:XcodeProj",
-        "name": "XcodeProj",
-        "outputs": {
+        "l": "@com_github_tuist_xcodeproj//:XcodeProj",
+        "n": "XcodeProj",
+        "o": {
             "s": {
                 "m": {
                     "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/XcodeProj.swiftmodule",
@@ -1521,23 +1500,13 @@
                 }
             }
         },
-        "package_bin_dir": "bazel-out/macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj",
-        "platform": {
-            "arch": "x86_64",
-            "minimum_os_version": "12.0",
-            "os": "macos",
-            "variant": "macosx"
-        },
-        "product": {
-            "additional_paths": [],
-            "executable_name": null,
-            "is_resource_bundle": false,
-            "name": "XcodeProj",
-            "path": {
+        "p": {
+            "n": "XcodeProj",
+            "p": {
                 "_": "macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1/bin/external/com_github_tuist_xcodeproj/libXcodeProj.a",
                 "t": "g"
             },
-            "type": "com.apple.product-type.library.static"
+            "t": "com.apple.product-type.library.static"
         }
     }
 ]

--- a/test/internal/platform/platform_info_to_dto_tests.bzl
+++ b/test/internal/platform/platform_info_to_dto_tests.bzl
@@ -70,10 +70,10 @@ def platform_info_to_dto_test_suite(name):
         arch = "wild",
         minimum_os_version = "12.0",
         expected_platform_dict = {
-            "arch": "wild",
-            "minimum_os_version": "12.0",
-            "os": "tvos",
-            "variant": "appletvos",
+            "a": "wild",
+            "m": "12.0",
+            "o": "tvos",
+            "v": "appletvos",
         },
     )
 
@@ -85,10 +85,10 @@ def platform_info_to_dto_test_suite(name):
         arch = "arm64",
         minimum_os_version = "12.1",
         expected_platform_dict = {
-            "arch": "arm64",
-            "minimum_os_version": "12.1",
-            "os": "macos",
-            "variant": "macosx",
+            "a": "arm64",
+            "m": "12.1",
+            "o": "macos",
+            "v": "macosx",
         },
     )
 

--- a/tools/generator/src/DTO/Inputs.swift
+++ b/tools/generator/src/DTO/Inputs.swift
@@ -52,12 +52,12 @@ extension Inputs {
 
 extension Inputs: Decodable {
     enum CodingKeys: String, CodingKey {
-        case srcs
-        case nonArcSrcs
-        case hdrs
-        case pch
-        case resources
-        case entitlements
+        case srcs = "s"
+        case nonArcSrcs = "n"
+        case hdrs = "h"
+        case pch = "p"
+        case resources = "r"
+        case entitlements = "e"
     }
 
     init(from decoder: Decoder) throws {

--- a/tools/generator/src/DTO/LinkerInputs.swift
+++ b/tools/generator/src/DTO/LinkerInputs.swift
@@ -14,7 +14,7 @@ struct LinkerInputs: Equatable {
 
 extension LinkerInputs: Decodable {
     enum CodingKeys: String, CodingKey {
-        case dynamicFrameworks
+        case dynamicFrameworks = "d"
     }
 
     init(from decoder: Decoder) throws {

--- a/tools/generator/src/DTO/Platform.swift
+++ b/tools/generator/src/DTO/Platform.swift
@@ -1,4 +1,4 @@
-struct Platform: Equatable, Hashable, Decodable {
+struct Platform: Equatable, Hashable {
     enum OS: String, Decodable {
         case macOS = "macos"
         case iOS = "ios"
@@ -133,5 +133,26 @@ extension Platform.Variant: Comparable {
         case (.watchOSDevice, _): return true
         case (_, .watchOSDevice): return false
         }
+    }
+}
+
+// MARK: - Decodable
+
+extension Platform: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case os = "o"
+        case variant = "v"
+        case arch = "a"
+        case minimumOsVersion = "m"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        os = try container.decode(Platform.OS.self, forKey: .os)
+        variant = try container.decode(Platform.Variant.self, forKey: .variant)
+        arch = try container.decode(String.self, forKey: .arch)
+        minimumOsVersion = try container
+            .decode(SemanticVersion.self, forKey: .minimumOsVersion)
     }
 }

--- a/tools/generator/src/DTO/Product.swift
+++ b/tools/generator/src/DTO/Product.swift
@@ -1,7 +1,7 @@
 import PathKit
 import XcodeProj
 
-struct Product: Equatable, Decodable {
+struct Product: Equatable {
     let type: PBXProductType
     let isResourceBundle: Bool
     let name: String
@@ -24,5 +24,32 @@ struct Product: Equatable, Decodable {
         self.path = path
         self.additionalPaths = additionalPaths
         self.executableName = executableName
+    }
+}
+
+// MARK: - Decodable
+
+extension Product: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case type = "t"
+        case isResourceBundle = "r"
+        case name = "n"
+        case path = "p"
+        case additionalPaths = "a"
+        case executableName = "e"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        type = try container.decode(PBXProductType.self, forKey: .type)
+        isResourceBundle = try container
+            .decodeIfPresent(Bool.self, forKey: .isResourceBundle) ?? false
+        name = try container.decode(String.self, forKey: .name)
+        path = try container.decodeIfPresent(FilePath.self, forKey: .path)
+        additionalPaths = try container
+            .decodeIfPresent([FilePath].self, forKey: .additionalPaths) ?? []
+        executableName = try container
+            .decodeIfPresent(String.self, forKey: .executableName)
     }
 }

--- a/tools/generator/src/DTO/Target.swift
+++ b/tools/generator/src/DTO/Target.swift
@@ -27,7 +27,7 @@ struct Target: Equatable {
     var additionalSchemeTargets: Set<TargetID>
 }
 
-struct CompileTarget: Equatable, Decodable {
+struct CompileTarget: Equatable {
     let id: TargetID
     let name: String
 }
@@ -42,31 +42,30 @@ extension Target {
 
 extension Target: Decodable {
     enum CodingKeys: String, CodingKey {
-        case name
-        case label
-        case configuration
-        case compileTarget
-        case packageBinDir
-        case platform
-        case product
-        case isTestonly
-        case isSwift
-        case testHost
-        case buildSettings
-        case hasModulemaps
-        case inputs
-        case linkerInputs
-        case linkParams
-        case infoPlist
-        case entitlements
-        case resourceBundleDependencies
-        case watchApplication
-        case extensions
-        case appClips
-        case dependencies
-        case outputs
-        case isUnfocusedDependency
-        case additionalSchemeTargets
+        case name = "n"
+        case label = "l"
+        case configuration = "c"
+        case compileTarget = "3"
+        case packageBinDir = "1"
+        case platform = "2"
+        case product = "p"
+        case isTestonly = "t"
+        case isSwift = "s"
+        case testHost = "h"
+        case buildSettings = "b"
+        case hasModulemaps = "m"
+        case inputs = "i"
+        case linkerInputs = "5"
+        case linkParams = "6"
+        case infoPlist = "4"
+        case resourceBundleDependencies = "r"
+        case watchApplication = "w"
+        case extensions = "e"
+        case appClips = "a"
+        case dependencies = "d"
+        case outputs = "o"
+        case isUnfocusedDependency = "u"
+        case additionalSchemeTargets = "7"
     }
 
     init(from decoder: Decoder) throws {
@@ -117,6 +116,21 @@ extension Target: Decodable {
             .decodeTargetIDs(.additionalSchemeTargets)
     }
 }
+
+extension CompileTarget: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case id = "i"
+        case name = "n"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decode(TargetID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+    }
+}
+
 
 private extension KeyedDecodingContainer where K == Target.CodingKeys {
     func decodeFilePaths(_ key: K) throws -> [FilePath] {

--- a/xcodeproj/internal/platform.bzl
+++ b/xcodeproj/internal/platform.bzl
@@ -55,10 +55,10 @@ def _platform_to_dto(platform):
     platform_type = apple_platform.platform_type
 
     dto = {
-        "os": str(platform_type),
-        "variant": _PLATFORM_NAME[apple_platform],
-        "arch": platform._arch,
-        "minimum_os_version": platform._os_version,
+        "o": str(platform_type),
+        "v": _PLATFORM_NAME[apple_platform],
+        "a": platform._arch,
+        "m": platform._os_version,
     }
 
     return dto

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -847,7 +847,7 @@ def _outputs_to_dto(outputs):
     return dto
 
 def _product_to_dto(product):
-    dto =  {
+    dto = {
         "n": product.name,
         "t": product.type,
     }

--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -503,34 +503,34 @@ def _xcode_target_to_dto(
     inputs = xcode_target.inputs
 
     dto = {
-        "name": xcode_target.name,
-        "label": str(xcode_target.label),
-        "configuration": xcode_target.configuration,
-        "package_bin_dir": xcode_target._package_bin_dir,
-        "platform": platform_info.to_dto(xcode_target.platform),
-        "product": _product_to_dto(xcode_target.product),
+        "n": xcode_target.name,
+        "l": str(xcode_target.label),
+        "c": xcode_target.configuration,
+        "1": xcode_target._package_bin_dir,
+        "2": platform_info.to_dto(xcode_target.platform),
+        "p": _product_to_dto(xcode_target.product),
     }
 
     if xcode_target._compile_target:
-        dto["compile_target"] = {
-            "id": xcode_target._compile_target.id,
-            "name": xcode_target._compile_target.name,
+        dto["3"] = {
+            "i": xcode_target._compile_target.id,
+            "n": xcode_target._compile_target.name,
         }
 
     if xcode_target._is_testonly:
-        dto["is_testonly"] = True
+        dto["t"] = True
 
     if not xcode_target.is_swift:
-        dto["is_swift"] = False
+        dto["s"] = False
 
     if is_unfocused_dependency:
-        dto["is_unfocused_dependency"] = True
+        dto["u"] = True
 
     if xcode_target._test_host not in unfocused_targets:
-        set_if_true(dto, "test_host", xcode_target._test_host)
+        set_if_true(dto, "h", xcode_target._test_host)
 
     if xcode_target._watch_application not in unfocused_targets:
-        set_if_true(dto, "watch_application", xcode_target._watch_application)
+        set_if_true(dto, "w", xcode_target._watch_application)
 
     generated_framework_search_paths = _generated_framework_search_paths(
         build_mode = build_mode,
@@ -556,7 +556,7 @@ def _xcode_target_to_dto(
 
     set_if_true(
         dto,
-        "build_settings",
+        "b",
         _build_settings_to_dto(
             build_mode = build_mode,
             is_fixture = is_fixture,
@@ -568,37 +568,37 @@ def _xcode_target_to_dto(
 
     set_if_true(
         dto,
-        "has_modulemaps",
+        "m",
         bool(xcode_target._modulemaps),
     )
     set_if_true(
         dto,
-        "resource_bundle_dependencies",
+        "r",
         [
             id
             for id in inputs.resource_bundle_dependencies.to_list()
             if id not in unfocused_targets
         ],
     )
-    set_if_true(dto, "inputs", _inputs_to_dto(inputs))
+    set_if_true(dto, "i", _inputs_to_dto(inputs))
     set_if_true(
         dto,
-        "linker_inputs",
+        "5",
         linker_inputs_dto,
     )
     set_if_true(
         dto,
-        "link_params",
+        "6",
         file_path_to_dto(file_path(link_params)),
     )
     set_if_true(
         dto,
-        "info_plist",
+        "4",
         file_path_to_dto(file_path(xcode_target.infoplist)),
     )
     set_if_true(
         dto,
-        "extensions",
+        "e",
         [
             id
             for id in xcode_target._extensions
@@ -607,7 +607,7 @@ def _xcode_target_to_dto(
     )
     set_if_true(
         dto,
-        "app_clips",
+        "a",
         [
             id
             for id in xcode_target._app_clips
@@ -616,11 +616,11 @@ def _xcode_target_to_dto(
     )
 
     if should_include_outputs:
-        set_if_true(dto, "outputs", _outputs_to_dto(xcode_target.outputs))
+        set_if_true(dto, "o", _outputs_to_dto(xcode_target.outputs))
 
     set_if_true(
         dto,
-        "additional_scheme_targets",
+        "7",
         additional_scheme_target_ids,
     )
 
@@ -637,7 +637,7 @@ def _xcode_target_to_dto(
 
     set_if_true(
         dto,
-        "dependencies",
+        "d",
         [
             _handle_dependency(id)
             for id in xcode_target._dependencies.to_list()
@@ -726,28 +726,28 @@ def _inputs_to_dto(inputs):
     """
     ret = {}
 
-    def _process_attr(attr):
+    def _process_attr(attr, key):
         value = getattr(inputs, attr)
         if value:
-            ret[attr] = [
+            ret[key] = [
                 file_path_to_dto(file_path(file))
                 for file in value.to_list()
             ]
 
-    _process_attr("srcs")
-    _process_attr("non_arc_srcs")
-    _process_attr("hdrs")
+    _process_attr("srcs", "s")
+    _process_attr("non_arc_srcs", "n")
+    _process_attr("hdrs", "h")
 
     if inputs.pch:
-        ret["pch"] = file_path_to_dto(file_path(inputs.pch))
+        ret["p"] = file_path_to_dto(file_path(inputs.pch))
 
     if inputs.entitlements:
-        ret["entitlements"] = file_path_to_dto(file_path(inputs.entitlements))
+        ret["e"] = file_path_to_dto(file_path(inputs.entitlements))
 
     if inputs.resources:
         set_if_true(
             ret,
-            "resources",
+            "r",
             [file_path_to_dto(fp) for fp in inputs.resources.to_list()],
         )
 
@@ -781,7 +781,7 @@ def _linker_inputs_to_dto(
     ret = {}
     set_if_true(
         ret,
-        "dynamic_frameworks",
+        "d",
         [
             file_path_to_dto(file_path(file, path = file.dirname))
             for file in linker_inputs.dynamic_frameworks
@@ -847,17 +847,24 @@ def _outputs_to_dto(outputs):
     return dto
 
 def _product_to_dto(product):
-    return {
-        "additional_paths": [
+    dto =  {
+        "n": product.name,
+        "t": product.type,
+    }
+
+    set_if_true(dto, "p", file_path_to_dto(product.file_path))
+    set_if_true(
+        dto,
+        "a",
+        [
             file_path_to_dto(normalized_file_path(file))
             for file in product._additional_files.to_list()
         ],
-        "executable_name": product.executable_name,
-        "is_resource_bundle": product._is_resource_bundle,
-        "name": product.name,
-        "path": file_path_to_dto(product.file_path),
-        "type": product.type,
-    }
+    )
+    set_if_true(dto, "r", product._is_resource_bundle)
+    set_if_true(dto, "e", product.executable_name)
+
+    return dto
 
 def _swift_to_dto(outputs):
     dto = {


### PR DESCRIPTION
Part of #237.

Also don't set some optional properties in json.

This is to reduce the size of `targets_spec.json` to increase generation speed.