### PR TITLE
Handle multiple Xcode configurations in `xcodeproj_rule.bzl`

### DIFF
--- a/xcodeproj/internal/xcode_targets.bzl
+++ b/xcodeproj/internal/xcode_targets.bzl
@@ -515,6 +515,7 @@ def _xcode_target_to_dto(
         should_include_outputs,
         excluded_targets = {},
         target_merges = {},
+        xcode_configuration,
         xcode_generated_paths,
         xcode_generated_paths_file):
     inputs = xcode_target.inputs
@@ -527,6 +528,9 @@ def _xcode_target_to_dto(
         "2": platform_info.to_dto(xcode_target.platform),
         "p": _product_to_dto(xcode_target.product),
     }
+
+    if xcode_configuration != "Debug":
+        dto["x"] = xcode_configuration
 
     if xcode_target._compile_target:
         dto["3"] = {

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -284,7 +284,8 @@ def _process_targets(
         unprocessed_targets.update(configuration_unprocessed_targets)
 
         xcode_configurations.update({
-            id: xcode_configuration for id in configuration_unprocessed_targets
+            id: xcode_configuration
+            for id in configuration_unprocessed_targets
         })
 
     configurations_map = {}
@@ -1336,7 +1337,7 @@ def _simulator_transition_impl(settings, attr):
             watchos_cpus = "x86_64"
 
     outputs = {
-        "Debug":{
+        "Debug": {
             "//command_line_option:ios_multi_cpus": ios_cpus,
             "//command_line_option:tvos_cpus": tvos_cpus,
             "//command_line_option:watchos_cpus": watchos_cpus,


### PR DESCRIPTION
Currently we hardcode it to be the same single “Debug” configuration, but the logic works for multiple once we have them.