### PR TITLE
Upgrade rules_apple to 2.1.0

### DIFF
--- a/examples/cc/MODULE.bazel
+++ b/examples/cc/MODULE.bazel
@@ -5,7 +5,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_apple",
-    version = "2.0.0",
+    version = "2.1.0",
     repo_name = "build_bazel_rules_apple",
 )
 bazel_dep(

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -83,8 +83,8 @@ def xcodeproj_rules_dependencies(
 
         is_bazel_6 = hasattr(apple_common, "link_multi_arch_static_library")
         if is_bazel_6:
-            rules_apple_sha256 = "43737f28a578d8d8d7ab7df2fb80225a6b23b9af9655fcdc66ae38eb2abcf2ed"
-            rules_apple_version = "2.0.0"
+            rules_apple_sha256 = "3e2c7ae0ddd181c4053b6491dad1d01ae29011bc322ca87eea45957c76d3a0c3"
+            rules_apple_version = "2.1.0"
         else:
             rules_apple_sha256 = "f94e6dddf74739ef5cb30f000e13a2a613f6ebfa5e63588305a71fce8a8a9911"
             rules_apple_version = "1.1.3"


### PR DESCRIPTION
But don’t force it on Bzlmod users, as it doesn’t contain anything we _need_.