### PR TITLE
Remove repo `--features=swift.use_global_module_cache`

### DIFF
--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -1,6 +1,5 @@
 build --incompatible_disallow_empty_glob
 build --experimental_convenience_symlinks=ignore
-build --features=swift.use_global_module_cache
 
 # Work around https://github.com/bazelbuild/bazel/issues/13912
 build --experimental_action_cache_store_output_metadata


### PR DESCRIPTION
We don't need to set this in our `.bazelrc` anymore, since it's the default since rules_swift 1.5.0.