### PR TITLE
Restrict target merging for non-Swift targets as well

### DIFF
--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -470,11 +470,6 @@ actual targets: {}
     for src, dests in target_merges.items():
         src_target = focused_targets[src]
 
-        if not src_target.is_swift:
-            # Only swiftmodule search paths are an issue for target merging.
-            # If the target isn't Swift, merge away!
-            continue
-
         for dest in dests:
             dest_target = focused_targets[dest]
 


### PR DESCRIPTION
It used to be the case that only swiftmodule search paths were an issue, but linker output paths matter as well, which non-Swift targets have.

I think there is a way to lift this restriction in the future, with further removal of `xcodeGeneratedPaths` from `generator`, but for now this fixes certain project generations.