### PR TITLE
Move `native.package_relative_label` into `workspace_name_resolvers`

### DIFF
--- a/test/internal/bazel_labels/normalize_tests.bzl
+++ b/test/internal/bazel_labels/normalize_tests.bzl
@@ -17,9 +17,12 @@ load(
 def _repo_prefix():
     return str(Label("@//:BUILD")).partition("//")[0]
 
+def _external_repo_prefix():
+    return _repo_prefix() or "@"
+
 bazel_labels = make_bazel_labels(
     workspace_name_resolvers = make_stub_workspace_name_resolvers(
-        repo_name = _repo_prefix(),
+        repo_name = _repo_prefix() or "@",
         pkg_name = "Sources/Foo",
     ),
 )
@@ -41,7 +44,7 @@ def _absolute_label_with_repo_name_test(ctx):
 
     value = "@my_dep//Sources/Foo:chicken"
     actual = bazel_labels.normalize(value)
-    expected = _repo_prefix() + "my_dep//Sources/Foo:chicken"
+    expected = _external_repo_prefix() + "my_dep//Sources/Foo:chicken"
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)

--- a/test/internal/bazel_labels/normalize_tests.bzl
+++ b/test/internal/bazel_labels/normalize_tests.bzl
@@ -14,25 +14,22 @@ load(
     "make_stub_workspace_name_resolvers",
 )
 
+def _repo_prefix():
+    return str(Label("@//:BUILD")).partition("//")[0]
+
 bazel_labels = make_bazel_labels(
     workspace_name_resolvers = make_stub_workspace_name_resolvers(
-        repo_name = "@",
+        repo_name = _repo_prefix(),
         pkg_name = "Sources/Foo",
     ),
 )
-
-def _main_repo_prefix():
-    return str(Label("@//:BUILD")).partition("//")[0]
-
-def _external_repo_prefix():
-    return str(Label("@_repo//:BUILD")).partition("_")[0]
 
 def _relative_label_test(ctx):
     env = unittest.begin(ctx)
 
     value = ":chicken"
     actual = bazel_labels.normalize(value)
-    expected = _main_repo_prefix() + "//Sources/Foo:chicken"
+    expected = _repo_prefix() + "//Sources/Foo:chicken"
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)
@@ -44,7 +41,7 @@ def _absolute_label_with_repo_name_test(ctx):
 
     value = "@my_dep//Sources/Foo:chicken"
     actual = bazel_labels.normalize(value)
-    expected = _external_repo_prefix() + "my_dep//Sources/Foo:chicken"
+    expected = _repo_prefix() + "my_dep//Sources/Foo:chicken"
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)
@@ -56,7 +53,7 @@ def _absolute_label_without_repo_name_test(ctx):
 
     value = "//Sources/Foo:chicken"
     actual = bazel_labels.normalize(value)
-    expected = _main_repo_prefix() + "//Sources/Foo:chicken"
+    expected = _repo_prefix() + "//Sources/Foo:chicken"
     asserts.equals(env, expected, actual)
 
     return unittest.end(env)

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -91,8 +91,11 @@ def make_bazel_labels(workspace_name_resolvers = workspace_name_resolvers):
         if type(value) == "Label":
             return str(value)
         else:
-            if hasattr(native, "package_relative_label"):
-                return str(native.package_relative_label(value))
+            package_relative_label = (
+                workspace_name_resolvers.package_relative_label(value)
+            )
+            if package_relative_label:
+                return str(package_relative_label)
 
             parts = _parse(value)
 
@@ -108,4 +111,6 @@ def make_bazel_labels(workspace_name_resolvers = workspace_name_resolvers):
         normalize = _normalize,
     )
 
-bazel_labels = make_bazel_labels(workspace_name_resolvers = workspace_name_resolvers)
+bazel_labels = make_bazel_labels(
+    workspace_name_resolvers = workspace_name_resolvers,
+)

--- a/xcodeproj/internal/workspace_name_resolvers.bzl
+++ b/xcodeproj/internal/workspace_name_resolvers.bzl
@@ -1,11 +1,16 @@
 """API for resolving workspace names"""
 
-def _make_workspace_name_resolvers(repository_name, package_name):
+def _make_workspace_name_resolvers(
+        repository_name,
+        package_name,
+        package_relative_label):
     """Create a name resolver module.
 
     Args:
         repository_name: A `function` that returns the current repository name.
         package_name: A `function` that returns the current package name.
+        package_relative_label: A `function` that returns the current package
+            relative label.
 
     Returns:
         A `struct` that can be used as a name resolver module.
@@ -13,11 +18,18 @@ def _make_workspace_name_resolvers(repository_name, package_name):
     return struct(
         repository_name = repository_name,
         package_name = package_name,
+        package_relative_label = package_relative_label,
     )
+
+def _package_relative_label_shim(value):
+    if hasattr(native, "package_relative_label"):
+        return native.package_relative_label(value)
+    return None
 
 workspace_name_resolvers = _make_workspace_name_resolvers(
     repository_name = native.repository_name,
     package_name = native.package_name,
+    package_relative_label = _package_relative_label_shim,
 )
 
 def make_stub_workspace_name_resolvers(repo_name = "@", pkg_name = ""):
@@ -37,7 +49,19 @@ def make_stub_workspace_name_resolvers(repo_name = "@", pkg_name = ""):
     def _stub_package_name():
         return pkg_name
 
+    def _stub_package_relative_label(value):
+        if not hasattr(native, "package_relative_label"):
+            return None
+        if value.startswith(":"):
+            return "{}//{}{}".format(repo_name, pkg_name, value)
+        if value.startswith("//"):
+            return "{}{}".format(repo_name, value)
+        if not value.startswith("@@"):
+            return repo_name + value[1:]
+        return value
+
     return _make_workspace_name_resolvers(
         repository_name = _stub_repository_name,
         package_name = _stub_package_name,
+        package_relative_label = _stub_package_relative_label,
     )


### PR DESCRIPTION
`native.package_relative_label` can only be used from a `BUILD` thread, so it needs to be abstracted away like our other label functions, in order to test Starlark that uses it.