### PR TITLE
Use `swift.file_prefix_map` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ to include it in the list above.
 
 | rules_xcodeproj | Bazel | [rules_apple][1] | [rules_swift][2] | Xcode | macOS | Supporting Branch |
 | :-------------: | :---: | :--------------: | :--------------: | :---: | :---: | :---------------: |
-| 1.x | 5.3–6.x  | 1.0.1–2.x | 1.x | 13.3–14.x | 12–13.x | `main` |
+| 1.1-1.x | 5.3–6.x  | 1.0.1–2.x | 1.5.2-1.x | 14.x | 12–13.x | `main` |
+| 1.0 | 5.3–6.x  | 1.0.1–2.x | 1.x | 13.3–14.x | 12–13.x | - |
 
 More versions of these tools and rulesets might be supported, but these are the
 ones we’ve officially tested with.

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -38,6 +38,10 @@ build:rules_xcodeproj --features=relative_ast_path
 # this in `swift_debug_settings.py`, so debugging still works.
 build:rules_xcodeproj --features=swift.cacheable_swiftmodules
 
+# `swift.file_prefix_map` is a more complete version of `swift.debug_prefix_map`
+# that also makes index store data reproducible.
+build:rules_xcodeproj --features=swift.file_prefix_map
+
 # `swift.index-while-building` passes `-index-store-path` to `swiftc`, which
 # generates index store data. We enable this globally, and don't disable it in
 # `rules_xcodeproj_indexbuild`, even though we only need it for the normal


### PR DESCRIPTION
The primary benefit for us is that index store data is reproducible, reducing extra uploads and downloads for the “same” index data.

Requires Xcode 14 and rules_swift 1.5.2.