### PR TITLE
Split `bazel_labels.normalize` into two functions

### DIFF
--- a/test/internal/bazel_labels/normalize_tests.bzl
+++ b/test/internal/bazel_labels/normalize_tests.bzl
@@ -1,4 +1,4 @@
-"""Tests for `bazel_labels.normalize`"""
+"""Tests for `bazel_labels.normalize_string`"""
 
 load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
 
@@ -31,7 +31,7 @@ def _relative_label_test(ctx):
     env = unittest.begin(ctx)
 
     value = ":chicken"
-    actual = bazel_labels.normalize(value)
+    actual = bazel_labels.normalize_string(value)
     expected = _repo_prefix() + "//Sources/Foo:chicken"
     asserts.equals(env, expected, actual)
 
@@ -43,7 +43,7 @@ def _absolute_label_with_repo_name_test(ctx):
     env = unittest.begin(ctx)
 
     value = "@my_dep//Sources/Foo:chicken"
-    actual = bazel_labels.normalize(value)
+    actual = bazel_labels.normalize_string(value)
     expected = _external_repo_prefix() + "my_dep//Sources/Foo:chicken"
     asserts.equals(env, expected, actual)
 
@@ -55,7 +55,7 @@ def _absolute_label_without_repo_name_test(ctx):
     env = unittest.begin(ctx)
 
     value = "//Sources/Foo:chicken"
-    actual = bazel_labels.normalize(value)
+    actual = bazel_labels.normalize_string(value)
     expected = _repo_prefix() + "//Sources/Foo:chicken"
     asserts.equals(env, expected, actual)
 

--- a/test/internal/xcode_schemes/model_tests.bzl
+++ b/test/internal/xcode_schemes/model_tests.bzl
@@ -61,7 +61,7 @@ def _build_target_test(ctx):
 
     actual = xcode_schemes.build_target("//Sources/Foo")
     expected = struct(
-        label = bazel_labels.normalize("//Sources/Foo"),
+        label = bazel_labels.normalize_string("//Sources/Foo"),
         build_for = xcode_schemes.BUILD_FOR_ALL_ENABLED,
     )
     asserts.equals(env, expected, actual, "no build_for")
@@ -71,7 +71,7 @@ def _build_target_test(ctx):
         xcode_schemes.build_for(),
     )
     expected = struct(
-        label = bazel_labels.normalize("//Sources/Foo"),
+        label = bazel_labels.normalize_string("//Sources/Foo"),
         build_for = xcode_schemes.build_for(),
     )
     asserts.equals(env, expected, actual, "with build_for")
@@ -140,8 +140,8 @@ def _build_action_test(ctx):
 
     expected = struct(
         targets = [
-            xcode_schemes.build_target(bazel_labels.normalize("//Sources/Bar")),
-            xcode_schemes.build_target(bazel_labels.normalize("//Sources/Foo")),
+            xcode_schemes.build_target(bazel_labels.normalize_string("//Sources/Bar")),
+            xcode_schemes.build_target(bazel_labels.normalize_string("//Sources/Foo")),
         ],
         pre_actions = [],
         post_actions = [],
@@ -160,7 +160,7 @@ def _test_action_test(ctx):
     actual = xcode_schemes.test_action(targets)
     expected = struct(
         build_configuration_name = None,
-        targets = [bazel_labels.normalize(t) for t in targets],
+        targets = [bazel_labels.normalize_string(t) for t in targets],
         args = None,
         diagnostics = None,
         env = None,
@@ -175,7 +175,7 @@ def _test_action_test(ctx):
     actual = xcode_schemes.test_action(targets, args = args, env = custom_env)
     expected = struct(
         build_configuration_name = None,
-        targets = [bazel_labels.normalize(t) for t in targets],
+        targets = [bazel_labels.normalize_string(t) for t in targets],
         args = args,
         diagnostics = None,
         env = custom_env,
@@ -193,7 +193,7 @@ def _test_action_test(ctx):
     )
     expected = struct(
         build_configuration_name = None,
-        targets = [bazel_labels.normalize(t) for t in targets],
+        targets = [bazel_labels.normalize_string(t) for t in targets],
         args = [],
         diagnostics = None,
         env = {},
@@ -214,11 +214,11 @@ def _test_action_test(ctx):
     )
     expected = struct(
         build_configuration_name = None,
-        targets = [bazel_labels.normalize(t) for t in targets],
+        targets = [bazel_labels.normalize_string(t) for t in targets],
         args = None,
         diagnostics = None,
         env = None,
-        expand_variables_based_on = bazel_labels.normalize(targets[0]),
+        expand_variables_based_on = bazel_labels.normalize_string(targets[0]),
         pre_actions = [],
         post_actions = [],
     )
@@ -247,7 +247,7 @@ def _launch_action_test(ctx):
     )
     expected = struct(
         build_configuration_name = None,
-        target = bazel_labels.normalize(target),
+        target = bazel_labels.normalize_string(target),
         args = args,
         diagnostics = None,
         env = env,

--- a/xcodeproj/internal/bazel_labels.bzl
+++ b/xcodeproj/internal/bazel_labels.bzl
@@ -87,28 +87,29 @@ def make_bazel_labels(workspace_name_resolvers = workspace_name_resolvers):
             name = name,
         )
 
-    def _normalize(value):
-        if type(value) == "Label":
-            return str(value)
-        else:
-            package_relative_label = (
-                workspace_name_resolvers.package_relative_label(value)
-            )
-            if package_relative_label:
-                return str(package_relative_label)
+    def _normalize_label(value):
+        return str(value)
 
-            parts = _parse(value)
+    def _normalize_string(value):
+        package_relative_label = (
+            workspace_name_resolvers.package_relative_label(value)
+        )
+        if package_relative_label:
+            return str(package_relative_label)
 
-            return str(Label("{repo_name}//{package}:{name}".format(
-                repo_name = parts.repository_name,
-                package = parts.package,
-                name = parts.name,
-            )))
+        parts = _parse(value)
+
+        return str(Label("{repo_name}//{package}:{name}".format(
+            repo_name = parts.repository_name,
+            package = parts.package,
+            name = parts.name,
+        )))
 
     return struct(
         create = _create_label_parts,
         parse = _parse,
-        normalize = _normalize,
+        normalize_label = _normalize_label,
+        normalize_string = _normalize_string,
     )
 
 bazel_labels = make_bazel_labels(

--- a/xcodeproj/internal/xcode_schemes.bzl
+++ b/xcodeproj/internal/xcode_schemes.bzl
@@ -280,7 +280,7 @@ def make_xcode_schemes(bazel_labels):
             _pre_post_action(
                 script = action.script,
                 expand_variables_based_on = (
-                    bazel_labels.normalize(
+                    bazel_labels.normalize_string(
                         action.expand_variables_based_on,
                     ) if action.expand_variables_based_on else None
                 ),
@@ -303,7 +303,7 @@ def make_xcode_schemes(bazel_labels):
         if not build_for:
             build_for = xcode_schemes_internal.BUILD_FOR_ALL_ENABLED
         return xcode_schemes_internal.build_target(
-            label = bazel_labels.normalize(label),
+            label = bazel_labels.normalize_string(label),
             build_for = build_for,
         )
 
@@ -369,7 +369,7 @@ def make_xcode_schemes(bazel_labels):
         """
         return xcode_schemes_internal.launch_action(
             build_configuration_name = None,
-            target = bazel_labels.normalize(target),
+            target = bazel_labels.normalize_string(target),
             args = args,
             diagnostics = diagnostics,
             env = env,
@@ -403,7 +403,7 @@ def make_xcode_schemes(bazel_labels):
         """
         return xcode_schemes_internal.profile_action(
             build_configuration = None,
-            target = bazel_labels.normalize(target),
+            target = bazel_labels.normalize_string(target),
             args = args,
             env = env,
             working_directory = working_directory,
@@ -449,13 +449,13 @@ def make_xcode_schemes(bazel_labels):
             if expand_variables_based_on.lower() == "none":
                 expand_variables_based_on = "none"
             else:
-                expand_variables_based_on = bazel_labels.normalize(
+                expand_variables_based_on = bazel_labels.normalize_string(
                     expand_variables_based_on,
                 )
 
         return xcode_schemes_internal.test_action(
             targets = [
-                bazel_labels.normalize(t)
+                bazel_labels.normalize_string(t)
                 for t in targets
             ],
             build_configuration_name = None,

--- a/xcodeproj/internal/xcodeproj_macro.bzl
+++ b/xcodeproj/internal/xcodeproj_macro.bzl
@@ -279,29 +279,29 @@ in your `.bazelrc` or `xcodeproj.bazelrc` file.""")
             actual_top_level_targets.append(target)
 
     top_level_device_targets = [
-        bazel_labels.normalize(top_level_target.label)
+        bazel_labels.normalize_string(top_level_target.label)
         for top_level_target in actual_top_level_targets
         if "device" in top_level_target.target_environments
     ]
     top_level_simulator_targets = [
-        bazel_labels.normalize(top_level_target.label)
+        bazel_labels.normalize_string(top_level_target.label)
         for top_level_target in actual_top_level_targets
         if "simulator" in top_level_target.target_environments
     ]
 
     focused_targets = [
-        bazel_labels.normalize(t)
+        bazel_labels.normalize_string(t)
         for t in focused_targets
     ]
     unfocused_targets = [
-        bazel_labels.normalize(t)
+        bazel_labels.normalize_string(t)
         for t in unfocused_targets
     ]
 
     owned_extra_files = {}
     for label, files in associated_extra_files.items():
         for f in files:
-            owned_extra_files[f] = bazel_labels.normalize(label)
+            owned_extra_files[f] = bazel_labels.normalize_string(label)
 
     schemes_json = None
     if schemes:
@@ -336,7 +336,7 @@ in your `.bazelrc` or `xcodeproj.bazelrc` file.""")
         pre_build = pre_build,
         project_name = project_name,
         project_options = project_options,
-        runner_label = bazel_labels.normalize(name),
+        runner_label = bazel_labels.normalize_string(name),
         scheme_autogeneration_mode = scheme_autogeneration_mode,
         schemes_json = schemes_json,
         temporary_directory = temporary_directory,

--- a/xcodeproj/internal/xcodeproj_rule.bzl
+++ b/xcodeproj/internal/xcodeproj_rule.bzl
@@ -151,7 +151,7 @@ def _process_extra_files(
     # Apply replacement labels
     extra_files = [
         (
-            bazel_labels.normalize(
+            bazel_labels.normalize_label(
                 replacement_labels_by_label.get(label, label),
             ),
             files,
@@ -215,7 +215,7 @@ def _process_xccurrentversions(
     # Apply replacement labels
     xccurrentversions_files = [
         (
-            bazel_labels.normalize(
+            bazel_labels.normalize_label(
                 replacement_labels_by_label.get(label, label),
             ),
             files,
@@ -320,7 +320,9 @@ def _process_targets(
     }
 
     targets_labels = {
-        bazel_labels.normalize(replacement_labels.get(t.id, t.label)): None
+        bazel_labels.normalize_label(
+            replacement_labels.get(t.id, t.label),
+        ): None
         for t in unprocessed_targets.values()
     }
 
@@ -368,7 +370,7 @@ targets.
             xcode_target.id,
             xcode_target.label,
         )
-        label_str = bazel_labels.normalize(label)
+        label_str = bazel_labels.normalize_label(label)
         if (label_str in unfocused_labels or
             (has_focused_labels and label_str not in focused_labels)):
             unfocused_targets[xcode_target.id] = xcode_target
@@ -408,7 +410,7 @@ targets.
             xcode_target.id,
             xcode_target.label,
         )
-        label_str = bazel_labels.normalize(label)
+        label_str = bazel_labels.normalize_label(label)
 
         # Remove from unfocused (to support `xcode_required_targets`)
         unfocused_targets.pop(xcode_target.id, None)
@@ -428,9 +430,9 @@ targets.
     raw_target_merge_dests = {}
     for merge in potential_target_merges:
         src_target = unprocessed_targets[merge.src.id]
-        src_label = bazel_labels.normalize(src_target.label)
+        src_label = bazel_labels.normalize_label(src_target.label)
         dest_target = unprocessed_targets[merge.dest]
-        dest_label = bazel_labels.normalize(dest_target.label)
+        dest_label = bazel_labels.normalize_label(dest_target.label)
         if src_label in unfocused_labels or dest_label in unfocused_labels:
             continue
         raw_target_merge_dests.setdefault(merge.dest, []).append(merge.src.id)
@@ -441,7 +443,7 @@ targets.
             # We can only merge targets with a single library dependency
             continue
         dest_target = unprocessed_targets[dest]
-        dest_label = bazel_labels.normalize(
+        dest_label = bazel_labels.normalize_label(
             replacement_labels.get(dest, dest_target.label),
         )
 
@@ -461,7 +463,7 @@ targets.
 
     for src in target_merge_dests.values():
         src_target = unprocessed_targets[src]
-        src_label = bazel_labels.normalize(
+        src_label = bazel_labels.normalize_label(
             replacement_labels.get(src, src_target.label),
         )
 
@@ -506,7 +508,7 @@ Are you using an `alias`? `associated_extra_files` requires labels of the \
 actual targets: {}
 """.format(invalid_extra_files_targets))
 
-        label_str = bazel_labels.normalize(label)
+        label_str = bazel_labels.normalize_label(label)
         for file, owner_label in owned_extra_files.items():
             if label_str == owner_label:
                 focused_targets_extra_files.append(


### PR DESCRIPTION
This removes a costly `type()` call. We always know the type we are normalizing.