### PR TITLE
Revert "Use the `--reuse_sandbox_directories` flag (#1784)"

### DIFF
--- a/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,10 +59,6 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
-# Allow sandbox directories to be reused, speeding up builds, especially if
-# other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --experimental_reuse_sandbox_directories
-
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/cc/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,10 +59,6 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
-# Allow sandbox directories to be reused, speeding up builds, especially if
-# other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --experimental_reuse_sandbox_directories
-
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,10 +59,6 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
-# Allow sandbox directories to be reused, speeding up builds, especially if
-# other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --experimental_reuse_sandbox_directories
-
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/integration/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,10 +59,6 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
-# Allow sandbox directories to be reused, speeding up builds, especially if
-# other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --experimental_reuse_sandbox_directories
-
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,10 +59,6 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
-# Allow sandbox directories to be reused, speeding up builds, especially if
-# other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --experimental_reuse_sandbox_directories
-
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/examples/sanitizers/test/fixtures/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,10 +59,6 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
-# Allow sandbox directories to be reused, speeding up builds, especially if
-# other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --experimental_reuse_sandbox_directories
-
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwb.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,10 +59,6 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
-# Allow sandbox directories to be reused, speeding up builds, especially if
-# other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --experimental_reuse_sandbox_directories
-
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
+++ b/test/fixtures/generator/bwx.xcodeproj/rules_xcodeproj/bazel/xcodeproj.bazelrc
@@ -59,10 +59,6 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
-# Allow sandbox directories to be reused, speeding up builds, especially if
-# other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --experimental_reuse_sandbox_directories
-
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0

--- a/xcodeproj/internal/xcodeproj.template.bazelrc
+++ b/xcodeproj/internal/xcodeproj.template.bazelrc
@@ -59,10 +59,6 @@ build:rules_xcodeproj --features=swift.use_global_module_cache
 # Removes potentially large unneeded event from the BEP
 build:rules_xcodeproj --nolegacy_important_outputs
 
-# Allow sandbox directories to be reused, speeding up builds, especially if
-# other processed (e.g. endpoint security) are watching the directories.
-common:rules_xcodeproj --experimental_reuse_sandbox_directories
-
 # `--show_result=0` prevents showing the spec.json and intermediate `.xcodeproj`
 # in the logs when generating, and all of the many outputs when building
 build:rules_xcodeproj --show_result=0


### PR DESCRIPTION
This reverts commit 928cb34e819300747980396b2b617d4a15ef7a92.

Ran into errors like this:
> ERROR: /Users/brentley/Developer/rules_xcodeproj/tools/generator/BUILD:20:14: Linking tools/generator/libgenerator.library.a [for tool] failed: I/O exception during sandboxed execution: /Users/brentley/Developer/rules_xcodeproj/bazel-output-base/rules_xcodeproj/build_output_base/sandbox/darwin-sandbox/45/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out (No such file or directory)

When I was running `./test/update_all_fixtures.sh`.