### PR TITLE
Stop sending defaults in `project_spec.json`

### DIFF
--- a/examples/cc/test/fixtures/bwb_project_spec.json
+++ b/examples/cc/test/fixtures/bwb_project_spec.json
@@ -10,9 +10,7 @@
         "USE_HEADERMAP": false,
         "VALIDATE_WORKSPACE": false
     },
-    "args": [],
     "configuration": "darwin_x86_64-dbg-STABLE-0",
-    "envs": [],
     "extra_files": [
         {
             "_": "examples_cc_external/lib.h",
@@ -29,15 +27,10 @@
         "test/fixtures/BUILD",
         "tool/BUILD"
     ],
-    "force_bazel_dependencies": true,
     "generator_label": "//test/fixtures:xcodeproj_bwb.generator",
     "index_import": "fixture-index-import-path",
     "minimum_xcode_version": "13.0",
     "name": "bwb",
-    "post_build_script": null,
-    "pre_build_script": null,
-    "replacement_labels": [],
     "runner_label": "//test/fixtures:xcodeproj_bwb",
-    "scheme_autogeneration_mode": "auto",
-    "target_hosts": []
+    "scheme_autogeneration_mode": "auto"
 }

--- a/examples/cc/test/fixtures/bwx_project_spec.json
+++ b/examples/cc/test/fixtures/bwx_project_spec.json
@@ -10,9 +10,7 @@
         "USE_HEADERMAP": false,
         "VALIDATE_WORKSPACE": false
     },
-    "args": [],
     "configuration": "darwin_x86_64-dbg-STABLE-0",
-    "envs": [],
     "extra_files": [
         {
             "_": "examples_cc_external/lib.h",
@@ -29,15 +27,10 @@
         "test/fixtures/BUILD",
         "tool/BUILD"
     ],
-    "force_bazel_dependencies": true,
     "generator_label": "//test/fixtures:xcodeproj_bwx.generator",
     "index_import": "fixture-index-import-path",
     "minimum_xcode_version": "13.0",
     "name": "bwx",
-    "post_build_script": null,
-    "pre_build_script": null,
-    "replacement_labels": [],
     "runner_label": "//test/fixtures:xcodeproj_bwx",
-    "scheme_autogeneration_mode": "auto",
-    "target_hosts": []
+    "scheme_autogeneration_mode": "auto"
 }

--- a/examples/integration/test/fixtures/bwb_project_spec.json
+++ b/examples/integration/test/fixtures/bwb_project_spec.json
@@ -1,4 +1,10 @@
 {
+    "args": [
+        "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
+        [
+            "--command_line_args=-AppleLanguages,(en-GB)"
+        ]
+    ],
     "bazel_config": "rules_xcodeproj_integration",
     "build_settings": {
         "ALWAYS_SEARCH_USER_PATHS": false,
@@ -10,12 +16,6 @@
         "USE_HEADERMAP": false,
         "VALIDATE_WORKSPACE": false
     },
-    "args": [
-        "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
-        [
-            "--command_line_args=-AppleLanguages,(en-GB)"
-        ]
-    ],
     "configuration": "darwin_x86_64-dbg-STABLE-0",
     "envs": [
         "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-20",
@@ -335,13 +335,10 @@
         "watchOSAppExtension/Info.plist",
         "watchOSAppExtension/Test/UnitTests/BUILD"
     ],
-    "force_bazel_dependencies": true,
     "generator_label": "//test/fixtures:xcodeproj_bwb.generator",
     "index_import": "fixture-index-import-path",
     "minimum_xcode_version": "13.0",
     "name": "bwb",
-    "post_build_script": null,
-    "pre_build_script": null,
     "replacement_labels": [
         "//CommandLine/CommandLineTool:tool.binary macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
         "//CommandLine/CommandLineTool:UniversalCommandLineTool",

--- a/examples/integration/test/fixtures/bwx_project_spec.json
+++ b/examples/integration/test/fixtures/bwx_project_spec.json
@@ -1,4 +1,10 @@
 {
+    "args": [
+        "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
+        [
+            "--command_line_args=-AppleLanguages,(en-GB)"
+        ]
+    ],
     "bazel_config": "rules_xcodeproj_integration",
     "build_settings": {
         "ALWAYS_SEARCH_USER_PATHS": false,
@@ -10,12 +16,6 @@
         "USE_HEADERMAP": false,
         "VALIDATE_WORKSPACE": false
     },
-    "args": [
-        "//iOSApp/Test/SwiftUnitTests:iOSAppSwiftUnitTests.__internal__.__test_bundle applebin_ios-ios_x86_64-dbg-STABLE-7",
-        [
-            "--command_line_args=-AppleLanguages,(en-GB)"
-        ]
-    ],
     "configuration": "darwin_x86_64-dbg-STABLE-0",
     "envs": [
         "//CommandLine/Tests:CommandLineToolTests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-20",
@@ -258,13 +258,10 @@
         "watchOSAppExtension/Info.plist",
         "watchOSAppExtension/Test/UnitTests/BUILD"
     ],
-    "force_bazel_dependencies": true,
     "generator_label": "//test/fixtures:xcodeproj_bwx.generator",
     "index_import": "fixture-index-import-path",
     "minimum_xcode_version": "13.0",
     "name": "bwx",
-    "post_build_script": null,
-    "pre_build_script": null,
     "replacement_labels": [
         "//CommandLine/CommandLineTool:tool.binary macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18",
         "//CommandLine/CommandLineTool:UniversalCommandLineTool",

--- a/examples/sanitizers/test/fixtures/bwb_project_spec.json
+++ b/examples/sanitizers/test/fixtures/bwb_project_spec.json
@@ -10,9 +10,7 @@
         "USE_HEADERMAP": false,
         "VALIDATE_WORKSPACE": false
     },
-    "args": [],
     "configuration": "darwin_x86_64-dbg-STABLE-0",
-    "envs": [],
     "extra_files": [
         "AddressSanitizerApp/BUILD",
         "AddressSanitizerApp/Info.plist",
@@ -27,10 +25,6 @@
     "index_import": "fixture-index-import-path",
     "minimum_xcode_version": "13.0",
     "name": "bwb",
-    "post_build_script": null,
-    "pre_build_script": null,
-    "replacement_labels": [],
     "runner_label": "//test/fixtures:xcodeproj_bwb",
-    "scheme_autogeneration_mode": "none",
-    "target_hosts": []
+    "scheme_autogeneration_mode": "none"
 }

--- a/examples/sanitizers/test/fixtures/bwx_project_spec.json
+++ b/examples/sanitizers/test/fixtures/bwx_project_spec.json
@@ -10,9 +10,7 @@
         "USE_HEADERMAP": false,
         "VALIDATE_WORKSPACE": false
     },
-    "args": [],
     "configuration": "darwin_x86_64-dbg-STABLE-0",
-    "envs": [],
     "extra_files": [
         "AddressSanitizerApp/BUILD",
         "AddressSanitizerApp/Info.plist",
@@ -27,10 +25,6 @@
     "index_import": "fixture-index-import-path",
     "minimum_xcode_version": "13.0",
     "name": "bwx",
-    "post_build_script": null,
-    "pre_build_script": null,
-    "replacement_labels": [],
     "runner_label": "//test/fixtures:xcodeproj_bwx",
-    "scheme_autogeneration_mode": "none",
-    "target_hosts": []
+    "scheme_autogeneration_mode": "none"
 }

--- a/test/fixtures/generator/bwb_project_spec.json
+++ b/test/fixtures/generator/bwb_project_spec.json
@@ -10,7 +10,6 @@
         "USE_HEADERMAP": false,
         "VALIDATE_WORKSPACE": false
     },
-    "args": [],
     "configuration": "darwin_x86_64-dbg-STABLE-0",
     "envs": [
         "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-2",
@@ -26,18 +25,14 @@
         "tools/generator/test/BUILD",
         "tools/swiftc_stub/BUILD"
     ],
-    "force_bazel_dependencies": true,
     "generator_label": "//test/fixtures/generator:xcodeproj_bwb.generator",
     "index_import": "fixture-index-import-path",
     "minimum_xcode_version": "13.0",
     "name": "bwb",
-    "post_build_script": null,
-    "pre_build_script": null,
     "replacement_labels": [
         "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-2",
         "//tools/generator/test:tests"
     ],
     "runner_label": "//test/fixtures/generator:xcodeproj_bwb",
-    "scheme_autogeneration_mode": "none",
-    "target_hosts": []
+    "scheme_autogeneration_mode": "none"
 }

--- a/test/fixtures/generator/bwx_project_spec.json
+++ b/test/fixtures/generator/bwx_project_spec.json
@@ -10,7 +10,6 @@
         "USE_HEADERMAP": false,
         "VALIDATE_WORKSPACE": false
     },
-    "args": [],
     "configuration": "darwin_x86_64-dbg-STABLE-0",
     "envs": [
         "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-2",
@@ -26,18 +25,14 @@
         "tools/generator/test/BUILD",
         "tools/swiftc_stub/BUILD"
     ],
-    "force_bazel_dependencies": true,
     "generator_label": "//test/fixtures/generator:xcodeproj_bwx.generator",
     "index_import": "fixture-index-import-path",
     "minimum_xcode_version": "13.0",
     "name": "bwx",
-    "post_build_script": null,
-    "pre_build_script": null,
     "replacement_labels": [
         "//tools/generator/test:tests.__internal__.__test_bundle applebin_macos-darwin_x86_64-dbg-STABLE-2",
         "//tools/generator/test:tests"
     ],
     "runner_label": "//test/fixtures/generator:xcodeproj_bwx",
-    "scheme_autogeneration_mode": "none",
-    "target_hosts": []
+    "scheme_autogeneration_mode": "none"
 }

--- a/tools/generator/src/DTO/Project.swift
+++ b/tools/generator/src/DTO/Project.swift
@@ -57,19 +57,24 @@ extension Project: Decodable {
         buildSettings = try container
             .decode([String: BuildSetting].self, forKey: .buildSettings)
         replacementLabels = try container
-            .decode([TargetID: BazelLabel].self, forKey: .replacementLabels)
+            .decodeIfPresent(
+                [TargetID: BazelLabel].self,
+                forKey: .replacementLabels
+            ) ?? [:]
         targetHosts = try container
-            .decode([TargetID: [TargetID]].self, forKey: .targetHosts)
+            .decodeIfPresent([TargetID: [TargetID]].self, forKey: .targetHosts)
+            ?? [:]
         args = try container
-            .decode([TargetID: [String]].self, forKey: .args)
+            .decodeIfPresent([TargetID: [String]].self, forKey: .args) ?? [:]
         envs = try container
-            .decode([TargetID: [String: String]].self, forKey: .envs)
+            .decodeIfPresent([TargetID: [String: String]].self, forKey: .envs)
+            ?? [:]
         extraFiles = try container
-            .decode(Set<FilePath>.self, forKey: .extraFiles)
+            .decodeIfPresent(Set<FilePath>.self, forKey: .extraFiles) ?? []
         schemeAutogenerationMode = try container
             .decode(SchemeAutogenerationMode.self, forKey: .schemeAutogenerationMode)
         forceBazelDependencies = try container
-            .decode(Bool.self, forKey: .forceBazelDependencies)
+            .decodeIfPresent(Bool.self, forKey: .forceBazelDependencies) ?? true
         indexImport = try container
             .decode(String.self, forKey: .indexImport)
         preBuildScript = try container


### PR DESCRIPTION
Part of #237.

Also, we now use `json.encode` instead of string formatting, hopefully being more memory efficient.