### PR TITLE
Move `@rules_xcodeproj_generated` to its own module extension

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,6 +27,9 @@ bazel_dep(
     dev_dependency = True,
 )
 
+internal = use_extension("//xcodeproj:extensions.bzl", "internal")
+use_repo(internal, "rules_xcodeproj_generated")
+
 non_module_deps = use_extension("//xcodeproj:extensions.bzl", "non_module_deps")
 use_repo(
     non_module_deps,
@@ -37,7 +40,6 @@ use_repo(
     "com_github_michaeleisel_zippyjsoncfamily",
     "com_github_tadija_aexml",
     "com_github_tuist_xcodeproj",
-    "rules_xcodeproj_generated",
     "rules_xcodeproj_index_import",
 )
 

--- a/xcodeproj/extensions.bzl
+++ b/xcodeproj/extensions.bzl
@@ -6,5 +6,7 @@ load(
     "xcodeproj_rules_dev_dependencies",
 )
 
+internal = module_extension(implementation = lambda _: xcodeproj_rules_dependencies(internal_only = True))
+
 dev_non_module_deps = module_extension(implementation = lambda _: xcodeproj_rules_dev_dependencies())
 non_module_deps = module_extension(implementation = lambda _: xcodeproj_rules_dependencies(include_bzlmod_ready_dependencies = False))

--- a/xcodeproj/repositories.bzl
+++ b/xcodeproj/repositories.bzl
@@ -73,7 +73,8 @@ generated_files_repo = repository_rule(
 # buildifier: disable=unnamed-macro
 def xcodeproj_rules_dependencies(
         ignore_version_differences = False,
-        include_bzlmod_ready_dependencies = True):
+        include_bzlmod_ready_dependencies = True,
+        internal_only = False):
     """Fetches repositories that are dependencies of `rules_xcodeproj`.
 
     Users should call this macro in their `WORKSPACE` to ensure that all of the
@@ -85,7 +86,16 @@ def xcodeproj_rules_dependencies(
             incompatible versions of dependency repositories will be silenced.
         include_bzlmod_ready_dependencies: Whether or not bzlmod-ready
             dependencies should be included.
+        internal_only: If `True`, only internal dependencies will be included.
+            Should only be called from `extensions.bzl`.
     """
+    if internal_only or include_bzlmod_ready_dependencies:
+        # Used to house generated files
+        generated_files_repo(name = "rules_xcodeproj_generated")
+
+    if internal_only:
+        return
+
     if include_bzlmod_ready_dependencies:
         _maybe(
             http_archive,
@@ -306,9 +316,6 @@ swift_library(
         url = "https://github.com/apple/swift-collections/archive/refs/tags/1.0.2.tar.gz",
         ignore_version_differences = ignore_version_differences,
     )
-
-    # Used to house generated files
-    generated_files_repo(name = "rules_xcodeproj_generated")
 
 # buildifier: disable=unnamed-macro
 def xcodeproj_rules_dev_dependencies(ignore_version_differences = False):


### PR DESCRIPTION
This is mainly to make the label look nicer in outputs.