### PR TITLE
Change default name of repo to `@rules_xcodeproj`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ into the directory if the example app is in a separate `WORKSPACE` with
 You can even test your changes in a separate project living outside this
 repo by overriding the repository in your `.bazelrc`.
 ```
-build --override_repository=com_github_buildbuddy_io_rules_xcodeproj=/Users/username/rules_xcodeproj
+build --override_repository=rules_xcodeproj=/Users/username/rules_xcodeproj
 ```
 It's important to add it to the `.bazelrc` instead of passing it as a
 flag to ensure all invocations will use the same configuration.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "rules_xcodeproj",
     version = "1.2.0",
     compatibility_level = 1,
-    repo_name = "com_github_buildbuddy_io_rules_xcodeproj",
+    repo_name = "rules_xcodeproj",
 )
 
 bazel_dep(name = "bazel_skylib", version = "1.3.0")

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ load(
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
+    "@rules_xcodeproj//xcodeproj:defs.bzl",
     "top_level_target",
     "xcodeproj",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "com_github_buildbuddy_io_rules_xcodeproj")
+workspace(name = "rules_xcodeproj")
 
 load(
     "//xcodeproj:repositories.bzl",

--- a/buildbuddy.yaml
+++ b/buildbuddy.yaml
@@ -46,7 +46,7 @@ x_templates:
         - examples/sanitizers/setup-bazel-output-base
 
   commands:
-    - &set_release_archive_override "--output_base=setup-bazel-output-base run --config=workflows @com_github_buildbuddy_io_rules_xcodeproj//tools:set_release_archive_override"
+    - &set_release_archive_override "--output_base=setup-bazel-output-base run --config=workflows @rules_xcodeproj//tools:set_release_archive_override"
     - &validate_integration "run --config=workflows --config=fixtures //test/fixtures:validate"
     - &build_all "build --config=workflows --noexperimental_enable_bzlmod //..."
     - &test_all "test --config=workflows --noexperimental_enable_bzlmod //..."

--- a/docs/bazel.md
+++ b/docs/bazel.md
@@ -9,10 +9,7 @@ For example, to use the [`xcodeproj`](#xcodeproj) rule, you would need to use
 this `load` statement:
 
 ```starlark
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcodeproj",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcodeproj")
 ```
 
 ### Index
@@ -193,10 +190,7 @@ To use these functions, `load` the `xcode_schemes` module from
 `xcodeproj/defs.bzl`:
 
 ```starlark
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcode_schemes",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcode_schemes")
 ```
 
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,7 +70,7 @@ have project-specific configurations you need to apply.
 ## Extra config flags
 
 Finally, there is one last way to adjust the Bazel configs, through the use of
-the `--@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_*_flags`
+the `--@rules_xcodeproj//xcodeproj:extra_*_flags`
 family of build flags. These flags apply changes to the configs after all other
 sources, and work when calling `bazel run` to generate the project. If using
 project-level configs, these flags adjust those instead of the base configs.
@@ -117,7 +117,7 @@ configs further.
 ### Project `xcodeproj_extra_flags.bazelrc`
 
 Finally, if any
-`--@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_*_flags` build
+`--@rules_xcodeproj//xcodeproj:extra_*_flags` build
 flags were used during project generation, then those adjustments are made in
 a project `xcodeproj_extra_flags.bazelrc` file, which is loaded after the
 workspace `.bazelrc` file. This ensures that they override any flags set
@@ -241,10 +241,10 @@ INFO: Invocation ID: e4be5bb9-1823-4ca9-a3fd-6066f936460a
 INFO: Analyzed target //:xcodeproj (0 packages loaded, 0 targets configured).
 INFO: Found 1 target...
 Target //:xcodeproj up-to-date:
-  /Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh
+  /Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh
 INFO: Elapsed time: 0.285s, Critical Path: 0.00s
 INFO: 1 process: 1 internal.
-INFO: Running command line: /Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh -v clean
+INFO: Running command line: /Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh -v clean
 INFO: Build completed successfully, 1 total action
 
 INFO: Invocation ID: 84c53471-73a4-4267-9289-0ad076ee94fb
@@ -259,14 +259,14 @@ INFO: Invocation ID: e4be5bb9-1823-4ca9-a3fd-6066f936460a
 INFO: Analyzed target //:xcodeproj (0 packages loaded, 0 targets configured).
 INFO: Found 1 target...
 Target //:xcodeproj up-to-date:
-  /Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh
+  /Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh
 INFO: Elapsed time: 0.285s, Critical Path: 0.00s
 INFO: 1 process: 1 internal.
-INFO: Running command line: /Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh -v clean
+INFO: Running command line: /Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh -v clean
 INFO: Build completed successfully, 1 total action
 
 Running Bazel command:
-+ env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /Users/brentley/Library/Caches/bazelisk/downloads/bazelbuild/bazel-5.3.0-darwin-arm64/bin/bazel --host_jvm_args=-Xdock:name=/Applications/Xcode-14.0.1.app/Contents/Developer --noworkspace_rc --bazelrc=/Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh.runfiles/com_github_buildbuddy_io_rules_xcodeproj/xcodeproj.bazelrc --bazelrc=.bazelrc --bazelrc=/Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh.runfiles/com_github_buildbuddy_io_rules_xcodeproj/xcodeproj-extra-flags.bazelrc --output_base /Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/_rules_xcodeproj/build_output_base clean --repo_env=DEVELOPER_DIR=/Applications/Xcode-14.0.1.app/Contents/Developer --repo_env=USE_CLANG_CL=14A400 --config=_rules_xcodeproj_build
++ env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin /Users/brentley/Library/Caches/bazelisk/downloads/bazelbuild/bazel-5.3.0-darwin-arm64/bin/bazel --host_jvm_args=-Xdock:name=/Applications/Xcode-14.0.1.app/Contents/Developer --noworkspace_rc --bazelrc=/Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh.runfiles/rules_xcodeproj/xcodeproj.bazelrc --bazelrc=.bazelrc --bazelrc=/Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-fastbuild/bin/xcodeproj-runner.sh.runfiles/rules_xcodeproj/xcodeproj-extra-flags.bazelrc --output_base /Users/brentley/Developer/rules_xcodeproj/bazel-output-base/execroot/_rules_xcodeproj/build_output_base clean --repo_env=DEVELOPER_DIR=/Applications/Xcode-14.0.1.app/Contents/Developer --repo_env=USE_CLANG_CL=14A400 --config=_rules_xcodeproj_build
 INFO: Invocation ID: 84c53471-73a4-4267-9289-0ad076ee94fb
 INFO: Starting clean.
 ```

--- a/examples/cc/BUILD
+++ b/examples/cc/BUILD
@@ -1,7 +1,4 @@
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcodeproj",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcodeproj")
 load(":xcodeproj_targets.bzl", "XCODEPROJ_TARGETS")
 
 xcodeproj(

--- a/examples/cc/MODULE.bazel
+++ b/examples/cc/MODULE.bazel
@@ -1,7 +1,6 @@
 bazel_dep(
     name = "rules_xcodeproj",
     version = "0.0.0",
-    repo_name = "rules_xcodeproj",
 )
 bazel_dep(
     name = "rules_apple",

--- a/examples/cc/MODULE.bazel
+++ b/examples/cc/MODULE.bazel
@@ -1,7 +1,7 @@
 bazel_dep(
     name = "rules_xcodeproj",
     version = "0.0.0",
-    repo_name = "com_github_buildbuddy_io_rules_xcodeproj",
+    repo_name = "rules_xcodeproj",
 )
 bazel_dep(
     name = "rules_apple",

--- a/examples/cc/WORKSPACE
+++ b/examples/cc/WORKSPACE
@@ -1,10 +1,10 @@
 local_repository(
-    name = "com_github_buildbuddy_io_rules_xcodeproj",
+    name = "rules_xcodeproj",
     path = "../..",
 )
 
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:repositories.bzl",
+    "@rules_xcodeproj//xcodeproj:repositories.bzl",
     "xcodeproj_rules_dependencies",
 )
 

--- a/examples/cc/test/fixtures/BUILD
+++ b/examples/cc/test/fixtures/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:testing.bzl",
+    "@rules_xcodeproj//xcodeproj:testing.bzl",
     "update_fixtures",
     "validate_fixtures",
     "xcodeproj_fixture",

--- a/examples/integration/.bazelrc
+++ b/examples/integration/.bazelrc
@@ -3,10 +3,10 @@ import %workspace%/../../shared.bazelrc
 
 # Exercise the extra flags feature
 
-build:rules_xcodeproj --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_common_flags='--verbose_failures'
-build:rules_xcodeproj --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_generator_flags='--noverbose_failures'
-build:rules_xcodeproj --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_indexbuild_flags='--noverbose_failures'
-build:rules_xcodeproj --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_swiftuipreviews_flags='--noverbose_failures'
+build:rules_xcodeproj --@rules_xcodeproj//xcodeproj:extra_common_flags='--verbose_failures'
+build:rules_xcodeproj --@rules_xcodeproj//xcodeproj:extra_generator_flags='--noverbose_failures'
+build:rules_xcodeproj --@rules_xcodeproj//xcodeproj:extra_indexbuild_flags='--noverbose_failures'
+build:rules_xcodeproj --@rules_xcodeproj//xcodeproj:extra_swiftuipreviews_flags='--noverbose_failures'
 
 build:rules_xcodeproj_integration --define=foo=bar
 

--- a/examples/integration/AppClip/BUILD
+++ b/examples/integration/AppClip/BUILD
@@ -2,10 +2,7 @@ load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_app_clip")
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcode_provisioning_profile",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcode_provisioning_profile")
 load(
     "//:xcodeproj_targets.bzl",
     "APP_CLIP_BUNDLE_ID",

--- a/examples/integration/BUILD
+++ b/examples/integration/BUILD
@@ -1,7 +1,4 @@
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcodeproj",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcodeproj")
 load(
     ":xcodeproj_targets.bzl",
     "ASSOCIATED_EXTRA_FILES",

--- a/examples/integration/MODULE.bazel
+++ b/examples/integration/MODULE.bazel
@@ -1,7 +1,6 @@
 bazel_dep(
     name = "rules_xcodeproj",
     version = "0.0.0",
-    repo_name = "rules_xcodeproj",
 )
 bazel_dep(
     name = "apple_support",

--- a/examples/integration/MODULE.bazel
+++ b/examples/integration/MODULE.bazel
@@ -1,7 +1,7 @@
 bazel_dep(
     name = "rules_xcodeproj",
     version = "0.0.0",
-    repo_name = "com_github_buildbuddy_io_rules_xcodeproj",
+    repo_name = "rules_xcodeproj",
 )
 bazel_dep(
     name = "apple_support",

--- a/examples/integration/WORKSPACE
+++ b/examples/integration/WORKSPACE
@@ -1,5 +1,5 @@
 local_repository(
-    name = "com_github_buildbuddy_io_rules_xcodeproj",
+    name = "rules_xcodeproj",
     path = "../..",
 )
 
@@ -14,7 +14,7 @@ http_archive(
 )
 
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:repositories.bzl",
+    "@rules_xcodeproj//xcodeproj:repositories.bzl",
     "xcodeproj_rules_dependencies",
 )
 

--- a/examples/integration/WidgetExtension/BUILD
+++ b/examples/integration/WidgetExtension/BUILD
@@ -6,10 +6,7 @@ load(
     "apple_resource_group",
 )
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcode_provisioning_profile",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcode_provisioning_profile")
 load(
     "//:xcodeproj_targets.bzl",
     "IOS_BUNDLE_ID",

--- a/examples/integration/iOSApp/Source/BUILD
+++ b/examples/integration/iOSApp/Source/BUILD
@@ -2,10 +2,7 @@ load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcode_provisioning_profile",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcode_provisioning_profile")
 load(
     "//:xcodeproj_targets.bzl",
     "IOS_BUNDLE_ID",

--- a/examples/integration/test/fixtures/BUILD
+++ b/examples/integration/test/fixtures/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:testing.bzl",
+    "@rules_xcodeproj//xcodeproj:testing.bzl",
     "update_fixtures",
     "validate_fixtures",
     "xcodeproj_fixture",

--- a/examples/integration/tvOSApp/Source/BUILD
+++ b/examples/integration/tvOSApp/Source/BUILD
@@ -1,10 +1,7 @@
 load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
 load("@build_bazel_rules_apple//apple:tvos.bzl", "tvos_application")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcode_provisioning_profile",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcode_provisioning_profile")
 load(
     "//:xcodeproj_targets.bzl",
     "TEAMID",

--- a/examples/integration/watchOSApp/BUILD
+++ b/examples/integration/watchOSApp/BUILD
@@ -1,9 +1,6 @@
 load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
 load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_application")
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcode_provisioning_profile",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcode_provisioning_profile")
 load(
     "//:xcodeproj_targets.bzl",
     "IOS_BUNDLE_ID",

--- a/examples/integration/watchOSAppExtension/BUILD
+++ b/examples/integration/watchOSAppExtension/BUILD
@@ -2,10 +2,7 @@ load("@build_bazel_rules_apple//apple:apple.bzl", "local_provisioning_profile")
 load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
 load("@build_bazel_rules_apple//apple:watchos.bzl", "watchos_extension")
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcode_provisioning_profile",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcode_provisioning_profile")
 load(
     "//:xcodeproj_targets.bzl",
     "TEAMID",

--- a/examples/integration/xcodeproj_targets.bzl
+++ b/examples/integration/xcodeproj_targets.bzl
@@ -1,7 +1,7 @@
 """Exposes targets used by `xcodeproj` to allow use in fixture tests."""
 
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
+    "@rules_xcodeproj//xcodeproj:defs.bzl",
     "project_options",
     "top_level_target",
     "top_level_targets",

--- a/examples/sanitizers/BUILD
+++ b/examples/sanitizers/BUILD
@@ -1,7 +1,4 @@
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcodeproj",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcodeproj")
 load(
     ":xcodeproj_targets.bzl",
     "SCHEME_AUTOGENERATION_MODE",

--- a/examples/sanitizers/WORKSPACE
+++ b/examples/sanitizers/WORKSPACE
@@ -1,10 +1,10 @@
 local_repository(
-    name = "com_github_buildbuddy_io_rules_xcodeproj",
+    name = "rules_xcodeproj",
     path = "../..",
 )
 
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:repositories.bzl",
+    "@rules_xcodeproj//xcodeproj:repositories.bzl",
     "xcodeproj_rules_dependencies",
 )
 

--- a/examples/sanitizers/test/fixtures/BUILD
+++ b/examples/sanitizers/test/fixtures/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:testing.bzl",
+    "@rules_xcodeproj//xcodeproj:testing.bzl",
     "update_fixtures",
     "validate_fixtures",
     "xcodeproj_fixture",

--- a/examples/sanitizers/xcodeproj_targets.bzl
+++ b/examples/sanitizers/xcodeproj_targets.bzl
@@ -1,9 +1,6 @@
 """Exposes targets used by `xcodeproj` to allow use in fixture tests."""
 
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcode_schemes",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcode_schemes")
 
 SCHEME_AUTOGENERATION_MODE = "none"
 

--- a/shared.bazelrc
+++ b/shared.bazelrc
@@ -33,9 +33,9 @@ build:cache --experimental_remote_cache_compression
 build:cache --jobs=100
 build:cache --modify_execution_info=^(BitcodeSymbolsCopy|BundleApp|BundleTreeApp|DsymDwarf|DsymLipo|GenerateAppleSymbolsFile|ObjcBinarySymbolStrip|CppLink|ObjcLink|ProcessAndSign|SignBinary|SwiftArchive|SwiftStdlibCopy)$=+no-remote,^(BundleResources|ImportedDynamicFrameworkProcessor)$=+no-remote-exec
 build:cache --remote_cache=grpcs://remote.buildbuddy.io
-build:cache --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_common_flags='--config=cache'
-build:cache --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_indexbuild_flags='--bes_backend= --bes_results_url='
-build:cache --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_generator_flags='--bes_backend= --bes_results_url='
+build:cache --@rules_xcodeproj//xcodeproj:extra_common_flags='--config=cache'
+build:cache --@rules_xcodeproj//xcodeproj:extra_indexbuild_flags='--bes_backend= --bes_results_url='
+build:cache --@rules_xcodeproj//xcodeproj:extra_generator_flags='--bes_backend= --bes_results_url='
 
 # Build with --config=remote to use BuildBuddy RBE
 build:remote --config=cache
@@ -49,7 +49,7 @@ build:workflows --remote_instance_name=buildbuddy-io/rules_xcodeproj/workflows
 build:workflows --color=yes
 build:workflows --terminal_columns=120
 build:workflows --disk_cache=
-build:workflows --@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:extra_generator_flags='--config=workflows --bes_backend= --bes_results_url='
+build:workflows --@rules_xcodeproj//xcodeproj:extra_generator_flags='--config=workflows --bes_backend= --bes_results_url='
 
 # Show detailed errors for test failures
 test --test_output=errors --test_summary=detailed

--- a/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwb.xcodeproj/project.pbxproj
@@ -1978,7 +1978,7 @@
 			);
 			mainGroup = 9FFDBC24588A91736E9C5DBD /* ../../../../.. */;
 			productRefGroup = 891FF4EFB55BD0CCB8B61ED5 /* Products */;
-			projectDirPath = "../../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+			projectDirPath = "../../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj";
 			projectRoot = "";
 			targets = (
 				7E7D155EBCA520F35DEA3571 /* BazelDependencies */,
@@ -3053,7 +3053,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";

--- a/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwb.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -241,15 +241,15 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/test/fixtures/generator/bwb_custom_xcode_schemes.json
+++ b/test/fixtures/generator/bwb_custom_xcode_schemes.json
@@ -30,9 +30,9 @@
         },
         "launch_action": {
             "args": [
-                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
-                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
-                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
+                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
+                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
+                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
                 "/tmp/out.xcodeproj",
                 "/tmp/out.final.xcodeproj",
                 "bazel",

--- a/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
+++ b/test/fixtures/generator/bwx.xcodeproj/project.pbxproj
@@ -2059,7 +2059,7 @@
 			);
 			mainGroup = 1EF2569752EC6D782DEDEF47 /* ../../../../.. */;
 			productRefGroup = C5DA04B2480EBE8D895B5826 /* Products */;
-			projectDirPath = "../../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+			projectDirPath = "../../../bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj";
 			projectRoot = "";
 			targets = (
 				FE59281FE487F27A37DC2EE7 /* BazelDependencies */,
@@ -3243,7 +3243,7 @@
 				INDEXING_DEPLOYMENT_LOCATION__YES = NO;
 				INDEXING_PROJECT_DIR__ = "$(INDEXING_PROJECT_DIR__NO)";
 				INDEXING_PROJECT_DIR__NO = "$(PROJECT_DIR)";
-				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj";
+				INDEXING_PROJECT_DIR__YES = "../../../../../bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj";
 				INDEX_FORCE_SCRIPT_EXECUTION = YES;
 				INSTALL_PATH = "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin";
 				INTERNAL_DIR = "$(PROJECT_FILE_PATH)/rules_xcodeproj";

--- a/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
+++ b/test/fixtures/generator/bwx.xcodeproj/xcshareddata/xcschemes/generator.xcscheme
@@ -215,15 +215,15 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers"
+            argument = "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/test/fixtures/generator/bwx_custom_xcode_schemes.json
+++ b/test/fixtures/generator/bwx_custom_xcode_schemes.json
@@ -30,9 +30,9 @@
         },
         "launch_action": {
             "args": [
-                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
-                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
-                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
+                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
+                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
+                "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
                 "/tmp/out.xcodeproj",
                 "/tmp/out.final.xcodeproj",
                 "bazel",

--- a/tools/generator/test/CreateCustomXCSchemesTests.swift
+++ b/tools/generator/test/CreateCustomXCSchemesTests.swift
@@ -56,7 +56,7 @@ class CreateCustomXCSchemesTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/CreateProjectTests.swift
+++ b/tools/generator/test/CreateProjectTests.swift
@@ -15,7 +15,7 @@ final class CreateProjectTests: XCTestCase {
         let directories = Directories(
             workspace: "/Users/TimApple/app",
             projectRoot: projectRootDirectory,
-            executionRoot: "/tmp/bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+            executionRoot: "/tmp/bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
             internalDirectoryName: "r_xcp",
             workspaceOutput: "X.xcodeproj"
         )
@@ -81,7 +81,7 @@ $(INDEXING_DEPLOYMENT_LOCATION__NO)
             "INDEXING_PROJECT_DIR__": "$(INDEXING_PROJECT_DIR__NO)",
             "INDEXING_PROJECT_DIR__NO": "$(PROJECT_DIR)",
             "INDEXING_PROJECT_DIR__YES": """
-/tmp/bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj
+/tmp/bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj
 """,
             "INSTALL_PATH": "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin",
             "INTERNAL_DIR": "$(PROJECT_FILE_PATH)/r_xcp",
@@ -163,7 +163,7 @@ $(PROJECT_TEMP_DIR)/$(BAZEL_PACKAGE_BIN_DIR)/$(COMPILE_TARGET_NAME)
         let directories = Directories(
             workspace: "/Users/TimApple/app",
             projectRoot: projectRootDirectory,
-            executionRoot: "/tmp/bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+            executionRoot: "/tmp/bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
             internalDirectoryName: "r_xcp",
             workspaceOutput: "X.xcodeproj"
         )
@@ -235,7 +235,7 @@ $(INDEXING_DEPLOYMENT_LOCATION__NO)
             "INDEXING_PROJECT_DIR__": "$(INDEXING_PROJECT_DIR__NO)",
             "INDEXING_PROJECT_DIR__NO": "$(PROJECT_DIR)",
             "INDEXING_PROJECT_DIR__YES": """
-/tmp/bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj
+/tmp/bazel-output-base/rules_xcodeproj/indexbuild_output_base/execroot/rules_xcodeproj
 """,
             "INSTALL_PATH": "$(BAZEL_PACKAGE_BIN_DIR)/$(TARGET_NAME)/bin",
             "INTERNAL_DIR": "$(PROJECT_FILE_PATH)/r_xcp",

--- a/tools/generator/test/SetTargetConfigurationsTests.swift
+++ b/tools/generator/test/SetTargetConfigurationsTests.swift
@@ -9,7 +9,7 @@ final class SetTargetConfigurationsTests: XCTestCase {
     private static let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "out/p.xcodeproj"
     )

--- a/tools/generator/test/SetTargetDependenciesTests.swift
+++ b/tools/generator/test/SetTargetDependenciesTests.swift
@@ -13,7 +13,7 @@ final class SetTargetDependenciesTests: XCTestCase {
         let directories = Directories(
             workspace: "/Users/TimApple/app",
             projectRoot: "/Users/TimApple",
-            executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+            executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
             internalDirectoryName: "rules_xcodeproj",
             workspaceOutput: "out/p.xcodeproj"
         )

--- a/tools/generator/test/XCScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XCScheme+ExtensionsTests.swift
@@ -420,7 +420,7 @@ class XCSchemeExtensionsTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/XCSchemeInfo+BuildActionInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+BuildActionInfoTests.swift
@@ -73,7 +73,7 @@ class XCSchemeInfoBuildActionInfoTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/XCSchemeInfo+BuildTargetInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+BuildTargetInfoTests.swift
@@ -23,7 +23,7 @@ class XCSchemeInfoBuildTargetInfoTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/XCSchemeInfo+HostInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+HostInfoTests.swift
@@ -84,7 +84,7 @@ class XCSchemeInfoHostInfoTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/XCSchemeInfo+LaunchActionInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+LaunchActionInfoTests.swift
@@ -254,7 +254,7 @@ class XCSchemeInfoLaunchActionInfoTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/XCSchemeInfo+PrePostActionInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+PrePostActionInfoTests.swift
@@ -21,7 +21,7 @@ final class XCSchemeInfoPrePostActionInfoTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/XCSchemeInfo+ProfileActionInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+ProfileActionInfoTests.swift
@@ -93,7 +93,7 @@ class XCSchemeInfoProfileActionInfoTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/XCSchemeInfo+TargetInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+TargetInfoTests.swift
@@ -241,7 +241,7 @@ class XCSchemeInfoTargetInfoTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/XCSchemeInfo+TestActionInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfo+TestActionInfoTests.swift
@@ -141,7 +141,7 @@ class XCSchemeInfoTestActionInfoTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/XCSchemeInfoTests.swift
+++ b/tools/generator/test/XCSchemeInfoTests.swift
@@ -235,7 +235,7 @@ class XCSchemeInfoTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/XcodeScheme+ExtensionsTests.swift
+++ b/tools/generator/test/XcodeScheme+ExtensionsTests.swift
@@ -503,7 +503,7 @@ class XcodeSchemeExtensionsTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/test/XcodeSchemeTests.swift
+++ b/tools/generator/test/XcodeSchemeTests.swift
@@ -365,7 +365,7 @@ class XcodeSchemeTests: XCTestCase {
     let directories = Directories(
         workspace: "/Users/TimApple/app",
         projectRoot: "/Users/TimApple",
-        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj",
+        executionRoot: "bazel-output-base/execroot/_rules_xcodeproj/build_output_base/execroot/rules_xcodeproj",
         internalDirectoryName: "rules_xcodeproj",
         workspaceOutput: "examples/foo/Foo.xcodeproj"
     )

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -63,9 +63,9 @@ def get_xcode_schemes():
             launch_action = xcode_schemes.launch_action(
                 _APP_TARGET,
                 args = [
-                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
-                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
-                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/com_github_buildbuddy_io_rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_root_dirs",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_xccurrentversions",
+                    "bazel-output-base/rules_xcodeproj/build_output_base/execroot/rules_xcodeproj/bazel-out/darwin_arm64-dbg/bin/tools/generator/xcodeproj.generator_extensionpointidentifiers",
                     "/tmp/out.xcodeproj",
                     "/tmp/out.final.xcodeproj",
                     "bazel",

--- a/xcodeproj/internal/docs/bazel.header.md
+++ b/xcodeproj/internal/docs/bazel.header.md
@@ -9,10 +9,7 @@ For example, to use the [`xcodeproj`](#xcodeproj) rule, you would need to use
 this `load` statement:
 
 ```starlark
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcodeproj",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcodeproj")
 ```
 
 ### Index

--- a/xcodeproj/internal/docs/xcode_schemes.bzl
+++ b/xcodeproj/internal/docs/xcode_schemes.bzl
@@ -4,10 +4,7 @@ To use these functions, `load` the `xcode_schemes` module from
 `xcodeproj/defs.bzl`:
 
 ```starlark
-load(
-    "@com_github_buildbuddy_io_rules_xcodeproj//xcodeproj:defs.bzl",
-    "xcode_schemes",
-)
+load("@rules_xcodeproj//xcodeproj:defs.bzl", "xcode_schemes")
 ```
 """
 

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -35,7 +35,7 @@ def _maybe(repo_rule, name, ignore_version_differences, **kwargs):
                 )
 
                 warn("""\
-`com_github_buildbuddy_io_rules_xcodeproj` depends on `{repo}` loaded from \
+`rules_xcodeproj` depends on `{repo}` loaded from \
 {expected}, but we have detected it already loaded into your workspace from \
 {existing}. You may run into compatibility issues. To silence this warning, \
 pass `ignore_version_differences = True` to `xcodeproj_rules_dependencies()`.


### PR DESCRIPTION
With bzlmod you can name your dependencies anything you want. Modules also have a default name. We’ve secured `rules_xcodeproj` on BCR, so that would be the default name if you don’t use `bazel_dep.repo_name`.

Given that, I’ve updated all of the self-reference to use that new shorter name. This rename also removes the reference to the BuildBuddy GitHub org, which won’t make sense soon with the move to the Mobile Native Foundation.