### PR TITLE
Fix output base hashing

### DIFF
--- a/xcodeproj/internal/runner.template.sh
+++ b/xcodeproj/internal/runner.template.sh
@@ -112,8 +112,8 @@ readonly output_base="${execution_root%/*/*}"
 readonly nested_output_base="$output_base/rules_xcodeproj/build_output_base"
 
 # Create files for the generator target
-nested_output_base_hash=$(/sbin/md5 -q -s "$nested_output_base")
-readonly generator_package_directory="/tmp/rules_xcodeproj/generated/$nested_output_base_hash/generator"
+output_base_hash=$(/sbin/md5 -q -s "$output_base")
+readonly generator_package_directory="/tmp/rules_xcodeproj/generated/$output_base_hash/generator"
 
 mkdir -p "$generator_package_directory"
 cp "$generator_build_file" "$generator_package_directory/BUILD"

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -50,7 +50,7 @@ pass `ignore_version_differences = True` to `xcodeproj_rules_dependencies()`.
 
 def _generated_files_repo_impl(repository_ctx):
     output_base_hash_result = repository_ctx.execute(
-        ["bash", "-c", '/sbin/md5 -q -s "${PWD%/*/*}"'],
+        ["bash", "-c", '/sbin/md5 -q -s "${PWD%/*/*/*/*}"'],
     )
     if output_base_hash_result.return_code != 0:
         fail("Failed to calculate output base hash: {}".format(


### PR DESCRIPTION
We need to use the outer output base, so `Index Build` can find the generator as well.