### PR TITLE
Adjust BCR Publish releaser

### DIFF
--- a/.bcr/config.yml
+++ b/.bcr/config.yml
@@ -1,3 +1,3 @@
 fixedReleaser:
-  login: BalestraPatrick
-  email: me@patrickbalestra.com
+  login: brentleyjones
+  email: github@brentleyjones.com


### PR DESCRIPTION
By having it be me, I can amend release commits easier. Later we should be able to use an organization fork instead, so any maintainers can amend the release commits.