### PR TITLE
Set `--xcode_version` in runner

### DIFF
--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -103,15 +103,17 @@ if [[ -s "$extra_flags_bazelrc" ]]; then
 fi
 
 developer_dir=$(xcode-select -p)
-xcode_build_version=$(/usr/bin/xcodebuild -version | tail -1 | cut -d " " -f3)
 pre_config_flags=(
+  # Be explicit about our desired Xcode version
+  "--xcode_version=%xcode_version%"
+
   # Set `DEVELOPER_DIR` in case a bazel wrapper filters it
   "--repo_env=DEVELOPER_DIR=$developer_dir"
 
   # Work around https://github.com/bazelbuild/bazel/issues/8902
   # `USE_CLANG_CL` is only used on Windows, we set it here to cause Bazel to
   # re-evaluate the cc_toolchain for a different Xcode version
-  "--repo_env=USE_CLANG_CL=$xcode_build_version"
+  "--repo_env=USE_CLANG_CL=%xcode_version%"
 )
 
 if [[ %is_fixture% -eq 1 && %is_bazel_6% -eq 1 ]]; then

--- a/xcodeproj/internal/xcodeproj_runner.bzl
+++ b/xcodeproj/internal/xcodeproj_runner.bzl
@@ -101,6 +101,7 @@ def _write_runner(
         project_name,
         runner_label,
         template,
+        xcode_version,
         xcodeproj_bazelrc):
     output = actions.declare_file("{}-runner.sh".format(name))
 
@@ -120,6 +121,7 @@ def _write_runner(
             "%is_fixture%": "1" if is_fixture else "0",
             "%project_name%": project_name,
             "%runner_label%": runner_label,
+            "%xcode_version%": xcode_version,
             "%xcodeproj_bazelrc%": xcodeproj_bazelrc.short_path,
         },
     )
@@ -129,6 +131,9 @@ def _write_runner(
 def _xcodeproj_runner_impl(ctx):
     config = ctx.attr.config
     project_name = ctx.attr.project_name
+
+    xcode_config = ctx.attr._xcode_config[apple_common.XcodeVersionConfig]
+    xcode_version = str(xcode_config.xcode_version()).split(".")[3]
 
     xcodeproj_bazelrc = _write_xcodeproj_bazelrc(
         name = ctx.attr.name,
@@ -157,6 +162,7 @@ def _xcodeproj_runner_impl(ctx):
         project_name = project_name,
         runner_label = str(ctx.label),
         template = ctx.file._runner_template,
+        xcode_version = xcode_version,
         xcodeproj_bazelrc = xcodeproj_bazelrc,
     )
 
@@ -217,6 +223,12 @@ xcodeproj_runner = rule(
         "_runner_template": attr.label(
             allow_single_file = True,
             default = Label("//xcodeproj/internal:runner.template.sh"),
+        ),
+        "_xcode_config": attr.label(
+            default = configuration_field(
+                name = "xcode_config_label",
+                fragment = "apple",
+            ),
         ),
     },
     executable = True,


### PR DESCRIPTION
We use the version that Bazel is using, either that it sets by default, or you've set explicitly.