### PR TITLE
Merge dest targets with single Xcode src target

### DIFF
--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -498,13 +498,11 @@ actual targets: {}
     target_merges = {}
     target_merge_srcs_by_label = {}
     for dest, src_targets in target_merge_dests.items():
-        focused_src_targets = [src_target for src_target in src_targets if focused_targets.get(src_target.id)]
-
-        if len(focused_src_targets) > 1:
+        if len(src_targets) > 1:
             # We can only merge targets with a single Xcode-target library dependency
             continue
 
-        src_target = focused_src_targets[0]
+        src_target = src_targets[0]
         target_merges.setdefault(src_target.id, []).append(dest)
         target_merge_srcs_by_label.setdefault(src_target.target.label, []).append(src_target.id)
 

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -501,7 +501,7 @@ actual targets: {}
         focused_src_targets = [src_target for src_target in src_targets if focused_targets.get(src_target.id)]
 
         if len(focused_src_targets) > 1:
-            # We can only merge targets with a single library dependency
+            # We can only merge targets with a single Xcode-target library dependency
             continue
 
         src_target = focused_src_targets[0]


### PR DESCRIPTION
# Summary
This is a slight change to pre-filter the `src_ids` by those that actually produce Xcode targets and then do the merge for those destinations with a single library dependency.

In my case, this merges "test helper" libraries that are depended on by a single unit/UI test target but not another static library.

This is work towards https://github.com/buildbuddy-io/rules_xcodeproj/issues/1724 but doesn’t solve it yet.