### PR TITLE
Limit visibility of `examples/integration` targets

### DIFF
--- a/examples/integration/AppClip/BUILD
+++ b/examples/integration/AppClip/BUILD
@@ -39,7 +39,7 @@ ios_app_clip(
     }),
     resources = [":ResourceGroup"],
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = ["//iOSApp:__subpackages__"],
     deps = [":AppClip.library"],
 )
 

--- a/examples/integration/CommandLine/CommandLineTool/BUILD
+++ b/examples/integration/CommandLine/CommandLineTool/BUILD
@@ -13,7 +13,7 @@ macos_command_line_application(
     launchdplists = ["Launchd.plist"],
     linkopts = ["-dead_strip"],
     minimum_os_version = "11.0",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = [":tool.library"],
 )
 
@@ -26,7 +26,7 @@ apple_universal_binary(
     ],
     minimum_os_version = "11.0",
     platform_type = "macos",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
 )
 
 swift_binary(

--- a/examples/integration/CommandLine/CommandLineToolLib/BUILD
+++ b/examples/integration/CommandLine/CommandLineToolLib/BUILD
@@ -74,5 +74,5 @@ objc_library(
 alias(
     name = "CommandLineToolLib",
     actual = ":lib_headers",
-    visibility = ["//visibility:public"],
+    visibility = ["//CommandLine/CommandLineTool:__subpackages__"],
 )

--- a/examples/integration/CommandLine/Tests/BUILD
+++ b/examples/integration/CommandLine/Tests/BUILD
@@ -6,9 +6,6 @@ swift_library(
     testonly = True,
     srcs = glob(["*.swift"]),
     module_name = "LibSwiftTestsLib",
-    visibility = [
-        "//visibility:public",
-    ],
     deps = [
         "//CommandLine/CommandLineToolLib:lib_swift",
     ],
@@ -17,9 +14,7 @@ swift_library(
 macos_unit_test(
     name = "CommandLineToolTests",
     minimum_os_version = "11.0",
-    visibility = [
-        "//visibility:public",
-    ],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = [
         ":CommandLineLibSwiftTestsLib",
     ],

--- a/examples/integration/CommandLine/swift_c_module/BUILD
+++ b/examples/integration/CommandLine/swift_c_module/BUILD
@@ -14,7 +14,7 @@ swift_c_module(
     name = "swift_c_module",
     module_map = "c_lib.modulemap",
     module_name = "SwiftCModule",
-    visibility = ["//visibility:public"],
+    visibility = ["//CommandLine:__subpackages__"],
     deps = [
         ":c_lib",
     ],

--- a/examples/integration/Lib/BUILD
+++ b/examples/integration/Lib/BUILD
@@ -19,7 +19,7 @@ ios_build_test(
     minimum_os_version = "15.0",
     tags = ["manual"],
     targets = [":Lib"],
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
 )
 
 swift_library(
@@ -35,7 +35,13 @@ swift_library(
     ),
     module_name = "Lib",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//AppClip:__subpackages__",
+        "//iMessageApp:__subpackages__",
+        "//Lib:__subpackages__",
+        "//UI:__subpackages__",
+        "//WidgetExtension:__subpackages__",
+    ],
     deps = [
         "@com_github_krzyzanowskim_cryptoswift//:CryptoSwift",
     ],
@@ -66,7 +72,7 @@ ios_framework(
     infoplists = ["Info.plist"],
     minimum_os_version = "15.0",
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = ["//UI:__pkg__"],
     deps = [":Lib"],
 )
 
@@ -80,7 +86,7 @@ tvos_framework(
     infoplists = ["Info.plist"],
     minimum_os_version = "15.0",
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = ["//UI:__pkg__"],
     deps = [":Lib"],
 )
 
@@ -91,6 +97,6 @@ watchos_framework(
     infoplists = ["Info.plist"],
     minimum_os_version = "7.0",
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = ["//UI:__pkg__"],
     deps = [":Lib"],
 )

--- a/examples/integration/Lib/BUILD
+++ b/examples/integration/Lib/BUILD
@@ -37,10 +37,10 @@ swift_library(
     tags = ["manual"],
     visibility = [
         "//AppClip:__subpackages__",
-        "//iMessageApp:__subpackages__",
         "//Lib:__subpackages__",
         "//UI:__subpackages__",
         "//WidgetExtension:__subpackages__",
+        "//iMessageApp:__subpackages__",
     ],
     deps = [
         "@com_github_krzyzanowskim_cryptoswift//:CryptoSwift",

--- a/examples/integration/Lib/dist/dynamic/BUILD
+++ b/examples/integration/Lib/dist/dynamic/BUILD
@@ -11,7 +11,7 @@ ios_dynamic_framework(
     infoplists = ["//Lib:Info.plist"],
     minimum_os_version = "15.0",
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = ["//Lib"],
 )
 
@@ -23,7 +23,7 @@ tvos_dynamic_framework(
     infoplists = ["//Lib:Info.plist"],
     minimum_os_version = "15.0",
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = ["//Lib"],
 )
 
@@ -35,6 +35,6 @@ watchos_dynamic_framework(
     infoplists = ["//Lib:Info.plist"],
     minimum_os_version = "7.0",
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = ["//Lib"],
 )

--- a/examples/integration/UI/BUILD
+++ b/examples/integration/UI/BUILD
@@ -9,7 +9,11 @@ swift_library(
     copts = ["-application-extension"],
     module_name = "UI",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//iOSApp:__subpackages__",
+        "//tvOSApp:__subpackages__",
+        "//watchOSAppExtension:__subpackages__",
+    ],
     deps = [
         "//Lib",
     ],
@@ -26,7 +30,10 @@ ios_framework(
     infoplists = ["Info.plist"],
     minimum_os_version = "15.0",
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//iOSApp:__subpackages__",
+        "@rules_xcodeproj_generated//:__subpackages__",
+    ],
     deps = [":UI"],
 )
 
@@ -38,7 +45,10 @@ tvos_framework(
     infoplists = ["Info.plist"],
     minimum_os_version = "15.0",
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//tvOSApp:__subpackages__",
+        "@rules_xcodeproj_generated//:__subpackages__",
+    ],
     deps = [":UI"],
 )
 
@@ -50,6 +60,9 @@ watchos_framework(
     infoplists = ["Info.plist"],
     minimum_os_version = "7.0",
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//watchOSAppExtension:__subpackages__",
+        "@rules_xcodeproj_generated//:__subpackages__",
+    ],
     deps = [":UI"],
 )

--- a/examples/integration/WidgetExtension/BUILD
+++ b/examples/integration/WidgetExtension/BUILD
@@ -32,7 +32,7 @@ ios_extension(
     }),
     resources = [":ResourceGroup"],
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = ["//iOSApp:__subpackages__"],
     deps = [":WidgetExtension.library"],
 )
 

--- a/examples/integration/iMessageApp/BUILD
+++ b/examples/integration/iMessageApp/BUILD
@@ -27,7 +27,7 @@ ios_imessage_application(
     infoplists = [":Info.plist"],
     minimum_os_version = "15.0",
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
 )
 
 ios_imessage_extension(
@@ -38,7 +38,6 @@ ios_imessage_extension(
     minimum_os_version = "15.0",
     resources = glob(["*.lproj/**"]),
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
     deps = [":iMessageAppExtension.library"],
 )
 

--- a/examples/integration/iOSApp/BUILD
+++ b/examples/integration/iOSApp/BUILD
@@ -5,7 +5,10 @@ exports_files(["ownership.yaml"])
 alias(
     name = "iOSApp",
     actual = "//iOSApp/Source:iOSApp",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//iOSApp/Test:__subpackages__",
+        "@rules_xcodeproj_generated//:__subpackages__",
+    ],
 )
 
 apple_bundle_version(

--- a/examples/integration/iOSApp/Resources/ExampleNestedResources/BUILD
+++ b/examples/integration/iOSApp/Resources/ExampleNestedResources/BUILD
@@ -9,5 +9,5 @@ apple_resource_bundle(
         "*.lproj/**",
     ]) + ["@examples_ios_app_external//:ExternalImportedBundle"],
     structured_resources = glob(["dir/**"]),
-    visibility = ["//visibility:public"],
+    visibility = ["//iOSApp:__subpackages__"],
 )

--- a/examples/integration/iOSApp/Resources/ExampleResources/BUILD
+++ b/examples/integration/iOSApp/Resources/ExampleResources/BUILD
@@ -10,7 +10,7 @@ apple_resource_bundle(
         ":deps_txt",
     ],
     structured_resources = ["nested/hello.txt"],
-    visibility = ["//visibility:public"],
+    visibility = ["//iOSApp:__subpackages__"],
 )
 
 dep_resources_collector(
@@ -21,5 +21,5 @@ dep_resources_collector(
 filegroup(
     name = "exported_resources",
     srcs = glob(["Assets.xcassets/**"]),
-    visibility = ["//visibility:public"],
+    visibility = ["//iOSApp:__subpackages__"],
 )

--- a/examples/integration/iOSApp/Resources/OnlyStructuredResources/BUILD
+++ b/examples/integration/iOSApp/Resources/OnlyStructuredResources/BUILD
@@ -6,5 +6,5 @@ apple_resource_bundle(
     bundle_name = "OnlyStructuredResources",
     infoplists = ["Info.plist"],
     structured_resources = glob(["Nested/*.json"]),
-    visibility = ["//visibility:public"],
+    visibility = ["//iOSApp:__subpackages__"],
 )

--- a/examples/integration/iOSApp/Source/BUILD
+++ b/examples/integration/iOSApp/Source/BUILD
@@ -62,7 +62,10 @@ ios_application(
     ),
     strings = glob(["*.lproj/Localizable.strings"]),
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//iOSApp:__pkg__",
+        "@rules_xcodeproj_generated//:__subpackages__",
+    ],
     watch_application = "//watchOSApp",
     deps = [
         ":iOSApp.library",

--- a/examples/integration/iOSApp/Source/CoreUtilsObjC/BUILD
+++ b/examples/integration/iOSApp/Source/CoreUtilsObjC/BUILD
@@ -17,7 +17,7 @@ objc_library(
     pch = "CoreUtils/CoreUtils.pch",
     sdk_dylibs = ["c++"],
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = ["//iOSApp:__subpackages__"],
 )
 
 ios_framework(
@@ -28,6 +28,6 @@ ios_framework(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     minimum_os_version = "15.0",
-    visibility = ["//visibility:public"],
+    visibility = ["//iOSApp:__subpackages__"],
     deps = [":CoreUtilsObjC"],
 )

--- a/examples/integration/iOSApp/Source/Utils/BUILD
+++ b/examples/integration/iOSApp/Source/Utils/BUILD
@@ -9,7 +9,7 @@ objc_library(
     data = ["@examples_ios_app_external//:ExternalImportedBundle"],
     module_name = "Utils",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = ["//iOSApp:__subpackages__"],
     deps = [
         "//iOSApp/Source/CoreUtilsObjC",
         "@FXPageControl",

--- a/examples/integration/iOSApp/Test/ObjCUnitTests/BUILD
+++ b/examples/integration/iOSApp/Test/ObjCUnitTests/BUILD
@@ -8,7 +8,7 @@ ios_unit_test(
     },
     minimum_os_version = "15.0",
     test_host = "//iOSApp",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = [":iOSAppObjCUnitTests.library"],
 )
 

--- a/examples/integration/iOSApp/Test/SwiftUnitTests/BUILD
+++ b/examples/integration/iOSApp/Test/SwiftUnitTests/BUILD
@@ -11,7 +11,7 @@ ios_unit_test(
     minimum_os_version = "15.0",
     resources = ["//iOSApp/Resources/ExampleResources:exported_resources"],
     test_host = "//iOSApp",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = [":iOSAppSwiftUnitTests.library"],
 )
 

--- a/examples/integration/iOSApp/Test/TestingUtils/BUILD
+++ b/examples/integration/iOSApp/Test/TestingUtils/BUILD
@@ -6,7 +6,7 @@ macos_build_test(
     minimum_os_version = "12.0",
     tags = ["manual"],
     targets = [":TestingUtils"],
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
 )
 
 swift_library(
@@ -18,7 +18,7 @@ swift_library(
     generates_header = True,
     module_name = "TestingUtils",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = ["//iOSApp/Test:__subpackages__"],
 )
 
 genrule(

--- a/examples/integration/iOSApp/Test/UITests/BUILD
+++ b/examples/integration/iOSApp/Test/UITests/BUILD
@@ -6,7 +6,7 @@ ios_ui_test(
     bundle_id = "io.buildbuddy.example.uitests",
     minimum_os_version = "15.0",
     test_host = "//iOSApp",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = [":iOSAppUITests.library"],
 )
 

--- a/examples/integration/macOSApp/Source/BUILD
+++ b/examples/integration/macOSApp/Source/BUILD
@@ -26,7 +26,10 @@ macos_application(
     minimum_os_version = "12.0",
     resources = [":ResourceGroup"],
     version = ":Version",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//macOSApp/Test:__subpackages__",
+        "@rules_xcodeproj_generated//:__subpackages__",
+    ],
     deps = [":macOSApp.library"],
 )
 

--- a/examples/integration/macOSApp/Test/UITests/BUILD
+++ b/examples/integration/macOSApp/Test/UITests/BUILD
@@ -8,7 +8,7 @@ macos_ui_test(
     # xctestrunner does not support macOS. So, don't try to run this.
     tags = ["manual"],
     test_host = "//macOSApp/Source:macOSApp",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = [":macOSAppUITests.library"],
 )
 

--- a/examples/integration/repositories.bzl
+++ b/examples/integration/repositories.bzl
@@ -82,9 +82,7 @@ objc_library(
     hdrs = ["FXPageControl/FXPageControl.h"],
     sdk_frameworks = ["CoreGraphics"],
     srcs = ["FXPageControl/FXPageControl.m"],
-    visibility = [
-        "//visibility:public",
-    ]
+    visibility = ["//visibility:public"],
 )
 """,
         sha256 = "1610603d6ccfbc80b17aa2944c2587f4800c06a4e229303f431091e4e2e7a6d1",

--- a/examples/integration/tvOSApp/BUILD
+++ b/examples/integration/tvOSApp/BUILD
@@ -1,5 +1,5 @@
 alias(
     name = "tvOSApp",
     actual = "//tvOSApp/Source:tvOSApp",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
 )

--- a/examples/integration/tvOSApp/Resources/BUILD
+++ b/examples/integration/tvOSApp/Resources/BUILD
@@ -3,11 +3,11 @@ load("@build_bazel_rules_apple//apple:resources.bzl", "apple_resource_group")
 filegroup(
     name = "PreviewContent",
     srcs = glob(["PreviewContent/**"]),
-    visibility = ["//visibility:public"],
+    visibility = ["//tvOSApp:__subpackages__"],
 )
 
 apple_resource_group(
     name = "ResourceGroup",
     resources = glob(["Assets.xcassets/**"]),
-    visibility = ["//visibility:public"],
+    visibility = ["//tvOSApp:__subpackages__"],
 )

--- a/examples/integration/tvOSApp/Source/BUILD
+++ b/examples/integration/tvOSApp/Source/BUILD
@@ -34,7 +34,10 @@ tvos_application(
         "//conditions:default": None,
     }),
     resources = ["//tvOSApp/Resources:ResourceGroup"],
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//tvOSApp:__subpackages__",
+        "@rules_xcodeproj_generated//:__subpackages__",
+    ],
     deps = [":tvOSApp.library"],
 )
 
@@ -61,7 +64,7 @@ swift_library(
     }),
     module_name = "tvOSApp",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = ["//tvOSApp:__subpackages__"],
     deps = [
         "//UI",
     ],

--- a/examples/integration/tvOSApp/Test/UITests/BUILD
+++ b/examples/integration/tvOSApp/Test/UITests/BUILD
@@ -8,7 +8,7 @@ tvos_ui_test(
     # xctestrunner does not support tvOS. So, don't try to run this.
     tags = ["manual"],
     test_host = "//tvOSApp/Source:tvOSApp",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = [":tvOSAppUITests.library"],
 )
 

--- a/examples/integration/tvOSApp/Test/UnitTests/BUILD
+++ b/examples/integration/tvOSApp/Test/UnitTests/BUILD
@@ -8,7 +8,7 @@ tvos_unit_test(
     # xctestrunner does not support tvOS. So, don't try to run this.
     tags = ["manual"],
     test_host = "//tvOSApp/Source:tvOSApp",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = [":tvOSAppUnitTests.library"],
 )
 

--- a/examples/integration/watchOSApp/BUILD
+++ b/examples/integration/watchOSApp/BUILD
@@ -27,7 +27,10 @@ watchos_application(
         "//conditions:default": None,
     }),
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//iOSApp:__subpackages__",
+        "//watchOSApp:__subpackages__",
+    ],
 )
 
 genrule(

--- a/examples/integration/watchOSApp/Test/UITests/BUILD
+++ b/examples/integration/watchOSApp/Test/UITests/BUILD
@@ -6,7 +6,7 @@ watchos_ui_test(
     minimum_os_version = "7.0",
     tags = ["manual"],
     test_host = "//watchOSApp",
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = [":watchOSAppUITests.library"],
 )
 

--- a/examples/integration/watchOSAppExtension/BUILD
+++ b/examples/integration/watchOSAppExtension/BUILD
@@ -36,7 +36,7 @@ watchos_extension(
     }),
     resources = [":ResourceGroup"],
     version = "//iOSApp:Version",
-    visibility = ["//visibility:public"],
+    visibility = ["//watchOSApp:__subpackages__"],
     deps = [":watchOSAppExtension.library"],
 )
 

--- a/examples/integration/watchOSAppExtension/Test/UnitTests/BUILD
+++ b/examples/integration/watchOSAppExtension/Test/UnitTests/BUILD
@@ -6,7 +6,7 @@ watchos_unit_test(
     frameworks = ["//UI:UIFramework.watchOS"],
     minimum_os_version = "7.0",
     tags = ["manual"],
-    visibility = ["//visibility:public"],
+    visibility = ["@rules_xcodeproj_generated//:__subpackages__"],
     deps = [":watchOSAppExtensionUnitTests.library"],
 )
 


### PR DESCRIPTION
This is mainly to verify a bug that currently exists when using bzlmod.