### PR TITLE
Check VFS overlay flags more efficiently

### DIFF
--- a/test/internal/opts/process_compiler_opts_tests.bzl
+++ b/test/internal/opts/process_compiler_opts_tests.bzl
@@ -443,6 +443,8 @@ def process_compiler_opts_test_suite(name):
             "ios",
             "-mmacosx-version-min=12.0",
             "-passthrough",
+            "--config",
+            "relative/Path.yaml",
         ],
         cxxopts = [
             "-isysroot",
@@ -460,6 +462,8 @@ def process_compiler_opts_test_suite(name):
             "macos",
             "-passthrough",
             "-mios-simulator-version-min=14.0",
+            "--config",
+            "relative/Path.yaml",
         ],
         swiftcopts = [
             "-output-file-map",
@@ -526,12 +530,16 @@ def process_compiler_opts_test_suite(name):
             "-I__BAZEL_XCODE_SOMETHING_/path",
             "-passthrough",
             "-passthrough",
+            "--config",
+            "$(CURRENT_EXECUTION_ROOT)/relative/Path.yaml",
         ],
         expected_cxxopts = [
             "-passthrough",
             "-passthrough",
             "-I__BAZEL_XCODE_BOSS_",
             "-passthrough",
+            "--config",
+            "$(CURRENT_EXECUTION_ROOT)/relative/Path.yaml",
         ],
         expected_swiftcopts = [
             "-passthrough",
@@ -596,6 +604,8 @@ def process_compiler_opts_test_suite(name):
             "ios",
             "-mmacosx-version-min=12.0",
             "-passthrough",
+            "--config",
+            "relative/Path.yaml",
         ],
         cxxopts = [
             "-isysroot",
@@ -613,6 +623,8 @@ def process_compiler_opts_test_suite(name):
             "macos",
             "-passthrough",
             "-mios-simulator-version-min=14.0",
+            "--config",
+            "relative/Path.yaml",
         ],
         swiftcopts = [
             "-output-file-map",
@@ -663,12 +675,16 @@ def process_compiler_opts_test_suite(name):
             "-I__BAZEL_XCODE_SOMETHING_/path",
             "-passthrough",
             "-passthrough",
+            "--config",
+            "$(CURRENT_EXECUTION_ROOT)/relative/Path.yaml",
         ],
         expected_cxxopts = [
             "-passthrough",
             "-passthrough",
             "-I__BAZEL_XCODE_BOSS_",
             "-passthrough",
+            "--config",
+            "$(CURRENT_EXECUTION_ROOT)/relative/Path.yaml",
         ],
         expected_swiftcopts = [
             "-passthrough",

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -357,6 +357,12 @@ def _process_cc_opts(opts, *, build_settings):
         # Short-circuit opts that are too short for our checks
         if len(opt) < 2:
             return opt
+
+        if previous_opt == "-ivfsoverlay" or previous_opt == "--config":
+            if opt[0] != "/":
+                return "$(CURRENT_EXECUTION_ROOT)/" + opt
+            return opt
+
         if opt[0] != "-":
             return opt
         opt_character = opt[1]
@@ -392,10 +398,6 @@ def _process_cc_opts(opts, *, build_settings):
             value = opt[12:]
             if not value.startswith("/"):
                 return "-ivfsoverlay" + "$(CURRENT_EXECUTION_ROOT)/" + value
-            return opt
-        if previous_opt == "-ivfsoverlay" or previous_opt == "--config":
-            if opt[0] != "/":
-                return "$(CURRENT_EXECUTION_ROOT)/" + opt
             return opt
 
         return opt

--- a/xcodeproj/internal/opts.bzl
+++ b/xcodeproj/internal/opts.bzl
@@ -253,6 +253,7 @@ def _process_base_compiler_opts(
     skip_next = 0
     previous_opt = None
     previous_frontend_opt = None
+    previous_clang_opt = None
     for idx, opt in enumerate(opts):
         if skip_next:
             skip_next -= 1
@@ -271,32 +272,20 @@ def _process_base_compiler_opts(
                 # No need to decrement 1, since we need to skip the first opt
                 continue
 
-        if opt != "-Xfrontend":
-            previous_vfsoverlay_opt = previous_frontend_opt or previous_opt
-
-            # -vfsoverlay doesn't apply `-working_directory=`, so we need to
-            # prefix it ourselves
-            _, opt_prefix, suffix = opt.partition("-vfsoverlay")
-            if not opt_prefix:
-                _, opt_prefix, suffix = opt.partition("-ivfsoverlay")
-            if suffix:
-                if suffix[0] != "/":
-                    opt = opt_prefix + "$(CURRENT_EXECUTION_ROOT)/" + suffix
-            elif (previous_opt == "--config" or
-                  previous_vfsoverlay_opt == "-vfsoverlay" or
-                  previous_vfsoverlay_opt == "-ivfsoverlay"):
-                if opt[0] != "/":
-                    opt = "$(CURRENT_EXECUTION_ROOT)/" + opt
-
         processed_opt = (
             extra_processing and
-            extra_processing(opt, previous_opt)
+            extra_processing(opt, previous_opt, previous_frontend_opt, previous_clang_opt)
         )
 
-        if previous_opt == "-Xfrontend":
-            previous_frontend_opt = opt
-        elif opt != "-Xfrontend":
+        if previous_opt == "-Xcc":
+            previous_clang_opt = opt
             previous_frontend_opt = None
+        elif opt != "-Xcc":
+            previous_clang_opt = None
+            if previous_opt == "-Xfrontend":
+                previous_frontend_opt = opt
+            elif opt != "-Xfrontend":
+                previous_frontend_opt = None
         previous_opt = opt
 
         opt = processed_opt
@@ -364,7 +353,7 @@ def _process_cc_opts(opts, *, build_settings):
     framework_includes = []
     has_debug_info = {}
 
-    def _inner_process_cc_opts(opt, _):
+    def _inner_process_cc_opts(opt, previous_opt, _previous_frontend_opt, _previous_clang_opt):
         # Short-circuit opts that are too short for our checks
         if len(opt) < 2:
             return opt
@@ -396,6 +385,19 @@ def _process_cc_opts(opts, *, build_settings):
                     build_settings["ENABLE_STRICT_OBJC_MSGSEND"] = True
                 return None
             return opt
+
+        # -ivfsoverlay and --config doesn't apply `-working_directory=`, so we
+        # need to prefix it ourselves
+        if opt.startswith("-ivfsoverlay"):
+            value = opt[12:]
+            if not value.startswith("/"):
+                return "-ivfsoverlay" + "$(CURRENT_EXECUTION_ROOT)/" + value
+            return opt
+        if previous_opt == "-ivfsoverlay" or previous_opt == "--config":
+            if opt[0] != "/":
+                return "$(CURRENT_EXECUTION_ROOT)/" + opt
+            return opt
+
         return opt
 
     processed_opts = _process_base_compiler_opts(
@@ -518,7 +520,7 @@ def _process_swiftcopts(
     clang_opts = []
     has_debug_info = {}
 
-    def _process_clang_opt(opt, previous_opt):
+    def _process_clang_opt(opt, previous_opt, previous_clang_opt):
         is_clang_opt = previous_opt == "-Xcc"
 
         if opt.startswith("-F"):
@@ -599,6 +601,16 @@ def _process_swiftcopts(
                     clang_opts.append(bwx_opt)
             return opt
         if is_clang_opt:
+            # -vfsoverlay doesn't apply `-working_directory=`, so we need to
+            # prefix it ourselves
+            if previous_clang_opt == "-ivfsoverlay":
+                if opt[0] != "/":
+                    opt = "$(CURRENT_EXECUTION_ROOT)/" + opt
+            elif opt.startswith("-ivfsoverlay"):
+                value = opt[12:]
+                if not value.startswith("/"):
+                    opt = "-ivfsoverlay$(CURRENT_EXECUTION_ROOT)/" + value
+
             # We do this check here, to prevent the `-O` logic below
             # from incorrectly detecting this situation
             clang_opts.append(opt)
@@ -606,8 +618,8 @@ def _process_swiftcopts(
 
         return None
 
-    def _inner_process_swiftcopts(opt, previous_opt):
-        clang_opt = _process_clang_opt(opt, previous_opt)
+    def _inner_process_swiftcopts(opt, previous_opt, previous_frontend_opt, previous_clang_opt):
+        clang_opt = _process_clang_opt(opt, previous_opt, previous_clang_opt)
         if clang_opt:
             return clang_opt
 
@@ -655,6 +667,23 @@ Using VFS overlays with `build_mode = "xcode"` is unsupported.
             # the future we could collect Swift compiler options similar to how
             # we collect C and C++ compiler options.
             return None
+
+        if opt == "-Xfrontend":
+            # We return early to prevent issues with the checks below
+            return opt
+
+        # -vfsoverlay doesn't apply `-working_directory=`, so we need to
+        # prefix it ourselves
+        previous_vfsoverlay_opt = previous_frontend_opt or previous_opt
+        if previous_vfsoverlay_opt == "-vfsoverlay":
+            if opt[0] != "/":
+                return "$(CURRENT_EXECUTION_ROOT)/" + opt
+            return opt
+        if opt.startswith("-vfsoverlay"):
+            value = opt[11:]
+            if value and value[0] != "/":
+                return "-vfsoverlay$(CURRENT_EXECUTION_ROOT)/" + value
+            return opt
 
         return opt
 


### PR DESCRIPTION
Before we would check Swift-only flags in the CC path, and vice versa.