### PR TITLE
Use the first arch if multiple are set

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
+++ b/xcodeproj/internal/bazel_integration_files/import_indexstores.sh
@@ -68,7 +68,7 @@ remaps=(
   # When we add support for C-based index imports we will have to use another
   # pattern:
   # https://github.com/bazelbuild/bazel/blob/c4a1ab8b6577c4376aaaa5c3c2d4ef07d524175c/src/main/java/com/google/devtools/build/lib/rules/cpp/CcCompilationHelper.java#L1358
-  -remap "^(?:$execution_root_regex/|\./)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/$ARCHS/\$4.o"
+  -remap "^(?:$execution_root_regex/|\./)?(bazel-out/[^/]+/bin/)(?:_swift_incremental/)?(.*?)([^/]+)_objs/.*?([^/]+?)(?:\.swift)?\.o\$=$object_file_prefix/\$1\$2\$3/Objects-normal/${ARCHS%% *}/\$4.o"
 
   # Generated sources and swiftmodules
   #


### PR DESCRIPTION
In very odd situations, most likely because of other bugs, `ARCHS` can be set to two architectures. This will 100% result in an invalid import, so let’s pick the first one, which is most likely the correct one.