### PR TITLE
Patch dSYM path

### DIFF
--- a/xcodeproj/internal/bazel_integration_files/copy_dsyms.sh
+++ b/xcodeproj/internal/bazel_integration_files/copy_dsyms.sh
@@ -2,6 +2,45 @@
 
 set -euo pipefail
 
+function patch_dsym() {
+  readonly dsym_name="$1"
+  readonly binary_name="${dsym_name%%.*}"
+  readonly binary_path="${dsym_name}/Contents/Resources/DWARF/${binary_name}"
+
+  if [[ ! -f "$binary_path" ]]; then
+    echo "dSYM DWARF ${binary_path} does not exist." \
+    "Skip dSYM patch."
+    return 1
+  fi
+
+  dwarf_uuid=$(dwarfdump --uuid "${binary_path}" | cut -d ' ' -f 2)
+  readonly dwarf_uuid
+  if [[ -z "${dwarf_uuid// /}" ]]; then
+    echo "Failed to get dSYM uuid." \
+    "Skip dSYM patch."
+    return 1
+  fi
+
+  cat > "${dsym_name}/Contents/Resources/${dwarf_uuid}.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  <dict>
+    <key>DBGVersion</key>
+    <string>3</string>
+    <key>DBGSourcePathRemapping</key>
+    <dict>
+      <key>./bazel-out/</key>
+      <string>$BAZEL_OUT/</string>
+      <key>./external/</key>
+      <string>$BAZEL_EXTERNAL/</string>
+      <key>./</key>
+      <string>$SRCROOT/</string>
+    </dict>
+  </dict>
+</plist>
+EOF
+}
+
 if [[ -n "${BAZEL_OUTPUTS_DSYM:-}" ]]; then
   cd "${BAZEL_OUT%/*}"
 
@@ -17,4 +56,11 @@ if [[ -n "${BAZEL_OUTPUTS_DSYM:-}" ]]; then
     --out-format="%n%L" \
     $(xargs -n1 <<< "$BAZEL_OUTPUTS_DSYM") \
     "$TARGET_BUILD_DIR"
+
+  cd "${TARGET_BUILD_DIR}"
+
+  export -f patch_dsym
+  # shellcheck disable=SC2016
+  xargs -n1 sh -c 'patch_dsym $(basename "$1")' _ \
+    <<< "$BAZEL_OUTPUTS_DSYM"
 fi


### PR DESCRIPTION
To improve some lldb handling of relative source paths, we create a plist file inside the dSYM file with `DBGSourcePathRemapping` which will remap relative paths to absolute paths (see [documentation](https://lldb.llvm.org/use/symbols.html#id2)).

This logic has been added to the `copy_dsyms.sh` script, which will be run as Launch and Profiling pre-actions.

