### PR TITLE
Stop creating a `BazelDependencies` script for resource bundles

### DIFF
--- a/tools/generator/src/Generator/AddTargets.swift
+++ b/tools/generator/src/Generator/AddTargets.swift
@@ -51,6 +51,7 @@ extension Generator {
                     in: pbxProj,
                     buildMode: buildMode,
                     productType: productType,
+                    isResourceBundle: target.product.isResourceBundle,
                     productBasename: productBasename,
                     outputs: outputs
                 ),
@@ -147,10 +148,11 @@ extension Generator {
         in pbxProj: PBXProj,
         buildMode: BuildMode,
         productType: PBXProductType,
+        isResourceBundle: Bool,
         productBasename: String?,
         outputs: ConsolidatedTargetOutputs
     ) throws -> PBXShellScriptBuildPhase? {
-        guard buildMode.usesBazelModeBuildScripts else {
+        guard buildMode.usesBazelModeBuildScripts && !isResourceBundle else {
             return nil
         }
 

--- a/tools/generator/src/Generator/ConsolidateTargets.swift
+++ b/tools/generator/src/Generator/ConsolidateTargets.swift
@@ -329,6 +329,7 @@ extension ConsolidatedTarget {
         product = ConsolidatedTargetProduct(
             name: aTarget.product.name,
             type: aTarget.product.type,
+            isResourceBundle: aTarget.product.isResourceBundle,
             basename: aTarget.product.path?.path.lastComponent,
             paths: Set(targets.values.flatMap { target in
                 return (target.product.path.flatMap { [$0] } ?? []) +
@@ -469,6 +470,7 @@ extension ConsolidatedTarget {
 struct ConsolidatedTargetProduct: Equatable {
     let name: String
     let type: PBXProductType
+    let isResourceBundle: Bool
     let basename: String?
     let paths: Set<FilePath>
 }


### PR DESCRIPTION
Currently resource bundles don't generate any files (though they should if they depend on generated files). Until they do, we don't need to have an extra build phase.