### PR TITLE
Fix `*_framework.exported_symbols_list` in BwX mode

### DIFF
--- a/examples/integration/Lib/BUILD
+++ b/examples/integration/Lib/BUILD
@@ -48,6 +48,16 @@ genrule(
     cmd = "echo 'public let greeting = \"Hello, world!\"' > $@",
 )
 
+genrule(
+    name = "gen-exported-symbols-list",
+    outs = ["exported-symbols.lds"],
+    cmd = """\
+echo '_$$s3Lib8greetingSSvau' > $@
+echo '_$$s3Lib18libResourcesStringSSvau' >> $@
+echo '_$$sSo8NSBundleC3LibE12libResourcesABvau' >> $@
+""",
+)
+
 ios_framework(
     name = "LibFramework.iOS",
     bundle_id = "io.budilebuddy.LibFramework",
@@ -63,6 +73,9 @@ ios_framework(
 tvos_framework(
     name = "LibFramework.tvOS",
     bundle_id = "io.budilebuddy.LibFramework",
+    exported_symbols_lists = [
+        ":gen-exported-symbols-list",
+    ],
     extension_safe = True,
     infoplists = ["Info.plist"],
     minimum_os_version = "15.0",

--- a/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/project.pbxproj
@@ -558,6 +558,7 @@
 		1D9A0A5ED747A10C0A54D1AF /* tool.binary.51.link.params */ = {isa = PBXFileReference; path = tool.binary.51.link.params; sourceTree = "<group>"; };
 		1DC15ADEF46CAB9AC4326F59 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		1E84E717BC47B0961159FC23 /* tvOSAppUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = tvOSAppUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F69218E6937EDB946998FFA /* exported-symbols.lds */ = {isa = PBXFileReference; path = "exported-symbols.lds"; sourceTree = "<group>"; };
 		211F5D02396A5F7F21B372C0 /* CommandLineToolTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CommandLineToolTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		222CF04F551342682A2DEA9D /* LibFramework.watchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LibFramework.watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2389FC2E3790FF01911CDBCC /* iOSAppObjCUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSAppObjCUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -764,6 +765,7 @@
 		C454C50B0428F3DA857A8F1E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C57ADE0D252CBF7D79E887FC /* Entitlements.withbundleid.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Entitlements.withbundleid.plist; sourceTree = "<group>"; };
 		C7D6E9EA886ACE2FD42D136F /* lib.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = lib.m; sourceTree = "<group>"; };
+		C8B77765BE405F34A6889358 /* exported-symbols.lds */ = {isa = PBXFileReference; path = "exported-symbols.lds"; sourceTree = "<group>"; };
 		C8DD100EC3FA656AEFE5A00B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C9C5A40EB514C4EC147C976B /* watchOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = watchOSApp.swift; sourceTree = "<group>"; };
 		CA0FA7E1E16CCBCAC217F4F3 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
@@ -2780,6 +2782,7 @@
 			children = (
 				A7AEEC0C76D97936DF8827FA /* dist */,
 				DECD57D0F6706821FCFDB3E1 /* rules_xcodeproj */,
+				1F69218E6937EDB946998FFA /* exported-symbols.lds */,
 			);
 			path = Lib;
 			sourceTree = "<group>";
@@ -3569,6 +3572,7 @@
 			children = (
 				0B4454C1A15431967BD283D4 /* dist */,
 				9E521FFBA17A1B14112C2011 /* rules_xcodeproj */,
+				C8B77765BE405F34A6889358 /* exported-symbols.lds */,
 			);
 			path = Lib;
 			sourceTree = "<group>";

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -21,10 +21,12 @@ $(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITest
 $(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool/rules_xcodeproj/CommandLineTool/Info.plist
 $(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests/rules_xcodeproj/CommandLineToolTests.__internal__.__test_bundle/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist
+$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/exported-symbols.lds
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist
+$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/exported-symbols.lds
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist

--- a/examples/integration/test/fixtures/bwb_project_spec.json
+++ b/examples/integration/test/fixtures/bwb_project_spec.json
@@ -119,6 +119,14 @@
             "t": "e"
         },
         {
+            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/exported-symbols.lds",
+            "t": "g"
+        },
+        {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/exported-symbols.lds",
+            "t": "g"
+        },
+        {
             "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension/Info.withbundleid.plist",
             "t": "g"
         },

--- a/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/project.pbxproj
@@ -1260,6 +1260,7 @@
 		31E3C6A8F9858634B7B6FA6E /* CommandLineToolTests.__internal__.__test_bundle.58.link.params */ = {isa = PBXFileReference; path = CommandLineToolTests.__internal__.__test_bundle.58.link.params; sourceTree = "<group>"; };
 		31E3D6F06983030936AF5737 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		31EBAA302BF21712CB52AF4A /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CryptoSwift.framework; sourceTree = "<group>"; };
+		334335CCE60C90764827E4B1 /* exported-symbols.lds */ = {isa = PBXFileReference; path = "exported-symbols.lds"; sourceTree = "<group>"; };
 		33ADD8EBAB43E8270162F9DC /* tool.binary.57.link.params */ = {isa = PBXFileReference; path = tool.binary.57.link.params; sourceTree = "<group>"; };
 		33F88ADEDB7809198F344595 /* liblib_swift.a */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = liblib_swift.a; path = "bazel-out/macos-arm64-min11.0-applebin_macos-darwin_arm64-dbg-STABLE-18/bin/CommandLine/CommandLineToolLib/liblib_swift.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		377BB3CE77D26BF4FC27696B /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CryptoSwift.framework; sourceTree = "<group>"; };
@@ -1439,6 +1440,7 @@
 		C85BD205586AA00838254725 /* MixedAnswer-Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MixedAnswer-Swift.h"; sourceTree = "<group>"; };
 		CA21FC409B2526105AF42299 /* watchOSAppExtension.70.link.params */ = {isa = PBXFileReference; path = watchOSAppExtension.70.link.params; sourceTree = "<group>"; };
 		CA4B849D45BE52A44401D569 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		CA947B313940F1452B368067 /* exported-symbols.lds */ = {isa = PBXFileReference; path = "exported-symbols.lds"; sourceTree = "<group>"; };
 		CA95EEF3FAE24FBB77E2EF38 /* Launchd.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Launchd.plist; sourceTree = "<group>"; };
 		CB4A0FB26B6A160C6B667828 /* Nested */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Nested; sourceTree = "<group>"; };
 		CC017E2E345368072FC2D726 /* BUILD */ = {isa = PBXFileReference; explicitFileType = text.script.python; path = BUILD; sourceTree = "<group>"; };
@@ -2371,6 +2373,7 @@
 			children = (
 				ED7AF36034C0D4EF0A2F3ABF /* dist */,
 				51F8402F9ECE8ACE48627C6E /* rules_xcodeproj */,
+				334335CCE60C90764827E4B1 /* exported-symbols.lds */,
 			);
 			path = Lib;
 			sourceTree = "<group>";
@@ -3128,6 +3131,7 @@
 			children = (
 				CA57FB748A60A622856ED2CD /* dist */,
 				9A6B3E7E863AFB1E6C66DDD1 /* rules_xcodeproj */,
+				CA947B313940F1452B368067 /* exported-symbols.lds */,
 			);
 			path = Lib;
 			sourceTree = "<group>";

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/generated.xcfilelist
@@ -23,10 +23,12 @@ $(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-16/bin/macOSApp/Test/UITest
 $(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/CommandLineTool/rules_xcodeproj/CommandLineTool/Info.plist
 $(BAZEL_OUT)/applebin_macos-darwin_x86_64-dbg-STABLE-20/bin/CommandLine/Tests/rules_xcodeproj/CommandLineToolTests.__internal__.__test_bundle/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist
+$(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/exported-symbols.lds
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/dist/dynamic/rules_xcodeproj/tvOS/Info.plist
+$(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/exported-symbols.lds
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/rules_xcodeproj/LibFramework.tvOS/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/UI/rules_xcodeproj/UIFramework.tvOS/Info.plist
 $(BAZEL_OUT)/applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/tvOSApp/Source/rules_xcodeproj/tvOSApp/Info.plist

--- a/examples/integration/test/fixtures/bwx_project_spec.json
+++ b/examples/integration/test/fixtures/bwx_project_spec.json
@@ -113,6 +113,14 @@
             "t": "e"
         },
         {
+            "_": "applebin_tvos-tvos_arm64-dbg-STABLE-14/bin/Lib/exported-symbols.lds",
+            "t": "g"
+        },
+        {
+            "_": "applebin_tvos-tvos_x86_64-dbg-STABLE-13/bin/Lib/exported-symbols.lds",
+            "t": "g"
+        },
+        {
             "_": "applebin_watchos-watchos_arm64_32-dbg-STABLE-10/bin/watchOSAppExtension/Info.withbundleid.plist",
             "t": "g"
         },

--- a/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
+++ b/xcodeproj/internal/default_automatic_target_processing_aspect.bzl
@@ -126,6 +126,8 @@ def _default_automatic_target_processing_aspect_impl(target, ctx):
             codesignopts = "codesignopts"
         if "entitlements" in attrs:
             entitlements = "entitlements"
+        if "exported_symbols_lists" in attrs:
+            exported_symbols_lists = ["exported_symbols_lists"]
         if "extension" in attrs:
             xcode_targets["extension"] = [target_type.compile]
         if "extensions" in attrs:


### PR DESCRIPTION
Fixes #1779.

Previously we were only generating this file for binary rules. Now we do the same for bundle rules as well.