### PR TITLE
Fix CC `copts` tokenization

### DIFF
--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -917,8 +917,10 @@ def _expand_make_variables(*, ctx, values, attribute_name):
         A `list` of strings with Make variables placeholders filled in.
     """
     return [
-        ctx.expand_make_variables(attribute_name, value, {})
+        ctx.expand_make_variables(attribute_name, token, {})
         for value in values
+        # TODO: Handle `no_copts_tokenization`
+        for token in ctx.tokenize(value)
     ]
 
 # API


### PR DESCRIPTION
Fixes #1809.

Both `cc_library` and `objc_library` tokenize their `copts` attributes. We use the undocumented `ctx.tokenize`, but if that goes away we could use something like https://github.com/bazelbuild/bazel/blob/1d73d72a45598e38c51b2618bb6fe4f27b390cb8/src/main/starlark/builtins_bzl/common/cc/cc_helper.bzl#L795-L853.