### PR TITLE
Add unstable API warning to public providers

### DIFF
--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -476,6 +476,10 @@ automatically process it.
 If you need more control over how a target or its dependencies are processed,
 return a `XcodeProjInfo` provider instance instead.
 
+**Warning:** This provider currently has an unstable API and may change in the
+future. If you are using this provider, please let us know so we can prioritize
+stabilizing it.
+
 
 **FIELDS**
 
@@ -518,6 +522,11 @@ XcodeProjInfo(<a href="#XcodeProjInfo-args">args</a>, <a href="#XcodeProjInfo-co
 </pre>
 
 Provides information needed to generate an Xcode project.
+
+**Warning:** This provider currently has an unstable API and may change in the
+future. If you are using this provider, please let us know so we can prioritize
+stabilizing it.
+
 
 **FIELDS**
 

--- a/xcodeproj/internal/providers.bzl
+++ b/xcodeproj/internal/providers.bzl
@@ -7,6 +7,10 @@ automatically process it.
 
 If you need more control over how a target or its dependencies are processed,
 return a `XcodeProjInfo` provider instance instead.
+
+**Warning:** This provider currently has an unstable API and may change in the
+future. If you are using this provider, please let us know so we can prioritize
+stabilizing it.
 """,
     fields = {
         "all_attrs": "",
@@ -97,7 +101,13 @@ target_type = struct(
 )
 
 XcodeProjInfo = provider(
-    "Provides information needed to generate an Xcode project.",
+    """\
+Provides information needed to generate an Xcode project.
+
+**Warning:** This provider currently has an unstable API and may change in the
+future. If you are using this provider, please let us know so we can prioritize
+stabilizing it.
+""",
     fields = {
         "args": """\
 A `depset` of `struct`s with `id` and `arg` fields. The `id` field is the


### PR DESCRIPTION
Since we are going to be releasing 1.0 soon, we need to be clear that these APIs aren't stable yet.