### PR TITLE
Allow not having output groups set

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/calculate_output_groups.py
+++ b/xcodeproj/internal/bazel_integration_files/calculate_output_groups.py
@@ -116,18 +116,6 @@ https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md""",
         )
         return scheme_labels_and_target_ids
 
-    if not labels_and_target_ids:
-        print(
-            """\
-warning: Couldn't determine labels and target ids from PIFCache
-
-warning: Using scheme labels and target ids as a fallback. Please file a bug \
-report here: \
-https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md""",
-            file = sys.stderr,
-        )
-        labels_and_target_ids = scheme_labels_and_target_ids
-
     return labels_and_target_ids
 
 def _calculate_guid_labels_and_target_ids(base_objroot):

--- a/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
+++ b/xcodeproj/internal/bazel_integration_files/generate_bazel_dependencies.sh
@@ -71,11 +71,9 @@ else
   done
 
   if [ -z "${output_groups:-}" ]; then
-    echo "error: BazelDependencies invoked without any output groups set." \
-"Please file a bug report here:" \
-"https://github.com/buildbuddy-io/rules_xcodeproj/issues/new?template=bug.md" \
-      >&2
-    exit 1
+    echo "BazelDependencies invoked without any output groups set." \
+      "Exiting early."
+    exit
   else
     labels=()
     while IFS= read -r -d '' label; do


### PR DESCRIPTION
If building a resource bundle, currently it won't have any output groups set (eventually it probably should have generated inputs?). This causes the "Couldn't determine labels and target ids from PIFCache" path to incorrectly get hit. Now we just exit the `Bazel Build` early.