### PR TITLE
Use the `--reuse_sandbox_directories` flag

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -61,7 +61,7 @@ build:rules_xcodeproj --nolegacy_important_outputs
 
 # Allow sandbox directories to be reused, speeding up builds, especially if
 # other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --reuse_sandbox_directories
+common:rules_xcodeproj --experimental_reuse_sandbox_directories
 
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building

--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,6 +59,10 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
+# Allow sandbox directories to be reused, speeding up builds, especially if
+# other processed (e.g. endpoint security) are watching the directories.
+common:rules_xcodeproj --reuse_sandbox_directories
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -61,7 +61,7 @@ build:rules_xcodeproj --nolegacy_important_outputs
 
 # Allow sandbox directories to be reused, speeding up builds, especially if
 # other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --reuse_sandbox_directories
+common:rules_xcodeproj --experimental_reuse_sandbox_directories
 
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,6 +59,10 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
+# Allow sandbox directories to be reused, speeding up builds, especially if
+# other processed (e.g. endpoint security) are watching the directories.
+common:rules_xcodeproj --reuse_sandbox_directories
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -61,7 +61,7 @@ build:rules_xcodeproj --nolegacy_important_outputs
 
 # Allow sandbox directories to be reused, speeding up builds, especially if
 # other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --reuse_sandbox_directories
+common:rules_xcodeproj --experimental_reuse_sandbox_directories
 
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,6 +59,10 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
+# Allow sandbox directories to be reused, speeding up builds, especially if
+# other processed (e.g. endpoint security) are watching the directories.
+common:rules_xcodeproj --reuse_sandbox_directories
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -61,7 +61,7 @@ build:rules_xcodeproj --nolegacy_important_outputs
 
 # Allow sandbox directories to be reused, speeding up builds, especially if
 # other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --reuse_sandbox_directories
+common:rules_xcodeproj --experimental_reuse_sandbox_directories
 
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,6 +59,10 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
+# Allow sandbox directories to be reused, speeding up builds, especially if
+# other processed (e.g. endpoint security) are watching the directories.
+common:rules_xcodeproj --reuse_sandbox_directories
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -61,7 +61,7 @@ build:rules_xcodeproj --nolegacy_important_outputs
 
 # Allow sandbox directories to be reused, speeding up builds, especially if
 # other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --reuse_sandbox_directories
+common:rules_xcodeproj --experimental_reuse_sandbox_directories
 
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,6 +59,10 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
+# Allow sandbox directories to be reused, speeding up builds, especially if
+# other processed (e.g. endpoint security) are watching the directories.
+common:rules_xcodeproj --reuse_sandbox_directories
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -61,7 +61,7 @@ build:rules_xcodeproj --nolegacy_important_outputs
 
 # Allow sandbox directories to be reused, speeding up builds, especially if
 # other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --reuse_sandbox_directories
+common:rules_xcodeproj --experimental_reuse_sandbox_directories
 
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,6 +59,10 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
+# Allow sandbox directories to be reused, speeding up builds, especially if
+# other processed (e.g. endpoint security) are watching the directories.
+common:rules_xcodeproj --reuse_sandbox_directories
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -61,7 +61,7 @@ build:rules_xcodeproj --nolegacy_important_outputs
 
 # Allow sandbox directories to be reused, speeding up builds, especially if
 # other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --reuse_sandbox_directories
+common:rules_xcodeproj --experimental_reuse_sandbox_directories
 
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,6 +59,10 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
+# Allow sandbox directories to be reused, speeding up builds, especially if
+# other processed (e.g. endpoint security) are watching the directories.
+common:rules_xcodeproj --reuse_sandbox_directories
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -61,7 +61,7 @@ build:rules_xcodeproj --nolegacy_important_outputs
 
 # Allow sandbox directories to be reused, speeding up builds, especially if
 # other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --reuse_sandbox_directories
+common:rules_xcodeproj --experimental_reuse_sandbox_directories
 
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,6 +59,10 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
+# Allow sandbox directories to be reused, speeding up builds, especially if
+# other processed (e.g. endpoint security) are watching the directories.
+common:rules_xcodeproj --reuse_sandbox_directories
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -61,7 +61,7 @@ build:rules_xcodeproj --nolegacy_important_outputs
 
 # Allow sandbox directories to be reused, speeding up builds, especially if
 # other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --reuse_sandbox_directories
+common:rules_xcodeproj --experimental_reuse_sandbox_directories
 
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -59,6 +59,10 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
+# Allow sandbox directories to be reused, speeding up builds, especially if
+# other processed (e.g. endpoint security) are watching the directories.
+common:rules_xcodeproj --reuse_sandbox_directories
+
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0


### PR DESCRIPTION
This is only a speed up if sandboxing is used, which is the default for us currently (outside of worker actions, like `SwiftCompile`).