### PR TITLE
Fix source code viewing in Instruments for `generator`

### DIFF
--- a/test/fixtures/generator/bazel-6/bwb_replacements.txt
+++ b/test/fixtures/generator/bazel-6/bwb_replacements.txt
@@ -1,5 +1,5 @@
 darwin_x86_64-dbg-STABLE-0 darwin_x86_64-dbg-ST-40b5e5d10671
 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-c233c8334636
-macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-ST-c233c8334636
+macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-ST-4d1cf0d4af7b
 applebin_macos-darwin_x86_64-dbg-STABLE-3 applebin_macos-darwin_x86_64-dbg-ST-c233c8334636
-applebin_macos-darwin_x86_64-opt-STABLE-4 applebin_macos-darwin_x86_64-opt-ST-c233c8334636
+applebin_macos-darwin_x86_64-opt-STABLE-4 applebin_macos-darwin_x86_64-opt-ST-4d1cf0d4af7b

--- a/test/fixtures/generator/bazel-6/bwx_replacements.txt
+++ b/test/fixtures/generator/bazel-6/bwx_replacements.txt
@@ -1,5 +1,5 @@
 darwin_x86_64-dbg-STABLE-0 darwin_x86_64-dbg-ST-40b5e5d10671
 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-STABLE-1 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-dbg-ST-c233c8334636
-macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-ST-c233c8334636
+macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-STABLE-2 macos-x86_64-min12.0-applebin_macos-darwin_x86_64-opt-ST-4d1cf0d4af7b
 applebin_macos-darwin_x86_64-dbg-STABLE-3 applebin_macos-darwin_x86_64-dbg-ST-c233c8334636
-applebin_macos-darwin_x86_64-opt-STABLE-4 applebin_macos-darwin_x86_64-opt-ST-c233c8334636
+applebin_macos-darwin_x86_64-opt-STABLE-4 applebin_macos-darwin_x86_64-opt-ST-4d1cf0d4af7b

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -21,6 +21,8 @@ XCODE_CONFIGURATIONS = {
     # handling (which includes code paths in both Starlark and the generator)
     "Profile": {
         "//command_line_option:compilation_mode": "opt",
+        # Until we have a solution for Instruments.app handling relative paths,
+        # we need the debug info to include absolute source paths
         "//command_line_option:features": ["-swift.debug_prefix_map"],
     },
     "Release": {

--- a/tools/generator/xcodeproj_targets.bzl
+++ b/tools/generator/xcodeproj_targets.bzl
@@ -15,14 +15,17 @@ TOP_LEVEL_TARGETS = [_APP_TARGET, _TEST_TARGET, _TOOL_TARGET]
 XCODE_CONFIGURATIONS = {
     "Debug": {
         "//command_line_option:compilation_mode": "dbg",
+        "//command_line_option:features": [],
     },
     # Profile and Release are identical to exercise identical configuration
     # handling (which includes code paths in both Starlark and the generator)
     "Profile": {
         "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:features": ["-swift.debug_prefix_map"],
     },
     "Release": {
         "//command_line_option:compilation_mode": "opt",
+        "//command_line_option:features": ["-swift.debug_prefix_map"],
     },
 }
 


### PR DESCRIPTION
This results in cache misses, since the paths are absolute to the machine they are run on. Ideally we can come up with a way to handle the relative paths (like launching `Instruments.app/Contents/MacOS/Instruments` from the Bazel execution root), but for now this makes it easier for me to profile things.